### PR TITLE
fix(landing): update domain to tryatlas.cc

### DIFF
--- a/landing/README.md
+++ b/landing/README.md
@@ -1,6 +1,6 @@
 # Atlas landing site
 
-Static landing page for [atlas.antarys.ai](https://atlas.antarys.ai). Pure
+Static landing page for [tryatlas.cc](https://www.tryatlas.cc/). Pure
 HTML + CSS + a tiny inline script, no build step, no framework, no Node
 dependency. The whole folder is what Vercel uploads.
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -21,7 +21,7 @@
 
 <link rel="icon" type="image/png" href="/antarys-logo.png" />
 <link rel="apple-touch-icon" href="/antarys-logo.png" />
-<link rel="canonical" href="https://atlas.antarys.ai/" />
+<link rel="canonical" href="https://www.tryatlas.cc/" />
 
 <link rel="stylesheet" href="atlas.css" />
 <script src="https://unpkg.com/lucide@latest"></script>


### PR DESCRIPTION
Updates the stale `atlas.antarys.ai` domain to `https://www.tryatlas.cc/` in two places: the landing page README and `index.html`.