### PR TITLE
fix: UX, runtime, and docs improvements for first-run experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,14 @@ Concretely:
 
 ### Prerequisites
 
+**To run the app (production .dmg):**
+- **Claude Code CLI** — install per [Anthropic's instructions](https://docs.anthropic.com/en/docs/claude-code). Must be on your `PATH` (typically `~/.local/bin/claude`). Required for the AI agent — the app checks for it on every launch.
+- **Node.js 18+** — required at runtime to spawn the ACP bridge (`npx -y @agentclientprotocol/claude-agent-acp`). On first launch the bridge package is downloaded and cached; subsequent launches are instant. If you installed Node via `nvm`, make sure at least one version is active.
+
+**To build from source (additional):**
 - **Node.js 20+** and a package manager (`pnpm`, `npm`, or `bun` — `bun` is the one wired into `tauri.conf.json` by default).
 - **Rust toolchain** (stable). Install via [rustup](https://rustup.rs/).
 - **Tauri prerequisites** for your OS. See the [Tauri prerequisites guide](https://tauri.app/start/prerequisites/). On macOS this is just Xcode Command Line Tools.
-- **(Optional) Claude Code CLI** if you want the agent. Install per Anthropic's instructions and make sure `claude` is on your `PATH`.
 
 ### Install and run in dev
 
@@ -210,31 +214,38 @@ The remaining `crates/` directories (`atlas-analysis`, `atlas-background`, `atla
 
 This is the most non-obvious part of the system, so it gets its own section.
 
-Atlas does **not** use ACP (Agent Client Protocol). It invokes the public `claude` CLI directly:
+Atlas uses **ACP (Agent Client Protocol)** — a structured stdio-based protocol for host apps to communicate with AI agents. Instead of spawning a new process per message, Atlas launches one persistent bridge process and exchanges JSON messages with it for the lifetime of the session.
+
+The bridge is the npm package `@agentclientprotocol/claude-agent-acp`. Atlas spawns it via:
 
 ```
-claude --print --output-format stream-json --verbose [--resume <sid>] [--permission-mode <m>] <prompt>
+npx -y @agentclientprotocol/claude-agent-acp
 ```
 
-Each invocation streams newline-delimited JSON to stdout. The Rust side spawns the process, reads stdout line by line in a blocking thread, parses each line, and re-emits it as a `claude-stream` Tauri event with payload:
+On first launch the package is downloaded and cached by npm. Every subsequent launch resolves instantly from the local cache. The bridge itself wraps the `claude` CLI and translates between ACP messages and Claude Code's own protocol.
 
-```ts
-{ session_id: string; event_type: "session" | "text" | "tool_use" | "tool_result" | "done" | "error"; content: string }
+**The full stack:**
+
+```
+Atlas (Rust/Tauri)
+  ↕  JSON over stdio (ACP)
+@agentclientprotocol/claude-agent-acp   ← Node.js bridge (spawned via npx)
+  ↕  spawns and manages
+claude CLI
 ```
 
-Two design decisions matter here:
+**How a session works:**
 
-**1. The `session_id` is per-send, not per-tab.**
-Each call to `handleSend()` in `chat-panel.tsx` mints a fresh `streamId` like `${tabId}-${ts36}-${rand6}` and passes it as the Rust `session_id`. The Rust backend keys its PID registry by this `streamId`, so two concurrent streams in the same tab don't collide, and the stop button always targets exactly one PID. The frontend listener also filters on `streamId`, so streams can't cross-contaminate each other's assistant message.
+1. When a chat tab opens, `ensureBound()` in `chat-panel.tsx` spawns the bridge via `agents_spawn("claude-code-ts")` in Rust. The `atlas-acp` crate handles the ACP handshake — the bridge responds with its capabilities (auth methods, permission modes, supported models).
+2. The user's message is sent as an ACP `run` request. The bridge streams back structured deltas: text chunks, thinking blocks, tool calls, tool results.
+3. When Claude Code wants to run a bash command or edit a file, it sends a `permission_request` event over ACP. Atlas surfaces the approval modal, waits for the user's click, and sends the decision back. This is what enables the per-tool permission UI — it's a first-class protocol event, not a heuristic parse of stdout.
+4. The bridge process stays alive across messages in the same tab. Spawning it once amortises the `npx` cold-start cost across the whole session.
 
-**2. Streams survive tab navigation via a "running archive".**
-When the user clicks a different history item in the session sidebar while a stream is running, `chat-store.archiveCurrent(tabId)` deep-copies the in-flight session into `runningArchive[claudeSessionId]`. The stream listener writes to whichever container currently holds its `streamId` — the tab if the user is still there, or the archive if they've moved on. When the stream finishes, the archive is dropped (the on-disk JSONL is now authoritative); when the user navigates back, `restoreArchive()` swaps it back into the tab.
+**Session IDs:**
+Each ACP session has a `session_id` minted by the bridge on `new_session`. The Rust layer routes all incoming deltas by `(agent_id, session_id)` to the right tab's store slice. Multiple tabs each have their own session, so three concurrent Claude Code streams never cross-contaminate.
 
-The result is that you can fire off three Claude Code requests in three tabs, switch freely between them and the history list, and each one keeps streaming independently with a working stop button.
-
-History rendering reads from `~/.claude/projects/<slug>/<session-id>.jsonl` directly, since Claude Code persists every session there. The `claude_run` command also accepts a `--resume` flag to continue prior conversations.
-
-In production builds, `claude.rs` falls back to a login-shell `which` resolution because macOS GUI apps get a stripped `PATH` — without this, the bundled `.app` can't find any user-installed CLI.
+**PATH resolution:**
+macOS GUI apps launch with a stripped `PATH` (only `/usr/bin:/bin:/usr/sbin:/sbin`). Atlas calls `sanitize_host_env()` at boot (`crates/atlas-acp/src/registry.rs`) to prepend `~/.local/bin`, `~/.cargo/bin`, `/opt/homebrew/bin`, and nvm-managed Node paths before any subprocess is spawned. This is why `claude` and `npx` resolve correctly inside the `.app` bundle even though they aren't on the system `PATH`.
 
 ### State, persistence, and IPC
 

--- a/crates/atlas-acp/src/registry.rs
+++ b/crates/atlas-acp/src/registry.rs
@@ -467,6 +467,7 @@ fn apply_cheap_path_extras() {
         extras.push(format!("{home}/.local/bin"));
         extras.push(format!("{home}/.bun/bin"));
         extras.push(format!("{home}/.cargo/bin"));
+        extras.push(format!("{home}/.local/share/fnm/aliases/default/bin"));
     }
     extras.push("/opt/homebrew/bin".into());
     extras.push("/opt/homebrew/sbin".into());

--- a/src-tauri/src/commands/claude_setup.rs
+++ b/src-tauri/src/commands/claude_setup.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as AsyncCommand;
+use tokio::time::{timeout, Duration};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // claude_status
@@ -38,13 +39,23 @@ pub struct ClaudeStatus {
 
 /// Fast probe — runs `claude --version` and `claude auth status` in parallel.
 /// Always returns a populated struct; never errors (an absent binary just
-/// surfaces as `installed: false`).
+/// surfaces as `installed: false`). Each subprocess is capped at 8 s so a
+/// hung claude process never freezes the setup banner indefinitely.
 #[tauri::command]
 pub async fn claude_status() -> ClaudeStatus {
-    let version_fut = AsyncCommand::new("claude").arg("--version").output();
-    let auth_fut = AsyncCommand::new("claude").args(["auth", "status"]).output();
+    let version_fut = timeout(
+        Duration::from_secs(8),
+        AsyncCommand::new("claude").arg("--version").output(),
+    );
+    let auth_fut = timeout(
+        Duration::from_secs(8),
+        AsyncCommand::new("claude").args(["auth", "status"]).output(),
+    );
 
     let (version_res, auth_res) = tokio::join!(version_fut, auth_fut);
+    // Flatten the timeout layer: Err(_) on either timeout or spawn failure.
+    let version_res = version_res.unwrap_or_else(|_| Err(std::io::Error::other("timeout")));
+    let auth_res = auth_res.unwrap_or_else(|_| Err(std::io::Error::other("timeout")));
 
     let (installed, version) = match version_res {
         Ok(out) if out.status.success() => {

--- a/src/features/chat/components/chat-input.tsx
+++ b/src/features/chat/components/chat-input.tsx
@@ -18,7 +18,7 @@ import {
   useMemo,
   useRef,
 } from "react";
-import { EditorState, Prec, type Extension } from "@codemirror/state";
+import { Compartment, EditorState, Prec, type Extension } from "@codemirror/state";
 import {
   drawSelection,
   EditorView,
@@ -117,6 +117,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
   ) {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
+    const placeholderCompartment = useMemo(() => new Compartment(), []);
 
     // Keep the latest callbacks in refs so the extensions captured at mount
     // can always reach the current handler without us tearing down the view
@@ -245,7 +246,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             EditorView.lineWrapping,
             submitKeymap,
             keymap.of([...historyKeymap, ...defaultKeymap]),
-            cmPlaceholder(placeholder),
+            placeholderCompartment.of(cmPlaceholder(placeholder)),
             theme,
             EditorView.contentAttributes.of({
               "aria-label": "Chat message",
@@ -285,11 +286,16 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         view.destroy();
         viewRef.current = null;
       };
-      // `placeholder` / `theme` / `extensionsKey` are stable enough not to
-      // bounce the view; if a caller needs to change them at runtime they
-      // can call `.setValue("")` after a remount instead.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+      const view = viewRef.current;
+      if (!view) return;
+      view.dispatch({
+        effects: placeholderCompartment.reconfigure(cmPlaceholder(placeholder)),
+      });
+    }, [placeholder]);
 
     useImperativeHandle(
       ref,

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -27,7 +27,7 @@ const MessagesList = lazy(() =>
   import("./messages-list").then((m) => ({ default: m.MessagesList }))
 );
 import type { MessagesListHandle } from "./messages-list";
-import { Sparkles, User, TerminalSquare, ListFilter, Search, Loader2, ChevronDown } from "lucide-react";
+import { Sparkles, User, TerminalSquare, ListFilter, Search, Loader2, ChevronDown, TriangleAlert, RefreshCw } from "lucide-react";
 import { AtlasIcon } from "@/components/atlas-icon";
 import { Kbd, KbdGroup } from "@/ui/kbd";
 import { logEvent } from "@/features/log/lib/log";
@@ -54,6 +54,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
   const [roleFilter, setRoleFilter] = useState<"all" | "user" | "assistant">("all");
   const [bashPanelOpen, setBashPanelOpen] = useState(false);
   const [searchPaletteOpen, setSearchPaletteOpen] = useState(false);
+  const [bindError, setBindError] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
 
   // Scroll-to-bottom state is owned here so the floating button can live
@@ -86,6 +87,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     const ensureBound = async () => {
       if (cancelled || pending) return;
       pending = true;
+      setBindError(null);
       try {
         const agent = await ensureDefaultAgent();
         if (cancelled) return;
@@ -109,6 +111,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
         }
       } catch (err) {
         console.warn("Agent session creation failed:", err);
+        if (!cancelled) setBindError(String(err));
       } finally {
         pending = false;
       }
@@ -424,6 +427,12 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
             running={session.status === "running"}
             showJumpToBottom={showJumpToBottom}
             onScrollToBottom={() => messagesListRef.current?.scrollToBottom()}
+            bindError={bindError}
+            onRetryBind={() =>
+              window.dispatchEvent(
+                new CustomEvent("atlas:chat-input-focused", { detail: { tabId } })
+              )
+            }
           />
         </div>
       </div>
@@ -472,9 +481,12 @@ function LoadingTranscriptState() {
 
 /**
  * Composer wrapper: the setup banner + login dialog + the real `MessageInput`.
- * Subscribes to the Claude-Code setup phase from `useClaudeSetupStore` and
- * hard-disables the input when Claude isn't installed/authed so we don't
- * surface confusing failures from inside the ACP spawn path.
+ * Handles two blocking states above the input:
+ *   1. Claude Code not ready (`useClaudeSetupStore` phase ≠ `ready`) — hard-disables
+ *      the input and shows the setup/install/auth pill.
+ *   2. ACP agent bind failed (`bindError`) — Claude Code is ready but the bridge
+ *      process couldn't spawn. Shows a retry pill without disabling the input so
+ *      the user can still read previous messages.
  */
 function ChatComposer({
   tabId,
@@ -483,6 +495,8 @@ function ChatComposer({
   running,
   showJumpToBottom,
   onScrollToBottom,
+  bindError,
+  onRetryBind,
 }: {
   tabId: string;
   onSend: (message: string, mentions: MentionData[]) => void;
@@ -490,22 +504,27 @@ function ChatComposer({
   running: boolean;
   showJumpToBottom: boolean;
   onScrollToBottom: () => void;
+  bindError: string | null;
+  onRetryBind: () => void;
 }) {
   const phase = useClaudeSetupStore.use.phase();
   const disabled = phase !== "ready";
   const disabledReason =
-    phase === "not-installed"
-      ? "Install Claude Code to start chatting"
-      : phase === "not-authed"
-        ? "Sign in to Claude Code to start chatting"
-        : phase === "installing"
-          ? "Installing Claude Code…"
-          : phase === "authing"
-            ? "Finishing sign-in…"
-            : undefined;
+    phase === "checking"
+      ? "Checking Claude Code…"
+      : phase === "not-installed"
+        ? "Install Claude Code to start chatting"
+        : phase === "not-authed"
+          ? "Sign in to Claude Code to start chatting"
+          : phase === "installing"
+            ? "Installing Claude Code…"
+            : phase === "authing"
+              ? "Finishing sign-in…"
+              : undefined;
 
   const setupVisible = phase !== "ready";
-  const showRow = setupVisible || showJumpToBottom;
+  const agentErrorVisible = phase === "ready" && !!bindError;
+  const showRow = setupVisible || showJumpToBottom || agentErrorVisible;
 
   return (
     <>
@@ -521,6 +540,23 @@ function ChatComposer({
                 <span key={`setup-${phase}`} className="atlas-pill-in">
                   <ClaudeSetupBanner />
                 </span>
+              )}
+              {agentErrorVisible && (
+                <button
+                  key="agent-error"
+                  onClick={onRetryBind}
+                  style={{ backdropFilter: "blur(4px)" }}
+                  className={cn(
+                    "atlas-pill-in inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+                    "border text-[11px] leading-none font-medium cursor-pointer transition-colors",
+                    "shadow-[0_2px_8px_rgba(0,0,0,0.35)]",
+                    "border-[var(--status-error)]/40 bg-[var(--status-error)]/15 text-[var(--status-error)] hover:bg-[var(--status-error)]/25",
+                  )}
+                >
+                  <TriangleAlert size={11} />
+                  <span>Couldn't connect to agent — Retry</span>
+                  <RefreshCw size={11} className="ml-1 opacity-70" />
+                </button>
               )}
               {showJumpToBottom && (
                 <button


### PR DESCRIPTION
## Summary

- **Frozen input placeholder** — CodeMirror baked the placeholder string at mount time (empty `useEffect` deps). Wrapped it in a `Compartment` so it reconfigures when the phase changes from `checking` → `ready`.
- **Silent agent bind failure** — `ensureBound()` errors were swallowed by `console.warn`, leaving the input silently broken. Now captured in `bindError` state with a red "Couldn't connect to agent — Retry" pill above the input.
- **Checking phase label** — `disabledReason` had no case for `"checking"`, showing the generic fallback during the startup probe. Now shows "Checking Claude Code…".
- **fnm PATH support** — `apply_cheap_path_extras()` only enriched nvm paths. Users with fnm had `npx` only at `~/.local/share/fnm/aliases/default/bin`, causing `npx -y @agentclientprotocol/claude-agent-acp` to fail with ENOENT and surface as `acp: driver task panicked before initialize`.
- **`claude_status` timeout** — `claude --version` and `claude auth status` had no timeout. Under load the Tauri executor could starve the command indefinitely, freezing the phase at `"checking"`. Added an 8 s timeout.
- **README** — split prerequisites into "To run" vs "To build from source"; rewrote the Claude Code integration section to describe the actual ACP stack (stale text said "Atlas does not use ACP").

## Pre-existing issues (not introduced here)

- `npx tsc --noEmit` fails with one type error in `editor-panel.tsx` (`Cannot find module '@lezer/highlight'`) — confirmed pre-existing on `main`.
- `npm run lint` is broken — no `eslint.config.js`; ESLint v9 requires the flat config format.

## Test plan

- [ ] App loads — input briefly shows "Checking Claude Code…" then becomes enabled
- [ ] If the ACP bridge fails to spawn, the red retry pill appears and clicking it retries
- [ ] Sending a message works end-to-end
- [ ] Users with fnm as their Node version manager can start the app without ENOENT errors