### PR TITLE
Editor: live-buffer mirror (ATL-26) + inline Git blame (ATL-27)

### DIFF
--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,6 +1,39 @@
+use parking_lot::Mutex;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use tauri::State;
+
+/// In-memory mirror of the editor's live (unsaved) buffers, keyed by absolute
+/// file path. The frontend pushes a file's current text here whenever it goes
+/// dirty (`editor_sync_buffer`) and drops it on save / reload / close
+/// (`editor_clear_buffer`). This lets the backend — and, later, the ACP
+/// `fs/read_text_file` handler — read a user's in-flight edits instead of the
+/// stale on-disk version.
+///
+/// Only dirty buffers are mirrored: a clean buffer equals disk, so the ordinary
+/// disk read path already serves it. Untitled scratch buffers are never
+/// mirrored (they have no real path to serve).
+#[derive(Default)]
+pub struct EditorBuffers(pub Mutex<HashMap<String, String>>);
+
+impl EditorBuffers {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Backend read accessor for the live-buffer registry: returns the mirrored
+/// text when the path has an unsaved buffer, `None` otherwise. The future ACP
+/// `fs/read_text_file` handler consults this first and falls back to reading
+/// disk when it returns `None`.
+// Intentionally unused in Phase 0 — wired up by the ACP `fs/read` handler in a
+// later phase; exposed now so that work has a stable accessor to call.
+#[allow(dead_code)]
+pub fn live_buffer(state: &EditorBuffers, path: &str) -> Option<String> {
+    state.0.lock().get(path).cloned()
+}
 
 #[derive(Debug, Serialize)]
 pub struct FileEntry {
@@ -174,6 +207,24 @@ pub async fn write_file_content(path: String, content: String) -> Result<(), Str
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+/// Mirror a dirty editor buffer's live text into the backend registry. Called
+/// (debounced) by the editor whenever a tracked file has unsaved changes, so
+/// the backend can serve in-flight edits instead of stale disk content.
+///
+/// Sync (no `async`) on purpose: it does no file I/O — just a lock + map insert
+/// — so it won't freeze the NSApp main thread the way the disk commands would.
+#[tauri::command]
+pub fn editor_sync_buffer(path: String, content: String, state: State<'_, EditorBuffers>) {
+    state.0.lock().insert(path, content);
+}
+
+/// Drop a file's live-buffer mirror — on save, reload, or tab close, when the
+/// buffer no longer diverges from disk (or is gone). Idempotent.
+#[tauri::command]
+pub fn editor_clear_buffer(path: String, state: State<'_, EditorBuffers>) {
+    state.0.lock().remove(&path);
 }
 
 /// Write a binary file from standard base64. Counterpart of `read_file_base64`

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -526,6 +526,115 @@ pub async fn git_diff_file(path: String, file: String) -> Result<String, String>
     }).await.map_err(|e| e.to_string())?
 }
 
