### PR TITLE
Inline editor git blame + composer attach menu with image prompts

### DIFF
--- a/crates/atlas-acp/src/driver.rs
+++ b/crates/atlas-acp/src/driver.rs
@@ -104,6 +104,13 @@ pub struct PendingPermissionEntry {
 /// MUST resolve as `Cancelled`).
 pub type PendingPermissions = DashMap<Uuid, PendingPermissionEntry>;
 
+/// Image attachments staged for the *next* prompt of each session, drained
+/// one-shot when that prompt is sent. A separate low-churn side-channel so
+/// the `text: String` prompt seam stays untouched. Safe because the frontend
+/// serialises sends per session — exactly one prompt is staged-then-fired at
+/// a time, so each turn drains its own images.
+pub type PendingAttachments = DashMap<SessionId, Vec<crate::registry::ImageAttachment>>;
+
 /// Resources owned by a single spawned ACP agent. Held inside the
 /// [`crate::registry::AgentRegistry`] under an [`AgentId`].
 pub struct AgentRuntime {
@@ -122,6 +129,13 @@ pub struct AgentRuntime {
     /// flow. Returned as a JSON-friendly projection so the Tauri layer
     /// can hand them straight to the frontend.
     pub auth_methods: Vec<AuthMethodWire>,
+    /// Whether the agent advertised `promptCapabilities.image` at
+    /// initialize. Gates whether staged image attachments are sent as
+    /// `ContentBlock::Image` or dropped (sending them anyway would violate
+    /// the ACP spec).
+    pub prompt_image_supported: bool,
+    /// Images staged for each session's next prompt. See [`PendingAttachments`].
+    pub pending_attachments: Arc<PendingAttachments>,
 }
 
 /// JSON-friendly projection of `AuthMethod` for the wire. The ACP Rust
@@ -199,6 +213,7 @@ fn extract_terminal_auth(meta: &Map<String, Value>) -> Option<TerminalAuth> {
 pub struct InitializedAgent {
     pub connection: ConnectionTo<Agent>,
     pub auth_methods: Vec<AuthMethodWire>,
+    pub prompt_image_supported: bool,
 }
 
 /// Spawn an ACP agent and wait for its `initialize` handshake to complete.
@@ -289,6 +304,8 @@ pub async fn spawn_agent(
         session_guards: guards,
         shutdown_tx: Some(shutdown_tx),
         auth_methods: initialized.auth_methods,
+        prompt_image_supported: initialized.prompt_image_supported,
+        pending_attachments: Arc::new(DashMap::new()),
     })
 }
 
@@ -473,9 +490,12 @@ async fn run_driver(
                                 })
                         })
                         .unwrap_or_default();
+                    let prompt_image_supported =
+                        resp.agent_capabilities.prompt_capabilities.image;
                     let _ = ready_tx.send(Ok(InitializedAgent {
                         connection: connection.clone(),
                         auth_methods: methods,
+                        prompt_image_supported,
                     }));
                 }
                 Err(e) => {

--- a/crates/atlas-acp/src/lib.rs
+++ b/crates/atlas-acp/src/lib.rs
@@ -17,7 +17,9 @@ pub mod spawn;
 pub use driver::AuthMethodWire;
 pub use error::{AcpError, ErrorClass, Result, classify_message};
 pub use events::{AcpEvent, EventSink};
-pub use registry::{AgentId, AgentInfo, AgentRegistry, AgentSpec, PermissionDecision};
+pub use registry::{
+    AgentId, AgentInfo, AgentRegistry, AgentSpec, ImageAttachment, PermissionDecision,
+};
 pub use schema::NewSessionInfo;
 pub use spawn::{managed_node_bin, register_managed_node_bin, sanitize_host_env};
 

--- a/crates/atlas-acp/src/registry.rs
+++ b/crates/atlas-acp/src/registry.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use agent_client_protocol::schema::v1::{
-    AuthenticateRequest, CancelNotification, ContentBlock, LoadSessionRequest, NewSessionRequest,
-    PermissionOptionId, PromptRequest, RequestPermissionOutcome, SelectedPermissionOutcome,
-    SessionConfigOptionValue, SessionId, SessionModeId, SetSessionConfigOptionRequest,
-    SetSessionModeRequest, StopReason, TextContent,
+    AuthenticateRequest, CancelNotification, ContentBlock, ImageContent, LoadSessionRequest,
+    NewSessionRequest, PermissionOptionId, PromptRequest, RequestPermissionOutcome,
+    SelectedPermissionOutcome, SessionConfigOptionValue, SessionId, SessionModeId,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TextContent,
 };
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,17 @@ impl Default for AgentId {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// One image attached to an outbound prompt (multimodal input): base64
+/// `data` + its MIME type, mapped to an ACP `ContentBlock::Image` at send
+/// time when the agent advertised `promptCapabilities.image`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageAttachment {
+    pub mime_type: String,
+    /// Raw base64 payload — no `data:` URI prefix.
+    pub data_base64: String,
 }
 
 /// Description of an agent process that Atlas knows how to spawn.
@@ -359,24 +370,82 @@ impl AgentRegistry {
         Ok(epoch)
     }
 
-    /// Send a single text prompt. Resolves with the turn's `StopReason` when
-    /// the agent finishes streaming. Notifications fire over the event sink
-    /// throughout the turn.
+    /// Send a single text prompt, plus any image attachments staged for this
+    /// session via [`Self::stage_attachments`]. Resolves with the turn's
+    /// `StopReason` when the agent finishes streaming. Notifications fire
+    /// over the event sink throughout the turn.
     pub async fn send_prompt(
         &self,
         agent_id: AgentId,
         session_id: SessionId,
         text: String,
     ) -> Result<StopReason> {
+        // Drain staged images one-shot before the request. Text always goes;
+        // images ride only when the agent advertised promptCapabilities.image
+        // (sending them anyway would violate the ACP spec) — dropped with a
+        // debug log otherwise, never an error.
+        let (image_supported, staged) = {
+            let entry = self.inner.get(&agent_id).ok_or(AcpError::UnknownAgent)?;
+            let staged = entry
+                .runtime
+                .pending_attachments
+                .remove(&session_id)
+                .map(|(_, v)| v)
+                .unwrap_or_default();
+            (entry.runtime.prompt_image_supported, staged)
+        };
+        let mut content = vec![ContentBlock::Text(TextContent::new(text))];
+        if !staged.is_empty() {
+            if image_supported {
+                for att in staged {
+                    content.push(ContentBlock::Image(ImageContent::new(
+                        att.data_base64,
+                        att.mime_type,
+                    )));
+                }
+            } else {
+                tracing::debug!(
+                    count = staged.len(),
+                    "dropping image attachments — agent did not advertise promptCapabilities.image"
+                );
+            }
+        }
         let connection = self.connection(agent_id)?;
         let resp = connection
-            .send_request(PromptRequest::new(
-                session_id,
-                vec![ContentBlock::Text(TextContent::new(text))],
-            ))
+            .send_request(PromptRequest::new(session_id, content))
             .block_task()
             .await?;
         Ok(resp.stop_reason)
+    }
+
+    /// Stage image attachments to ride on this session's *next* prompt. A
+    /// non-empty vec overwrites any previously staged set; an empty vec
+    /// clears. Drained one-shot by [`Self::send_prompt`].
+    pub fn stage_attachments(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+        attachments: Vec<ImageAttachment>,
+    ) -> Result<()> {
+        let entry = self.inner.get(&agent_id).ok_or(AcpError::UnknownAgent)?;
+        if attachments.is_empty() {
+            entry.runtime.pending_attachments.remove(&session_id);
+        } else {
+            entry
+                .runtime
+                .pending_attachments
+                .insert(session_id, attachments);
+        }
+        Ok(())
+    }
+
+    /// Whether the agent advertised `promptCapabilities.image` at
+    /// initialize. `false` for unknown agents.
+    pub fn prompt_image_supported(&self, agent_id: AgentId) -> bool {
+        self.inner
+            .get(&agent_id)
+            .map(|e| e.runtime.prompt_image_supported)
+            .unwrap_or(false)
     }
 
     /// Switch the session's permission mode (default / acceptEdits / plan /

--- a/crates/atlas-agents/src/apply.rs
+++ b/crates/atlas-agents/src/apply.rs
@@ -21,7 +21,8 @@ use parking_lot::Mutex;
 use crate::events::{Emitter, SessionDelta, SessionDeltaEnvelope};
 use crate::session::{
     MessageMode, MessageRole, PlanEntry, SessionState, SessionStatus, ToolCall, ToolCallStatus,
-    extract_text_block, format_tool_content, map_tool_status, new_assistant_text,
+    extract_image_block, extract_text_block, format_tool_content, map_tool_status,
+    new_assistant_text,
     new_assistant_thinking, new_assistant_tool, normalise_tool_input,
 };
 
@@ -160,6 +161,14 @@ fn apply_session_update(
             };
             if let Some(text) = extract_text_block(&block) {
                 append_text_chunk(emitter, state, text);
+            } else if let Some((mime, data)) = extract_image_block(&block) {
+                // Agent-sent images fold into the existing markdown pipeline
+                // as a data-URI image — no new delta variant or frontend path.
+                append_text_chunk(
+                    emitter,
+                    state,
+                    format!("\n\n![image](data:{mime};base64,{data})\n\n"),
+                );
             }
         }
         "agent_thought_chunk" => {

--- a/crates/atlas-agents/src/backend.rs
+++ b/crates/atlas-agents/src/backend.rs
@@ -16,7 +16,8 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use atlas_acp::{
-    AgentRegistry, AuthMethodWire, NewSessionInfo, PermissionDecision, Result as AcpResult,
+    AgentRegistry, AuthMethodWire, ImageAttachment, NewSessionInfo, PermissionDecision,
+    Result as AcpResult,
 };
 use atlas_acp::{AgentId, SessionId};
 use atlas_cersei::CerseiRuntime;
@@ -66,6 +67,23 @@ pub trait AgentBackend: Send + Sync {
     fn set_compress(&self, _agent_id: AgentId, _session_id: &SessionId, _on: bool) -> AcpResult<()> {
         Ok(())
     }
+    /// Stage image attachments to ride on the session's next prompt.
+    /// Default: no-op (the native agent has no multimodal input path yet;
+    /// its frontend gate — `prompt_image_supported() == false` — means
+    /// images degrade to path mentions before ever reaching here).
+    fn stage_attachments(
+        &self,
+        _agent_id: AgentId,
+        _session_id: SessionId,
+        _attachments: Vec<ImageAttachment>,
+    ) -> AcpResult<()> {
+        Ok(())
+    }
+    /// Whether the agent advertised `promptCapabilities.image` at
+    /// initialize. Default: false (native agent, unknown agents).
+    fn prompt_image_supported(&self, _agent_id: AgentId) -> bool {
+        false
+    }
     /// Re-arm the session lifecycle guard for a new turn and return the new
     /// turn epoch (the identity stamped onto this turn's events).
     fn mark_turn_started(&self, agent_id: AgentId, session_id: &SessionId) -> AcpResult<u64>;
@@ -113,6 +131,17 @@ impl AgentBackend for AcpBackend {
         cwd: PathBuf,
     ) -> AcpResult<Option<serde_json::Value>> {
         self.0.load_session(agent_id, session_id, cwd).await
+    }
+    fn stage_attachments(
+        &self,
+        agent_id: AgentId,
+        session_id: SessionId,
+        attachments: Vec<ImageAttachment>,
+    ) -> AcpResult<()> {
+        self.0.stage_attachments(agent_id, session_id, attachments)
+    }
+    fn prompt_image_supported(&self, agent_id: AgentId) -> bool {
+        self.0.prompt_image_supported(agent_id)
     }
     async fn send_prompt(
         &self,

--- a/crates/atlas-agents/src/manager.rs
+++ b/crates/atlas-agents/src/manager.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use atlas_acp::{
-    AcpEvent, AgentId, AgentInfo, AgentRegistry, AuthMethodWire, EventSink, NewSessionInfo,
-    PermissionDecision, SessionId,
+    AcpEvent, AgentId, AgentInfo, AgentRegistry, AuthMethodWire, EventSink, ImageAttachment,
+    NewSessionInfo, PermissionDecision, SessionId,
 };
 use dashmap::DashMap;
 use parking_lot::Mutex;
@@ -333,12 +333,35 @@ impl AgentManager {
 
     pub fn snapshot(&self, key: &SessionKey) -> Result<SessionSnapshot> {
         let handle = self.handle_for(key)?;
-        let snap = handle.state.lock().snapshot();
+        let mut snap = handle.state.lock().snapshot();
+        // Transport capability, not session state — stamped here so
+        // SessionState stays transport-agnostic.
+        snap.prompt_image_supported = self
+            .backend_for(key.agent_id)
+            .map(|b| b.prompt_image_supported(key.agent_id))
+            .unwrap_or(false);
         Ok(snap)
     }
 
     pub fn send(&self, key: &SessionKey, text: String) -> Result<()> {
         self.handle_for(key)?.send_prompt(text)
+    }
+
+    /// Stage image attachments to ride on this session's next prompt.
+    /// ACP agents only — the native agent's backend no-ops (its capability
+    /// reads false, so the frontend degrades images to path mentions first).
+    pub fn stage_attachments(
+        &self,
+        key: &SessionKey,
+        attachments: Vec<ImageAttachment>,
+    ) -> Result<()> {
+        let backend = self.backend_for(key.agent_id)?;
+        backend.stage_attachments(
+            key.agent_id,
+            SessionId::new(key.session_id.clone()),
+            attachments,
+        )?;
+        Ok(())
     }
 
     /// Cancel an in-flight turn. The actor services this on its control channel

--- a/crates/atlas-agents/src/session.rs
+++ b/crates/atlas-agents/src/session.rs
@@ -126,6 +126,12 @@ pub struct SessionSnapshot {
     /// selection; drives the composer's model picker for Claude Code / Codex.
     pub available_models: Vec<SessionModeInfo>,
     pub available_commands: Vec<serde_json::Value>,
+    /// Whether the agent's transport supports image content blocks in
+    /// prompts (`promptCapabilities.image`). Stamped by the manager from the
+    /// live backend — `SessionState::snapshot()` leaves it false so session
+    /// state stays transport-agnostic. Drives the composer's attach routing.
+    #[serde(default)]
+    pub prompt_image_supported: bool,
     pub plan: Vec<PlanEntry>,
     pub messages: Vec<Message>,
     pub usage: Usage,
@@ -193,6 +199,7 @@ impl SessionState {
             available_modes: self.available_modes.clone(),
             available_models: self.available_models.clone(),
             available_commands: self.available_commands.clone(),
+            prompt_image_supported: false,
             plan: self.plan.clone(),
             messages: self.messages.clone(),
             usage: self.usage.clone(),
@@ -351,4 +358,17 @@ pub fn extract_text_block(content: &acp_schema::ContentBlock) -> Option<String> 
         return None;
     }
     v.get("text").and_then(|t| t.as_str()).map(|s| s.to_string())
+}
+
+/// Pull `(mime_type, base64_data)` out of an image ContentBlock. Returns
+/// `None` for anything else. Same JSON round-trip as [`extract_text_block`]
+/// (`ContentBlock` is `#[non_exhaustive]`).
+pub fn extract_image_block(content: &acp_schema::ContentBlock) -> Option<(String, String)> {
+    let v = serde_json::to_value(content).ok()?;
+    if v.get("type").and_then(|t| t.as_str()) != Some("image") {
+        return None;
+    }
+    let mime = v.get("mimeType").and_then(|m| m.as_str())?.to_string();
+    let data = v.get("data").and_then(|d| d.as_str())?.to_string();
+    Some((mime, data))
 }

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -349,6 +349,7 @@ const INJECT_BUDGET_SECS: u64 = 8;
 pub async fn agents_send(
     key: SessionKey,
     text: String,
+    attachments: Option<Vec<atlas_acp::ImageAttachment>>,
     manager: State<'_, AgentManager>,
     sharing: State<'_, MemorySharingState>,
     app: AppHandle,
@@ -359,6 +360,15 @@ pub async fn agents_send(
         "agent_turn_started",
         serde_json::json!({ "agent_kind": key.agent_id.0.to_string() }),
     );
+
+    // Stage image attachments up front so every send exit below (bare or
+    // memory-prefixed) drains them into this turn's prompt. Best-effort: a
+    // staging failure must not block the text send.
+    if let Some(atts) = attachments {
+        if !atts.is_empty() {
+            let _ = manager.stage_attachments(&key, atts);
+        }
+    }
 
     // Resolve the project cwd. Unknown session → fail with the SAME error
     // shape `manager.send` produces, without attempting a send that would

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -612,3 +612,88 @@ pub async fn git_delete_branch(path: String, name: String) -> Result<(), String>
         Ok(())
     }).await.map_err(|e| e.to_string())?
 }
+
+/// One line of blame output, in final-file order (`line` is 1-based).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlameLine {
+    pub line: u32,
+    pub sha: String,
+    pub short_sha: String,
+    pub author: String,
+    /// Author time as unix milliseconds (0 if unparsable).
+    pub time_ms: i64,
+    pub summary: String,
+    /// False for git's synthetic all-zero sha ("Not Committed Yet").
+    pub committed: bool,
+}
+
+/// Blame `file` against the working tree. `-w` keeps whitespace-only
+/// reformatting from stealing authorship. Untracked files and non-repos are
+/// not errors — they return an empty vec and the editor renders nothing.
+#[tauri::command]
+pub async fn git_blame_file(path: String, file: String) -> Result<Vec<BlameLine>, String> {
+    tokio::task::spawn_blocking(move || {
+        let output = Command::new("git")
+            .args(["blame", "-w", "--line-porcelain", "--", &file])
+            .current_dir(&path)
+            .output()
+            .map_err(|e| e.to_string())?;
+        if !output.status.success() {
+            return Ok(Vec::new());
+        }
+        Ok(parse_line_porcelain(&String::from_utf8_lossy(&output.stdout)))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Parse `git blame --line-porcelain`: every line group starts with a
+/// "<40-hex sha> <orig> <final> [count]" header, carries a full metadata block
+/// (author / author-time / summary / …), and ends with the tab-prefixed file
+/// content — which is our emit signal.
+fn parse_line_porcelain(out: &str) -> Vec<BlameLine> {
+    const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
+    let mut result = Vec::new();
+    let (mut sha, mut line_no): (String, u32) = (String::new(), 0);
+    let (mut author, mut time_ms, mut summary): (String, i64, String) =
+        (String::new(), 0, String::new());
+
+    for raw in out.lines() {
+        if raw.starts_with('\t') {
+            let committed = !sha.is_empty() && sha != ZERO_SHA;
+            result.push(BlameLine {
+                short_sha: sha.chars().take(7).collect(),
+                sha: std::mem::take(&mut sha),
+                line: line_no,
+                author: if committed { std::mem::take(&mut author) } else { "You".into() },
+                time_ms,
+                summary: if committed {
+                    std::mem::take(&mut summary)
+                } else {
+                    "Uncommitted changes".into()
+                },
+                committed,
+            });
+            author.clear();
+            summary.clear();
+            time_ms = 0;
+            continue;
+        }
+
+        // Header vs metadata: only headers start with a 40-char hex token.
+        let first = raw.split(' ').next().unwrap_or("");
+        if first.len() == 40 && first.bytes().all(|b| b.is_ascii_hexdigit()) {
+            sha = first.to_string();
+            line_no = raw.split(' ').nth(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+        } else if let Some(rest) = raw.strip_prefix("author ") {
+            author = rest.to_string();
+        } else if let Some(rest) = raw.strip_prefix("author-time ") {
+            time_ms = rest.trim().parse::<i64>().map(|s| s * 1000).unwrap_or(0);
+        } else if let Some(rest) = raw.strip_prefix("summary ") {
+            summary = rest.to_string();
+        }
+    }
+    result
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,6 +281,7 @@ pub fn run() {
             commands::git::git_checkout,
             commands::git::git_create_branch,
             commands::git::git_delete_branch,
+            commands::git::git_blame_file,
             commands::git::git_refs,
             commands::git::git_graph_signature,
             commands::git_graph::git_graph_build,

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -193,6 +193,11 @@ pub struct AppSettings {
     /// theme; persisted so it survives relaunch.
     #[serde(default = "default_atlas_theme")]
     pub atlas_theme: String,
+    /// Inline Git blame in the code editor — a dim author / age / commit
+    /// summary annotation trailing the active line. Default ON; when off the
+    /// editor doesn't even load the extension (no blame IPC).
+    #[serde(default = "default_true")]
+    pub git_blame_inline: bool,
     /// Auto-update master switch. When ON (default), every startup runs a
     /// non-blocking check against PostHog remote config and prompts if a newer
     /// version is available. See `crate::commands::updater`.
@@ -245,6 +250,7 @@ impl Default for AppSettings {
             llm_model_id: default_llm_model(),
             code_editor_theme: default_code_editor_theme(),
             atlas_theme: default_atlas_theme(),
+            git_blame_inline: true,
             auto_update: true,
             updater_ignored_version: None,
         }

--- a/src/features/chat/components/chat-input.tsx
+++ b/src/features/chat/components/chat-input.tsx
@@ -103,6 +103,10 @@ interface ChatInputProps {
    *  has no skill integration). Read live so switching agents takes effect
    *  without remounting the view. Defaults to true. */
   allowSkillMention?: boolean;
+  /** Offered clipboard image files BEFORE the default file-paste handling.
+   *  Return true to consume them (e.g. stage as inline attachments); false
+   *  falls through to the path-paste path. Read live via ref. */
+  onPasteImages?: (files: File[]) => boolean;
   /** Slot for future extensions. */
   extraExtensions?: Extension[];
   /** Min height in pixels (matches old textarea: 44). */
@@ -122,6 +126,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       onSlashTrigger,
       keyInterceptor,
       allowSkillMention = true,
+      onPasteImages,
       extraExtensions,
       minHeight = 44,
       maxHeight = 200,
@@ -148,6 +153,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     keyInterceptorRef.current = keyInterceptor;
     const allowSkillRef = useRef(allowSkillMention);
     allowSkillRef.current = allowSkillMention;
+    const onPasteImagesRef = useRef(onPasteImages);
+    onPasteImagesRef.current = onPasteImages;
 
     // Build the theme once — sized to the container, transparent
     // background so the parent's chip rounding shows through.
@@ -307,6 +314,21 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               // text/markdown pastes (no files) fall through to CodeMirror.
               paste: (event, view) => {
                 const dt = event.clipboardData;
+                // Clipboard images (screenshots) first: offer them to the
+                // parent, which stages them as inline base64 attachments
+                // when the agent supports image prompts. Unconsumed images
+                // fall through to the path-paste below.
+                const imageFiles = dt?.files
+                  ? Array.from(dt.files).filter((f) => f.type.startsWith("image/"))
+                  : [];
+                if (
+                  imageFiles.length > 0 &&
+                  onPasteImagesRef.current?.(imageFiles)
+                ) {
+                  event.preventDefault();
+                  markInputActivity();
+                  return true;
+                }
                 const hasFiles =
                   !!dt &&
                   (Array.from(dt.types).includes("Files") ||

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -4,7 +4,7 @@ import { appendNextStepsDirective } from "../lib/next-steps";
 import { agents, ensureAgent, CODEX_PLUGIN_ID, CERSEI_PLUGIN_ID, DEFAULT_PLUGIN_ID, codexStatus } from "../lib/agents-api";
 import { loadCachedAcpModes } from "../lib/acp-modes-cache";
 import { warmAcpModels, otherAcpAgent } from "../lib/warm-acp-models";
-import type { SessionKey } from "@/types/agents";
+import type { ImageAttachment, SessionKey } from "@/types/agents";
 import { hasInFlightToolCalls, isBusyAgentStatus } from "@/types/agent";
 import {
   composePrompt,
@@ -488,7 +488,11 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     agents.cancel(key).catch(() => {});
   };
 
-  const handleSend = async (content: string, mentions: MentionData[]) => {
+  const handleSend = async (
+    content: string,
+    mentions: MentionData[],
+    attachments?: ImageAttachment[],
+  ) => {
     const actualContent = content;
 
     // The mount effect kicks off the bind in parallel, but on a fresh
@@ -520,7 +524,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     // The user-visible message keeps the prose as the user typed it,
     // including the shortform mention references (`@file:src/foo.rs` etc).
     // The context block goes only to the agent, not the local transcript.
-    addMessage(tabId, "user", actualContent);
+    addMessage(tabId, "user", actualContent, attachments);
     logEvent({
       source: "chat",
       kind: "send-agent",
@@ -585,7 +589,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
       session_id: bound.acpSessionId,
     };
     try {
-      await agents.send(key, wirePrompt);
+      await agents.send(key, wirePrompt, attachments);
       logEvent({
         source: "agent",
         kind: "stream-started",
@@ -863,7 +867,11 @@ function ChatComposer({
   onScrollToBottom,
 }: {
   tabId: string;
-  onSend: (message: string, mentions: MentionData[]) => void;
+  onSend: (
+    message: string,
+    mentions: MentionData[],
+    attachments?: ImageAttachment[],
+  ) => void;
   onStop: () => void;
   running: boolean;
   stopping: boolean;

--- a/src/features/chat/components/composer-add-menu.tsx
+++ b/src/features/chat/components/composer-add-menu.tsx
@@ -1,0 +1,156 @@
+// The composer's "+" attach menu — "Add files or photos" plus a Skills
+// submenu. Presentation only: the file dialog and image-vs-path routing live
+// in the parent (`message-input.tsx::pickFilesOrPhotos`), and the skill list
+// reuses the `#` rail's search source so menu and rail cannot drift.
+//
+// `imageSupported` only changes the wording ("files or photos" vs "files"):
+// without image support a picked image still works — it rides along as a
+// path mention chip the agent reads off disk.
+
+import { useEffect, useState } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { ChevronRight, Loader2, Paperclip, Plus, SquareSlash } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { searchMentions, type MentionSkill } from "../lib/mentions";
+
+interface ComposerAddMenuProps {
+  disabled?: boolean;
+  /** Project root — scopes the skill list to global + this project. */
+  projectPath: string | null;
+  /** Skill-registry agent id (e.g. "claude-code" | "codex" | "cersei"). */
+  agentId?: string;
+  /** Agent accepts inline base64 images (`promptCapabilities.image`). */
+  imageSupported: boolean;
+  onAddFilesOrPhotos: () => void;
+  onPickSkill: (skill: MentionSkill) => void;
+}
+
+const ITEM_CLASS =
+  "flex items-center gap-2 px-3 h-[26px] text-[11px] cursor-default outline-none " +
+  "text-[var(--text-secondary)] data-[highlighted]:bg-[var(--bg-hover)] " +
+  "data-[highlighted]:text-[var(--text-primary)]";
+
+const CONTENT_CLASS =
+  "rounded-md border border-[var(--border-default)] bg-[var(--bg-secondary)] " +
+  "shadow-[var(--shadow-overlay)] py-1";
+
+export function ComposerAddMenu({
+  disabled,
+  projectPath,
+  agentId,
+  imageSupported,
+  onAddFilesOrPhotos,
+  onPickSkill,
+}: ComposerAddMenuProps) {
+  const [open, setOpen] = useState(false);
+  // null = not loaded yet (spinner on first open); [] = loaded, none found.
+  const [skills, setSkills] = useState<MentionSkill[] | null>(null);
+  const [skillsError, setSkillsError] = useState(false);
+
+  // Lazy-load skills the first time the menu opens; refetch never (the menu
+  // is short-lived and the catalog changes rarely — reopening a chat tab
+  // remounts the composer anyway).
+  useEffect(() => {
+    if (!open || skills !== null) return;
+    let cancelled = false;
+    searchMentions("", "skill", { projectPath, agentId })
+      .then((found) => {
+        if (cancelled) return;
+        setSkills(found.filter((m): m is MentionSkill => m.kind === "skill"));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setSkills([]);
+        setSkillsError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, skills, projectPath, agentId]);
+
+  return (
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          disabled={disabled}
+          className={cn(
+            "flex items-center justify-center w-6.5 h-6.5 rounded-full border border-[var(--border-default)]",
+            "bg-[var(--bg-elevated)] text-[var(--text-secondary)] transition-colors outline-none",
+            disabled
+              ? "opacity-50 cursor-default"
+              : "hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer",
+          )}
+          title="Add files, photos, or skills"
+        >
+          <Plus size={13} />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          side="top"
+          sideOffset={6}
+          className={cn(CONTENT_CLASS, "min-w-[190px]")}
+          style={{ zIndex: 9999 }}
+        >
+          <DropdownMenu.Item className={ITEM_CLASS} onSelect={onAddFilesOrPhotos}>
+            <Paperclip size={11} />
+            <span>{imageSupported ? "Add files or photos" : "Add files"}</span>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger className={ITEM_CLASS}>
+              <SquareSlash size={11} />
+              <span>Skills</span>
+              <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent
+                sideOffset={6}
+                className={cn(CONTENT_CLASS, "min-w-[220px] max-w-[280px] max-h-[320px] overflow-y-auto")}
+                style={{ zIndex: 9999 }}
+              >
+                {skills === null ? (
+                  <div className="flex items-center gap-2 px-3 h-[26px] text-[11px] text-[var(--text-tertiary)]">
+                    <Loader2 size={11} className="animate-spin" />
+                    Loading skills…
+                  </div>
+                ) : skills.length === 0 ? (
+                  <div className="px-3 py-1.5 text-[11px] text-[var(--text-tertiary)]">
+                    {skillsError ? "Couldn't load skills." : "No skills installed"}
+                  </div>
+                ) : (
+                  skills.map((skill) => (
+                    <DropdownMenu.Item
+                      key={skill.id}
+                      className={cn(ITEM_CLASS, "h-auto items-start py-1.5")}
+                      onSelect={() => onPickSkill(skill)}
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="truncate text-[var(--text-primary)]">
+                            {skill.displayName}
+                          </span>
+                          {skill.scope === "project" && (
+                            <span className="shrink-0 rounded px-1 text-[9px] leading-4 border border-[var(--border-default)] text-[var(--text-tertiary)]">
+                              project
+                            </span>
+                          )}
+                        </div>
+                        {skill.description && (
+                          <div className="text-[10px] text-[var(--text-tertiary)] line-clamp-2">
+                            {skill.description}
+                          </div>
+                        )}
+                      </div>
+                    </DropdownMenu.Item>
+                  ))
+                )}
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -46,7 +46,10 @@ import { commandRequiresArgs } from "./slash-command-picker";
 import { CodexLoginDialog } from "./codex-login-dialog";
 import { PlanDock } from "./plan-dock";
 import { RetryPill } from "./retry-pill";
-import type { MentionFile } from "../lib/mentions";
+import { ComposerAddMenu } from "./composer-add-menu";
+import { imageMimeFromPath } from "@/features/model-chat/lib/model-capabilities";
+import type { ImageAttachment } from "@/types/agents";
+import type { MentionFile, MentionSkill } from "../lib/mentions";
 import { useComposerFileDrop } from "../hooks/use-composer-file-drop";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useClaudeSetupStore } from "@/features/claude-setup/stores/claude-setup-store";
@@ -71,14 +74,38 @@ const slashCommandPickerPromise: Promise<typeof import("./slash-command-picker")
 // queue" hand back a stable reference instead of allocating per render.
 const EMPTY_QUEUE: readonly string[] = Object.freeze([]);
 
+/** Read an image `File` (clipboard paste) into a base64 attachment. Returns
+ *  null for non-images. The `data:` URI prefix is stripped — the wire shape
+ *  carries raw base64 + mime separately. */
+async function fileToImageAttachment(file: File): Promise<ImageAttachment | null> {
+  if (!file.type.startsWith("image/")) return null;
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  }).catch(() => null);
+  if (!dataUrl) return null;
+  const comma = dataUrl.indexOf(",");
+  return {
+    mimeType: file.type,
+    dataBase64: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl,
+  };
+}
+
 interface MessageInputProps {
   tabId: string;
   /**
    * Send a message right now (used when idle, or to dequeue). Receives
-   * both the plain prose text and the list of mention records the user
-   * inserted — the panel-level handler composes the final wire prompt.
+   * the plain prose text, the list of mention records the user inserted,
+   * and any staged image attachments — the panel-level handler composes
+   * the final wire prompt and stages the images.
    */
-  onSend: (message: string, mentions: MentionData[]) => void;
+  onSend: (
+    message: string,
+    mentions: MentionData[],
+    attachments?: ImageAttachment[],
+  ) => void;
   /** Stop the current generation. */
   onStop?: () => void;
   /** Stop was clicked; awaiting the cancelled turn's terminal delta. */
@@ -778,6 +805,98 @@ export function MessageInput({
     onDropFiles: handleDropFiles,
   });
 
+  // ── Image attachments (multimodal input) ─────────────────────────────────
+  // Images staged for the next send, shown as thumbnails above the input.
+  // Only populated when the bound agent advertised promptCapabilities.image;
+  // otherwise picked images degrade to path mention chips (any agent can
+  // read those off disk).
+  const [stagedImages, setStagedImages] = useState<ImageAttachment[]>([]);
+  const acpBoundKey = useChatStore((s) => {
+    const sess = s.sessions[tabId];
+    return sess?.acpAgentId && sess.acpSessionId
+      ? `${sess.acpAgentId}::${sess.acpSessionId}`
+      : null;
+  });
+  const [imageSupported, setImageSupported] = useState(false);
+  useEffect(() => {
+    if (!acpBoundKey) {
+      setImageSupported(false);
+      return;
+    }
+    const [agent_id, session_id] = acpBoundKey.split("::");
+    let cancelled = false;
+    agents
+      .snapshot({ agent_id, session_id })
+      .then((snap) => {
+        if (!cancelled) setImageSupported(!!snap.prompt_image_supported);
+      })
+      .catch(() => {
+        if (!cancelled) setImageSupported(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [acpBoundKey]);
+  // Rebinding to an agent without image support (agent switch, crash rebind)
+  // drops staged images — they could no longer be sent truthfully.
+  useEffect(() => {
+    if (!imageSupported) setStagedImages([]);
+  }, [imageSupported]);
+
+  // "+" menu → "Add files or photos". The Tauri dialog hands back real
+  // paths (a browser file input wouldn't), which is what makes the routing
+  // possible: images become inline base64 attachments when the agent
+  // supports them; everything else — and any unreadable image — becomes a
+  // path mention chip via the same handler the drag-drop path uses.
+  const pickFilesOrPhotos = useCallback(async () => {
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const picked = await open({ multiple: true, title: "Attach files or photos" });
+      if (!picked) return;
+      const paths = (Array.isArray(picked) ? picked : [picked]) as string[];
+      const images: ImageAttachment[] = [];
+      const mentionPaths: string[] = [];
+      for (const p of paths) {
+        const mime = imageSupported ? imageMimeFromPath(p) : null;
+        if (mime) {
+          try {
+            const data = await invoke<string>("read_file_base64", { path: p });
+            images.push({ mimeType: mime, dataBase64: data });
+            continue;
+          } catch {
+            // Unreadable as base64 → fall through to a path mention.
+          }
+        }
+        mentionPaths.push(p);
+      }
+      if (images.length) setStagedImages((prev) => [...prev, ...images]);
+      if (mentionPaths.length) handleDropFiles(mentionPaths);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    } catch (err) {
+      console.warn("attach picker failed:", err);
+    }
+  }, [imageSupported, handleDropFiles]);
+
+  const handlePickSkill = useCallback((skill: MentionSkill) => {
+    inputRef.current?.insertMention(skill);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  // Clipboard images (screenshots) → staged attachments. Returning false
+  // lets chat-input's default file-paste (native pasteboard → quoted paths)
+  // handle everything else.
+  const handlePasteImages = useCallback(
+    (files: File[]) => {
+      if (!imageSupported) return false;
+      void Promise.all(files.map(fileToImageAttachment)).then((atts) => {
+        const ok = atts.filter((a): a is ImageAttachment => a !== null);
+        if (ok.length) setStagedImages((prev) => [...prev, ...ok]);
+      });
+      return true;
+    },
+    [imageSupported],
+  );
+
   const handleSlashSelect = useCallback(
     (cmd: SlashCommand) => {
       const t = slashTriggerRef.current;
@@ -996,17 +1115,20 @@ export function MessageInput({
       // Queued messages don't carry mentions yet — the queue holds raw
       // strings and the agent will see whatever shortform text was in the
       // composer. Mentions are dropped here intentionally; promoting the
-      // queue to a structured shape is a follow-up.
+      // queue to a structured shape is a follow-up. Staged images likewise
+      // stay in the composer strip and ride the next direct send.
       enqueueMessage(tabId, trimmed);
     } else {
-      onSend(trimmed, mentions);
+      const images = stagedImages;
+      onSend(trimmed, mentions, images.length ? images : undefined);
+      if (images.length) setStagedImages([]);
     }
     inputRef.current?.clear();
     setValue("");
     // The value→draft sync effect will collapse the empty value into a
     // `delete s.drafts[tabId]` on the next commit, so no explicit
     // clearDraft call is needed.
-  }, [value, running, onSend, onStop, enqueueMessage, tabId, disabled]);
+  }, [value, running, onSend, onStop, enqueueMessage, tabId, disabled, stagedImages]);
 
   const trimmed = value.trim();
   // Tri-state button:
@@ -1096,6 +1218,28 @@ export function MessageInput({
               </span>
             </div>
           )}
+          {stagedImages.length > 0 && (
+            <div className="flex flex-wrap gap-2 px-3 pt-3">
+              {stagedImages.map((img, i) => (
+                <div key={i} className="relative group">
+                  <img
+                    src={`data:${img.mimeType};base64,${img.dataBase64}`}
+                    alt="attachment"
+                    className="h-14 w-14 object-cover rounded-lg border border-[var(--border-default)]"
+                  />
+                  <button
+                    onClick={() =>
+                      setStagedImages((prev) => prev.filter((_, j) => j !== i))
+                    }
+                    className="absolute -top-1.5 -right-1.5 hidden group-hover:flex items-center justify-center w-4 h-4 rounded-full bg-[var(--bg-elevated)] border border-[var(--border-default)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] cursor-pointer"
+                    title="Remove image"
+                  >
+                    <X size={9} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           {LazyChatInput ? (
             <LazyChatInput
               ref={inputRef}
@@ -1105,6 +1249,7 @@ export function MessageInput({
               onSubmit={submit}
               onMentionTrigger={setTrigger}
               onSlashTrigger={setSlashTrigger}
+              onPasteImages={handlePasteImages}
               keyInterceptor={keyInterceptor}
               // All agents (incl. the native Atlas/cersei agent) support skills
               // now — the `#` rail inlines a skill body via compose_prompt, and the
@@ -1124,6 +1269,20 @@ export function MessageInput({
           )}
           <div className="flex items-center justify-between px-2 pb-2 pt-1">
             <div className="flex items-center gap-1">
+              <ComposerAddMenu
+                disabled={disabled}
+                projectPath={useProjectStore.getState().currentProject?.path ?? null}
+                agentId={
+                  agentType === "codex"
+                    ? "codex"
+                    : agentType === "cersei"
+                      ? "cersei"
+                      : "claude-code"
+                }
+                imageSupported={imageSupported}
+                onAddFilesOrPhotos={() => void pickFilesOrPhotos()}
+                onPickSkill={handlePickSkill}
+              />
               {/* Which coding agent this chat is bound to (Claude / Codex).
                   Switch with ⌥/ (only on a fresh chat). */}
               <span

--- a/src/features/chat/components/message-item.tsx
+++ b/src/features/chat/components/message-item.tsx
@@ -239,6 +239,21 @@ export const MessageItem = memo(function MessageItem({
               />
             )}
 
+            {/* Images the user attached to this message (optimistic echo —
+                not recovered on replay; see ChatMessage.attachments). */}
+            {message.attachments && message.attachments.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {message.attachments.map((img, i) => (
+                  <img
+                    key={i}
+                    src={`data:${img.mimeType};base64,${img.dataBase64}`}
+                    alt="attachment"
+                    className="max-h-48 max-w-full rounded-lg border border-[var(--border-default)] object-contain"
+                  />
+                ))}
+              </div>
+            )}
+
             {/* Block-level markdown, formatted LIVE while streaming: only the
                 trailing block re-parses per frame; completed blocks are
                 source-keyed cache hits. Same renderer streaming + settled, so

--- a/src/features/chat/lib/agents-api.ts
+++ b/src/features/chat/lib/agents-api.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/types/acp";
 import type {
   AgentDelta,
+  ImageAttachment,
   PluginSpec,
   SessionKey,
   SessionSnapshot,
@@ -53,8 +54,12 @@ export const agents = {
   snapshot: (key: SessionKey) =>
     invoke<SessionSnapshot>("agents_snapshot", { key }),
 
-  send: (key: SessionKey, text: string) =>
-    invoke<void>("agents_send", { key, text }),
+  send: (key: SessionKey, text: string, attachments?: ImageAttachment[]) =>
+    invoke<void>("agents_send", {
+      key,
+      text,
+      attachments: attachments?.length ? attachments : null,
+    }),
   cancel: (key: SessionKey) => invoke<void>("agents_cancel", { key }),
   /** Tear down a session's backend state (actor + driver guard) on tab close
    *  or project switch. Idempotent; fire-and-forget from UI paths. */

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -15,6 +15,7 @@ import type { PendingPermission } from "@/types/acp";
 import type {
   AgentDelta,
   ToolCall as AgentToolCall,
+  ImageAttachment,
   SessionModeInfo,
 } from "@/types/agents";
 import { splitAtlasContext } from "../lib/atlas-context";
@@ -258,7 +259,8 @@ interface ChatActions {
     addMessage: (
       sessionId: string,
       role: MessageRole,
-      content: string
+      content: string,
+      attachments?: ImageAttachment[]
     ) => void;
     appendToolCall: (
       sessionId: string,
@@ -679,7 +681,7 @@ export const useChatStore = createSelectors(
           set((s) => {
             s.activeSessionId = id;
           }),
-        addMessage: (sessionId, role, content) =>
+        addMessage: (sessionId, role, content, attachments) =>
           set((s) => {
             const session = s.sessions[sessionId];
             if (!session) return;
@@ -692,6 +694,7 @@ export const useChatStore = createSelectors(
               id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
               role,
               content,
+              ...(attachments?.length ? { attachments } : {}),
               toolCalls: [],
               fileChanges: [],
               plan: null,

--- a/src/features/editor/components/editor-panel.tsx
+++ b/src/features/editor/components/editor-panel.tsx
@@ -15,6 +15,8 @@ import { ChevronRight, RefreshCw } from "lucide-react";
 import { logEvent } from "@/features/log/lib/log";
 import { diffGutter, applyDiffStatus } from "../lib/diff-gutter";
 import { gitDiffLineStatus } from "@/features/git/lib/git-diff-api";
+import { blameInline, applyBlame } from "../lib/blame-inline";
+import { gitBlameFile } from "@/features/git/lib/git-blame-api";
 
 const TOOLBAR_HEIGHT = 32;
 const DIRTY_CHECK_DEBOUNCE = 300; // ms — only check dirty state, not sync content
@@ -23,6 +25,10 @@ const DIRTY_CHECK_DEBOUNCE = 300; // ms — only check dirty state, not sync con
 // from the theme registry (src/features/editor/themes), keyed by the persisted
 // `settings.codeEditorTheme`.
 const themeCompartment = new Compartment();
+
+// Inline git blame — live-toggleable via a Compartment so flipping the
+// `gitBlameInline` setting doesn't rebuild the view (buffer/undo survive).
+const blameCompartment = new Compartment();
 
 function themeExtensions(themeId: string | undefined | null): Extension {
   const theme = getEditorTheme(themeId);
@@ -111,6 +117,7 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   const viewRef = useRef<EditorView | null>(null);
   const onSaveRef = useRef<() => void>(() => {});
   const refreshGutterRef = useRef<() => void>(() => {});
+  const refreshBlameRef = useRef<() => void>(() => {});
   const dirtyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Load file content from disk — unless this is an untitled scratch
@@ -202,6 +209,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       });
       // Repaint this editor's diff gutter against the just-saved content.
       refreshGutterRef.current();
+      // Buffer and disk agree again — refresh the inline blame snapshot.
+      refreshBlameRef.current();
     } catch (err) {
       console.error("Save failed:", err);
     }
@@ -223,6 +232,28 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       .catch(() => {});
   }, [path, projectPath, isUntitled]);
   refreshGutterRef.current = refreshDiffGutter;
+
+  // Fetch this file's per-line blame and hand it to the inline-blame
+  // extension. Blame is computed against the file on disk, so we skip the
+  // fetch while the buffer is dirty (line numbers would misalign) — the
+  // extension keeps showing the last snapshot, degrading edited lines to
+  // "Uncommitted changes" on its own. No-op for untitled buffers, files
+  // outside the project, or when the setting is off.
+  const refreshBlame = useCallback(() => {
+    const view = viewRef.current;
+    if (!view || isUntitled || !projectPath) return;
+    if (!useProjectStore.getState().settings.gitBlameInline) return;
+    if (!path.startsWith(projectPath + "/")) return;
+    if (useEditorStore.getState().buffers[path]?.dirty) return;
+    const rel = path.slice(projectPath.length + 1);
+    void gitBlameFile(projectPath, rel)
+      .then((lines) => {
+        // Ignore late results after the view was destroyed or swapped.
+        if (viewRef.current === view) applyBlame(view, lines);
+      })
+      .catch(() => {});
+  }, [path, projectPath, isUntitled]);
+  refreshBlameRef.current = refreshBlame;
 
   // Re-seed the live CodeMirror view from a string without polluting undo
   // history (external reload, not a user edit).
@@ -268,6 +299,7 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     reloadBuffer(path, content, mtime);
     replaceViewDoc(content);
     refreshDiffGutter();
+    refreshBlameRef.current();
   }, [path, isUntitled, reloadBuffer, markExternallyChanged, replaceViewDoc, refreshDiffGutter]);
   const revalidateRef = useRef(revalidate);
   revalidateRef.current = revalidate;
@@ -286,16 +318,20 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     reloadBuffer(path, content, mtime);
     replaceViewDoc(content);
     refreshDiffGutter();
+    refreshBlameRef.current();
   }, [path, isUntitled, reloadBuffer, replaceViewDoc, refreshDiffGutter]);
 
   // Repaint the gutter when the working tree changes elsewhere (commits,
   // stage/unstage, external edits) — same event the git store listens to.
   useEffect(() => {
-    const un = listen("atlas:git-changed", () => refreshDiffGutter());
+    const un = listen("atlas:git-changed", () => {
+      refreshDiffGutter();
+      refreshBlame();
+    });
     return () => {
       un.then((u) => u());
     };
-  }, [refreshDiffGutter]);
+  }, [refreshDiffGutter, refreshBlame]);
 
   // Reconcile with disk on the signals that indicate an external edit:
   //  • buffer mount (fixes close-then-reopen showing a stale cached buffer),
@@ -320,7 +356,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   // common case; this covers the late-projectPath race.
   useEffect(() => {
     refreshDiffGutter();
-  }, [refreshDiffGutter, buffer]);
+    refreshBlame();
+  }, [refreshDiffGutter, refreshBlame, buffer]);
 
   // Create/destroy CodeMirror view
   useEffect(() => {
@@ -343,6 +380,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
           langExt,
           lineNumbers(),
           diffGutter(),
+          blameCompartment.of(
+            useProjectStore.getState().settings.gitBlameInline ? blameInline() : [],
+          ),
           highlightActiveLine(),
           drawSelection(),
           bracketMatching(),
@@ -384,6 +424,7 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       const latest = useEditorStore.getState().buffers[path]?.originalContent;
       if (latest !== undefined) replaceViewDoc(latest);
       refreshDiffGutter();
+      refreshBlameRef.current();
     })();
 
     return () => {
@@ -404,6 +445,18 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     if (!view) return;
     view.dispatch({ effects: themeCompartment.reconfigure(themeExtensions(codeEditorTheme)) });
   }, [codeEditorTheme]);
+
+  // Live-toggle inline blame: reconfigure the compartment in place; turning it
+  // on also fetches a fresh snapshot (the extension starts empty).
+  const gitBlameInline = useProjectStore.use.settings().gitBlameInline;
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: blameCompartment.reconfigure(gitBlameInline ? blameInline() : []),
+    });
+    if (gitBlameInline) refreshBlameRef.current();
+  }, [gitBlameInline]);
 
   if (!buffer) {
     return (

--- a/src/features/editor/lib/blame-inline.ts
+++ b/src/features/editor/lib/blame-inline.ts
@@ -1,0 +1,169 @@
+// CodeMirror extension: inline Git blame on the active line only — a dim
+// trailing "Author, 3 days ago · commit summary" annotation that follows the
+// cursor. Fed by the native `git_blame_file` engine via the `setBlame` effect.
+//
+// Committed lines live in a RangeSet keyed by line start, so attribution
+// shifts correctly through edits; any line the user touches (and any line git
+// already reports as uncommitted) falls back to "You · Uncommitted changes"
+// instead of ever showing another commit's info.
+
+import { EditorView, Decoration, WidgetType, ViewPlugin } from "@codemirror/view";
+import type { DecorationSet, ViewUpdate } from "@codemirror/view";
+import { StateField, StateEffect, RangeSet, RangeValue } from "@codemirror/state";
+import type { Extension, Text } from "@codemirror/state";
+import type { BlameLine } from "@/features/git/lib/git-blame-api";
+
+/** Push a fresh blame snapshot into the editor. An empty array clears the
+ *  state entirely (untracked file / not a repo → nothing is rendered). */
+export const setBlame = StateEffect.define<BlameLine[]>();
+
+/** Convenience: dispatch a blame snapshot onto a view. */
+export function applyBlame(view: EditorView, lines: BlameLine[]): void {
+  view.dispatch({ effects: setBlame.of(lines) });
+}
+
+class BlameValue extends RangeValue {
+  constructor(readonly info: BlameLine) {
+    super();
+  }
+}
+
+// null = no blame loaded → render nothing at all.
+// RangeSet = loaded; only committed lines are in the set, so an active line
+// absent from it renders the "Uncommitted changes" fallback.
+type BlameState = RangeSet<BlameValue> | null;
+
+function buildSet(doc: Text, lines: BlameLine[]): BlameState {
+  const entries: { from: number; value: BlameValue }[] = [];
+  for (const b of lines) {
+    if (!b.committed) continue;
+    if (b.line < 1 || b.line > doc.lines) continue;
+    entries.push({ from: doc.line(b.line).from, value: new BlameValue(b) });
+  }
+  if (entries.length === 0) return lines.length === 0 ? null : RangeSet.empty;
+  entries.sort((a, z) => a.from - z.from);
+  return RangeSet.of(
+    entries.map((e) => e.value.range(e.from)),
+    /* sort */ true,
+  );
+}
+
+const blameField = StateField.define<BlameState>({
+  create: () => null,
+  update(value, tr) {
+    for (const e of tr.effects) {
+      if (e.is(setBlame)) return e.value.length === 0 ? null : buildSet(tr.state.doc, e.value);
+    }
+    if (value === null || !tr.docChanged) return value;
+    // Shift markers through the edit, then drop every line the edit touched so
+    // it reads as uncommitted rather than keeping stale attribution.
+    let set = value.map(tr.changes);
+    const touched = new Set<number>();
+    tr.changes.iterChangedRanges((_fromA, _toA, fromB, toB) => {
+      const first = tr.state.doc.lineAt(fromB).number;
+      const last = tr.state.doc.lineAt(toB).number;
+      for (let n = first; n <= last; n++) touched.add(tr.state.doc.line(n).from);
+    });
+    if (touched.size) set = set.update({ filter: (from) => !touched.has(from) });
+    return set;
+  },
+});
+
+function relativeTime(ms: number): string {
+  if (!ms) return "";
+  const s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return m === 1 ? "1 minute ago" : `${m} minutes ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return h === 1 ? "1 hour ago" : `${h} hours ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return d === 1 ? "1 day ago" : `${d} days ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return mo === 1 ? "1 month ago" : `${mo} months ago`;
+  const y = Math.floor(d / 365);
+  return y <= 1 ? "1 year ago" : `${y} years ago`;
+}
+
+class BlameWidget extends WidgetType {
+  constructor(readonly text: string) {
+    super();
+  }
+  eq(other: BlameWidget) {
+    return other.text === this.text;
+  }
+  toDOM() {
+    const el = document.createElement("span");
+    el.className = "cm-blame-inline";
+    el.textContent = this.text;
+    return el;
+  }
+  ignoreEvent() {
+    return true;
+  }
+}
+
+function blameTextFor(state: BlameState, doc: Text, head: number): string | null {
+  if (state === null) return null;
+  const line = doc.lineAt(head);
+  let found: BlameLine | null = null;
+  state.between(line.from, line.from, (_f, _t, v) => {
+    found = v.info;
+    return false;
+  });
+  if (found === null) return "You · Uncommitted changes";
+  const b: BlameLine = found;
+  const when = relativeTime(b.timeMs);
+  return `${b.author}${when ? `, ${when}` : ""} · ${b.summary}`;
+}
+
+const blameDecorations = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = this.build(view);
+    }
+
+    update(update: ViewUpdate) {
+      const blameChanged = update.transactions.some((tr) =>
+        tr.effects.some((e) => e.is(setBlame)),
+      );
+      if (update.docChanged || update.selectionSet || update.focusChanged || blameChanged) {
+        this.decorations = this.build(update.view);
+      }
+    }
+
+    build(view: EditorView): DecorationSet {
+      const text = blameTextFor(
+        view.state.field(blameField),
+        view.state.doc,
+        view.state.selection.main.head,
+      );
+      if (text === null) return Decoration.none;
+      const line = view.state.doc.lineAt(view.state.selection.main.head);
+      const deco = Decoration.widget({ widget: new BlameWidget(text), side: 1 });
+      return Decoration.set([deco.range(line.to)]);
+    }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+const blameTheme = EditorView.baseTheme({
+  ".cm-blame-inline": {
+    marginLeft: "2em",
+    color: "var(--text-tertiary, #6b7280)",
+    opacity: "0.65",
+    fontStyle: "italic",
+    fontSize: "0.9em",
+    whiteSpace: "pre",
+    pointerEvents: "none",
+    userSelect: "none",
+  },
+});
+
+/** The inline-blame extension. Add to the editor's extensions, then dispatch
+ *  `setBlame` snapshots (via `applyBlame`) to populate it. */
+export function blameInline(): Extension {
+  return [blameField, blameDecorations, blameTheme];
+}

--- a/src/features/git/lib/git-blame-api.ts
+++ b/src/features/git/lib/git-blame-api.ts
@@ -1,0 +1,21 @@
+// Bridge to the native `git_blame_file` command — per-line blame for the
+// editor's inline annotation. Empty array ⇒ untracked file / not a repo.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface BlameLine {
+  /** 1-based line number in the current file. */
+  line: number;
+  sha: string;
+  shortSha: string;
+  author: string;
+  /** Author time as unix milliseconds (0 if unparsable). */
+  timeMs: number;
+  summary: string;
+  /** False for lines git attributes to "Not Committed Yet". */
+  committed: boolean;
+}
+
+export function gitBlameFile(repoPath: string, file: string): Promise<BlameLine[]> {
+  return invoke<BlameLine[]>("git_blame_file", { path: repoPath, file });
+}

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -71,6 +71,9 @@ export interface AppSettings {
    *  `<next_steps>` block (uses the live session context, no BYOK); "off"
    *  disables it. (Legacy "parse"/"llm" values are treated as enabled.) */
   adaptiveSuggestions: "off" | "agent";
+  /** Inline Git blame in the code editor — dim author/age/summary annotation
+   *  trailing the active line. Off = the CodeMirror extension isn't loaded. */
+  gitBlameInline: boolean;
   /** Auto-update master switch. ON (default) → every startup checks PostHog
    *  remote config and prompts when a newer signed DMG is available. */
   autoUpdate: boolean;
@@ -90,6 +93,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   codeEditorTheme: DEFAULT_EDITOR_THEME_ID,
   atlasTheme: DEFAULT_ATLAS_THEME_ID,
   adaptiveSuggestions: "agent",
+  gitBlameInline: true,
   autoUpdate: true,
   updaterIgnoredVersion: null,
 };

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -270,6 +270,15 @@ function GeneralSettings() {
         />
       </SettingRow>
       <SettingRow
+        label="Inline Git blame"
+        description="Show who last changed the current line, when, and the commit summary as a dim annotation at the end of the line — following your cursor. Only for files inside a git repository."
+      >
+        <Toggle
+          checked={settings.gitBlameInline}
+          onChange={(next) => updateSettings({ gitBlameInline: next })}
+        />
+      </SettingRow>
+      <SettingRow
         label="Enable Atlas Logs"
         description="Record Atlas-internal events (sign-in, agent start/finish, browser/file open, etc.) into the Logs tab under the `atlas` source. Default ON so when something goes wrong you can open the Logs tab, filter by `atlas`, and share a timeline. Turn off if the noise bothers you."
       >

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -212,6 +212,10 @@ export interface ChatMessage {
   id: string;
   role: MessageRole;
   content: string;
+  /** Images the user attached to this message. Optimistic user-echo only —
+   *  never set on assistant messages, and not recovered on session replay
+   *  (Rust history is text-only). Rendered as thumbnails in the bubble. */
+  attachments?: import("./agents").ImageAttachment[];
   toolCalls: ToolCallDisplay[];
   fileChanges: FileChange[];
   plan: PlanStep[] | null;

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -11,6 +11,14 @@ export interface SessionKey {
 
 export type TranscriptKind = { kind: "none" } | { kind: "claude_jsonl" };
 
+/** One image attached to an outbound prompt. Mirrors atlas-acp's
+ *  `ImageAttachment` (serde camelCase). `dataBase64` is raw base64 — no
+ *  `data:` URI prefix. */
+export interface ImageAttachment {
+  mimeType: string;
+  dataBase64: string;
+}
+
 export interface PluginSpec {
   plugin_id: string;
   display_name: string;
@@ -85,6 +93,11 @@ export interface SessionSnapshot {
    *  Claude Code / Codex model picker; empty when unsupported. */
   available_models: SessionModeInfo[];
   available_commands: unknown[];
+  /** Whether the agent's transport accepts image content blocks in prompts
+   *  (`promptCapabilities.image`). Drives the composer's attach routing:
+   *  true → picked/pasted images become inline base64 attachments; false →
+   *  they degrade to path mention chips. */
+  prompt_image_supported: boolean;
   plan: PlanEntry[];
   messages: SessionMessage[];
   usage: Usage;


### PR DESCRIPTION
Two editor/chat features on top of the reliability work merged in #41.

## Inline git blame (editor)

A dim `Author, 3 days ago · commit summary` annotation at the end of the active line, following the cursor — Zed-style.

- New `git_blame_file` command: `git blame -w --line-porcelain` with a small parser; uncommitted lines show "You · Uncommitted changes", untracked files and non-repos render nothing
- CodeMirror extension keeps blame in a RangeSet that shifts through edits; any line you touch drops to "Uncommitted changes" instead of showing stale attribution
- One blame fetch per open/save/git-change (skipped while the buffer is dirty so line numbers never misalign); cursor movement is a pure lookup
- Toggleable via a new "Inline Git blame" setting (default on), wired through a CodeMirror compartment so flipping it doesn't rebuild the editor

## Composer "+" attach menu with image prompts (chat)

A "+" button in the chat composer: "Add files or photos" plus a Skills submenu that reuses the `#` rail's search source.

- `promptCapabilities.image` is now captured at initialize (it was previously discarded) and surfaced on session snapshots
- Images attach as base64 ACP image content blocks when the agent supports them — staged per session in a side-channel and drained at send, so the existing text prompt path is untouched; agents without image support get path mention chips instead, which they can read off disk
- Clipboard image paste stages the same way; staged images show as removable thumbnails and echo in the sent message bubble
- Agent-sent image blocks now render in the thread (previously dropped)
- The native agent is unaffected: its backend hooks are no-ops and its capability reads false

## Test plan

- [x] `cargo check` clean across the workspace; `atlas-agents` tests 15/15; `tsc --noEmit` clean
- [x] Blame parser validated against real `--line-porcelain` output (committed, uncommitted, untracked cases)
- [x] Manual: blame annotation follows cursor, drops to "Uncommitted changes" on edit, setting toggle works live
- [x] Manual: attach a PNG in a Claude Code chat and confirm the agent reads it without a file-read tool call; confirm path-chip fallback on a non-image file