+/// One line of `git blame` output, in final-file line order.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlameLine {
+    /// 1-based line number in the current (final) file.
+    pub line: u32,
+    pub sha: String,
+    pub short_sha: String,
+    pub author: String,
+    /// Author time as unix milliseconds (0 if unparsable).
+    pub time_ms: i64,
+    pub summary: String,
+    /// False for the synthetic all-zero sha git uses for local/uncommitted
+    /// lines ("Not Committed Yet").
+    pub committed: bool,
+}
+
+/// Blame a file against the working tree. `-w` ignores whitespace-only changes
+/// so reformatting doesn't reassign authorship. Returns one entry per line in
+/// final-file order; an empty vec when the file isn't tracked or the path isn't
+/// a repo (the frontend then shows nothing).
+#[tauri::command]
+pub async fn git_blame_file(path: String, file: String) -> Result<Vec<BlameLine>, String> {
+    tokio::task::spawn_blocking(move || {
+        let output = Command::new("git")
+            .args(["blame", "-w", "--porcelain", "--", &file])
+            .current_dir(&path)
+            .output()
+            .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Ok(Vec::new());
+        }
+        Ok(parse_blame_porcelain(&String::from_utf8_lossy(&output.stdout)))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Parse `git blame --porcelain`. Commit metadata (author/summary/time) is
+/// emitted only the first time each sha appears; later lines with the same sha
+/// carry just the header + content, so we cache per-sha metadata and look it up.
+fn parse_blame_porcelain(out: &str) -> Vec<BlameLine> {
+    use std::collections::HashMap;
+
+    #[derive(Default, Clone)]
+    struct Commit {
+        author: String,
+        time_ms: i64,
+        summary: String,
+    }
+
+    let mut commits: HashMap<String, Commit> = HashMap::new();
+    let mut result: Vec<BlameLine> = Vec::new();
+    let mut cur_sha = String::new();
+    let mut cur_line: u32 = 0;
+
+    for raw in out.lines() {
+        // The actual file content is the only tab-prefixed line in each group;
+        // seeing it means the current group's metadata is complete → emit.
+        if raw.starts_with('\t') {
+            let c = commits.get(&cur_sha).cloned().unwrap_or_default();
+            let committed = !cur_sha.is_empty() && !cur_sha.chars().all(|ch| ch == '0');
+            let short_sha = cur_sha.chars().take(7).collect::<String>();
+            result.push(BlameLine {
+                line: cur_line,
+                sha: cur_sha.clone(),
+                short_sha,
+                author: if c.author.is_empty() && !committed {
+                    "You".to_string()
+                } else {
+                    c.author.clone()
+                },
+                time_ms: c.time_ms,
+                summary: if c.summary.is_empty() && !committed {
+                    "Uncommitted changes".to_string()
+                } else {
+                    c.summary.clone()
+                },
+                committed,
+            });
+            continue;
+        }
+
+        // A header line: "<40-hex-sha> <origLine> <finalLine> [numLines]".
+        // Distinguish it from "key value" metadata by the 40-char hex first token.
+        let mut parts = raw.splitn(4, ' ');
+        let first = parts.next().unwrap_or("");
+        if first.len() == 40 && first.bytes().all(|b| b.is_ascii_hexdigit()) {
+            cur_sha = first.to_string();
+            let _orig = parts.next();
+            cur_line = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+            commits.entry(cur_sha.clone()).or_default();
+            continue;
+        }
+
+        // Metadata line for the current sha: "key value".
+        let entry = commits.entry(cur_sha.clone()).or_default();
+        if let Some(rest) = raw.strip_prefix("author ") {
+            entry.author = rest.to_string();
+        } else if let Some(rest) = raw.strip_prefix("author-time ") {
+            entry.time_ms = rest.trim().parse::<i64>().map(|s| s * 1000).unwrap_or(0);
+        } else if let Some(rest) = raw.strip_prefix("summary ") {
+            entry.summary = rest.to_string();
+        }
+    }
+
+    result
+}
+
 #[tauri::command]
 pub async fn git_stage(path: String, files: Vec<String>) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -271,6 +271,7 @@ pub fn run() {
             commands::mission_control::mission_control_export_markdown,
             commands::mission_control::mission_control_write_file,
             commands::git::git_diff_file,
+            commands::git::git_blame_file,
             commands::git::git_stage,
             commands::git::git_unstage,
             commands::git::git_commit,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,6 +210,7 @@ pub fn run() {
         .manage(commands::memory_sharing::MemorySharingState::new())
         .manage(commands::shared_memory::SharedMemoryStore::new())
         .manage(commands::updater::UpdaterState::new())
+        .manage(commands::fs::EditorBuffers::new())
         // Drop a window's per-window index + mention caches when it closes, so
         // its file watcher stops and memory is freed (these states are keyed by
         // webview label for multi-window project scoping).
@@ -249,6 +250,8 @@ pub fn run() {
             commands::fs::file_mtime_ms,
             commands::fs::asset_allow_dir,
             commands::fs::write_file_content,
+            commands::fs::editor_sync_buffer,
+            commands::fs::editor_clear_buffer,
             commands::fs::write_file_base64,
             commands::fs::ensure_atlas_gitignore,
             commands::fs::fs_create_file,

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -193,6 +193,11 @@ pub struct AppSettings {
     /// theme; persisted so it survives relaunch.
     #[serde(default = "default_atlas_theme")]
     pub atlas_theme: String,
+    /// Show inline Git blame (author · relative time · commit summary) at the
+    /// end of the editor's active line, Zed-style. Default ON; when off the
+    /// blame extension is left out of the editor entirely (no overhead).
+    #[serde(default = "default_true")]
+    pub git_blame_inline: bool,
     /// Auto-update master switch. When ON (default), every startup runs a
     /// non-blocking check against PostHog remote config and prompts if a newer
     /// version is available. See `crate::commands::updater`.
@@ -245,6 +250,7 @@ impl Default for AppSettings {
             llm_model_id: default_llm_model(),
             code_editor_theme: default_code_editor_theme(),
             atlas_theme: default_atlas_theme(),
+            git_blame_inline: true,
             auto_update: true,
             updater_ignored_version: None,
         }

--- a/src/features/editor/components/editor-panel.tsx
+++ b/src/features/editor/components/editor-panel.tsx
@@ -14,7 +14,9 @@ import { listen } from "@tauri-apps/api/event";
 import { ChevronRight, RefreshCw } from "lucide-react";
 import { logEvent } from "@/features/log/lib/log";
 import { diffGutter, applyDiffStatus } from "../lib/diff-gutter";
+import { inlineBlame, applyBlame } from "../lib/blame-inline";
 import { gitDiffLineStatus } from "@/features/git/lib/git-diff-api";
+import { gitBlameFile } from "@/features/git/lib/git-blame-api";
 
 const TOOLBAR_HEIGHT = 32;
 const DIRTY_CHECK_DEBOUNCE = 300; // ms — only check dirty state, not sync content
@@ -23,6 +25,10 @@ const DIRTY_CHECK_DEBOUNCE = 300; // ms — only check dirty state, not sync con
 // from the theme registry (src/features/editor/themes), keyed by the persisted
 // `settings.codeEditorTheme`.
 const themeCompartment = new Compartment();
+
+// Inline git-blame — swappable via a Compartment so the `gitBlameInline`
+// setting can add/remove the whole extension live (off == zero overhead).
+const blameCompartment = new Compartment();
 
 function themeExtensions(themeId: string | undefined | null): Extension {
   const theme = getEditorTheme(themeId);
@@ -111,6 +117,7 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   const viewRef = useRef<EditorView | null>(null);
   const onSaveRef = useRef<() => void>(() => {});
   const refreshGutterRef = useRef<() => void>(() => {});
+  const refreshBlameRef = useRef<() => void>(() => {});
   const dirtyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Load file content from disk — unless this is an untitled scratch
@@ -204,6 +211,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       });
       // Repaint this editor's diff gutter against the just-saved content.
       refreshGutterRef.current();
+      // Re-blame: the just-saved lines may now differ from HEAD (uncommitted).
+      refreshBlameRef.current();
     } catch (err) {
       console.error("Save failed:", err);
     }
@@ -225,6 +234,23 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       .catch(() => {});
   }, [path, projectPath, isUntitled]);
   refreshGutterRef.current = refreshDiffGutter;
+
+  // Fetch this file's git blame and push it into the inline-blame extension.
+  // No-op when the setting is off, for untitled buffers, or files outside the
+  // repo. Mirrors refreshDiffGutter's guards.
+  const refreshBlame = useCallback(() => {
+    const view = viewRef.current;
+    if (!view || isUntitled || !projectPath) return;
+    if (!useProjectStore.getState().settings.gitBlameInline) return;
+    if (!path.startsWith(projectPath + "/")) return;
+    const rel = path.slice(projectPath.length + 1);
+    void gitBlameFile(projectPath, rel)
+      .then((lines) => {
+        if (viewRef.current) applyBlame(viewRef.current, lines);
+      })
+      .catch(() => {});
+  }, [path, projectPath, isUntitled]);
+  refreshBlameRef.current = refreshBlame;
 
   // Re-seed the live CodeMirror view from a string without polluting undo
   // history (external reload, not a user edit).
@@ -299,7 +325,10 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   // Repaint the gutter when the working tree changes elsewhere (commits,
   // stage/unstage, external edits) — same event the git store listens to.
   useEffect(() => {
-    const un = listen("atlas:git-changed", () => refreshDiffGutter());
+    const un = listen("atlas:git-changed", () => {
+      refreshDiffGutter();
+      refreshBlameRef.current();
+    });
     return () => {
       un.then((u) => u());
     };
@@ -351,6 +380,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
           langExt,
           lineNumbers(),
           diffGutter(),
+          blameCompartment.of(
+            useProjectStore.getState().settings.gitBlameInline ? inlineBlame() : [],
+          ),
           highlightActiveLine(),
           drawSelection(),
           bracketMatching(),
@@ -402,6 +434,7 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       const latest = useEditorStore.getState().buffers[path]?.originalContent;
       if (latest !== undefined) replaceViewDoc(latest);
       refreshDiffGutter();
+      refreshBlameRef.current();
     })();
 
     return () => {
@@ -424,6 +457,18 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     if (!view) return;
     view.dispatch({ effects: themeCompartment.reconfigure(themeExtensions(codeEditorTheme)) });
   }, [codeEditorTheme]);
+
+  // Toggle inline blame live when the setting flips — add/remove the whole
+  // extension via its compartment, and fetch fresh blame when turning it on.
+  const gitBlameInline = useProjectStore.use.settings().gitBlameInline;
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: blameCompartment.reconfigure(gitBlameInline ? inlineBlame() : []),
+    });
+    if (gitBlameInline) refreshBlameRef.current();
+  }, [gitBlameInline]);
 
   if (!buffer) {
     return (

--- a/src/features/editor/components/editor-panel.tsx
+++ b/src/features/editor/components/editor-panel.tsx
@@ -183,6 +183,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       await invoke("write_file_content", { path, content });
       const mtime = await invoke<number>("file_mtime_ms", { path }).catch(() => 0);
       markSaved(path, content, mtime);
+      // Buffer now equals disk — drop the live-buffer mirror.
+      void invoke("editor_clear_buffer", { path });
       logEvent({
         source: "editor",
         kind: "save",
@@ -259,6 +261,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     if (content === liveDoc) {
       // Content matches what's shown (e.g. our own save) — just record mtime.
       reloadBuffer(path, content, mtime);
+      // Buffer now matches disk — drop any stale live-buffer mirror.
+      void invoke("editor_clear_buffer", { path });
       return;
     }
     if (cur.dirty) {
@@ -268,6 +272,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     reloadBuffer(path, content, mtime);
     replaceViewDoc(content);
     refreshDiffGutter();
+    // Clean buffer silently reloaded from disk — mirror (if any) is now stale.
+    void invoke("editor_clear_buffer", { path });
   }, [path, isUntitled, reloadBuffer, markExternallyChanged, replaceViewDoc, refreshDiffGutter]);
   const revalidateRef = useRef(revalidate);
   revalidateRef.current = revalidate;
@@ -286,6 +292,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     reloadBuffer(path, content, mtime);
     replaceViewDoc(content);
     refreshDiffGutter();
+    // User discarded unsaved edits for disk — the mirror is now stale.
+    void invoke("editor_clear_buffer", { path });
   }, [path, isUntitled, reloadBuffer, replaceViewDoc, refreshDiffGutter]);
 
   // Repaint the gutter when the working tree changes elsewhere (commits,
@@ -364,7 +372,17 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
               dirtyTimerRef.current = setTimeout(() => {
                 const current = update.view.state.doc.toString();
                 const orig = useEditorStore.getState().buffers[path]?.originalContent ?? "";
-                setDirty(path, current !== orig);
+                const dirty = current !== orig;
+                setDirty(path, dirty);
+                // Phase 0 live-buffer mirror: keep the backend registry in sync
+                // with the editor's unsaved text so agents can read in-flight
+                // edits. Dirty-only (a clean buffer equals disk); untitled
+                // scratch buffers have no real path to serve. Reuses this timer
+                // — no extra per-keystroke work, no store write.
+                if (!isUntitled) {
+                  if (dirty) void invoke("editor_sync_buffer", { path, content: current });
+                  else void invoke("editor_clear_buffer", { path });
+                }
               }, DIRTY_CHECK_DEBOUNCE);
             }
           }),
@@ -393,6 +411,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
         viewRef.current.destroy();
         viewRef.current = null;
       }
+      // Editor for this path is going away (tab close) — drop its mirror.
+      if (!isUntitled) void invoke("editor_clear_buffer", { path });
     };
   }, [path, !!buffer]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/features/editor/lib/blame-inline.ts
+++ b/src/features/editor/lib/blame-inline.ts
@@ -1,0 +1,196 @@
+// CodeMirror extension: Zed-style inline Git blame. Renders a dim, trailing
+// annotation at the end of the *active* line only — "Author, 3 days ago ·
+// commit summary" — fed by the native `git_blame_file` engine via `setBlame`.
+//
+// Blame is stored as a RangeSet keyed per line, so it auto-shifts as the doc is
+// edited; lines the user touches are dropped from the set and fall back to an
+// "Uncommitted changes" annotation instead of showing another commit's info.
+
+import {
+  EditorView,
+  Decoration,
+  WidgetType,
+  ViewPlugin,
+  type DecorationSet,
+  type ViewUpdate,
+} from "@codemirror/view";
+import {
+  StateField,
+  StateEffect,
+  RangeSet,
+  RangeValue,
+  type Extension,
+  type Text,
+} from "@codemirror/state";
+import type { BlameLine } from "@/features/git/lib/git-blame-api";
+
+/** Push a fresh blame snapshot into the editor. An empty array clears it
+ *  (used for untracked files / non-repos → nothing is shown). */
+export const setBlame = StateEffect.define<BlameLine[]>();
+
+/** Convenience: dispatch a blame update onto a view. */
+export function applyBlame(view: EditorView, lines: BlameLine[]): void {
+  view.dispatch({ effects: setBlame.of(lines) });
+}
+
+// A per-line point value carrying that line's committed blame.
+class BlameValue extends RangeValue {
+  constructor(readonly info: BlameLine) {
+    super();
+  }
+}
+
+// null  = no blame loaded (not a repo / untracked) → render nothing.
+// RangeSet (possibly empty) = loaded; lines absent from it are uncommitted.
+type BlameState = RangeSet<BlameValue> | null;
+
+function buildSet(doc: Text, lines: BlameLine[]): BlameState {
+  if (lines.length === 0) return null;
+  const ranges: { from: number; value: BlameValue }[] = [];
+  for (const b of lines) {
+    if (!b.committed) continue; // uncommitted lines carry no marker
+    if (b.line < 1 || b.line > doc.lines) continue;
+    ranges.push({ from: doc.line(b.line).from, value: new BlameValue(b) });
+  }
+  ranges.sort((a, z) => a.from - z.from);
+  return RangeSet.of(
+    ranges.map((r) => r.value.range(r.from)),
+    /* sort */ true,
+  );
+}
+
+const blameField = StateField.define<BlameState>({
+  create: () => null,
+  update(value, tr) {
+    for (const e of tr.effects) {
+      if (e.is(setBlame)) return buildSet(tr.state.doc, e.value);
+    }
+    if (value === null || !tr.docChanged) return value;
+    // Shift markers through the edit, then drop any line the edit touched so it
+    // reads as uncommitted rather than showing stale attribution.
+    let set = value.map(tr.changes);
+    const drop = new Set<number>();
+    tr.changes.iterChangedRanges((_fromA, _toA, fromB, toB) => {
+      const first = tr.state.doc.lineAt(fromB).number;
+      const last = tr.state.doc.lineAt(toB).number;
+      for (let n = first; n <= last; n++) drop.add(tr.state.doc.line(n).from);
+    });
+    if (drop.size) set = set.update({ filter: (from) => !drop.has(from) });
+    return set;
+  },
+});
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+function relativeTime(ms: number): string {
+  if (!ms) return "";
+  const diff = Date.now() - ms;
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min} minute${min === 1 ? "" : "s"} ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} hour${hr === 1 ? "" : "s"} ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day} day${day === 1 ? "" : "s"} ago`;
+  const wk = Math.floor(day / 7);
+  if (day < 30) return `${wk} week${wk === 1 ? "" : "s"} ago`;
+  const mo = Math.floor(day / 30);
+  if (day < 365) return `${mo} month${mo === 1 ? "" : "s"} ago`;
+  const yr = Math.floor(day / 365);
+  return `${yr} year${yr === 1 ? "" : "s"} ago`;
+}
+
+function formatBlame(info: BlameLine): string {
+  const rel = relativeTime(info.timeMs);
+  const when = rel ? `, ${rel}` : "";
+  const summary = info.summary ? ` · ${truncate(info.summary, 60)}` : "";
+  return `${info.author}${when}${summary}`;
+}
+
+class BlameWidget extends WidgetType {
+  constructor(
+    readonly text: string,
+    readonly uncommitted: boolean,
+  ) {
+    super();
+  }
+  eq(other: BlameWidget) {
+    return other.text === this.text && other.uncommitted === this.uncommitted;
+  }
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-inline-blame" + (this.uncommitted ? " cm-inline-blame-uncommitted" : "");
+    span.textContent = this.text;
+    return span;
+  }
+  ignoreEvent() {
+    return true;
+  }
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const state = view.state.field(blameField, false);
+  if (state === undefined || state === null) return Decoration.none;
+  const sel = view.state.selection.main;
+  const line = view.state.doc.lineAt(sel.head);
+  // Don't annotate an empty line — nothing to attribute, and it looks noisy.
+  if (line.length === 0) return Decoration.none;
+
+  let info: BlameLine | null = null;
+  state.between(line.from, line.from, (_from, _to, value) => {
+    info = value.info;
+    return false;
+  });
+
+  const text = info ? formatBlame(info) : "You · Uncommitted changes";
+  const widget = Decoration.widget({
+    widget: new BlameWidget(text, !info),
+    side: 1,
+  });
+  return Decoration.set([widget.range(line.to)]);
+}
+
+const blamePlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+    update(u: ViewUpdate) {
+      if (
+        u.docChanged ||
+        u.selectionSet ||
+        u.transactions.some((t) => t.effects.some((e) => e.is(setBlame)))
+      ) {
+        this.decorations = buildDecorations(u.view);
+      }
+    }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+const blameTheme = EditorView.baseTheme({
+  ".cm-inline-blame": {
+    marginLeft: "2.5em",
+    color: "var(--text-tertiary, #6b7280)",
+    opacity: "0.65",
+    fontStyle: "italic",
+    fontSize: "0.9em",
+    userSelect: "none",
+    pointerEvents: "none",
+    whiteSpace: "pre",
+  },
+  ".cm-inline-blame-uncommitted": {
+    opacity: "0.5",
+  },
+});
+
+/** The inline-blame extension. Add to the editor's extensions, then dispatch
+ *  `setBlame` effects (via `applyBlame`) to populate it. Leaving it out of the
+ *  extension set entirely disables the feature with zero overhead. */
+export function inlineBlame(): Extension {
+  return [blameField, blamePlugin, blameTheme];
+}

--- a/src/features/git/lib/git-blame-api.ts
+++ b/src/features/git/lib/git-blame-api.ts
@@ -1,0 +1,26 @@
+// Bridge to the native `git_blame_file` command — per-line blame (author,
+// time, commit summary) for the editor's inline blame feature. Mirrors the
+// shape of `git-diff-api.ts`.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface BlameLine {
+  /** 1-based line number in the current file. */
+  line: number;
+  sha: string;
+  shortSha: string;
+  author: string;
+  /** Author time as unix milliseconds (0 if unknown). */
+  timeMs: number;
+  summary: string;
+  /** False for locally-modified / uncommitted lines. */
+  committed: boolean;
+}
+
+/**
+ * Blame `file` (relative to `repoPath`) against the working tree. Resolves to
+ * an empty array when the file isn't tracked or the path isn't a git repo.
+ */
+export function gitBlameFile(repoPath: string, file: string): Promise<BlameLine[]> {
+  return invoke<BlameLine[]>("git_blame_file", { path: repoPath, file });
+}

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -77,6 +77,9 @@ export interface AppSettings {
   /** A version the user chose to "Ignore" in the update prompt; the startup
    *  check won't re-prompt for exactly this version. */
   updaterIgnoredVersion: string | null;
+  /** Show inline Git blame at the end of the editor's active line (author,
+   *  relative time, commit summary), Zed-style. Default ON. */
+  gitBlameInline: boolean;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -92,6 +95,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   adaptiveSuggestions: "agent",
   autoUpdate: true,
   updaterIgnoredVersion: null,
+  gitBlameInline: true,
 };
 
 /**

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -270,6 +270,15 @@ function GeneralSettings() {
         />
       </SettingRow>
       <SettingRow
+        label="Inline Git blame"
+        description="Show who last changed the current line — author, relative time, and commit summary — dimmed at the end of the active line in the code editor, Zed-style. Updates as you move the cursor. Default ON."
+      >
+        <Toggle
+          checked={settings.gitBlameInline}
+          onChange={(next) => updateSettings({ gitBlameInline: next })}
+        />
+      </SettingRow>
+      <SettingRow
         label="Enable Atlas Logs"
         description="Record Atlas-internal events (sign-in, agent start/finish, browser/file open, etc.) into the Logs tab under the `atlas` source. Default ON so when something goes wrong you can open the Logs tab, filter by `atlas`, and share a timeline. Turn off if the noise bothers you."
       >


### PR DESCRIPTION
Two editor features:

- **ATL-26** — mirror unsaved buffers to the backend so agents can read in-flight edits (dirty-only; cleared on save/reload/close).
- **ATL-27** — Zed-style inline Git blame on the active line, toggleable in Settings.

Both compile (`cargo check` + `tsc`) and were verified in the running app.