### PR TITLE
feat(auth): Atlas account in the desktop app (ATL-35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,13 @@ src-tauri/target/
 .claude/
 .atlas/
 
-# Markdown docs (working notes, PRDs, comparison docs) — except README
+# Markdown docs (working notes, PRDs, comparison docs) — except the ones that
+# ship with the app. TELEMETRY.md is referenced from the telemetry module and
+# from the consent toggle in Settings, so it has to be in the repo the user is
+# pointed at.
 *.md
 !README.md
+!TELEMETRY.md
 graphify-out/
 # Local-only working folders (plans/specs + helper scripts)
 plans/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Atlas wraps a code editor, a multi-session AI chat (with first-class Claude Code
 
 - [Why Atlas](#why-atlas)
 - [Features](#features)
+- [Accounts and privacy](#accounts-and-privacy)
 - [Getting started](#getting-started)
 - [Architecture](#architecture)
   - [High-level layout](#high-level-layout)
@@ -26,13 +27,14 @@ Atlas wraps a code editor, a multi-session AI chat (with first-class Claude Code
 
 ## Why Atlas
 
-Most "AI IDEs" today are forks of VS Code with a chat pane bolted on. Atlas is the opposite: a small, opinionated shell that treats the AI agent and your own thinking as equal first-class citizens, alongside the editor and terminal. The goal is a tool that an individual researcher / engineer can keep open all day and trust with project context — not a hosted product, not a fork, no telemetry, no account.
+Most "AI IDEs" today are forks of VS Code with a chat pane bolted on. Atlas is the opposite: a small, opinionated shell that treats the AI agent and your own thinking as equal first-class citizens, alongside the editor and terminal. The goal is a tool that an individual researcher / engineer can keep open all day and trust with project context — not a hosted product, not a fork.
 
 Concretely:
 
 - **The agent is plural.** Multiple Claude Code sessions run concurrently, each with its own thread history and stop button. Switching tabs never freezes a running stream.
 - **State is just files.** No SQLite, no proprietary format. Chat history is JSONL on disk (read directly by Claude Code's own resume flag), notes are markdown, canvases are JSON.
-- **Local-first.** Everything except outbound API calls is on your machine. There is no Atlas account or server.
+- **Local-first.** Your projects, notes, chat history, and memory live on your machine and are never uploaded. Atlas does talk to the network — the model providers you point it at, the research and GitHub features you invoke, an update check, and anonymous usage data you can switch off — but none of that carries your content. See [Accounts and privacy](#accounts-and-privacy).
+- **The account is optional.** Atlas has an Atlas account you can connect to (see [Accounts and privacy](#accounts-and-privacy)), but nothing is gated behind it. Signed out, every feature works exactly as it does signed in.
 
 ---
 
@@ -55,7 +57,26 @@ Concretely:
 | **Project** | Open / close project, project picker, per-project state in `.atlas/`. |
 | **Monitor** | Token-usage tracker per provider/model. |
 | **Tasks** | Lightweight task list driven by agent plans. |
+| **Account** | Optional sign-in to an Atlas account via the OAuth 2.0 device grant — click the title-bar avatar, approve in your browser. Shows who is signed in, the Organisation this device acts for and your role in it, and an account menu that doubles as the entry point to Settings. Nothing is gated behind it. |
 | **Settings** | Provider / model / API key, theme tokens, keyboard shortcuts. |
+
+---
+
+## Accounts and privacy
+
+Atlas used to have no account and no server. It now has both, and this section says exactly what that does and does not mean.
+
+**Signing in is optional and purely additive.** Every feature in the table above works signed out, and none of them changes behaviour when you sign in. There is no paid tier, no gated feature, and no plan. If you never click the avatar, Atlas talks to no Atlas server at all.
+
+**Signing in does not upload anything.** No code, chat history, notes, knowledge, memory, or file paths leave your machine as a result of connecting an account. What sign-in currently buys you is identity — your photo in the title bar, your name, Organisation and role in the account menu — and the foundation for sync work that has not shipped yet. When it does, it will be its own opt-in with its own consent, not a silent consequence of having signed in once.
+
+**The credential stays in Rust.** The session token never crosses into the renderer, is never written to a log, and lives in a `0600` file in the app config directory. Signing out deletes it immediately and unconditionally, before the server is contacted at all — so it works with the network off.
+
+**Telemetry is anonymous, and stays anonymous after you sign in.** Atlas sends coarse usage and crash metadata to PostHog under a random install id, behind **Settings → General → "Share anonymous usage data"**. It defaults on and can be turned off at any time. Signing in does **not** link that id to your account — there is no `identify` and no `alias` call in the app, and the sign-in and sign-out events carry no user id, email, or Organisation id. An install that has opted out sends nothing extra as a result of signing in.
+
+Prompts, code, file paths, notes, terminal I/O, browser URLs, and API keys are never collected. The complete event catalogue and the full never-collected list are in **[TELEMETRY.md](TELEMETRY.md)**.
+
+**The update check is separate.** Atlas asks for the latest version on launch, independently of the telemetry toggle, because an app that stops learning about security updates when you decline analytics is a worse deal than the one you thought you were making. It has its own switch: **Settings → Updates → "Automatic updates"**.
 
 ---
 
@@ -302,7 +323,8 @@ atlas/
 ├── tsconfig.json
 ├── postcss.config.js
 ├── LICENSE
-└── README.md
+├── README.md
+└── TELEMETRY.md                     event catalogue + never-collected list
 ```
 
 ---
@@ -315,7 +337,7 @@ Contributions are very welcome — Atlas is a one-person project and there's ple
 
 1. **Open an issue first** for anything bigger than a small fix. It's easier to align on direction before you write the code.
 2. **Match the existing patterns.** Feature folder, Zustand store with `createSelectors`, Tailwind classes via `cn()`, IPC verbs in a single `commands/<domain>.rs` module. If you're adding something that doesn't fit, propose the structure in the issue.
-3. **No telemetry, no analytics, no auto-update pings.** Atlas is local-first by design.
+3. **Nothing leaves the machine that isn't in [TELEMETRY.md](TELEMETRY.md).** Atlas is local-first by design. The existing telemetry is anonymous, consent-gated, and metadata-only; adding an event means adding it to that catalogue in the same PR, and anything that would send content, paths, or account identity needs its own issue first.
 4. **No new heavy dependencies without discussion.** The current dep list is intentional.
 
 ### Local dev loop

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,181 @@
+# Telemetry
+
+Atlas collects anonymous, metadata-only usage data to find out what breaks and what
+gets used. This file is the complete catalogue: every event, every property, and the
+list of things that are never collected under any circumstance.
+
+If something is not in the table below, Atlas does not send it. If you find something
+that contradicts this file, that is a bug — please open an issue.
+
+- Emitter: [`src-tauri/src/telemetry/mod.rs`](src-tauri/src/telemetry/mod.rs) (Rust, all product events)
+- Crash reporter: [`src/features/telemetry/posthog-client.ts`](src/features/telemetry/posthog-client.ts) (renderer failures only)
+- Backend: [PostHog](https://posthog.com)
+
+---
+
+## Consent
+
+The toggle is **Settings → General → "Share anonymous usage data"**. It defaults to
+**ON**, the same opt-out posture as VS Code and Zed, and it can be turned off at any
+time — the change takes effect immediately, without a restart.
+
+With the toggle off, `capture()` returns before anything is queued. Nothing is
+buffered for later, and nothing is sent.
+
+A build with no PostHog key resolved is **inert**: the client is constructed dead, the
+frontend never loads `posthog-js` at all, and the toggle does nothing. Source builds
+are inert unless you supply your own key (see [Self-hosting](#self-hosting-and-opting-out-entirely)).
+
+---
+
+## Identity: one anonymous install, permanently
+
+Telemetry identity is a single random UUID (`telemetry_anon_id`) generated on first
+launch and stored in `state.json`. It is the PostHog `distinct_id` for both the Rust
+emitter and the renderer's crash reporter, so one install maps to one anonymous
+person. It is not derived from your machine, your account, or anything about you.
+
+**Signing in to an Atlas account does not change this.** There is no `identify` and no
+`alias` call anywhere in the desktop app. The account events below carry no user id,
+no email, and no Organisation id.
+
+This is not an oversight — it is the point. Linking the install UUID to a real user on
+sign-in would retroactively de-anonymize every event the install had ever sent, under
+a consent string that promised the opposite. Identified analytics happens server-side,
+where an account already exists and the user is signing in to it knowingly.
+
+The consequence, stated plainly: **an install that has never opted in sends nothing
+extra as a result of signing in.** The account feature is not a telemetry backdoor.
+
+---
+
+## Common properties
+
+Every event carries these four and nothing else implicitly:
+
+| Property | Value |
+| --- | --- |
+| `$lib` | `atlas-rust` (Rust emitter) or `atlas-js` (renderer crash reporter) |
+| `app_version` | Atlas version, e.g. `0.2.1` |
+| `os` | `macos`, `linux`, `windows` |
+| `arch` | `aarch64`, `x86_64` |
+
+PostHog also records the ingest timestamp and the request's IP, which it uses for
+coarse geo-resolution. Atlas sends no other device, network, or locale information.
+
+---
+
+## Event catalogue
+
+### Lifecycle
+
+| Event | When | Properties |
+| --- | --- | --- |
+| `app_started` | Atlas launches | `is_first_launch` (bool) |
+| `rust_panic` | A Rust panic, sent synchronously from the panic hook | `location` (Atlas's own `file:line`), `message` (redacted of path / URL / email tokens, truncated to 160 chars) |
+
+### Account (ATL-52)
+
+| Event | When | Properties |
+| --- | --- | --- |
+| `auth_signed_in` | A device-authorization grant completes | *none* |
+| `auth_signed_out` | The user signs out from the account menu | *none* |
+
+Both carry **no user id, email, or Organisation id** — see
+[Identity](#identity-one-anonymous-install-permanently). `auth_signed_out` records the
+*user's* action only; a session the server ended (expiry or revocation) emits nothing,
+because folding the two together would leave a count that means neither one thing nor
+the other.
+
+### Agents and models
+
+| Event | When | Properties |
+| --- | --- | --- |
+| `agent_turn_started` | A turn is sent to an agent | `agent_kind` |
+| `agent_turn_finished` | A turn completes | `agent_kind`, `stop_reason`, `usage` (token counts) |
+| `agent_turn_failed` | A turn errors | `agent_kind`, `error_summary` (redacted, ≤160 chars) |
+| `model_chat_sent` | A direct model chat completes | `provider`, `model`, `input_tokens`, `output_tokens` |
+| `code_review_completed` | An AI code review finishes | `provider`, `model` |
+
+`agent_kind` is currently the agent instance's internal `AgentId`, which is a random
+UUID minted per registration — it identifies nothing outside the process and does not
+survive a restart. The name overpromises; it is documented here as what it actually
+is rather than what it sounds like.
+
+Note what these do *not* carry: no prompt, no response, no file name, no repository,
+no diff.
+
+### Consent itself
+
+| Event | When | Properties |
+| --- | --- | --- |
+| `telemetry_opt_in` | The toggle is switched on | *none* |
+| `telemetry_opt_out` | The toggle is switched off | *none* |
+
+`telemetry_opt_out` is sent while telemetry is still enabled, so nothing is
+transmitted after the moment you opted out.
+
+### Renderer crashes
+
+`posthog-js` is loaded for **crash reporting only**. Autocapture, pageviews, page-leave
+events, and session recording are all explicitly disabled — the renderer captures no
+usage events of any kind.
+
+| Event | When | Properties |
+| --- | --- | --- |
+| `$exception` | A React render error, uncaught `window.onerror`, or unhandled promise rejection | The error message and stack, plus `type` (`react_error_boundary` / `uncaught_error` / `unhandled_rejection`), `source`, and a truncated `component_stack` |
+
+A short list of known-benign, non-actionable errors is dropped before it reaches
+PostHog. Note that a JavaScript stack trace can contain bundled file names; it does not
+contain your files, your project path, or your content.
+
+---
+
+## Never collected
+
+None of the following leaves your machine as telemetry, with or without consent:
+
+- **Prompts and responses.** No message you write to an agent, and nothing it writes back.
+- **Code.** No file contents, no diffs, no patches, no repository names or remotes.
+- **Paths.** No absolute or relative file paths, no project or directory names. Free-text
+  fields (`message`, `error_summary`) are run through a redactor that strips path-like,
+  URL-like, and email-like tokens before sending.
+- **Knowledge, notes, canvases, chat history, memory.** None of it, in any form.
+- **API keys and credentials.** No provider keys, no Atlas session token, no access JWT,
+  no device code. These are never logged either.
+- **Terminal input or output.**
+- **Browser URLs, page contents, or history** from the in-app browser.
+- **Account identity.** No user id, name, email, avatar URL, Organisation id, or role —
+  see [Identity](#identity-one-anonymous-install-permanently).
+- **Keystrokes, screenshots, or session recordings.**
+
+---
+
+## The one thing that is not consent-gated
+
+The **auto-update check** queries PostHog's remote-config endpoint for the latest
+version and download URL. It carries the anonymous install id and the common
+properties, and it runs on launch and every few hours.
+
+It is deliberately independent of the telemetry toggle, because an app that stops
+learning about security updates when you decline analytics is a worse deal than the
+one you thought you were making. It is not analytics and captures no event.
+
+It is gated by its own setting: **Settings → Updates → "Automatic updates"**. Turn that
+off and Atlas makes no background update request. An inert build never makes one at
+all.
+
+---
+
+## Self-hosting and opting out entirely
+
+The PostHog key and host resolve in this order, first match winning:
+
+1. `ATLAS_POSTHOG_KEY` / `POSTHOG_KEY` (+ `ATLAS_POSTHOG_HOST` / `POSTHOG_HOST`) from
+   the environment or a `.env` file
+2. `<app_config_dir>/telemetry.json` — `{ "key": "...", "host": "..." }`
+3. A compile-time key baked into official release builds
+4. Nothing — the client is permanently inert and makes no network calls
+
+Point rungs 1 or 2 at your own PostHog project to keep your organisation's data in
+your own instance. Build from source without a key to have no telemetry path at all.

--- a/landing/index.html
+++ b/landing/index.html
@@ -1999,7 +1999,7 @@
       <span class="hero-meta-sep">·</span>
       <span>macOS Apple Silicon only</span>
       <span class="hero-meta-sep">·</span>
-      <span>local-first · no telemetry</span>
+      <span>local-first · anonymous telemetry you can turn off</span>
     </div>
   </div>
 </header>
@@ -3584,7 +3584,7 @@
 <section class="cta-section" id="download">
   <div class="wrap-tight">
     <h2 class="cta-title">Make agents part of the team.</h2>
-    <p class="cta-sub">Free during the alpha. Bring your own keys. Apple Silicon binary, no Electron, no telemetry, no account.</p>
+    <p class="cta-sub">Free during the alpha. Bring your own keys. Apple Silicon binary, no Electron. The Atlas account is optional — nothing is gated behind it.</p>
     <div class="cta-row">
       <a href="https://github.com/pacifio/atlas/releases/download/alpha-0.1.20/Atlas_0.1.20_aarch64.dmg" class="btn btn-primary btn-lg">
         Download for Mac

--- a/src-tauri/src/auth/avatar.rs
+++ b/src-tauri/src/auth/avatar.rs
@@ -1,0 +1,192 @@
+//! Fetching and caching the profile photo.
+//!
+//! The photo is fetched **once**, when the remote URL first appears or changes,
+//! and read from disk on every launch after that. The point is not speed: the
+//! provider URL points at Google or GitHub, and re-fetching on every launch
+//! would hand one of them a beacon carrying the user's IP and a rough activity
+//! log, for a picture we already have. That is the opposite of what a
+//! local-first app should do, and it would also blank the title bar on a plane.
+//!
+//! The claim is precisely "never for a photo we already have", not "never".
+//! When there is no cached file — a first sign-in, or a photo that has failed
+//! to download so far — every launch does try again, unbounded. That is the
+//! deliberate side of the trade: caching a *failure* would mean one CDN outage
+//! during sign-in costs the user their photo until they next change it. The
+//! request only recurs while we have nothing to show, and a launch already
+//! talks to the Atlas auth server twice regardless.
+//!
+//! The remote URL is therefore the cache key, and it never crosses to the
+//! frontend — an `<img src>` pointed at the provider would reinstate exactly
+//! the per-launch request this module exists to avoid. The frontend gets a
+//! local path.
+//!
+//! Every failure here is non-fatal by construction: the caller gets `None` and
+//! renders initials. A photo is never worth blocking or failing a sign-in for.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+
+/// Enough for any provider avatar (GitHub's largest is well under 1 MB) and
+/// small enough that a hostile or misconfigured host cannot fill the disk.
+const MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// The whole fetch, bounded. A photo is decoration; it does not get to hold
+/// sign-in open, and this is the entire budget including connect and TLS.
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What we are willing to write into a directory the asset protocol serves.
+///
+/// SVG is deliberately absent. `<img>` does not execute script in an SVG, so
+/// this is not load-bearing, but there is no provider that needs it and no
+/// reason to be the first app to find out otherwise.
+fn extension_for(content_type: &str) -> Option<&'static str> {
+    let base = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    match base.as_str() {
+        "image/png" => Some("png"),
+        "image/jpeg" | "image/jpg" => Some("jpg"),
+        "image/webp" => Some("webp"),
+        "image/gif" => Some("gif"),
+        _ => None,
+    }
+}
+
+/// Cache file for a given remote URL.
+///
+/// The URL is hashed into the name so that a changed photo lands at a *changed
+/// path*. That matters beyond tidiness: the webview caches by URL, so reusing
+/// one filename would leave a stale face on screen until a restart.
+fn cache_path(dir: &Path, url: &str, ext: &str) -> PathBuf {
+    let digest = Sha256::digest(url.as_bytes());
+    let short: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    dir.join(format!("avatar-{short}.{ext}"))
+}
+
+/// A photo we hold, as the remote URL it came from and where it landed.
+///
+/// The two travel together because neither means anything alone: the URL is the
+/// cache key and the path is the payload, and it is the *pair* that has to be
+/// written back or left alone atomically. Splitting them is what makes it
+/// possible to record a new URL against an old file — a state that reads as
+/// "cached" and never re-fetches.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CachedAvatar {
+    pub url: Option<String>,
+    pub path: Option<String>,
+}
+
+impl CachedAvatar {
+    pub(crate) fn new(url: Option<String>, path: Option<String>) -> Self {
+        Self { url, path }
+    }
+
+    /// The cached file, if it is actually still on disk. A user or a cleanup
+    /// tool can delete it behind our back, and a path to nothing would render
+    /// as a broken image.
+    fn existing_path(&self) -> Option<&str> {
+        self.path.as_deref().filter(|p| Path::new(p).exists())
+    }
+}
+
+/// The photo to hold for `url`, fetching it only if we do not already have it.
+///
+/// Returns the pair to persist. There is no error case: a photo is decoration,
+/// and no failure here has a decision the user could make about it. What varies
+/// is *which* pair comes back —
+///
+/// - no URL: nothing, and the old file is deleted. The user cleared their photo
+///   and we should not keep a face they removed.
+/// - URL unchanged and the file is there: `previous`, untouched, no request.
+/// - fetched: the new pair, and the superseded file is deleted.
+/// - **fetch failed: `previous`, untouched, and nothing is deleted.** We learned
+///   nothing about the new photo, so a five-second blip must not cost the
+///   known-good one — that file is the whole reason an offline launch renders a
+///   face. Leaving the *old URL* recorded is what makes the next launch see a
+///   mismatch and try again, instead of filing the new URL against an old file
+///   and never re-fetching.
+pub(crate) async fn resolve(
+    http: &reqwest::Client,
+    dir: &Path,
+    url: Option<&str>,
+    previous: &CachedAvatar,
+) -> CachedAvatar {
+    let Some(url) = url else {
+        prune(previous.path.as_deref(), None);
+        return CachedAvatar::default();
+    };
+
+    if previous.url.as_deref() == Some(url) {
+        if let Some(path) = previous.existing_path() {
+            return CachedAvatar::new(Some(url.to_string()), Some(path.to_string()));
+        }
+    }
+
+    let Some(fetched) = fetch(http, dir, url).await else {
+        // Keep what we have, minus any path that has gone missing — recording a
+        // path to nothing would just defer the failure to the `<img>`.
+        return CachedAvatar::new(
+            previous.url.clone(),
+            previous.existing_path().map(str::to_string),
+        );
+    };
+
+    prune(previous.path.as_deref(), Some(&fetched));
+    CachedAvatar::new(Some(url.to_string()), Some(fetched))
+}
+
+/// Download and write, or `None`.
+async fn fetch(http: &reqwest::Client, dir: &Path, url: &str) -> Option<String> {
+    let mut res = http.get(url).timeout(TIMEOUT).send().await.ok()?;
+    if !res.status().is_success() {
+        return None;
+    }
+
+    let ext = extension_for(res.headers().get(reqwest::header::CONTENT_TYPE)?.to_str().ok()?)?;
+
+    // A declared length over the cap saves us downloading it to find out. It is
+    // only a hint — absent or dishonest lengths are caught by the loop below.
+    if res.content_length().is_some_and(|n| n > MAX_BYTES as u64) {
+        return None;
+    }
+
+    let mut bytes: Vec<u8> = Vec::new();
+    loop {
+        match res.chunk().await {
+            Ok(Some(chunk)) => {
+                if bytes.len() + chunk.len() > MAX_BYTES {
+                    return None;
+                }
+                bytes.extend_from_slice(&chunk);
+            }
+            Ok(None) => break,
+            // A truncated body would be written as a half image, which renders
+            // as the broken-image glyph — worse than initials.
+            Err(_) => return None,
+        }
+    }
+
+    if bytes.is_empty() {
+        return None;
+    }
+
+    std::fs::create_dir_all(dir).ok()?;
+    let path = cache_path(dir, url, ext);
+    std::fs::write(&path, &bytes).ok()?;
+    Some(path.to_string_lossy().into_owned())
+}
+
+/// Remove a superseded cache file. Best-effort, and never removes the file we
+/// just wrote (a URL that hashes to the same name is the same photo).
+fn prune(old: Option<&str>, keep: Option<&str>) {
+    if let Some(old) = old {
+        if Some(old) != keep {
+            let _ = std::fs::remove_file(old);
+        }
+    }
+}

--- a/src-tauri/src/auth/avatar.rs
+++ b/src-tauri/src/auth/avatar.rs
@@ -181,6 +181,12 @@ async fn fetch(http: &reqwest::Client, dir: &Path, url: &str) -> Option<String> 
     Some(path.to_string_lossy().into_owned())
 }
 
+/// Drop a cached photo we are done with — sign-out, where the face on disk
+/// outlives the credential unless something deletes it.
+pub(crate) fn discard(path: Option<&str>) {
+    prune(path, None);
+}
+
 /// Remove a superseded cache file. Best-effort, and never removes the file we
 /// just wrote (a URL that hashes to the same name is the same photo).
 fn prune(old: Option<&str>, keep: Option<&str>) {

--- a/src-tauri/src/auth/backoff.rs
+++ b/src-tauri/src/auth/backoff.rs
@@ -1,0 +1,98 @@
+//! The retry schedule for the INDETERMINATE class (ATL-48).
+//!
+//! Only failures that told us *nothing* about the credential come here. A 401
+//! is answered by signing out and a 403 by doing nothing at all; neither ever
+//! reaches this module. See [`crate::auth::AuthFailure`] for the split.
+//!
+//! The schedule is exponential from one second to a five-minute ceiling, with
+//! jitter, and **no attempt limit**: a laptop closed on a plane and opened six
+//! hours later must come back signed in on its own, without the user
+//! restarting Atlas or redoing the device grant. An attempt cap would turn that
+//! into a silent dead end that looks exactly like being signed out.
+//!
+//! The ceiling is also what keeps the retry path clear of the auth worker's
+//! global rate limit — 100 requests per 60-second window across every
+//! `/api/auth/*` path, keyed by IP, so an office behind one NAT shares the
+//! budget. At the ceiling this loop costs 12 requests an hour. Anyone
+//! shortening the ceiling should re-check it against that number.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Delay before the first retry.
+pub(crate) const BASE: Duration = Duration::from_secs(1);
+
+/// Longest we will ever wait between attempts.
+pub(crate) const CEILING: Duration = Duration::from_secs(300);
+
+/// Where doubling stops mattering. `BASE << 32` is already centuries, so this
+/// only exists to keep the shift from overflowing.
+const MAX_SHIFT: u32 = 32;
+
+/// An exponential schedule with jitter, bounded above.
+pub(crate) struct Backoff {
+    base: Duration,
+    ceiling: Duration,
+    attempt: u32,
+}
+
+impl Backoff {
+    pub(crate) fn new(base: Duration, ceiling: Duration) -> Self {
+        Self {
+            base,
+            ceiling,
+            attempt: 0,
+        }
+    }
+
+    /// The un-jittered delay for the current attempt.
+    fn cap(&self) -> Duration {
+        let doubled = self
+            .base
+            .checked_mul(1u32.checked_shl(self.attempt.min(MAX_SHIFT)).unwrap_or(u32::MAX))
+            .unwrap_or(self.ceiling);
+        doubled.min(self.ceiling)
+    }
+
+    /// Consume one attempt and return how long to wait.
+    ///
+    /// The delay is drawn from `[cap/2, cap]` rather than the more common
+    /// `[0, cap]`. Full jitter can put the tenth retry a millisecond after the
+    /// ninth, which throws away the backoff exactly when the server is least
+    /// able to absorb it; half jitter still de-synchronises a fleet of clients
+    /// that all lost connectivity at the same moment, which is the point.
+    pub(crate) fn next(&mut self) -> Duration {
+        let cap = self.cap();
+        self.attempt = self.attempt.saturating_add(1);
+        let half = cap / 2;
+        half + half.mul_f64(fraction())
+    }
+
+    /// The delay before the next attempt, letting the server overrule it.
+    ///
+    /// A `Retry-After` is honoured but **clamped into the same window**. It is
+    /// a number from the network: taken verbatim, a `0` spins this loop against
+    /// a server already asking for quiet, and an `86400` strands a signed-in
+    /// user for a day over one bad header. The attempt still advances either
+    /// way, so a server that answers every request with `Retry-After: 0` cannot
+    /// hold the schedule at its floor.
+    pub(crate) fn next_after(&mut self, retry_after: Option<Duration>) -> Duration {
+        let jittered = self.next();
+        match retry_after {
+            Some(asked) => asked.clamp(self.base, self.ceiling),
+            None => jittered,
+        }
+    }
+}
+
+/// A fraction in `[0, 1)` from the sub-second part of the clock.
+///
+/// Deliberately not a PRNG dependency: this only has to stop simultaneous
+/// clients from retrying in lockstep, and nothing about it is security
+/// relevant — the value is a sleep duration, never a token or a nonce.
+fn fraction() -> f64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    f64::from(nanos) / 1_000_000_000.0
+}

--- a/src-tauri/src/auth/config.rs
+++ b/src-tauri/src/auth/config.rs
@@ -1,0 +1,37 @@
+//! Where the desktop talks to.
+//!
+//! Resolution order, highest priority first:
+//!   1. env `ATLAS_AUTH_URL` — how a developer points at `wrangler dev`.
+//!   2. compile-time `option_env!("ATLAS_AUTH_URL")` — staging builds.
+//!   3. the production auth host.
+//!
+//! The telemetry module has a similar ladder with a `<config_dir>/*.json` rung
+//! in the middle. That rung is **deliberately absent here**: a persistent
+//! on-disk override of the *sign-in* host is a phishing foothold in a way an
+//! analytics host is not — one stray file write and every future sign-in goes
+//! to an attacker. An environment variable at least requires code execution in
+//! the user's session at launch time.
+
+/// Production auth worker. Desktop talks to it directly; the browser half of
+/// the device grant happens on the web origin, whose URL the server hands back
+/// in the grant response (never constructed here).
+const DEFAULT_AUTH_BASE: &str = "https://auth.tryatlas.cc/api/auth";
+
+/// Baked in at build time for staging/QA builds. `None` in ordinary builds.
+const BUILD_AUTH_BASE: Option<&str> = option_env!("ATLAS_AUTH_URL");
+
+/// The auth API base, with no trailing slash.
+pub fn auth_base() -> String {
+    let raw = std::env::var("ATLAS_AUTH_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| BUILD_AUTH_BASE.map(str::to_string))
+        .unwrap_or_else(|| DEFAULT_AUTH_BASE.to_string());
+    normalize(&raw)
+}
+
+/// Trim whitespace and any trailing slashes so callers can always append
+/// `/device/code` and friends without doubling the separator.
+pub(crate) fn normalize(raw: &str) -> String {
+    raw.trim().trim_end_matches('/').to_string()
+}

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -35,7 +35,10 @@ pub struct PendingGrant {
     /// The short human-readable code. A display string, not a secret.
     pub user_code: String,
     pub verification_uri: String,
-    /// Pre-fills the code, so the happy path needs no typing at all.
+    /// The pre-filled approval URL. Parsed because RFC 8628 defines it and the
+    /// server sends it, but **deliberately never opened** — see the comment in
+    /// `commands::auth::auth_sign_in`. A link that carries the code is the
+    /// remote-phishing surface the copy-and-paste hand-off exists to close.
     pub verification_uri_complete: String,
     pub expires_at: SystemTime,
     pub interval: Duration,
@@ -46,6 +49,22 @@ pub struct PendingGrant {
 impl PendingGrant {
     fn expired(&self) -> bool {
         SystemTime::now() >= self.expires_at
+    }
+
+    /// The page to open in the browser: the **plain** verification URI.
+    ///
+    /// A named method rather than a field access at the call site, because this
+    /// is a security decision and not a formatting one. Opening
+    /// `verification_uri_complete` instead would put the code in the URL, and a
+    /// link that carries the code is the whole remote-phishing attack — an
+    /// already-signed-in user is then one click from approving a grant someone
+    /// else started. Sending them to an empty box means the code that gets
+    /// approved is necessarily the one this window is showing.
+    ///
+    /// It reads as a harmless UX improvement to "just pre-fill it", which is
+    /// exactly why it is stated here and pinned by a test.
+    pub fn approval_url(&self) -> &str {
+        &self.verification_uri
     }
 }
 

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -1,0 +1,379 @@
+//! The device grant, the poll loop, and credential lifecycle.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use serde::Deserialize;
+
+use super::store::{self, StoredSession};
+use super::AuthSnapshot;
+
+/// RFC 8628 `client_id` for this app, matching the server's device plugin.
+const CLIENT_ID: &str = "atlas-desktop";
+const DEVICE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// Floor on the poll interval so a misbehaving or hostile server cannot make us
+/// hammer it. The server normally says 5s.
+const MIN_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// A grant awaiting approval in the browser.
+#[derive(Debug, Clone)]
+pub struct PendingGrant {
+    /// The secret the desktop polls with. Never leaves Rust, never logged.
+    pub device_code: String,
+    /// The short human-readable code. A display string, not a secret.
+    pub user_code: String,
+    pub verification_uri: String,
+    /// Pre-fills the code, so the happy path needs no typing at all.
+    pub verification_uri_complete: String,
+    pub expires_at: SystemTime,
+    pub interval: Duration,
+    /// Flipped by `cancel_grant`; the loop checks it between polls.
+    cancel: Arc<AtomicBool>,
+}
+
+impl PendingGrant {
+    fn expired(&self) -> bool {
+        SystemTime::now() >= self.expires_at
+    }
+}
+
+/// One poll of `/device/token`, classified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PollOutcome {
+    /// Approved. Carries the Better Auth session token.
+    Token(String),
+    /// Not approved yet — keep going at the current interval.
+    Pending,
+    /// Polled too fast; RFC 8628 says add 5 seconds.
+    SlowDown,
+    /// The human pressed Deny.
+    Denied,
+    /// The code aged out server-side.
+    Expired,
+    /// We learned nothing: network error, 5xx, or an unparseable body. NOT a
+    /// reason to end the grant — see `run_grant`.
+    Transient,
+}
+
+/// Why a grant ended without a token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantError {
+    Denied,
+    Expired,
+    Cancelled,
+    /// Could not even start the grant.
+    Start(String),
+}
+
+impl GrantError {
+    /// Message for the connecting dialog.
+    pub fn user_message(&self) -> String {
+        match self {
+            GrantError::Denied => "Connection denied in the browser.".into(),
+            GrantError::Expired => "That code expired. Get a new one to try again.".into(),
+            GrantError::Cancelled => "Sign-in cancelled.".into(),
+            GrantError::Start(e) => format!("Could not reach Atlas: {e}"),
+        }
+    }
+}
+
+/// The auth module's whole public surface.
+pub struct AuthCore {
+    base: String,
+    dir: PathBuf,
+    http: reqwest::Client,
+    /// At most one grant in flight. Guards against a double-click minting two
+    /// competing codes, and is what makes a second click *resume* rather than
+    /// restart — the recovery path for someone who got lost mid-flow.
+    pending: Mutex<Option<PendingGrant>>,
+}
+
+impl AuthCore {
+    pub fn new(base: impl Into<String>, dir: impl Into<PathBuf>, http: reqwest::Client) -> Self {
+        Self {
+            base: super::config::normalize(&base.into()),
+            dir: dir.into(),
+            http,
+            pending: Mutex::new(None),
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base, path)
+    }
+
+    // ---- credential ----------------------------------------------------
+
+    pub fn stored(&self) -> Option<StoredSession> {
+        store::load(&self.dir)
+    }
+
+    pub fn clear_session(&self) -> Result<(), String> {
+        store::clear(&self.dir)
+    }
+
+    fn persist(&self, session_token: &str) -> Result<(), String> {
+        store::save(
+            &self.dir,
+            &StoredSession {
+                session_token: session_token.to_string(),
+                saved_at: chrono::Utc::now().to_rfc3339(),
+            },
+        )
+    }
+
+    /// What the frontend may see.
+    pub fn snapshot(&self) -> AuthSnapshot {
+        if let Some(p) = self.pending.lock().ok().and_then(|g| g.clone()) {
+            if !p.expired() {
+                return AuthSnapshot::Connecting {
+                    user_code: p.user_code,
+                    verification_uri: p.verification_uri,
+                    expires_at: chrono::DateTime::<chrono::Utc>::from(p.expires_at).to_rfc3339(),
+                };
+            }
+        }
+        if self.stored().is_some() {
+            AuthSnapshot::SignedIn
+        } else {
+            AuthSnapshot::SignedOut
+        }
+    }
+
+    // ---- device grant --------------------------------------------------
+
+    /// Begin a grant, or hand back the one already in flight.
+    ///
+    /// Reuse is load-bearing rather than an optimisation: a first-run user who
+    /// has to sign in on the web often loses their way back, and clicking the
+    /// account button again must return them to the *same* approval page —
+    /// now with a browser session in hand — instead of stranding a fresh code.
+    pub async fn start_grant(&self) -> Result<PendingGrant, GrantError> {
+        if let Some(existing) = self.pending.lock().ok().and_then(|g| g.clone()) {
+            if !existing.expired() && !existing.cancel.load(Ordering::SeqCst) {
+                return Ok(existing);
+            }
+        }
+
+        let res = self
+            .http
+            .post(self.url("/device/code"))
+            .json(&serde_json::json!({ "client_id": CLIENT_ID }))
+            .send()
+            .await
+            .map_err(|e| GrantError::Start(redact(&e.to_string())))?;
+
+        if !res.status().is_success() {
+            return Err(GrantError::Start(format!("server said {}", res.status())));
+        }
+
+        let body: DeviceCodeResponse = res
+            .json()
+            .await
+            .map_err(|e| GrantError::Start(format!("unreadable response: {e}")))?;
+
+        let grant = PendingGrant {
+            device_code: body.device_code,
+            user_code: body.user_code,
+            verification_uri: body.verification_uri,
+            verification_uri_complete: body.verification_uri_complete,
+            expires_at: SystemTime::now() + Duration::from_secs(body.expires_in.max(1)),
+            interval: Duration::from_secs(body.interval).max(MIN_POLL_INTERVAL),
+            cancel: Arc::new(AtomicBool::new(false)),
+        };
+
+        if let Ok(mut slot) = self.pending.lock() {
+            *slot = Some(grant.clone());
+        }
+        Ok(grant)
+    }
+
+    /// Abandon the in-flight grant, if any. Idempotent.
+    pub fn cancel_grant(&self) {
+        if let Ok(mut slot) = self.pending.lock() {
+            if let Some(p) = slot.as_ref() {
+                p.cancel.store(true, Ordering::SeqCst);
+            }
+            *slot = None;
+        }
+    }
+
+    /// One poll, classified. Anything we cannot interpret is `Transient` —
+    /// "we do not know" is never the same as "no".
+    pub async fn poll_once(&self, device_code: &str) -> PollOutcome {
+        let res = self
+            .http
+            .post(self.url("/device/token"))
+            .json(&serde_json::json!({
+                "grant_type": DEVICE_GRANT,
+                "device_code": device_code,
+                "client_id": CLIENT_ID,
+            }))
+            .send()
+            .await;
+
+        let Ok(res) = res else {
+            return PollOutcome::Transient;
+        };
+
+        if res.status().is_server_error() {
+            return PollOutcome::Transient;
+        }
+
+        if res.status().is_success() {
+            return match res.json::<DeviceTokenSuccess>().await {
+                Ok(b) if !b.access_token.is_empty() => PollOutcome::Token(b.access_token),
+                _ => PollOutcome::Transient,
+            };
+        }
+
+        match res.json::<DeviceTokenError>().await {
+            Ok(b) => match b.error.as_str() {
+                "authorization_pending" => PollOutcome::Pending,
+                "slow_down" => PollOutcome::SlowDown,
+                "access_denied" => PollOutcome::Denied,
+                "expired_token" => PollOutcome::Expired,
+                _ => PollOutcome::Transient,
+            },
+            Err(_) => PollOutcome::Transient,
+        }
+    }
+
+    /// Drive the grant to a conclusion, persisting the token on success.
+    ///
+    /// Transient failures deliberately do **not** end the grant: a two-second
+    /// wifi blip must not discard an approval the human has already given in
+    /// the browser. They simply cost one poll, and the 10-minute server-side
+    /// deadline still bounds the whole thing.
+    pub async fn run_grant(&self, grant: &PendingGrant) -> Result<(), GrantError> {
+        let mut interval = grant.interval;
+
+        loop {
+            if grant.cancel.load(Ordering::SeqCst) {
+                return Err(GrantError::Cancelled);
+            }
+            if grant.expired() {
+                self.finish();
+                return Err(GrantError::Expired);
+            }
+
+            tokio::time::sleep(interval).await;
+
+            if grant.cancel.load(Ordering::SeqCst) {
+                return Err(GrantError::Cancelled);
+            }
+
+            match self.poll_once(&grant.device_code).await {
+                PollOutcome::Token(token) => {
+                    self.persist(&token).map_err(GrantError::Start)?;
+                    self.finish();
+                    return Ok(());
+                }
+                PollOutcome::Pending | PollOutcome::Transient => continue,
+                PollOutcome::SlowDown => {
+                    interval += Duration::from_secs(5);
+                    continue;
+                }
+                PollOutcome::Denied => {
+                    self.finish();
+                    return Err(GrantError::Denied);
+                }
+                PollOutcome::Expired => {
+                    self.finish();
+                    return Err(GrantError::Expired);
+                }
+            }
+        }
+    }
+
+    /// Clear the pending slot without signalling cancellation (the grant is
+    /// over on its own terms).
+    fn finish(&self) {
+        if let Ok(mut slot) = self.pending.lock() {
+            *slot = None;
+        }
+    }
+
+    // ---- token ----------------------------------------------------------
+
+    /// Mint a short-TTL access JWT from the stored session token.
+    ///
+    /// `Ok(None)` means the server authoritatively rejected the credential
+    /// (401). `Err` means we could not find out — the caller must treat those
+    /// completely differently, which is what ATL-48 formalises.
+    pub async fn mint_access_token(&self) -> Result<Option<String>, String> {
+        let Some(stored) = self.stored() else {
+            return Ok(None);
+        };
+
+        let res = self
+            .http
+            .get(self.url("/token"))
+            .bearer_auth(&stored.session_token)
+            .send()
+            .await
+            .map_err(|e| redact(&e.to_string()))?;
+
+        if res.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Ok(None);
+        }
+        if !res.status().is_success() {
+            return Err(format!("token mint failed: {}", res.status()));
+        }
+
+        #[derive(Deserialize)]
+        struct TokenResponse {
+            token: String,
+        }
+        let body: TokenResponse = res.json().await.map_err(|e| e.to_string())?;
+        Ok(Some(body.token))
+    }
+
+    /// Boot check.
+    ///
+    /// **Preserves the credential on every failure, including 401.** ATL-48
+    /// introduces the authoritative-401-signs-you-out rule; until it lands the
+    /// safe default is to keep a credential we are unsure about. The worst case
+    /// here is a stale signed-in state, never a destroyed valid session — which
+    /// is the right way round if that ticket slips.
+    pub async fn validate_stored(&self) -> AuthSnapshot {
+        if self.stored().is_none() {
+            return AuthSnapshot::SignedOut;
+        }
+        let _ = self.mint_access_token().await;
+        AuthSnapshot::SignedIn
+    }
+}
+
+/// Strip anything that could carry a credential out of an error string before
+/// it reaches a log or the UI. `reqwest` puts the request URL in its errors,
+/// and a URL is the one place a token could plausibly appear.
+fn redact(message: &str) -> String {
+    match message.find(" for url") {
+        Some(i) => message[..i].to_string(),
+        None => message.to_string(),
+    }
+}
+
+#[derive(Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    verification_uri_complete: String,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Deserialize)]
+struct DeviceTokenSuccess {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct DeviceTokenError {
+    error: String,
+}

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -1,5 +1,6 @@
 //! The device grant, the poll loop, and the credential and identity lifecycle.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -8,7 +9,7 @@ use std::time::{Duration, SystemTime};
 use serde::Deserialize;
 
 use super::backoff::{self, Backoff};
-use super::store::{self, StoredIdentity, StoredSession};
+use super::store::{self, Role, StoredIdentity, StoredOrg, StoredSession};
 use super::{avatar, AuthSnapshot};
 
 /// RFC 8628 `client_id` for this app, matching the server's device plugin.
@@ -252,9 +253,18 @@ impl AuthCore {
             }
         }
         match self.stored() {
-            Some(session) => AuthSnapshot::SignedIn {
-                user: session.identity.map(Into::into),
-            },
+            Some(session) => {
+                let identity = session.identity;
+                AuthSnapshot::SignedIn {
+                    orgs: identity.as_ref().and_then(|i| {
+                        i.orgs
+                            .as_ref()
+                            .map(|orgs| orgs.iter().cloned().map(Into::into).collect())
+                    }),
+                    active_org_id: identity.as_ref().and_then(StoredIdentity::active_org),
+                    user: identity.map(Into::into),
+                }
+            }
             None => AuthSnapshot::SignedOut,
         }
     }
@@ -267,8 +277,9 @@ impl AuthCore {
     /// `/get-session` expresses that as **200 with a `null` body**, not a 401
     /// (proven in ATL-44), so status alone would never see it. It is reported
     /// rather than classified: [`Self::validate_once`] takes its verdict from
-    /// `/token` instead, and this call only ever decides a name and a photo.
-    async fn fetch_profile(&self) -> Authed<Option<Profile>> {
+    /// `/token` instead, and this call only ever decides a name, a photo, and
+    /// which organisation was last made active.
+    async fn fetch_profile(&self) -> Authed<Option<SessionResponse>> {
         let res = self.authed_get("/get-session").await?;
 
         let body = res
@@ -280,28 +291,132 @@ impl AuthCore {
         }
         let session: SessionResponse = serde_json::from_str(&body)
             .map_err(|e| AuthFailure::indeterminate(format!("unreadable profile: {e}")))?;
-        Ok(Some(session.user))
+        Ok(Some(session))
     }
 
-    /// Pull the profile and write it onto the stored credential.
+    /// Every organisation the user belongs to, with the role they hold in each
+    /// (ATL-51).
+    ///
+    /// Two calls, because neither answers alone: `/organization/list` has the
+    /// names and no roles, and the access token's `orgs` claim has the roles
+    /// and no names.
+    ///
+    /// **A failed list keeps the one already stored.** Same rule as the avatar
+    /// cache and the credential itself: a call that never landed says nothing
+    /// about the user's membership, and trading a known-good list for an empty
+    /// one would empty the menu on every flaky launch — including the offline
+    /// one this snapshot exists to serve.
+    ///
+    /// That includes a 401 here, which does **not** clear the credential:
+    /// [`Self::validate_once`] takes its verdict from `/token` alone and has
+    /// already confirmed it by the time this runs, so a rejection arriving on
+    /// this call means the session died in between and the next validation is
+    /// what acts on it. Only one call in this module may destroy a credential.
+    ///
+    /// A 403 is not surfaced to the user either, deviating from the spec's
+    /// "DENIED → surface in context". There is no honest context to surface it
+    /// in: this runs unprompted on the launch path, the endpoint is
+    /// caller-scoped so a 403 on it indicates a server fault rather than
+    /// anything the user can act on, and a toast on every launch would be
+    /// noise. The section simply stays as it was, or absent — which is the
+    /// truthful rendering of "we do not know".
+    async fn resolve_orgs(
+        &self,
+        access_token: Option<String>,
+        previous: Option<&StoredIdentity>,
+    ) -> Option<Vec<StoredOrg>> {
+        let Ok(listed) = self.fetch_orgs().await else {
+            // `None` propagates when there was nothing stored either: still not
+            // known, which the menu renders as no section rather than as "no
+            // organisation".
+            return previous.and_then(|p| p.orgs.clone());
+        };
+
+        // An empty list is a *verdict*, not a failure — a user who has joined
+        // no organisation — so it is stored as-is and reaches the menu as the
+        // empty state.
+        let roles = match access_token {
+            Some(jwt) => org_roles(&jwt),
+            // Nothing minted one for us: this is the sign-in path, where the
+            // credential is seconds old and no validation has run yet. A failure
+            // costs the roles, never the names.
+            None => self
+                .mint_access_token()
+                .await
+                .ok()
+                .and_then(|jwt| org_roles(&jwt)),
+        };
+
+        Some(
+            listed
+                .into_iter()
+                .map(|org| StoredOrg {
+                    role: match &roles {
+                        // The claim was read. Absent from it means absent —
+                        // membership per the server, not a failure to look.
+                        Some(roles) => roles.get(&org.id).copied(),
+                        // The claim was never read at all. Downgrading a label
+                        // we already have would be the same mistake as trading
+                        // a known-good photo for initials over one timeout.
+                        None => previous.and_then(|p| p.role_of(&org.id)),
+                    },
+                    id: org.id,
+                    name: org.name,
+                })
+                .collect(),
+        )
+    }
+
+    /// `GET /organization/list` — the only source of organisation *names*.
+    ///
+    /// **One extra request per successful validation**, and one extra `/token`
+    /// mint on the sign-in path. Re-checked against the auth worker's global
+    /// ceiling of 100 requests per 60s, as the spec requires of anyone changing
+    /// the request count: the retry path is untouched, because
+    /// [`Self::validate_once`] only loops when `/token` itself fails and
+    /// [`Self::refresh_identity`] never runs on the backoff schedule. A
+    /// successful validation costs 3 requests and happens about once a launch.
+    async fn fetch_orgs(&self) -> Authed<Vec<OrgEntry>> {
+        let res = self.authed_get("/organization/list").await?;
+        res.json::<Vec<OrgEntry>>()
+            .await
+            .map_err(|e| AuthFailure::indeterminate(format!("unreadable organisations: {e}")))
+    }
+
+    /// Pull the profile and organisations and write them onto the stored
+    /// credential.
     ///
     /// Silent about every failure on purpose: this runs on the boot path behind
-    /// an already-rendered signed-in title bar, and a photo or a stale display
-    /// name is never worth a toast, let alone touching the credential.
+    /// an already-rendered signed-in title bar, and a photo, a stale display
+    /// name, or a stale role is never worth a toast, let alone touching the
+    /// credential.
     ///
-    /// `previous` is the identity being replaced — it supplies the avatar cache
-    /// key, and is what lets an unchanged photo cost zero requests.
-    async fn refresh_identity(&self, previous: Option<StoredIdentity>) {
-        let Ok(Some(profile)) = self.fetch_profile().await else {
+    /// `previous` is the identity being replaced. It supplies the avatar cache
+    /// key — what lets an unchanged photo cost zero requests — and is also what
+    /// every fallback in [`Self::resolve_orgs`] falls back *to*.
+    ///
+    /// `access_token` is a JWT the caller has *already* minted, so the common
+    /// path costs no second mint: [`Self::validate_once`] takes its verdict from
+    /// one and would otherwise throw it away.
+    async fn refresh_identity(
+        &self,
+        previous: Option<StoredIdentity>,
+        access_token: Option<String>,
+    ) {
+        let Ok(Some(session)) = self.fetch_profile().await else {
             return;
         };
+        let profile = session.user;
         let held = previous
-            .map(|p| avatar::CachedAvatar::new(p.avatar_url, p.avatar_path))
+            .as_ref()
+            .map(|p| avatar::CachedAvatar::new(p.avatar_url.clone(), p.avatar_path.clone()))
             .unwrap_or_default();
         // Writes back the *pair* — a failed fetch returns the previous one
         // untouched, so a blip never trades a known-good photo for initials.
         let avatar =
             avatar::resolve(&self.http, &self.dir, profile.image.as_deref(), &held).await;
+
+        let orgs = self.resolve_orgs(access_token, previous.as_ref()).await;
 
         // Re-read *after* the network work rather than reusing an earlier load,
         // and after the photo rather than before it: both calls above are round
@@ -323,6 +438,8 @@ impl AuthCore {
                     email: profile.email,
                     avatar_url: avatar.url,
                     avatar_path: avatar.path,
+                    orgs,
+                    active_org_id: session.session.active_organization_id,
                 }),
                 ..current
             },
@@ -465,7 +582,10 @@ impl AuthCore {
                     // The alternative flashes a nameless signed-in title bar on
                     // every sign-in to save a few hundred milliseconds behind a
                     // spinner the user is already watching.
-                    self.refresh_identity(previous).await;
+                    //
+                    // `None`: nothing has minted an access token yet on this
+                    // path, so the roles cost one of their own.
+                    self.refresh_identity(previous, None).await;
                     return Ok(());
                 }
                 PollOutcome::Pending | PollOutcome::Transient => continue,
@@ -572,13 +692,17 @@ impl AuthCore {
         };
 
         match self.mint_access_token().await {
-            Ok(_) => {
-                // Every successful validation refreshes the snapshot, so a name
-                // or photo changed on the web reaches the desktop without a
-                // re-sign-in. It runs only after the credential is confirmed —
+            Ok(jwt) => {
+                // Every successful validation refreshes the snapshot, so a name,
+                // photo, or role changed on the web reaches the desktop without
+                // a re-sign-in. It runs only after the credential is confirmed —
                 // there is no point fetching a profile we may be about to
                 // discard, and a failure here must never reach the credential.
-                self.refresh_identity(current.identity).await;
+                //
+                // The JWT is handed on rather than dropped: it is the only
+                // source of per-organisation roles, and this call already paid
+                // for it.
+                self.refresh_identity(current.identity, Some(jwt)).await;
                 Validation::Confirmed
             }
             Err(AuthFailure::NoCredential) => Validation::NoCredential,
@@ -638,8 +762,11 @@ impl AuthCore {
     /// here pretends otherwise: [`Self::snapshot`] is derived from the file, so
     /// the state the caller broadcasts next is whatever is really on disk.
     ///
-    /// There is no in-memory access token to clear yet; minting is currently
-    /// lazy and uncached. Whatever ATL-51 adds to hold one belongs here.
+    /// There is still no in-memory access token to clear. ATL-51 added none:
+    /// the JWT it needs for the `orgs` claim is minted, read, and dropped inside
+    /// a single call, and nothing else in the desktop consumes one. A cache
+    /// would buy nothing and would be one more thing this function had to
+    /// remember to clear.
     pub fn sign_out(&self) -> Option<RevocationTicket> {
         let stored = self.stored();
         // Before the credential, not after: the identity is where the path to
@@ -718,11 +845,79 @@ struct DeviceTokenSuccess {
     access_token: String,
 }
 
-/// `GET /get-session`. The session half is ignored — expiry is the server's
-/// business, and nothing here is improved by a second opinion on it.
+/// `GET /get-session`.
 #[derive(Deserialize)]
 struct SessionResponse {
+    /// `default` so a body without one still yields a profile. Expiry is
+    /// deliberately still ignored — it is the server's business, and nothing
+    /// here is improved by a second opinion on it.
+    #[serde(default)]
+    session: SessionMeta,
     user: Profile,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct SessionMeta {
+    /// Which organisation the user last made active, or `None` — which is the
+    /// normal state for a device-granted session, since only the web ever calls
+    /// `/organization/set-active`. [`active_org`] is what copes with that.
+    #[serde(default)]
+    active_organization_id: Option<String>,
+}
+
+/// One entry of `GET /organization/list`. Slug, logo, and timestamps are
+/// deliberately not read: the menu renders a name, and ATL-36 owns the rest.
+#[derive(Deserialize)]
+struct OrgEntry {
+    id: String,
+    name: String,
+}
+
+/// The `orgs` claim — `{ organisationId: role }` — off an access token.
+///
+/// **The signature is deliberately not verified.** We minted this token
+/// ourselves, over TLS, from the issuer, seconds ago; JWKS verification exists
+/// for parties receiving tokens from untrusted sources, and checking our own
+/// proves nothing it did not already know. The claims are used only to label a
+/// row in a menu — nothing here authorises anything (spec, "Deviations from the
+/// API doc", §5.2).
+///
+/// `None` for a token that could not be read at all — the same "we learned
+/// nothing" the rest of the module turns on, kept distinct from `Some({})`,
+/// which is the server genuinely placing the user in no organisation (API doc
+/// §5.1: "`orgs` is `{}` until the user belongs to an Organisation"). Only the
+/// caller can tell what to do with the difference, and it does: an unread claim
+/// keeps the roles already known, an empty one clears them.
+///
+/// Never an error, and never a reason to doubt the credential — nothing here
+/// authorises anything.
+fn org_roles(jwt: &str) -> Option<HashMap<String, Role>> {
+    use base64::Engine;
+
+    #[derive(Deserialize)]
+    struct Claims {
+        #[serde(default)]
+        orgs: HashMap<String, String>,
+    }
+
+    let payload = jwt.split('.').nth(1)?;
+    // JWTs are base64**url** with the padding stripped, which the standard
+    // alphabet decodes into garbage rather than rejecting.
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims = serde_json::from_slice::<Claims>(&bytes).ok()?;
+
+    Some(
+        claims
+            .orgs
+            .into_iter()
+            // A role this build does not know is dropped, leaving its
+            // organisation role-less rather than absent.
+            .filter_map(|(id, role)| Role::from_claim(&role).map(|role| (id, role)))
+            .collect(),
+    )
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, SystemTime};
 
 use serde::Deserialize;
 
+use super::backoff::{self, Backoff};
 use super::store::{self, StoredIdentity, StoredSession};
 use super::{avatar, AuthSnapshot};
 
@@ -87,6 +88,72 @@ impl GrantError {
     }
 }
 
+/// Why an authenticated call produced no value (ATL-48).
+///
+/// This is the failure classification the whole module turns on, and the reason
+/// it is an enum rather than a `String`: a caller that cannot see the class
+/// cannot avoid the mistake this ticket exists to prevent, which is treating
+/// "the server never answered" as "the server said no". **Only [`Rejected`] may
+/// ever clear the credential.**
+///
+/// [`Rejected`]: AuthFailure::Rejected
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthFailure {
+    /// Nothing stored to authenticate with. Not a failure — there was simply
+    /// nothing to ask about, and no request was made.
+    NoCredential,
+    /// **AUTHORITATIVE (401).** The server looked at the credential and
+    /// rejected it. The session is dead and no amount of retrying revives it.
+    Rejected,
+    /// **DENIED (403).** The credential is valid; this particular action is
+    /// not permitted. Neither sign out nor retry.
+    ///
+    /// Every other unexpected 4xx joins this class rather than earning a fourth
+    /// one: a 400 or a 404 is not a verdict on the credential either, and
+    /// repeating the request will not change it — which is exactly how this
+    /// class is handled.
+    Denied,
+    /// **INDETERMINATE.** Transport failure, timeout, DNS failure, 5xx, or 429.
+    /// We learned *nothing* about the credential, so everything is preserved
+    /// and the call is retried on the schedule in [`super::backoff`].
+    Indeterminate {
+        /// From the response's `Retry-After`, when the server supplied one.
+        retry_after: Option<Duration>,
+        /// For logs. Carries no URL and no token — see [`redact`].
+        reason: String,
+    },
+}
+
+impl AuthFailure {
+    fn indeterminate(reason: impl Into<String>) -> Self {
+        AuthFailure::Indeterminate {
+            retry_after: None,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// An authenticated call: a value, or a classified failure.
+pub type Authed<T> = Result<T, AuthFailure>;
+
+/// What one validation of the stored credential settled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Validation {
+    /// Nothing stored. Signed out, and no network call was made.
+    NoCredential,
+    /// The server accepted the credential; the identity snapshot was refreshed.
+    Confirmed,
+    /// **401.** The credential and its snapshot have been cleared.
+    Rejected,
+    /// **403.** Nothing was changed and nothing will be retried.
+    Denied,
+    /// We learned nothing. Everything is preserved; the caller retries.
+    Indeterminate {
+        /// Honoured by the backoff when present — see [`Backoff::next_after`].
+        retry_after: Option<Duration>,
+    },
+}
+
 /// The auth module's whole public surface.
 pub struct AuthCore {
     base: String,
@@ -96,6 +163,10 @@ pub struct AuthCore {
     /// competing codes, and is what makes a second click *resume* rather than
     /// restart — the recovery path for someone who got lost mid-flow.
     pending: Mutex<Option<PendingGrant>>,
+    /// First retry delay for [`Self::revalidate`]. A field only so tests can
+    /// exercise the loop without sleeping through a real schedule; production
+    /// always uses [`backoff::BASE`].
+    backoff_base: Duration,
 }
 
 impl AuthCore {
@@ -105,7 +176,17 @@ impl AuthCore {
             dir: dir.into(),
             http,
             pending: Mutex::new(None),
+            backoff_base: backoff::BASE,
         }
+    }
+
+    /// Shrink the retry schedule so a test can drive the loop through several
+    /// failures in milliseconds. Absent from the shipped binary by
+    /// construction, so no production path can reach for it.
+    #[cfg(test)]
+    pub fn with_backoff_base(mut self, base: Duration) -> Self {
+        self.backoff_base = base;
+        self
     }
 
     fn url(&self, path: &str) -> String {
@@ -163,18 +244,21 @@ impl AuthCore {
     ///
     /// `Ok(None)` is the server saying nobody is signed in — note that
     /// `/get-session` expresses that as **200 with a `null` body**, not a 401
-    /// (proven in ATL-44), so status alone would never see it.
-    async fn fetch_profile(&self) -> Result<Option<Profile>, String> {
-        let Some(res) = self.authed_get("/get-session").await? else {
-            return Ok(None);
-        };
+    /// (proven in ATL-44), so status alone would never see it. It is reported
+    /// rather than classified: [`Self::validate_once`] takes its verdict from
+    /// `/token` instead, and this call only ever decides a name and a photo.
+    async fn fetch_profile(&self) -> Authed<Option<Profile>> {
+        let res = self.authed_get("/get-session").await?;
 
-        let body = res.text().await.map_err(|e| redact(&e.to_string()))?;
+        let body = res
+            .text()
+            .await
+            .map_err(|e| AuthFailure::indeterminate(redact(&e.to_string())))?;
         if body.trim().is_empty() || body.trim() == "null" {
             return Ok(None);
         }
         let session: SessionResponse = serde_json::from_str(&body)
-            .map_err(|e| format!("unreadable profile: {e}"))?;
+            .map_err(|e| AuthFailure::indeterminate(format!("unreadable profile: {e}")))?;
         Ok(Some(session.user))
     }
 
@@ -387,70 +471,140 @@ impl AuthCore {
 
     /// A GET carrying the stored session token as a Bearer.
     ///
-    /// Every authenticated call goes through here so the distinction the whole
-    /// module turns on is written **once**: `Ok(None)` is the server looking at
-    /// the credential and rejecting it, `Err` is us never finding out. Conflating
-    /// them is what signs people out for opening a laptop on a plane, and ATL-48
-    /// builds its retry policy directly on the split.
-    async fn authed_get(&self, path: &str) -> Result<Option<reqwest::Response>, String> {
+    /// **This is the only place a response is classified**, so the distinction
+    /// the whole module turns on is written once rather than per endpoint:
+    /// [`AuthFailure::Rejected`] is the server looking at the credential and
+    /// refusing it, [`AuthFailure::Indeterminate`] is us never finding out.
+    /// Conflating them is what signs people out for opening a laptop on a plane.
+    async fn authed_get(&self, path: &str) -> Authed<reqwest::Response> {
         let Some(stored) = self.stored() else {
-            return Ok(None);
+            return Err(AuthFailure::NoCredential);
         };
 
-        let res = self
+        let res = match self
             .http
             .get(self.url(path))
             .bearer_auth(&stored.session_token)
             .timeout(AUTHED_TIMEOUT)
             .send()
             .await
-            .map_err(|e| redact(&e.to_string()))?;
+        {
+            Ok(res) => res,
+            // Refused, timed out, DNS gone, TLS failed — the request never got
+            // an answer, so it says nothing whatsoever about the credential.
+            // This branch is the entire reason the class exists.
+            Err(e) => return Err(AuthFailure::indeterminate(redact(&e.to_string()))),
+        };
 
-        if res.status() == reqwest::StatusCode::UNAUTHORIZED {
-            return Ok(None);
+        let status = res.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(AuthFailure::Rejected);
         }
-        if !res.status().is_success() {
-            // The path, never the response body: an error body from an auth
-            // server is the one place a token could plausibly be echoed back.
-            return Err(format!("{path} failed: {}", res.status()));
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+            return Err(AuthFailure::Indeterminate {
+                retry_after: retry_after(res.headers()),
+                // The path and the status, never the response body: an error
+                // body from an auth server is the one place a token could
+                // plausibly be echoed back.
+                reason: format!("{path} failed: {status}"),
+            });
         }
-        Ok(Some(res))
+        if !status.is_success() {
+            return Err(AuthFailure::Denied);
+        }
+        Ok(res)
     }
 
     /// Mint a short-TTL access JWT from the stored session token.
-    pub async fn mint_access_token(&self) -> Result<Option<String>, String> {
-        let Some(res) = self.authed_get("/token").await? else {
-            return Ok(None);
-        };
+    pub async fn mint_access_token(&self) -> Authed<String> {
+        let res = self.authed_get("/token").await?;
 
         #[derive(Deserialize)]
         struct TokenResponse {
             token: String,
         }
-        let body: TokenResponse = res.json().await.map_err(|e| e.to_string())?;
-        Ok(Some(body.token))
+        // A 200 we cannot read is not a verdict on the credential either — the
+        // server answered, but not with anything that proves or disproves it.
+        let body: TokenResponse = res
+            .json()
+            .await
+            .map_err(|e| AuthFailure::indeterminate(format!("unreadable token: {e}")))?;
+        Ok(body.token)
     }
 
-    /// Boot check.
+    /// Check the stored credential against the server, once.
     ///
-    /// **Preserves the credential on every failure, including 401.** ATL-48
-    /// introduces the authoritative-401-signs-you-out rule; until it lands the
-    /// safe default is to keep a credential we are unsure about. The worst case
-    /// here is a stale signed-in state, never a destroyed valid session — which
-    /// is the right way round if that ticket slips.
-    pub async fn validate_stored(&self) -> AuthSnapshot {
+    /// The verdict is taken from `/token`, not from `/get-session`. Both answer
+    /// for a dead session, but `/get-session` expresses it as **200 with a
+    /// `null` body** (ATL-44) — a far weaker signal than a status code, and one
+    /// an unrelated serialisation change could start emitting by accident. A
+    /// misread here destroys a valid credential, so the reading that carries
+    /// that power is the unambiguous one.
+    pub async fn validate_once(&self) -> Validation {
         let Some(current) = self.stored() else {
-            return AuthSnapshot::SignedOut;
+            return Validation::NoCredential;
         };
-        let _ = self.mint_access_token().await;
-        // Every successful validation refreshes the snapshot, so a name or photo
-        // changed on the web reaches the desktop without a re-sign-in. A failed
-        // one leaves the last-known identity in place — which is the whole point
-        // of persisting it, and is what makes an offline launch render a
-        // complete title bar rather than a nameless one.
-        self.refresh_identity(current.identity).await;
-        self.snapshot()
+
+        match self.mint_access_token().await {
+            Ok(_) => {
+                // Every successful validation refreshes the snapshot, so a name
+                // or photo changed on the web reaches the desktop without a
+                // re-sign-in. It runs only after the credential is confirmed —
+                // there is no point fetching a profile we may be about to
+                // discard, and a failure here must never reach the credential.
+                self.refresh_identity(current.identity).await;
+                Validation::Confirmed
+            }
+            Err(AuthFailure::NoCredential) => Validation::NoCredential,
+            // The one branch permitted to destroy a credential.
+            Err(AuthFailure::Rejected) => {
+                let _ = self.clear_session();
+                Validation::Rejected
+            }
+            Err(AuthFailure::Denied) => Validation::Denied,
+            Err(AuthFailure::Indeterminate { retry_after, .. }) => {
+                // Deliberately touches nothing. The stored snapshot is what
+                // renders a complete signed-in title bar on a plane.
+                Validation::Indeterminate { retry_after }
+            }
+        }
     }
+
+    /// Validate at launch and keep trying until the answer means something.
+    ///
+    /// Indeterminate failures retry on the backoff schedule with **no attempt
+    /// limit**, for as long as this task lives: someone offline for six hours
+    /// is signed in the moment they reconnect, without restarting Atlas.
+    ///
+    /// `on_settled` fires exactly once, with the resulting snapshot. Nothing is
+    /// emitted between attempts — by design. The signed-in state has no
+    /// "verifying" variant, because a spinner or a warning in the title bar
+    /// every time a laptop lid opens only teaches people to ignore it.
+    pub async fn revalidate(&self, on_settled: impl FnOnce(AuthSnapshot)) -> Validation {
+        let mut backoff = Backoff::new(self.backoff_base, backoff::CEILING);
+
+        loop {
+            match self.validate_once().await {
+                Validation::Indeterminate { retry_after } => {
+                    tokio::time::sleep(backoff.next_after(retry_after)).await;
+                }
+                settled => {
+                    on_settled(self.snapshot());
+                    return settled;
+                }
+            }
+        }
+    }
+}
+
+/// `Retry-After` as delta-seconds.
+///
+/// The HTTP-date form is not parsed: the auth worker sends seconds, and a date
+/// read against a skewed local clock is worse than the backoff we already have
+/// waiting behind it.
+fn retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    Some(Duration::from_secs(raw.trim().parse().ok()?))
 }
 
 /// Strip anything that could carry a credential out of an error string before

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -154,6 +154,27 @@ pub enum Validation {
     },
 }
 
+/// The credential a completed sign-out has already cleared, kept just long
+/// enough to tell the server about it (ATL-50).
+///
+/// The ordering the ticket exists for is written as a type rather than a
+/// comment: the only way to obtain one is to have *already* cleared the local
+/// state, so no caller can revoke first and clear second — the mistake that
+/// makes sign-out fail exactly when someone closing a borrowed laptop most
+/// needs it to work. [`AuthCore::revoke`] then consumes it, so "fired once and
+/// forgotten" is not a discipline anyone has to keep either: there is no second
+/// ticket to retry with.
+pub struct RevocationTicket(String);
+
+impl std::fmt::Debug for RevocationTicket {
+    /// Hand-written because this is the one type here whose entire content is a
+    /// credential; a derived `Debug` would put the user's session into any log
+    /// line that ever formatted a struct holding one.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RevocationTicket(<redacted>)")
+    }
+}
+
 /// The auth module's whole public surface.
 pub struct AuthCore {
     base: String,
@@ -274,12 +295,6 @@ impl AuthCore {
         let Ok(Some(profile)) = self.fetch_profile().await else {
             return;
         };
-        // Re-read rather than reusing an earlier load: the profile call is a
-        // network round trip, and a sign-out during it must not be undone here.
-        let Some(current) = self.stored() else {
-            return;
-        };
-
         let held = previous
             .map(|p| avatar::CachedAvatar::new(p.avatar_url, p.avatar_path))
             .unwrap_or_default();
@@ -287,6 +302,17 @@ impl AuthCore {
         // untouched, so a blip never trades a known-good photo for initials.
         let avatar =
             avatar::resolve(&self.http, &self.dir, profile.image.as_deref(), &held).await;
+
+        // Re-read *after* the network work rather than reusing an earlier load,
+        // and after the photo rather than before it: both calls above are round
+        // trips, and a sign-out landing in either must not be undone by the
+        // write below — a resurrected credential file would sign the user
+        // straight back in on the next launch. A photo fetched into that gap
+        // goes with it, since nothing will ever point at it again.
+        let Some(current) = self.stored() else {
+            avatar::discard(avatar.path.as_deref());
+            return;
+        };
 
         let _ = store::save(
             &self.dir,
@@ -593,6 +619,66 @@ impl AuthCore {
                     return settled;
                 }
             }
+        }
+    }
+
+    // ---- sign-out --------------------------------------------------------
+
+    /// Sign out of this device. Touches nothing but local state, and cannot
+    /// fail (ATL-50).
+    ///
+    /// The credential, the identity snapshot, and the cached photo all go
+    /// first and unconditionally — no network call gates any of it, which is
+    /// what makes signing out work with the wifi off. The returned ticket is
+    /// the only way to reach [`Self::revoke`], and it is `None` when there was
+    /// nothing stored: already signed out is a success with nothing to tell the
+    /// server about.
+    ///
+    /// If the unlink itself somehow fails — a read-only config dir — nothing
+    /// here pretends otherwise: [`Self::snapshot`] is derived from the file, so
+    /// the state the caller broadcasts next is whatever is really on disk.
+    ///
+    /// There is no in-memory access token to clear yet; minting is currently
+    /// lazy and uncached. Whatever ATL-51 adds to hold one belongs here.
+    pub fn sign_out(&self) -> Option<RevocationTicket> {
+        let stored = self.stored();
+        // Before the credential, not after: the identity is where the path to
+        // the cached photo is recorded, so clearing the file first would leave
+        // a face on disk with nothing left pointing at it.
+        if let Some(identity) = stored.as_ref().and_then(|s| s.identity.as_ref()) {
+            avatar::discard(identity.avatar_path.as_deref());
+        }
+        let _ = self.clear_session();
+        stored.map(|s| RevocationTicket(s.session_token))
+    }
+
+    /// Tell the server the session is over. Best-effort, fired **once**.
+    ///
+    /// Deliberately outside [`Self::authed_get`] and the retry policy it feeds:
+    /// the credential arrives on the ticket because the store is already empty
+    /// by the time this runs, and there is nothing left for a backoff schedule
+    /// to protect. A failure costs a residual server session that expires on
+    /// its own — which the user is told about, rather than retried at.
+    ///
+    /// `true` when the session is definitely gone server-side.
+    pub async fn revoke(&self, ticket: RevocationTicket) -> bool {
+        let res = self
+            .http
+            .post(self.url("/sign-out"))
+            .bearer_auth(&ticket.0)
+            .json(&serde_json::json!({}))
+            .timeout(AUTHED_TIMEOUT)
+            .send()
+            .await;
+
+        match res {
+            // A 401 is the server saying it does not recognise this credential,
+            // so there is no live session left to caveat. Every other refusal
+            // is counted as a failure: we cannot tell whether it ended.
+            Ok(res) => {
+                res.status().is_success() || res.status() == reqwest::StatusCode::UNAUTHORIZED
+            }
+            Err(_) => false,
         }
     }
 }

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -1,4 +1,4 @@
-//! The device grant, the poll loop, and credential lifecycle.
+//! The device grant, the poll loop, and the credential and identity lifecycle.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -7,8 +7,8 @@ use std::time::{Duration, SystemTime};
 
 use serde::Deserialize;
 
-use super::store::{self, StoredSession};
-use super::AuthSnapshot;
+use super::store::{self, StoredIdentity, StoredSession};
+use super::{avatar, AuthSnapshot};
 
 /// RFC 8628 `client_id` for this app, matching the server's device plugin.
 const CLIENT_ID: &str = "atlas-desktop";
@@ -17,6 +17,13 @@ const DEVICE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
 /// Floor on the poll interval so a misbehaving or hostile server cannot make us
 /// hammer it. The server normally says 5s.
 const MIN_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Ceiling on an authenticated call. The shared `reqwest::Client` carries no
+/// default, and one of these sits on the sign-in path between approval and the
+/// dialog closing: a server that accepts the connection and then never answers
+/// would otherwise leave "Continue in your browser…" on screen forever, long
+/// after the credential was safely written.
+const AUTHED_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A grant awaiting approval in the browser.
 #[derive(Debug, Clone)]
@@ -115,12 +122,18 @@ impl AuthCore {
         store::clear(&self.dir)
     }
 
+    /// Write a freshly granted credential, deliberately with **no identity**.
+    ///
+    /// A new grant can be a different person, so carrying the old snapshot over
+    /// would show one user another user's name until the profile call returned.
+    /// [`Self::refresh_identity`] fills it in a moment later.
     fn persist(&self, session_token: &str) -> Result<(), String> {
         store::save(
             &self.dir,
             &StoredSession {
                 session_token: session_token.to_string(),
                 saved_at: chrono::Utc::now().to_rfc3339(),
+                identity: None,
             },
         )
     }
@@ -136,11 +149,74 @@ impl AuthCore {
                 };
             }
         }
-        if self.stored().is_some() {
-            AuthSnapshot::SignedIn
-        } else {
-            AuthSnapshot::SignedOut
+        match self.stored() {
+            Some(session) => AuthSnapshot::SignedIn {
+                user: session.identity.map(Into::into),
+            },
+            None => AuthSnapshot::SignedOut,
         }
+    }
+
+    // ---- identity --------------------------------------------------------
+
+    /// Read the signed-in user from the server.
+    ///
+    /// `Ok(None)` is the server saying nobody is signed in — note that
+    /// `/get-session` expresses that as **200 with a `null` body**, not a 401
+    /// (proven in ATL-44), so status alone would never see it.
+    async fn fetch_profile(&self) -> Result<Option<Profile>, String> {
+        let Some(res) = self.authed_get("/get-session").await? else {
+            return Ok(None);
+        };
+
+        let body = res.text().await.map_err(|e| redact(&e.to_string()))?;
+        if body.trim().is_empty() || body.trim() == "null" {
+            return Ok(None);
+        }
+        let session: SessionResponse = serde_json::from_str(&body)
+            .map_err(|e| format!("unreadable profile: {e}"))?;
+        Ok(Some(session.user))
+    }
+
+    /// Pull the profile and write it onto the stored credential.
+    ///
+    /// Silent about every failure on purpose: this runs on the boot path behind
+    /// an already-rendered signed-in title bar, and a photo or a stale display
+    /// name is never worth a toast, let alone touching the credential.
+    ///
+    /// `previous` is the identity being replaced — it supplies the avatar cache
+    /// key, and is what lets an unchanged photo cost zero requests.
+    async fn refresh_identity(&self, previous: Option<StoredIdentity>) {
+        let Ok(Some(profile)) = self.fetch_profile().await else {
+            return;
+        };
+        // Re-read rather than reusing an earlier load: the profile call is a
+        // network round trip, and a sign-out during it must not be undone here.
+        let Some(current) = self.stored() else {
+            return;
+        };
+
+        let held = previous
+            .map(|p| avatar::CachedAvatar::new(p.avatar_url, p.avatar_path))
+            .unwrap_or_default();
+        // Writes back the *pair* — a failed fetch returns the previous one
+        // untouched, so a blip never trades a known-good photo for initials.
+        let avatar =
+            avatar::resolve(&self.http, &self.dir, profile.image.as_deref(), &held).await;
+
+        let _ = store::save(
+            &self.dir,
+            &StoredSession {
+                identity: Some(StoredIdentity {
+                    id: profile.id,
+                    name: profile.name,
+                    email: profile.email,
+                    avatar_url: avatar.url,
+                    avatar_path: avatar.path,
+                }),
+                ..current
+            },
+        );
     }
 
     // ---- device grant --------------------------------------------------
@@ -268,8 +344,18 @@ impl AuthCore {
 
             match self.poll_once(&grant.device_code).await {
                 PollOutcome::Token(token) => {
+                    // Captured before the write: a new grant may be a different
+                    // person, and this is what lets the avatar cache prune the
+                    // previous user's photo and skip a re-fetch for the same.
+                    let previous = self.stored().and_then(|s| s.identity);
                     self.persist(&token).map_err(GrantError::Start)?;
                     self.finish();
+                    // Inline rather than spawned, so the single state broadcast
+                    // the caller emits already carries the user's name and face.
+                    // The alternative flashes a nameless signed-in title bar on
+                    // every sign-in to save a few hundred milliseconds behind a
+                    // spinner the user is already watching.
+                    self.refresh_identity(previous).await;
                     return Ok(());
                 }
                 PollOutcome::Pending | PollOutcome::Transient => continue,
@@ -299,20 +385,23 @@ impl AuthCore {
 
     // ---- token ----------------------------------------------------------
 
-    /// Mint a short-TTL access JWT from the stored session token.
+    /// A GET carrying the stored session token as a Bearer.
     ///
-    /// `Ok(None)` means the server authoritatively rejected the credential
-    /// (401). `Err` means we could not find out — the caller must treat those
-    /// completely differently, which is what ATL-48 formalises.
-    pub async fn mint_access_token(&self) -> Result<Option<String>, String> {
+    /// Every authenticated call goes through here so the distinction the whole
+    /// module turns on is written **once**: `Ok(None)` is the server looking at
+    /// the credential and rejecting it, `Err` is us never finding out. Conflating
+    /// them is what signs people out for opening a laptop on a plane, and ATL-48
+    /// builds its retry policy directly on the split.
+    async fn authed_get(&self, path: &str) -> Result<Option<reqwest::Response>, String> {
         let Some(stored) = self.stored() else {
             return Ok(None);
         };
 
         let res = self
             .http
-            .get(self.url("/token"))
+            .get(self.url(path))
             .bearer_auth(&stored.session_token)
+            .timeout(AUTHED_TIMEOUT)
             .send()
             .await
             .map_err(|e| redact(&e.to_string()))?;
@@ -321,8 +410,18 @@ impl AuthCore {
             return Ok(None);
         }
         if !res.status().is_success() {
-            return Err(format!("token mint failed: {}", res.status()));
+            // The path, never the response body: an error body from an auth
+            // server is the one place a token could plausibly be echoed back.
+            return Err(format!("{path} failed: {}", res.status()));
         }
+        Ok(Some(res))
+    }
+
+    /// Mint a short-TTL access JWT from the stored session token.
+    pub async fn mint_access_token(&self) -> Result<Option<String>, String> {
+        let Some(res) = self.authed_get("/token").await? else {
+            return Ok(None);
+        };
 
         #[derive(Deserialize)]
         struct TokenResponse {
@@ -340,11 +439,17 @@ impl AuthCore {
     /// here is a stale signed-in state, never a destroyed valid session — which
     /// is the right way round if that ticket slips.
     pub async fn validate_stored(&self) -> AuthSnapshot {
-        if self.stored().is_none() {
+        let Some(current) = self.stored() else {
             return AuthSnapshot::SignedOut;
-        }
+        };
         let _ = self.mint_access_token().await;
-        AuthSnapshot::SignedIn
+        // Every successful validation refreshes the snapshot, so a name or photo
+        // changed on the web reaches the desktop without a re-sign-in. A failed
+        // one leaves the last-known identity in place — which is the whole point
+        // of persisting it, and is what makes an offline launch render a
+        // complete title bar rather than a nameless one.
+        self.refresh_identity(current.identity).await;
+        self.snapshot()
     }
 }
 
@@ -371,6 +476,22 @@ struct DeviceCodeResponse {
 #[derive(Deserialize)]
 struct DeviceTokenSuccess {
     access_token: String,
+}
+
+/// `GET /get-session`. The session half is ignored — expiry is the server's
+/// business, and nothing here is improved by a second opinion on it.
+#[derive(Deserialize)]
+struct SessionResponse {
+    user: Profile,
+}
+
+#[derive(Deserialize)]
+struct Profile {
+    id: String,
+    name: String,
+    email: String,
+    /// The provider photo URL. Absent for a user who set none.
+    image: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -31,10 +31,11 @@ mod store;
 
 pub use config::auth_base;
 pub use core::{AuthCore, GrantError, Validation};
+pub use store::Role;
 
 use serde::Serialize;
 
-use store::StoredIdentity;
+use store::{StoredIdentity, StoredOrg};
 
 /// Who is signed in, as the frontend sees them.
 ///
@@ -60,6 +61,30 @@ impl From<StoredIdentity> for AccountUser {
             name: id.name,
             email: id.email,
             avatar_path: id.avatar_path,
+        }
+    }
+}
+
+/// One organisation the account belongs to, as the frontend sees it (ATL-51).
+///
+/// Read-only here by design: switching and creating belong to ATL-36, which
+/// owns the whole organisation data layer. This carries what is already true.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountOrg {
+    pub id: String,
+    pub name: String,
+    /// `None` when the access token's `orgs` claim did not place the user in
+    /// this organisation, or named a role this build does not know.
+    pub role: Option<Role>,
+}
+
+impl From<StoredOrg> for AccountOrg {
+    fn from(org: StoredOrg) -> Self {
+        Self {
+            id: org.id,
+            name: org.name,
+            role: org.role,
         }
     }
 }
@@ -98,6 +123,21 @@ pub enum AuthSnapshot {
         /// successful validation fills it in. Signed-in-but-nameless is a far
         /// better outcome than discarding a valid credential over a photo.
         user: Option<AccountUser>,
+        /// Every organisation the user belongs to (ATL-51).
+        ///
+        /// Alongside `user` rather than inside it, matching the spec's
+        /// `AuthState`: the two are refreshed together but neither implies the
+        /// other, and nesting would make the no-profile window lose the
+        /// organisations as well.
+        ///
+        /// `Some([])` is "belongs to none" and gets the deliberate empty state.
+        /// `None` is "not known yet" and gets no section at all — see
+        /// [`StoredIdentity::orgs`] for why the two must not be collapsed.
+        orgs: Option<Vec<AccountOrg>>,
+        /// Which of `orgs` this device is acting for, already resolved — see
+        /// [`StoredIdentity::active_org`]. `None` whenever `orgs` is empty or
+        /// not yet known.
+        active_org_id: Option<String>,
     },
 }
 

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -12,6 +12,11 @@
 //! client, the real poll loop, and the real file I/O. The Tauri commands in
 //! `commands::auth` are thin adapters that translate and emit events.
 //!
+//! Every authenticated call is classified before anything acts on it — see
+//! [`AuthFailure`](core::AuthFailure) for the rule and [`backoff`] for what
+//! happens to the failures that told us nothing. The short version: a 401 is
+//! the only thing in this module that may ever destroy a credential.
+//!
 //! **Token material never leaves this module.** The session token is the user's
 //! whole account, and the renderer runs with no CSP while displaying
 //! agent-authored markdown, so neither the session token nor the access JWT is
@@ -19,12 +24,13 @@
 //! which carries no credentials. Nothing here logs a token or a device code.
 
 mod avatar;
+mod backoff;
 mod config;
 mod core;
 mod store;
 
 pub use config::auth_base;
-pub use core::{AuthCore, GrantError};
+pub use core::{AuthCore, GrantError, Validation};
 
 use serde::Serialize;
 

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -1,0 +1,60 @@
+//! Atlas account authentication (ATL-35).
+//!
+//! The desktop is an untrusted OAuth client: it has no cookie and no redirect
+//! URI, so it connects via the **OAuth 2.0 Device Authorization Grant**
+//! (RFC 8628) — show a code, let the human approve it in a real browser, poll
+//! for the result. See `docs/api/atlas-auth-api.md` §7 in the server repo.
+//!
+//! Everything here is deliberately free of Tauri types. The whole module is
+//! driven through [`AuthCore`], constructed from an auth base URL, a config
+//! directory, and an HTTP client — which is what lets the tests point it at a
+//! stub server on loopback with a temporary directory and exercise the real
+//! client, the real poll loop, and the real file I/O. The Tauri commands in
+//! `commands::auth` are thin adapters that translate and emit events.
+//!
+//! **Token material never leaves this module.** The session token is the user's
+//! whole account, and the renderer runs with no CSP while displaying
+//! agent-authored markdown, so neither the session token nor the access JWT is
+//! ever handed across the IPC boundary — the frontend receives [`AuthSnapshot`],
+//! which carries no credentials. Nothing here logs a token or a device code.
+
+mod config;
+mod core;
+mod store;
+
+pub use config::auth_base;
+pub use core::{AuthCore, GrantError};
+
+use serde::Serialize;
+
+/// What the frontend is allowed to know about the account.
+///
+/// Deliberately carries no credential. There is also no "verifying" variant:
+/// whether the stored session has been revalidated against the server is an
+/// implementation concern, and surfacing it would put a spinner in the title
+/// bar every time a laptop lid opens, which only teaches people to ignore it.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "kebab-case")]
+pub enum AuthSnapshot {
+    /// No credential stored.
+    SignedOut,
+    /// A device grant is in flight and awaiting approval in the browser.
+    #[serde(rename_all = "camelCase")]
+    Connecting {
+        /// Shown only behind the dialog's "enter the code manually" disclosure.
+        /// A display string, not a secret — the `device_code` is the secret and
+        /// never leaves Rust.
+        user_code: String,
+        /// The *plain* approval URL, for the manual fallback. The pre-filled
+        /// variant stays in Rust: the browser is opened from there, so the
+        /// frontend never needs it.
+        verification_uri: String,
+        /// ISO-8601. The dialog uses this to stop offering a dead code.
+        expires_at: String,
+    },
+    /// A credential is held. ATL-47 adds the user identity to this variant.
+    SignedIn,
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -18,6 +18,7 @@
 //! ever handed across the IPC boundary — the frontend receives [`AuthSnapshot`],
 //! which carries no credentials. Nothing here logs a token or a device code.
 
+mod avatar;
 mod config;
 mod core;
 mod store;
@@ -26,6 +27,36 @@ pub use config::auth_base;
 pub use core::{AuthCore, GrantError};
 
 use serde::Serialize;
+
+use store::StoredIdentity;
+
+/// Who is signed in, as the frontend sees them.
+///
+/// Notice what is missing: the remote avatar URL. Handing it over would let one
+/// `<img src>` reinstate the per-launch request to Google or GitHub that the
+/// avatar cache exists to avoid, so the frontend only ever learns a local path.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountUser {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+    /// Absolute path to the cached photo, or `None` — no photo set, or the
+    /// fetch failed. Both render as initials; the UI draws no distinction
+    /// because the user cannot act on one.
+    pub avatar_path: Option<String>,
+}
+
+impl From<StoredIdentity> for AccountUser {
+    fn from(id: StoredIdentity) -> Self {
+        Self {
+            id: id.id,
+            name: id.name,
+            email: id.email,
+            avatar_path: id.avatar_path,
+        }
+    }
+}
 
 /// What the frontend is allowed to know about the account.
 ///
@@ -52,8 +83,16 @@ pub enum AuthSnapshot {
         /// ISO-8601. The dialog uses this to stop offering a dead code.
         expires_at: String,
     },
-    /// A credential is held. ATL-47 adds the user identity to this variant.
-    SignedIn,
+    /// A credential is held.
+    #[serde(rename_all = "camelCase")]
+    SignedIn {
+        /// `None` only in the gap between holding a credential and the first
+        /// successful profile fetch — a blip between approval and the profile
+        /// call, or an upgrade from a build that stored no identity. The next
+        /// successful validation fills it in. Signed-in-but-nameless is a far
+        /// better outcome than discarding a valid credential over a photo.
+        user: Option<AccountUser>,
+    },
 }
 
 #[cfg(test)]

--- a/src-tauri/src/auth/store.rs
+++ b/src-tauri/src/auth/store.rs
@@ -1,0 +1,86 @@
+//! On-disk credential storage.
+//!
+//! The session token lives in `atlas-session.json` in the app's private config
+//! directory, mode `0600`, in **its own file** separate from `byok-keys.json`
+//! so that signing out is a single unlink.
+//!
+//! ## Why not the OS keychain
+//!
+//! `docs/api/atlas-auth-api.md` §12.5 says to put this in the keychain. We
+//! knowingly do not, for the same reason `commands::byok` does not: on macOS an
+//! unsigned, frequently-rebuilt binary prompts for keychain permission on
+//! *every* access. `tauri.conf.json` sets no signing identity, and the
+//! auto-updater replaces the binary on every release — which invalidates the
+//! keychain ACL and would re-prompt every user after every update. Keychain is
+//! therefore *worse* in release than in development here.
+//!
+//! Revisit once a real Developer ID signing identity is configured; that also
+//! fixes the auto-update ACL problem.
+//!
+//! The access JWT is never written here — it is minted on demand and held in
+//! memory only.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// File name inside the app config directory.
+const SESSION_FILE: &str = "atlas-session.json";
+
+/// The persisted credential.
+///
+/// ATL-47 grows this with the identity snapshot (name, email, avatar, orgs) so
+/// an offline launch can render a complete signed-in state rather than a
+/// half-populated one.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredSession {
+    /// Better Auth session token. The long-lived credential — 7-day rolling,
+    /// and able to mint access tokens for every organisation the user is in.
+    pub session_token: String,
+    /// ISO-8601, for diagnostics only. Expiry is the server's business.
+    pub saved_at: String,
+}
+
+pub(crate) fn session_path(dir: &Path) -> PathBuf {
+    dir.join(SESSION_FILE)
+}
+
+/// Read the stored credential. `None` when absent or unreadable — a corrupt
+/// file is treated as "signed out" rather than an error, since the recovery is
+/// the same either way and there is nothing useful to tell the user.
+pub(crate) fn load(dir: &Path) -> Option<StoredSession> {
+    let raw = fs::read_to_string(session_path(dir)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Write the credential, owner-only.
+pub(crate) fn save(dir: &Path, session: &StoredSession) -> Result<(), String> {
+    fs::create_dir_all(dir).map_err(|e| format!("create config dir: {e}"))?;
+    let path = session_path(dir);
+    let json = serde_json::to_string_pretty(session).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| format!("write session: {e}"))?;
+    restrict(&path);
+    Ok(())
+}
+
+/// Remove the credential. Absent is success — sign-out must be idempotent and
+/// must never fail on a machine that was already signed out.
+pub(crate) fn clear(dir: &Path) -> Result<(), String> {
+    match fs::remove_file(session_path(dir)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("clear session: {e}")),
+    }
+}
+
+/// Best-effort owner-only permissions.
+#[cfg(unix)]
+fn restrict(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn restrict(_path: &Path) {}

--- a/src-tauri/src/auth/store.rs
+++ b/src-tauri/src/auth/store.rs
@@ -28,11 +28,32 @@ use serde::{Deserialize, Serialize};
 /// File name inside the app config directory.
 const SESSION_FILE: &str = "atlas-session.json";
 
-/// The persisted credential.
+/// Who the credential belongs to, as of the last successful profile fetch.
 ///
-/// ATL-47 grows this with the identity snapshot (name, email, avatar, orgs) so
-/// an offline launch can render a complete signed-in state rather than a
-/// half-populated one.
+/// This is what makes an offline launch render a *complete* signed-in state —
+/// a face and a name — rather than a half-populated one. Refreshed on every
+/// successful validation, so a name or photo changed on the web reaches the
+/// desktop on the next launch.
+///
+/// ATL-51 adds the organisation list and active organisation alongside it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredIdentity {
+    pub id: String,
+    pub name: String,
+    pub email: String,
+    /// The remote photo URL last seen on the profile. Kept **only** to decide
+    /// whether the cache is stale: a URL that still matches means the bytes on
+    /// disk are still the right bytes, so a launch costs no request to Google
+    /// or GitHub. It is never handed to the frontend — that would put the
+    /// per-launch request back, one `<img src>` away.
+    pub avatar_url: Option<String>,
+    /// Absolute path to the cached photo. `None` when the user has no photo or
+    /// the fetch failed; the UI falls back to initials either way.
+    pub avatar_path: Option<String>,
+}
+
+/// The persisted credential, plus who it belongs to.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct StoredSession {
@@ -41,6 +62,13 @@ pub struct StoredSession {
     pub session_token: String,
     /// ISO-8601, for diagnostics only. Expiry is the server's business.
     pub saved_at: String,
+    /// Absent until the first profile fetch succeeds. That window is real: a
+    /// connectivity blip between approval and the profile call leaves a valid
+    /// credential with nobody's name attached, and losing the credential over
+    /// that would be far worse than showing a generic icon until the next
+    /// launch refreshes it.
+    #[serde(default)]
+    pub identity: Option<StoredIdentity>,
 }
 
 pub(crate) fn session_path(dir: &Path) -> PathBuf {

--- a/src-tauri/src/auth/store.rs
+++ b/src-tauri/src/auth/store.rs
@@ -28,14 +28,60 @@ use serde::{Deserialize, Serialize};
 /// File name inside the app config directory.
 const SESSION_FILE: &str = "atlas-session.json";
 
+/// A role in an organisation (API doc §6), highest privilege first.
+///
+/// A closed set rather than a `String` because it reaches the UI as a label: an
+/// unrecognised value has no label to render, and the server's own contract
+/// (`packages/contracts`) defines exactly these four. Anything else is dropped
+/// at the boundary by [`Role::from_claim`] rather than carried inward.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    Admin,
+    ProductOwner,
+    Developer,
+    Member,
+}
+
+impl Role {
+    /// Read one value of the access token's `orgs` claim.
+    ///
+    /// `None` for anything unrecognised — a role added server-side after this
+    /// build shipped. The organisation is still listed, just without a role:
+    /// omitting a name we know is worse than omitting a label we do not.
+    ///
+    /// Routed through the `serde` attribute above rather than a second
+    /// hand-written table of the same four strings. That attribute already
+    /// decides how a role is spelled on disk, and a table that drifted from it
+    /// would read back a role this file had just written.
+    pub(crate) fn from_claim(raw: &str) -> Option<Self> {
+        serde_json::from_value(serde_json::Value::String(raw.to_string())).ok()
+    }
+}
+
+/// One organisation the user belongs to, as of the last successful refresh.
+///
+/// Assembled from two sources because neither is sufficient alone: the name
+/// comes from `/organization/list`, the role from the access token's `orgs`
+/// claim, which carries `{ organisationId: role }` and no names at all.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredOrg {
+    pub id: String,
+    pub name: String,
+    /// `None` when the claim did not mention this organisation, or named a role
+    /// this build does not know. Membership can change between the mint and the
+    /// list, and the two calls are not atomic with respect to each other.
+    #[serde(default)]
+    pub role: Option<Role>,
+}
+
 /// Who the credential belongs to, as of the last successful profile fetch.
 ///
 /// This is what makes an offline launch render a *complete* signed-in state —
-/// a face and a name — rather than a half-populated one. Refreshed on every
-/// successful validation, so a name or photo changed on the web reaches the
-/// desktop on the next launch.
-///
-/// ATL-51 adds the organisation list and active organisation alongside it.
+/// a face, a name, and the organisation this device is acting for — rather than
+/// a half-populated one. Refreshed on every successful validation, so a name,
+/// photo, or role changed on the web reaches the desktop on the next launch.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct StoredIdentity {
@@ -51,6 +97,68 @@ pub struct StoredIdentity {
     /// Absolute path to the cached photo. `None` when the user has no photo or
     /// the fetch failed; the UI falls back to initials either way.
     pub avatar_path: Option<String>,
+    /// Every organisation the user belongs to.
+    ///
+    /// Three states, and the menu renders each differently, so collapsing any
+    /// two would make it state something untrue:
+    ///
+    /// - `Some(non-empty)` — known, and rendered.
+    /// - `Some([])` — **known to be none.** A real answer about a real user,
+    ///   and the one the deliberate empty state is for.
+    /// - `None` — **not known yet.** A credential file written before this
+    ///   field existed (`#[serde(default)]`, so an ATL-47 build's file still
+    ///   loads instead of signing the user out), or one whose every list call
+    ///   has failed. Offline, that state can last indefinitely — so telling
+    ///   such a user they belong to no organisation would be a lie with no
+    ///   expiry. The section is omitted instead, exactly as the identity header
+    ///   is omitted when there is no profile yet.
+    #[serde(default)]
+    pub orgs: Option<Vec<StoredOrg>>,
+    /// The organisation the user last made active **on the web**, when they ever
+    /// did. Never written from the desktop: `/organization/set-active` is
+    /// ATL-36's, and this ticket is read-only.
+    ///
+    /// Kept separate from "which one to display" — see [`Self::active_org`],
+    /// which resolves that and has to cope with this being `None`, the common
+    /// case for a device-granted session.
+    #[serde(default)]
+    pub active_org_id: Option<String>,
+}
+
+impl StoredIdentity {
+    /// Which organisation the desktop is acting for.
+    ///
+    /// Prefers the one the user made active **on the web**, and falls back to
+    /// the first they belong to. The fallback is not a nicety:
+    /// `/organization/set-active` is the only thing that sets the stored value,
+    /// the desktop never calls it (ATL-36 owns switching), and a device-granted
+    /// session starts with it unset — so without the fallback almost every
+    /// desktop user would see an empty section while plainly belonging to an
+    /// organisation. The web dashboard defaults the same way, so the two
+    /// surfaces agree.
+    ///
+    /// A stored id that is no longer in the list — membership removed on the
+    /// web — falls through to the fallback rather than resolving to nothing.
+    pub(crate) fn active_org(&self) -> Option<String> {
+        let orgs = self.orgs.as_ref()?;
+        self.active_org_id
+            .as_ref()
+            .filter(|id| orgs.iter().any(|org| &org.id == *id))
+            .cloned()
+            .or_else(|| orgs.first().map(|org| org.id.clone()))
+    }
+
+    /// The role last known for one organisation, if any.
+    ///
+    /// The fallback for a refresh that could not read the `orgs` claim: a
+    /// label we already have beats one we just failed to fetch.
+    pub(crate) fn role_of(&self, id: &str) -> Option<Role> {
+        self.orgs
+            .as_ref()?
+            .iter()
+            .find(|org| org.id == id)
+            .and_then(|org| org.role)
+    }
 }
 
 /// The persisted credential, plus who it belongs to.

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
+use super::backoff::{Backoff, BASE, CEILING};
+use super::core::AuthFailure;
 use super::*;
 
 // ---------------------------------------------------------------- temp dir
@@ -61,6 +63,9 @@ struct Reply {
     /// fetch's *streaming* size cap: with an honest length the cheap up-front
     /// check fires first, and an understated one just makes `reqwest` truncate.
     content_length: Option<usize>,
+    /// Extra raw header lines, without the trailing CRLF. Currently only
+    /// `Retry-After`, which the classification has to read off a 429.
+    headers: Vec<String>,
 }
 
 impl Reply {
@@ -70,6 +75,7 @@ impl Reply {
             body: body.into(),
             content_type,
             content_length: Some(body.len()),
+            headers: Vec::new(),
         }
     }
     fn ok(body: &str) -> Self {
@@ -86,6 +92,11 @@ impl Reply {
     }
     fn without_content_length(mut self) -> Self {
         self.content_length = None;
+        self
+    }
+    /// One extra header line, e.g. `"Retry-After: 42"`.
+    fn with_header(mut self, line: &str) -> Self {
+        self.headers.push(line.to_string());
         self
     }
 }
@@ -143,9 +154,14 @@ impl Stub {
                         Some(n) => format!("Content-Length: {n}\r\n"),
                         None => String::new(),
                     };
+                    let extra = reply
+                        .headers
+                        .iter()
+                        .map(|h| format!("{h}\r\n"))
+                        .collect::<String>();
                     let out = format!(
-                        "HTTP/1.1 {} X\r\nContent-Type: {}\r\n{}Connection: close\r\n\r\n{}",
-                        reply.status, reply.content_type, length, reply.body
+                        "HTTP/1.1 {} X\r\nContent-Type: {}\r\n{}{}Connection: close\r\n\r\n{}",
+                        reply.status, reply.content_type, length, extra, reply.body
                     );
                     let _ = sock.write_all(out.as_bytes()).await;
                     let _ = sock.shutdown().await;
@@ -229,6 +245,9 @@ async fn sign_in(auth: &AuthCore) {
 }
 
 const TOKEN_OK: &str = r#"{"access_token":"session-tok","token_type":"Bearer"}"#;
+/// A successful `/token` mint — the call [`AuthCore::validate_once`] takes its
+/// verdict from, so any test that validates has to script it.
+const JWT_OK: &str = r#"{"token":"jwt-here"}"#;
 /// Stands in for image bytes. Content is irrelevant — nothing decodes it.
 const PIXELS: &str = "not-really-a-png-but-nothing-here-decodes-it";
 
@@ -511,68 +530,243 @@ async fn boot_with_no_credential_makes_no_network_call() {
     let dir = TempDir::new();
     let auth = core(&stub, &dir);
 
-    assert_eq!(auth.validate_stored().await, AuthSnapshot::SignedOut);
+    assert_eq!(auth.validate_once().await, Validation::NoCredential);
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
     assert_eq!(stub.hits("/token"), 0, "a signed-out launch must be silent");
 }
 
 #[tokio::test]
-async fn boot_preserves_the_credential_even_when_the_server_rejects_it() {
-    // Safe-by-default until ATL-48 lands the authoritative-401 rule. The worst
-    // outcome here is a stale signed-in state; the alternative would destroy a
-    // valid session, which is much harder to undo.
+async fn minting_reports_rejection_and_unreachability_differently() {
+    // The distinction the whole ticket is built on: `Rejected` is "the server
+    // said no", `Indeterminate` is "we never found out". Conflating them is
+    // what signs people out for opening a laptop on a plane.
     let stub = Stub::start().await;
     let dir = TempDir::new();
-    stub.grant_ready(600);
-    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+    scripted_grant(&stub);
 
     let auth = core(&stub, &dir);
-    let grant = auth.start_grant().await.unwrap();
-    auth.run_grant(&grant).await.unwrap();
+    sign_in(&auth).await;
 
     stub.on("/token", vec![Reply::err(401, "unauthorized")]);
-    assert!(signed_in(&auth.validate_stored().await));
-    assert!(auth.stored().is_some(), "a 401 must not clear the credential yet");
+    assert_eq!(auth.mint_access_token().await, Err(AuthFailure::Rejected));
+
+    stub.on("/token", vec![Reply::ok(JWT_OK)]);
+    assert_eq!(auth.mint_access_token().await, Ok("jwt-here".into()));
+
+    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    assert!(
+        matches!(
+            offline.mint_access_token().await,
+            Err(AuthFailure::Indeterminate { .. })
+        ),
+        "unreachable is not a rejection"
+    );
+}
+
+// ------------------------------------------------- failure classification
+//
+// The highest-value group in the module (ATL-48). Every case below is one row
+// of the rule: only an authoritative rejection may ever cost the credential.
+
+/// Sign in, then hand back a core pointed at a server that will never answer.
+/// This is what launching on a plane looks like.
+async fn signed_in_then_offline(stub: &Stub, dir: &TempDir) -> AuthCore {
+    let auth = core(stub, dir);
+    sign_in(&auth).await;
+    AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new())
 }
 
 #[tokio::test]
-async fn boot_preserves_the_credential_when_the_server_is_unreachable() {
+async fn a_rejected_session_is_cleared_and_signs_the_user_out() {
     let stub = Stub::start().await;
     let dir = TempDir::new();
-    stub.grant_ready(600);
-    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+    scripted_grant(&stub);
 
     let auth = core(&stub, &dir);
-    let grant = auth.start_grant().await.unwrap();
-    auth.run_grant(&grant).await.unwrap();
+    sign_in(&auth).await;
 
-    // Point a fresh core at a dead port — the offline launch case.
-    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
-    assert!(signed_in(&offline.validate_stored().await));
+    stub.on("/token", vec![Reply::err(401, "unauthorized")]);
+    assert_eq!(auth.validate_once().await, Validation::Rejected);
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+    assert!(
+        auth.stored().is_none(),
+        "a 401 is the server refusing this credential — keeping it would leave \
+         a signed-in UI that silently fails every call"
+    );
+}
+
+#[tokio::test]
+async fn a_server_error_never_costs_the_credential() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", None);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    stub.on("/token", vec![Reply::err(500, "boom")]);
+    assert_eq!(
+        auth.validate_once().await,
+        Validation::Indeterminate { retry_after: None }
+    );
+    assert!(auth.stored().is_some(), "an outage says nothing about the session");
+    assert_eq!(user_of(&auth.snapshot()).name, "Ada Lovelace");
+}
+
+#[tokio::test]
+async fn a_refused_connection_never_costs_the_credential() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+
+    let offline = signed_in_then_offline(&stub, &dir).await;
+    assert_eq!(
+        offline.validate_once().await,
+        Validation::Indeterminate { retry_after: None }
+    );
     assert!(offline.stored().is_some());
 }
 
 #[tokio::test]
-async fn minting_reports_rejection_and_unreachability_differently() {
-    // The distinction ATL-48 is built on: Ok(None) is "the server said no",
-    // Err is "we never found out". Conflating them is what signs people out
-    // for opening a laptop on a plane.
+async fn an_offline_launch_renders_a_fully_populated_signed_in_state() {
+    // The case that would otherwise ship as a session-destroying bug: no
+    // network at all, and the title bar still shows a name and a face.
     let stub = Stub::start().await;
     let dir = TempDir::new();
-    stub.grant_ready(600);
-    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
 
     let auth = core(&stub, &dir);
-    let grant = auth.start_grant().await.unwrap();
-    auth.run_grant(&grant).await.unwrap();
-
-    stub.on("/token", vec![Reply::err(401, "unauthorized")]);
-    assert_eq!(auth.mint_access_token().await, Ok(None), "401 is authoritative");
-
-    stub.on("/token", vec![Reply::ok(r#"{"token":"jwt-here"}"#)]);
-    assert_eq!(auth.mint_access_token().await, Ok(Some("jwt-here".into())));
+    sign_in(&auth).await;
+    let known = user_of(&auth.snapshot());
 
     let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
-    assert!(offline.mint_access_token().await.is_err(), "unreachable is not a rejection");
+    // Before any network attempt — the launch path renders this first.
+    assert_eq!(user_of(&offline.snapshot()), known);
+
+    offline.validate_once().await;
+    let after = user_of(&offline.snapshot());
+    assert_eq!(after, known, "a failed validation must change nothing");
+    assert!(after.avatar_path.is_some(), "the cached photo is the whole point");
+    assert!(!after.name.is_empty());
+}
+
+#[tokio::test]
+async fn a_forbidden_response_neither_signs_out_nor_retries() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+
+    let auth = core(&stub, &dir).with_backoff_base(Duration::from_millis(1));
+    sign_in(&auth).await;
+
+    stub.on("/token", vec![Reply::err(403, "forbidden")]);
+    assert_eq!(auth.revalidate(|_| {}).await, Validation::Denied);
+    assert!(auth.stored().is_some(), "403 says the credential is fine");
+    assert_eq!(
+        stub.hits("/token"),
+        1,
+        "retrying a permission decision would loop forever against a settled answer"
+    );
+}
+
+#[tokio::test]
+async fn two_failures_then_a_success_end_signed_in_with_no_user_action() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", None);
+
+    let auth = core(&stub, &dir).with_backoff_base(Duration::from_millis(1));
+    sign_in(&auth).await;
+
+    stub.on(
+        "/token",
+        vec![Reply::err(503, "down"), Reply::err(500, "down"), Reply::ok(JWT_OK)],
+    );
+
+    let mut settled_with = None;
+    assert_eq!(
+        auth.revalidate(|snapshot| settled_with = Some(snapshot)).await,
+        Validation::Confirmed
+    );
+    assert!(signed_in(&settled_with.expect("the loop must report once, at the end")));
+    assert_eq!(stub.hits("/token"), 3, "it kept trying without being asked to");
+}
+
+#[tokio::test]
+async fn a_rate_limit_is_indeterminate_and_honours_retry_after() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    stub.on(
+        "/token",
+        vec![Reply::err(429, "slow down").with_header("Retry-After: 42")],
+    );
+    assert_eq!(
+        auth.validate_once().await,
+        Validation::Indeterminate {
+            retry_after: Some(Duration::from_secs(42))
+        },
+        "a 429 is the server rationing us, not rejecting us"
+    );
+    assert!(auth.stored().is_some());
+
+    // Without the header it simply falls into the same backoff.
+    stub.on("/token", vec![Reply::err(429, "slow down")]);
+    assert_eq!(
+        auth.validate_once().await,
+        Validation::Indeterminate { retry_after: None }
+    );
+}
+
+#[test]
+fn backoff_grows_and_is_bounded() {
+    let mut schedule = Backoff::new(BASE, CEILING);
+    let mut previous = Duration::ZERO;
+
+    for attempt in 0..40 {
+        let delay = schedule.next();
+        assert!(delay <= CEILING, "attempt {attempt} exceeded the ceiling: {delay:?}");
+        // Each delay is drawn from [cap/2, cap] and cap doubles, so the lowest
+        // a delay can be is the highest the previous one could have been.
+        // Growth therefore holds without depending on the jitter — until the
+        // ceiling, where both draws come from the same window.
+        if delay < CEILING / 2 {
+            assert!(
+                delay >= previous,
+                "attempt {attempt} went backwards: {previous:?} -> {delay:?}"
+            );
+        }
+        previous = delay;
+    }
+
+    assert!(
+        previous >= CEILING / 2,
+        "a long outage must settle at the ceiling, not drift below it"
+    );
+}
+
+#[test]
+fn a_hostile_retry_after_cannot_escape_the_window() {
+    let mut schedule = Backoff::new(BASE, CEILING);
+    assert_eq!(
+        schedule.next_after(Some(Duration::from_secs(86_400))),
+        CEILING,
+        "one bad header must not strand a signed-in user for a day"
+    );
+    assert_eq!(
+        schedule.next_after(Some(Duration::ZERO)),
+        BASE,
+        "a zero must not turn the loop into a spin against a server asking for quiet"
+    );
+    assert_eq!(schedule.next_after(Some(Duration::from_secs(30))), Duration::from_secs(30));
 }
 
 // ---------------------------------------------------------------- identity
@@ -597,6 +791,17 @@ fn cached_avatars(dir: &TempDir) -> Vec<PathBuf> {
 fn scripted_grant(stub: &Stub) {
     stub.grant_ready(600);
     stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+    // Validation takes its verdict from `/token`, and the identity refresh only
+    // runs once the credential is confirmed — so a test about a photo has to
+    // let the credential pass first.
+    stub.on("/token", vec![Reply::ok(JWT_OK)]);
+}
+
+/// Validate, then hand back the resulting snapshot. The shape the identity
+/// tests want: they care about the name and the photo, not the outcome class.
+async fn validated(auth: &AuthCore) -> AuthSnapshot {
+    auth.validate_once().await;
+    auth.snapshot()
 }
 
 #[tokio::test]
@@ -643,7 +848,7 @@ async fn a_photo_that_has_not_changed_is_never_fetched_again() {
     let first = user_of(&auth.snapshot()).avatar_path;
 
     let relaunched = core(&stub, &dir);
-    let snapshot = relaunched.validate_stored().await;
+    let snapshot = validated(&relaunched).await;
 
     assert_eq!(stub.hits("/photo.png"), 1, "a relaunch must reuse the cache");
     assert_eq!(user_of(&snapshot).avatar_path, first);
@@ -669,7 +874,7 @@ async fn a_changed_photo_url_re_fetches_and_drops_the_old_file() {
     stub.profile("Ada Lovelace", Some(&stub.url("/photo-v2.png")));
     stub.on("/photo-v2.png", vec![Reply::with_content_type("image/png", "new-pixels")]);
 
-    let snapshot = core(&stub, &dir).validate_stored().await;
+    let snapshot = validated(&core(&stub, &dir)).await;
     let new = user_of(&snapshot).avatar_path.expect("second photo");
 
     assert_eq!(stub.hits("/photo-v2.png"), 1, "a changed URL must re-fetch");
@@ -698,7 +903,7 @@ async fn a_failed_re_fetch_keeps_the_photo_it_already_had() {
     stub.profile("Ada Lovelace", Some(&stub.url("/photo-v2.png")));
     stub.on("/photo-v2.png", vec![Reply::err(503, "unavailable")]);
 
-    let snapshot = core(&stub, &dir).validate_stored().await;
+    let snapshot = validated(&core(&stub, &dir)).await;
     assert_eq!(
         user_of(&snapshot).avatar_path.as_deref(),
         Some(known_good.as_str()),
@@ -715,7 +920,7 @@ async fn a_failed_re_fetch_keeps_the_photo_it_already_had() {
         "/photo-v2.png",
         vec![Reply::with_content_type("image/png", "new-pixels")],
     );
-    let recovered = core(&stub, &dir).validate_stored().await;
+    let recovered = validated(&core(&stub, &dir)).await;
     let new = user_of(&recovered).avatar_path.expect("second photo");
     assert_ne!(new, known_good, "the retry must land the new photo");
     assert_eq!(std::fs::read_to_string(&new).unwrap(), "new-pixels");
@@ -742,7 +947,7 @@ async fn a_photo_that_fails_to_fetch_falls_back_without_blocking_sign_in() {
     // Self-healing: the recorded URL matches but no file exists, so the next
     // launch tries again rather than treating the failure as permanent.
     stub.on("/gone.png", vec![Reply::with_content_type("image/png", PIXELS)]);
-    let snapshot = core(&stub, &dir).validate_stored().await;
+    let snapshot = validated(&core(&stub, &dir)).await;
     assert!(
         user_of(&snapshot).avatar_path.is_some(),
         "a failed fetch must be retried on the next launch, not cached as a no"
@@ -832,8 +1037,10 @@ async fn a_successful_validation_refreshes_a_stale_snapshot() {
 
     // Renamed on the web. The desktop must pick it up without a re-sign-in.
     stub.profile("Ada Byron", None);
-    let snapshot = core(&stub, &dir).validate_stored().await;
-    assert_eq!(user_of(&snapshot).name, "Ada Byron");
+    stub.on("/token", vec![Reply::ok(JWT_OK)]);
+    let relaunched = core(&stub, &dir);
+    assert_eq!(relaunched.validate_once().await, Validation::Confirmed);
+    assert_eq!(user_of(&relaunched.snapshot()).name, "Ada Byron");
 }
 
 #[tokio::test]
@@ -851,7 +1058,8 @@ async fn a_validation_that_fails_keeps_the_last_known_identity() {
     let known = user_of(&auth.snapshot());
 
     let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
-    assert_eq!(user_of(&offline.validate_stored().await), known);
+    offline.validate_once().await;
+    assert_eq!(user_of(&offline.snapshot()), known);
     assert!(offline.stored().is_some());
 }
 
@@ -899,8 +1107,9 @@ async fn a_credential_stored_before_identities_existed_still_loads() {
     );
 
     stub.profile("Ada Lovelace", None);
+    stub.on("/token", vec![Reply::ok(JWT_OK)]);
     assert_eq!(
-        user_of(&auth.validate_stored().await).name,
+        user_of(&validated(&auth).await).name,
         "Ada Lovelace",
         "the first validation after upgrade fills the identity in"
     );

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -1,0 +1,506 @@
+//! Tests for the auth core.
+//!
+//! These drive [`AuthCore`] against a **stub HTTP server bound to loopback**,
+//! with a temporary directory standing in for the app config dir. That works
+//! because the auth base is injected rather than hardcoded, so the seam already
+//! exists by design — no mock traits, no dependency-injection scaffolding, and
+//! the real `reqwest` client, the real poll loop and the real file I/O are all
+//! exercised.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use super::*;
+
+// ---------------------------------------------------------------- temp dir
+
+/// A unique directory removed on drop. Avoids a `tempfile` dev-dependency for
+/// what is fifteen lines.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        static N: AtomicU32 = AtomicU32::new(0);
+        let unique = format!(
+            "atlas-auth-test-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        );
+        let path = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        Self(path)
+    }
+    fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+// ------------------------------------------------------------- stub server
+
+/// One canned HTTP response.
+#[derive(Clone)]
+struct Reply {
+    status: u16,
+    body: String,
+}
+
+impl Reply {
+    fn ok(body: &str) -> Self {
+        Self { status: 200, body: body.into() }
+    }
+    fn err(status: u16, body: &str) -> Self {
+        Self { status, body: body.into() }
+    }
+}
+
+/// Scriptable auth server. Each path holds a queue of replies; the last one
+/// repeats once the queue is drained, so a test only scripts what it cares
+/// about.
+#[derive(Default)]
+struct Script {
+    replies: HashMap<String, Vec<Reply>>,
+    hits: HashMap<String, u32>,
+}
+
+struct Stub {
+    addr: SocketAddr,
+    script: Arc<Mutex<Script>>,
+}
+
+impl Stub {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let script = Arc::new(Mutex::new(Script::default()));
+        let handle = Arc::clone(&script);
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let handle = Arc::clone(&handle);
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 8192];
+                    let Ok(n) = sock.read(&mut buf).await else { return };
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let path = req
+                        .lines()
+                        .next()
+                        .and_then(|l| l.split_whitespace().nth(1))
+                        .unwrap_or("/")
+                        .to_string();
+
+                    let reply = {
+                        let mut s = handle.lock().unwrap();
+                        *s.hits.entry(path.clone()).or_insert(0) += 1;
+                        let queue = s.replies.get_mut(&path);
+                        match queue {
+                            Some(q) if q.len() > 1 => q.remove(0),
+                            Some(q) if q.len() == 1 => q[0].clone(),
+                            _ => Reply::err(404, "{}"),
+                        }
+                    };
+
+                    let out = format!(
+                        "HTTP/1.1 {} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        reply.status,
+                        reply.body.len(),
+                        reply.body
+                    );
+                    let _ = sock.write_all(out.as_bytes()).await;
+                    let _ = sock.shutdown().await;
+                });
+            }
+        });
+
+        Self { addr, script }
+    }
+
+    fn base(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    fn on(&self, path: &str, replies: Vec<Reply>) {
+        self.script.lock().unwrap().replies.insert(path.into(), replies);
+    }
+
+    fn hits(&self, path: &str) -> u32 {
+        self.script.lock().unwrap().hits.get(path).copied().unwrap_or(0)
+    }
+
+    /// A grant that is immediately pollable, with no artificial delay.
+    fn grant_ready(&self, expires_in: u64) {
+        self.on(
+            "/device/code",
+            vec![Reply::ok(&format!(
+                r#"{{"device_code":"dev-secret","user_code":"ABCD-1234",
+                     "verification_uri":"https://app.example/device",
+                     "verification_uri_complete":"https://app.example/device?user_code=ABCD-1234",
+                     "expires_in":{expires_in},"interval":0}}"#
+            ))],
+        );
+    }
+}
+
+fn core(stub: &Stub, dir: &TempDir) -> AuthCore {
+    AuthCore::new(stub.base(), dir.path(), reqwest::Client::new())
+}
+
+const TOKEN_OK: &str = r#"{"access_token":"session-tok","token_type":"Bearer"}"#;
+
+// ------------------------------------------------------------------ config
+
+#[test]
+fn auth_base_prefers_the_environment_and_trims_slashes() {
+    // Serialised implicitly: this is the only test touching the process env.
+    std::env::set_var("ATLAS_AUTH_URL", "http://localhost:8787/api/auth/");
+    assert_eq!(auth_base(), "http://localhost:8787/api/auth");
+
+    std::env::set_var("ATLAS_AUTH_URL", "   ");
+    assert!(
+        auth_base().starts_with("https://"),
+        "a blank override must fall through to the built-in default"
+    );
+
+    std::env::remove_var("ATLAS_AUTH_URL");
+    assert_eq!(auth_base(), "https://auth.tryatlas.cc/api/auth");
+}
+
+// ----------------------------------------------------------------- storage
+
+#[tokio::test]
+async fn a_granted_token_is_persisted_and_survives_a_restart() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.expect("start");
+    auth.run_grant(&grant).await.expect("grant");
+
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+
+    // A fresh core over the same directory is what a relaunch looks like.
+    let relaunched = AuthCore::new(stub.base(), dir.path(), reqwest::Client::new());
+    assert_eq!(relaunched.snapshot(), AuthSnapshot::SignedIn);
+    assert_eq!(relaunched.stored().unwrap().session_token, "session-tok");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn the_credential_file_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.unwrap();
+
+    let mode = std::fs::metadata(dir.path().join("atlas-session.json"))
+        .unwrap()
+        .permissions()
+        .mode();
+    assert_eq!(mode & 0o777, 0o600, "credential must not be group/world readable");
+}
+
+#[tokio::test]
+async fn clearing_is_idempotent_and_returns_to_signed_out() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    let auth = core(&stub, &dir);
+
+    assert!(auth.clear_session().is_ok(), "clearing when absent must succeed");
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.unwrap();
+
+    auth.clear_session().unwrap();
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+    assert!(auth.clear_session().is_ok());
+}
+
+// ------------------------------------------------------------- grant matrix
+
+#[tokio::test]
+async fn pending_polls_continue_until_approval() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on(
+        "/device/token",
+        vec![
+            Reply::err(400, r#"{"error":"authorization_pending"}"#),
+            Reply::err(400, r#"{"error":"authorization_pending"}"#),
+            Reply::ok(TOKEN_OK),
+        ],
+    );
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.expect("should end signed in");
+
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+    assert_eq!(stub.hits("/device/token"), 3);
+}
+
+#[tokio::test]
+async fn a_transient_failure_does_not_discard_an_approval() {
+    // The point of the whole classification: a 500 and a dropped connection
+    // tell us nothing about whether the human approved, so the grant must
+    // survive them. Ending here would throw away an approval already given.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on(
+        "/device/token",
+        vec![
+            Reply::err(500, "boom"),
+            Reply::err(502, "still boom"),
+            Reply::ok(TOKEN_OK),
+        ],
+    );
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.expect("transient errors must not end the grant");
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+}
+
+#[tokio::test]
+async fn slow_down_backs_off_and_keeps_going() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on(
+        "/device/token",
+        vec![Reply::err(400, r#"{"error":"slow_down"}"#), Reply::ok(TOKEN_OK)],
+    );
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    let started = std::time::Instant::now();
+    auth.run_grant(&grant).await.expect("slow_down is not terminal");
+
+    assert!(
+        started.elapsed() >= Duration::from_secs(5),
+        "slow_down must add 5s to the interval before the next poll"
+    );
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+}
+
+#[tokio::test]
+async fn denial_is_terminal_and_stores_nothing() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::err(400, r#"{"error":"access_denied"}"#)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    assert_eq!(auth.run_grant(&grant).await, Err(GrantError::Denied));
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+}
+
+#[tokio::test]
+async fn a_server_expired_code_is_terminal() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::err(400, r#"{"error":"expired_token"}"#)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    assert_eq!(auth.run_grant(&grant).await, Err(GrantError::Expired));
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+}
+
+#[tokio::test]
+async fn the_local_deadline_ends_a_grant_the_server_never_finishes() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(1); // expires almost immediately
+    stub.on("/device/token", vec![Reply::err(400, r#"{"error":"authorization_pending"}"#)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    assert_eq!(auth.run_grant(&grant).await, Err(GrantError::Expired));
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+}
+
+#[tokio::test]
+async fn cancelling_ends_the_grant_and_stops_polling() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::err(400, r#"{"error":"authorization_pending"}"#)]);
+
+    let auth = Arc::new(core(&stub, &dir));
+    let grant = auth.start_grant().await.unwrap();
+
+    let runner = {
+        let auth = Arc::clone(&auth);
+        let grant = grant.clone();
+        tokio::spawn(async move { auth.run_grant(&grant).await })
+    };
+
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    auth.cancel_grant();
+
+    assert_eq!(runner.await.unwrap(), Err(GrantError::Cancelled));
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+
+    // Nothing keeps polling after cancellation.
+    let after = stub.hits("/device/token");
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_eq!(stub.hits("/device/token"), after, "poll loop must be stopped");
+}
+
+#[tokio::test]
+async fn a_second_start_resumes_the_same_grant_instead_of_minting_another() {
+    // The recovery path: someone who got lost signing in on the web clicks the
+    // account button again and must land back on the SAME approval page.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::err(400, r#"{"error":"authorization_pending"}"#)]);
+
+    let auth = core(&stub, &dir);
+    let first = auth.start_grant().await.unwrap();
+    let second = auth.start_grant().await.unwrap();
+
+    assert_eq!(first.user_code, second.user_code);
+    assert_eq!(first.device_code, second.device_code);
+    assert_eq!(stub.hits("/device/code"), 1, "must not mint a competing code");
+}
+
+#[tokio::test]
+async fn the_connecting_snapshot_exposes_the_code_but_never_the_secret() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+
+    match auth.snapshot() {
+        AuthSnapshot::Connecting { user_code, verification_uri, .. } => {
+            assert_eq!(user_code, "ABCD-1234");
+            // The PLAIN url, for manual entry. The pre-filled variant is used
+            // to open the browser from Rust and never needs to cross over.
+            assert_eq!(verification_uri, "https://app.example/device");
+            let json = serde_json::to_string(&auth.snapshot()).unwrap();
+            assert!(
+                !json.contains(&grant.device_code),
+                "the device_code is the secret and must never cross to the frontend"
+            );
+        }
+        other => panic!("expected Connecting, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn an_unreachable_server_fails_to_start_without_leaking_the_url() {
+    let dir = TempDir::new();
+    // Port 1 on loopback: nothing listens, so the connection is refused.
+    let auth = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+
+    match auth.start_grant().await {
+        Err(GrantError::Start(msg)) => {
+            assert!(!msg.contains("127.0.0.1:1"), "error text must not carry the URL");
+        }
+        other => panic!("expected a start failure, got {other:?}"),
+    }
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+}
+
+// -------------------------------------------------------------------- boot
+
+#[tokio::test]
+async fn boot_with_no_credential_makes_no_network_call() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    let auth = core(&stub, &dir);
+
+    assert_eq!(auth.validate_stored().await, AuthSnapshot::SignedOut);
+    assert_eq!(stub.hits("/token"), 0, "a signed-out launch must be silent");
+}
+
+#[tokio::test]
+async fn boot_preserves_the_credential_even_when_the_server_rejects_it() {
+    // Safe-by-default until ATL-48 lands the authoritative-401 rule. The worst
+    // outcome here is a stale signed-in state; the alternative would destroy a
+    // valid session, which is much harder to undo.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.unwrap();
+
+    stub.on("/token", vec![Reply::err(401, "unauthorized")]);
+    assert_eq!(auth.validate_stored().await, AuthSnapshot::SignedIn);
+    assert!(auth.stored().is_some(), "a 401 must not clear the credential yet");
+}
+
+#[tokio::test]
+async fn boot_preserves_the_credential_when_the_server_is_unreachable() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.unwrap();
+
+    // Point a fresh core at a dead port — the offline launch case.
+    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    assert_eq!(offline.validate_stored().await, AuthSnapshot::SignedIn);
+    assert!(offline.stored().is_some());
+}
+
+#[tokio::test]
+async fn minting_reports_rejection_and_unreachability_differently() {
+    // The distinction ATL-48 is built on: Ok(None) is "the server said no",
+    // Err is "we never found out". Conflating them is what signs people out
+    // for opening a laptop on a plane.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.unwrap();
+    auth.run_grant(&grant).await.unwrap();
+
+    stub.on("/token", vec![Reply::err(401, "unauthorized")]);
+    assert_eq!(auth.mint_access_token().await, Ok(None), "401 is authoritative");
+
+    stub.on("/token", vec![Reply::ok(r#"{"token":"jwt-here"}"#)]);
+    assert_eq!(auth.mint_access_token().await, Ok(Some("jwt-here".into())));
+
+    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    assert!(offline.mint_access_token().await.is_err(), "unreachable is not a rejection");
+}

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -66,6 +66,8 @@ struct Reply {
     /// Extra raw header lines, without the trailing CRLF. Currently only
     /// `Retry-After`, which the classification has to read off a 429.
     headers: Vec<String>,
+    /// Held before answering, so a test can act while a call is in flight.
+    delay: Option<Duration>,
 }
 
 impl Reply {
@@ -76,6 +78,7 @@ impl Reply {
             content_type,
             content_length: Some(body.len()),
             headers: Vec::new(),
+            delay: None,
         }
     }
     fn ok(body: &str) -> Self {
@@ -99,6 +102,42 @@ impl Reply {
         self.headers.push(line.to_string());
         self
     }
+    /// Answer only after `ms`, which is what makes a call *observably* in
+    /// flight — the only way to test what a user action racing one does.
+    fn slow(mut self, ms: u64) -> Self {
+        self.delay = Some(Duration::from_millis(ms));
+        self
+    }
+}
+
+/// What the stub was *sent*, so a test can assert on the request and not only
+/// on the reply. Carries only what something asserts on: sign-out is defined by
+/// the call it makes, not by the answer it chooses to ignore.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Seen {
+    method: String,
+    /// The credential from `Authorization: Bearer …`, when one was sent.
+    bearer: Option<String>,
+}
+
+impl Seen {
+    /// Parse the request line and headers out of a raw request.
+    fn parse(req: &str) -> Self {
+        let method = req
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().next())
+            .unwrap_or("")
+            .to_string();
+        let bearer = req
+            .lines()
+            .find(|l| l.to_ascii_lowercase().starts_with("authorization:"))
+            .and_then(|l| l.split_once(':'))
+            .map(|(_, v)| v.trim())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .map(str::to_string);
+        Self { method, bearer }
+    }
 }
 
 /// Scriptable auth server. Each path holds a queue of replies; the last one
@@ -108,6 +147,7 @@ impl Reply {
 struct Script {
     replies: HashMap<String, Vec<Reply>>,
     hits: HashMap<String, u32>,
+    seen: HashMap<String, Vec<Seen>>,
 }
 
 struct Stub {
@@ -142,6 +182,7 @@ impl Stub {
                     let reply = {
                         let mut s = handle.lock().unwrap();
                         *s.hits.entry(path.clone()).or_insert(0) += 1;
+                        s.seen.entry(path.clone()).or_default().push(Seen::parse(&req));
                         let queue = s.replies.get_mut(&path);
                         match queue {
                             Some(q) if q.len() > 1 => q.remove(0),
@@ -149,6 +190,10 @@ impl Stub {
                             _ => Reply::err(404, "{}"),
                         }
                     };
+
+                    if let Some(delay) = reply.delay {
+                        tokio::time::sleep(delay).await;
+                    }
 
                     let length = match reply.content_length {
                         Some(n) => format!("Content-Length: {n}\r\n"),
@@ -182,6 +227,11 @@ impl Stub {
 
     fn hits(&self, path: &str) -> u32 {
         self.script.lock().unwrap().hits.get(path).copied().unwrap_or(0)
+    }
+
+    /// Every request the stub received for a path, in order.
+    fn seen(&self, path: &str) -> Vec<Seen> {
+        self.script.lock().unwrap().seen.get(path).cloned().unwrap_or_default()
     }
 
     /// A grant that is immediately pollable, with no artificial delay.
@@ -1113,4 +1163,169 @@ async fn a_credential_stored_before_identities_existed_still_loads() {
         "Ada Lovelace",
         "the first validation after upgrade fills the identity in"
     );
+}
+
+// ---------------------------------------------------------------- sign-out
+//
+// The ordering is the whole ticket (ATL-50): everything local goes first and
+// unconditionally, and only then is the server told. Revoking first would make
+// sign-out fail while offline — precisely when someone closing a borrowed
+// laptop most needs it to work.
+
+/// Signed in with a photo on disk, which is the state sign-out has to erase.
+async fn signed_in_with_a_photo(stub: &Stub, dir: &TempDir) -> AuthCore {
+    scripted_grant(stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+    let auth = core(stub, dir);
+    sign_in(&auth).await;
+    assert!(!cached_avatars(dir).is_empty(), "the photo should be cached");
+    auth
+}
+
+#[tokio::test]
+async fn signing_out_clears_everything_local_before_the_server_is_told() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.on("/sign-out", vec![Reply::ok("{}")]);
+    let auth = signed_in_with_a_photo(&stub, &dir).await;
+
+    let ticket = auth.sign_out().expect("a stored credential to revoke");
+
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+    assert!(auth.stored().is_none(), "the credential must be gone");
+    assert!(
+        !dir.path().join("atlas-session.json").exists(),
+        "the identity snapshot lives in the credential file and goes with it"
+    );
+    assert!(cached_avatars(&dir).is_empty(), "the cached photo must be gone too");
+    assert_eq!(
+        stub.hits("/sign-out"),
+        0,
+        "nothing may be sent before the local state is clear — that ordering is \
+         what makes sign-out work with the network off"
+    );
+
+    // A fresh core over the same directory is what a relaunch looks like: it
+    // must start signed out, and reach for nothing.
+    let relaunched = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    assert_eq!(relaunched.snapshot(), AuthSnapshot::SignedOut);
+    assert_eq!(relaunched.validate_once().await, Validation::NoCredential);
+
+    assert!(auth.revoke(ticket).await, "a 200 is the session confirmed gone");
+    assert_eq!(
+        stub.seen("/sign-out"),
+        vec![Seen {
+            method: "POST".into(),
+            bearer: Some("session-tok".into()),
+        }],
+        "revocation is one POST carrying the session token as a Bearer (ATL-44)"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_revocation_is_reported_once_and_never_retried() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.on("/sign-out", vec![Reply::err(500, "boom")]);
+    let auth = signed_in_with_a_photo(&stub, &dir).await;
+
+    let ticket = auth.sign_out().expect("signed in");
+    assert!(!auth.revoke(ticket).await, "a 500 leaves the server session up");
+
+    // The local state a retry would protect is already gone, so there is
+    // nothing left for a backoff schedule to defend — see `revoke`.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert_eq!(stub.hits("/sign-out"), 1, "fired once and forgotten");
+    assert!(auth.stored().is_none(), "and the failure never resurrects the credential");
+}
+
+#[tokio::test]
+async fn signing_out_with_the_network_off_still_signs_out() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    // Sign in against the reachable stub, then throw that core away.
+    drop(signed_in_with_a_photo(&stub, &dir).await);
+
+    // Port 1 on loopback: nothing listens, so the connection is refused. This
+    // is the case the ordering exists for.
+    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    let ticket = offline.sign_out().expect("signed in");
+
+    assert_eq!(offline.snapshot(), AuthSnapshot::SignedOut);
+    assert!(offline.stored().is_none());
+    assert!(cached_avatars(&dir).is_empty());
+    assert!(
+        !offline.revoke(ticket).await,
+        "unreachable is not confirmation — the user is owed the caveat that the \
+         server session may stay up until it expires"
+    );
+}
+
+#[tokio::test]
+async fn a_session_the_server_has_already_forgotten_needs_no_caveat() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    // 401: the server does not recognise the credential, so there is no live
+    // session left to warn anyone about.
+    stub.on("/sign-out", vec![Reply::err(401, "unauthorized")]);
+    let auth = signed_in_with_a_photo(&stub, &dir).await;
+
+    let ticket = auth.sign_out().expect("signed in");
+    assert!(auth.revoke(ticket).await);
+}
+
+#[tokio::test]
+async fn signing_out_when_already_signed_out_asks_the_server_nothing() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    let auth = core(&stub, &dir);
+
+    assert!(
+        auth.sign_out().is_none(),
+        "no credential means no ticket, and nothing to revoke"
+    );
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+    assert_eq!(stub.hits("/sign-out"), 0);
+}
+
+#[tokio::test]
+async fn a_refresh_in_flight_cannot_resurrect_a_signed_out_credential() {
+    // Sign-out is not the only thing running: a launch validates in the
+    // background, and that path *writes the credential file* once its profile
+    // and photo calls return. A click landing in that window would otherwise be
+    // undone — the title bar signed out, the file back on disk, and the next
+    // launch signed straight back in.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    let auth = Arc::new(signed_in_with_a_photo(&stub, &dir).await);
+
+    // A changed photo URL, served slowly: the refresh is now provably still in
+    // flight when the sign-out below happens.
+    stub.profile("Ada Lovelace", Some(&stub.url("/slow.png")));
+    stub.on(
+        "/slow.png",
+        vec![Reply::with_content_type("image/png", PIXELS).slow(300)],
+    );
+
+    let refreshing = {
+        let auth = Arc::clone(&auth);
+        tokio::spawn(async move { auth.validate_once().await })
+    };
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let ticket = auth.sign_out().expect("signed in");
+    let _ = refreshing.await;
+
+    assert!(
+        auth.stored().is_none(),
+        "a write from a call that started before the sign-out must not put the \
+         credential back"
+    );
+    assert_eq!(auth.snapshot(), AuthSnapshot::SignedOut);
+    assert!(
+        cached_avatars(&dir).is_empty(),
+        "nor may it leave a face behind in the config directory"
+    );
+    drop(ticket);
 }

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -55,14 +55,38 @@ impl Drop for TempDir {
 struct Reply {
     status: u16,
     body: String,
+    content_type: &'static str,
+    /// `None` omits the header entirely, so the client must read to EOF without
+    /// knowing how much is coming. That is the only way to reach the avatar
+    /// fetch's *streaming* size cap: with an honest length the cheap up-front
+    /// check fires first, and an understated one just makes `reqwest` truncate.
+    content_length: Option<usize>,
 }
 
 impl Reply {
+    fn new(status: u16, body: &str, content_type: &'static str) -> Self {
+        Self {
+            status,
+            body: body.into(),
+            content_type,
+            content_length: Some(body.len()),
+        }
+    }
     fn ok(body: &str) -> Self {
-        Self { status: 200, body: body.into() }
+        Self::new(200, body, "application/json")
     }
     fn err(status: u16, body: &str) -> Self {
-        Self { status, body: body.into() }
+        Self::new(status, body, "application/json")
+    }
+    /// A 200 with an explicit content type — used for image bodies, and for
+    /// proving what happens when the "photo" turns out not to be one. The bytes
+    /// are never a real image: nothing in the Rust layer decodes them.
+    fn with_content_type(content_type: &'static str, body: &str) -> Self {
+        Self::new(200, body, content_type)
+    }
+    fn without_content_length(mut self) -> Self {
+        self.content_length = None;
+        self
     }
 }
 
@@ -115,11 +139,13 @@ impl Stub {
                         }
                     };
 
+                    let length = match reply.content_length {
+                        Some(n) => format!("Content-Length: {n}\r\n"),
+                        None => String::new(),
+                    };
                     let out = format!(
-                        "HTTP/1.1 {} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        reply.status,
-                        reply.body.len(),
-                        reply.body
+                        "HTTP/1.1 {} X\r\nContent-Type: {}\r\n{}Connection: close\r\n\r\n{}",
+                        reply.status, reply.content_type, length, reply.body
                     );
                     let _ = sock.write_all(out.as_bytes()).await;
                     let _ = sock.shutdown().await;
@@ -154,13 +180,57 @@ impl Stub {
             ))],
         );
     }
+
+    /// A `/get-session` profile. `image` is the *absolute* URL the desktop will
+    /// fetch, so tests point it back at this same stub.
+    fn profile(&self, name: &str, image: Option<&str>) {
+        let image = match image {
+            Some(url) => format!(r#""{url}""#),
+            None => "null".to_string(),
+        };
+        self.on(
+            "/get-session",
+            vec![Reply::ok(&format!(
+                r#"{{"session":{{"id":"sess_1"}},
+                     "user":{{"id":"user_1","name":"{name}",
+                              "email":"ada@atlas.example","image":{image}}}}}"#
+            ))],
+        );
+    }
+
+    /// Absolute URL for a stub path, for use as a profile `image`.
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base(), path)
+    }
 }
 
 fn core(stub: &Stub, dir: &TempDir) -> AuthCore {
     AuthCore::new(stub.base(), dir.path(), reqwest::Client::new())
 }
 
+/// Signed in, whoever it turns out to be — for the tests that are about the
+/// grant rather than the user.
+fn signed_in(snapshot: &AuthSnapshot) -> bool {
+    matches!(snapshot, AuthSnapshot::SignedIn { .. })
+}
+
+/// The identity on a signed-in snapshot, or a panic naming what we got instead.
+fn user_of(snapshot: &AuthSnapshot) -> AccountUser {
+    match snapshot {
+        AuthSnapshot::SignedIn { user: Some(user) } => user.clone(),
+        other => panic!("expected a signed-in snapshot with an identity, got {other:?}"),
+    }
+}
+
+/// Drive a grant to completion against an already-scripted stub.
+async fn sign_in(auth: &AuthCore) {
+    let grant = auth.start_grant().await.expect("start grant");
+    auth.run_grant(&grant).await.expect("complete grant");
+}
+
 const TOKEN_OK: &str = r#"{"access_token":"session-tok","token_type":"Bearer"}"#;
+/// Stands in for image bytes. Content is irrelevant — nothing decodes it.
+const PIXELS: &str = "not-really-a-png-but-nothing-here-decodes-it";
 
 // ------------------------------------------------------------------ config
 
@@ -193,11 +263,11 @@ async fn a_granted_token_is_persisted_and_survives_a_restart() {
     let grant = auth.start_grant().await.expect("start");
     auth.run_grant(&grant).await.expect("grant");
 
-    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+    assert!(signed_in(&auth.snapshot()));
 
     // A fresh core over the same directory is what a relaunch looks like.
     let relaunched = AuthCore::new(stub.base(), dir.path(), reqwest::Client::new());
-    assert_eq!(relaunched.snapshot(), AuthSnapshot::SignedIn);
+    assert!(signed_in(&relaunched.snapshot()));
     assert_eq!(relaunched.stored().unwrap().session_token, "session-tok");
 }
 
@@ -259,7 +329,7 @@ async fn pending_polls_continue_until_approval() {
     let grant = auth.start_grant().await.unwrap();
     auth.run_grant(&grant).await.expect("should end signed in");
 
-    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+    assert!(signed_in(&auth.snapshot()));
     assert_eq!(stub.hits("/device/token"), 3);
 }
 
@@ -283,7 +353,7 @@ async fn a_transient_failure_does_not_discard_an_approval() {
     let auth = core(&stub, &dir);
     let grant = auth.start_grant().await.unwrap();
     auth.run_grant(&grant).await.expect("transient errors must not end the grant");
-    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+    assert!(signed_in(&auth.snapshot()));
 }
 
 #[tokio::test]
@@ -305,7 +375,7 @@ async fn slow_down_backs_off_and_keeps_going() {
         started.elapsed() >= Duration::from_secs(5),
         "slow_down must add 5s to the interval before the next poll"
     );
-    assert_eq!(auth.snapshot(), AuthSnapshot::SignedIn);
+    assert!(signed_in(&auth.snapshot()));
 }
 
 #[tokio::test]
@@ -460,7 +530,7 @@ async fn boot_preserves_the_credential_even_when_the_server_rejects_it() {
     auth.run_grant(&grant).await.unwrap();
 
     stub.on("/token", vec![Reply::err(401, "unauthorized")]);
-    assert_eq!(auth.validate_stored().await, AuthSnapshot::SignedIn);
+    assert!(signed_in(&auth.validate_stored().await));
     assert!(auth.stored().is_some(), "a 401 must not clear the credential yet");
 }
 
@@ -477,7 +547,7 @@ async fn boot_preserves_the_credential_when_the_server_is_unreachable() {
 
     // Point a fresh core at a dead port — the offline launch case.
     let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
-    assert_eq!(offline.validate_stored().await, AuthSnapshot::SignedIn);
+    assert!(signed_in(&offline.validate_stored().await));
     assert!(offline.stored().is_some());
 }
 
@@ -503,4 +573,335 @@ async fn minting_reports_rejection_and_unreachability_differently() {
 
     let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
     assert!(offline.mint_access_token().await.is_err(), "unreachable is not a rejection");
+}
+
+// ---------------------------------------------------------------- identity
+
+/// How many avatar files the cache is holding. Growth here would mean every
+/// photo change leaks a file into the config directory forever.
+fn cached_avatars(dir: &TempDir) -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = std::fs::read_dir(dir.path())
+        .expect("read config dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("avatar-"))
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+fn scripted_grant(stub: &Stub) {
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+}
+
+#[tokio::test]
+async fn the_identity_snapshot_is_written_on_sign_in_and_survives_a_restart() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    let user = user_of(&auth.snapshot());
+    assert_eq!(user.name, "Ada Lovelace");
+    assert_eq!(user.email, "ada@atlas.example");
+    let path = user.avatar_path.clone().expect("a photo was fetched");
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        PIXELS,
+        "the cached file must hold the bytes the server served"
+    );
+
+    // A fresh core over the same directory is what a relaunch looks like — and
+    // it must render a complete title bar with no network involved at all.
+    let relaunched = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    let offline = user_of(&relaunched.snapshot());
+    assert_eq!(offline, user, "the snapshot must survive a restart intact");
+}
+
+#[tokio::test]
+async fn a_photo_that_has_not_changed_is_never_fetched_again() {
+    // The privacy claim, made testable: a launch must not tell Google or GitHub
+    // that this user opened their editor, for a picture already on disk.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    assert_eq!(stub.hits("/photo.png"), 1, "fetched once on sign-in");
+    let first = user_of(&auth.snapshot()).avatar_path;
+
+    let relaunched = core(&stub, &dir);
+    let snapshot = relaunched.validate_stored().await;
+
+    assert_eq!(stub.hits("/photo.png"), 1, "a relaunch must reuse the cache");
+    assert_eq!(user_of(&snapshot).avatar_path, first);
+    assert!(
+        stub.hits("/get-session") >= 2,
+        "the profile itself is still refreshed — it is the photo that is cached"
+    );
+}
+
+#[tokio::test]
+async fn a_changed_photo_url_re_fetches_and_drops_the_old_file() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    let old = user_of(&auth.snapshot()).avatar_path.expect("first photo");
+
+    // The user changed their photo; the provider hands back a new URL.
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo-v2.png")));
+    stub.on("/photo-v2.png", vec![Reply::with_content_type("image/png", "new-pixels")]);
+
+    let snapshot = core(&stub, &dir).validate_stored().await;
+    let new = user_of(&snapshot).avatar_path.expect("second photo");
+
+    assert_eq!(stub.hits("/photo-v2.png"), 1, "a changed URL must re-fetch");
+    assert_ne!(new, old, "a new photo must land at a new path, or the webview caches the old face");
+    assert_eq!(std::fs::read_to_string(&new).unwrap(), "new-pixels");
+    assert_eq!(cached_avatars(&dir).len(), 1, "the superseded file must not linger");
+}
+
+#[tokio::test]
+async fn a_failed_re_fetch_keeps_the_photo_it_already_had() {
+    // The rule the whole failure classification turns on, applied to the cache:
+    // a timeout tells us nothing about the new photo, so it must not cost the
+    // known-good old one. Deleting it would mean a five-second blip during one
+    // launch leaves the title bar blank on every offline launch afterwards.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    let known_good = user_of(&auth.snapshot()).avatar_path.expect("first photo");
+
+    // The photo changes, but the CDN is having a bad minute.
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo-v2.png")));
+    stub.on("/photo-v2.png", vec![Reply::err(503, "unavailable")]);
+
+    let snapshot = core(&stub, &dir).validate_stored().await;
+    assert_eq!(
+        user_of(&snapshot).avatar_path.as_deref(),
+        Some(known_good.as_str()),
+        "an indeterminate failure must not trade a good photo for initials"
+    );
+    assert!(
+        std::path::Path::new(&known_good).exists(),
+        "nor delete the bytes behind it"
+    );
+
+    // And the next launch must still notice the photo changed, rather than
+    // filing the new URL against the old file and never trying again.
+    stub.on(
+        "/photo-v2.png",
+        vec![Reply::with_content_type("image/png", "new-pixels")],
+    );
+    let recovered = core(&stub, &dir).validate_stored().await;
+    let new = user_of(&recovered).avatar_path.expect("second photo");
+    assert_ne!(new, known_good, "the retry must land the new photo");
+    assert_eq!(std::fs::read_to_string(&new).unwrap(), "new-pixels");
+    assert_eq!(cached_avatars(&dir).len(), 1, "and only then drop the old one");
+}
+
+#[tokio::test]
+async fn a_photo_that_fails_to_fetch_falls_back_without_blocking_sign_in() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/gone.png")));
+    stub.on("/gone.png", vec![Reply::err(404, "nope")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    let user = user_of(&auth.snapshot());
+    assert_eq!(user.avatar_path, None, "a failed fetch renders as initials");
+    assert_eq!(user.name, "Ada Lovelace", "and must not cost the rest of the identity");
+    assert!(auth.stored().is_some(), "least of all the credential");
+    assert!(cached_avatars(&dir).is_empty(), "nothing half-written on disk");
+
+    // Self-healing: the recorded URL matches but no file exists, so the next
+    // launch tries again rather than treating the failure as permanent.
+    stub.on("/gone.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+    let snapshot = core(&stub, &dir).validate_stored().await;
+    assert!(
+        user_of(&snapshot).avatar_path.is_some(),
+        "a failed fetch must be retried on the next launch, not cached as a no"
+    );
+}
+
+#[tokio::test]
+async fn an_oversized_photo_is_refused_however_the_length_is_declared() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    let huge = "x".repeat(2 * 1024 * 1024 + 1);
+
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/huge.png")));
+    stub.on("/huge.png", vec![Reply::with_content_type("image/png", &huge)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    assert_eq!(
+        user_of(&auth.snapshot()).avatar_path,
+        None,
+        "a declared length over the cap must be refused before downloading it"
+    );
+
+    // No Content-Length at all: the cap has to hold while streaming, which is
+    // the case a host that wants to fill the disk would actually use.
+    let dir2 = TempDir::new();
+    stub.on(
+        "/huge.png",
+        vec![Reply::with_content_type("image/png", &huge).without_content_length()],
+    );
+    let auth2 = core(&stub, &dir2);
+    sign_in(&auth2).await;
+    assert_eq!(
+        user_of(&auth2.snapshot()).avatar_path,
+        None,
+        "an undeclared length must be capped while streaming"
+    );
+    assert!(cached_avatars(&dir2).is_empty());
+}
+
+#[tokio::test]
+async fn a_response_that_is_not_an_image_is_never_written_to_disk() {
+    // The avatar cache lives in a directory the asset protocol serves, so what
+    // gets written there is worth being narrow about.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/login.html")));
+    stub.on(
+        "/login.html",
+        vec![Reply::with_content_type("text/html", "<h1>sign in</h1>")],
+    );
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    assert_eq!(user_of(&auth.snapshot()).avatar_path, None);
+    assert!(cached_avatars(&dir).is_empty(), "only image types reach the disk");
+}
+
+#[tokio::test]
+async fn a_user_with_no_photo_is_still_fully_identified() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Grace Hopper", None);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    let user = user_of(&auth.snapshot());
+    assert_eq!(user.name, "Grace Hopper");
+    assert_eq!(user.avatar_path, None, "the UI draws an initial for this");
+}
+
+#[tokio::test]
+async fn a_successful_validation_refreshes_a_stale_snapshot() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", None);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    assert_eq!(user_of(&auth.snapshot()).name, "Ada Lovelace");
+
+    // Renamed on the web. The desktop must pick it up without a re-sign-in.
+    stub.profile("Ada Byron", None);
+    let snapshot = core(&stub, &dir).validate_stored().await;
+    assert_eq!(user_of(&snapshot).name, "Ada Byron");
+}
+
+#[tokio::test]
+async fn a_validation_that_fails_keeps_the_last_known_identity() {
+    // The offline launch. The snapshot exists precisely so this renders a
+    // complete title bar rather than a nameless one.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    let known = user_of(&auth.snapshot());
+
+    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    assert_eq!(user_of(&offline.validate_stored().await), known);
+    assert!(offline.stored().is_some());
+}
+
+#[tokio::test]
+async fn the_signed_in_snapshot_identifies_the_user_and_carries_no_credential() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", Some(&stub.url("/photo.png")));
+    stub.on("/photo.png", vec![Reply::with_content_type("image/png", PIXELS)]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    let json = serde_json::to_string(&auth.snapshot()).unwrap();
+    assert!(json.contains("ada@atlas.example"), "identity is what the frontend is for");
+    assert!(
+        !json.contains("session-tok"),
+        "the session token must never cross to the frontend"
+    );
+    assert!(
+        !json.contains("/photo.png"),
+        "nor the remote photo URL — an <img> pointed at it would put the \
+         per-launch request to the provider straight back"
+    );
+}
+
+#[tokio::test]
+async fn a_credential_stored_before_identities_existed_still_loads() {
+    // Anyone who signed in on an ATL-46 build has a file with no `identity`
+    // key. Treating that as corrupt would sign them out on upgrade.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    std::fs::write(
+        dir.path().join("atlas-session.json"),
+        r#"{"sessionToken":"session-tok","savedAt":"2026-07-22T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    let auth = core(&stub, &dir);
+    assert_eq!(
+        auth.snapshot(),
+        AuthSnapshot::SignedIn { user: None },
+        "signed in, just not yet identified"
+    );
+
+    stub.profile("Ada Lovelace", None);
+    assert_eq!(
+        user_of(&auth.validate_stored().await).name,
+        "Ada Lovelace",
+        "the first validation after upgrade fills the identity in"
+    );
 }

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -250,18 +250,42 @@ impl Stub {
     /// A `/get-session` profile. `image` is the *absolute* URL the desktop will
     /// fetch, so tests point it back at this same stub.
     fn profile(&self, name: &str, image: Option<&str>) {
+        self.profile_active_org(name, image, None);
+    }
+
+    /// The same, with the session naming an active organisation — what the
+    /// server returns once the *web* has called `/organization/set-active`.
+    /// `None` is the normal state for a device-granted session.
+    fn profile_active_org(&self, name: &str, image: Option<&str>, active: Option<&str>) {
         let image = match image {
             Some(url) => format!(r#""{url}""#),
+            None => "null".to_string(),
+        };
+        let active = match active {
+            Some(id) => format!(r#""{id}""#),
             None => "null".to_string(),
         };
         self.on(
             "/get-session",
             vec![Reply::ok(&format!(
-                r#"{{"session":{{"id":"sess_1"}},
+                r#"{{"session":{{"id":"sess_1","activeOrganizationId":{active}}},
                      "user":{{"id":"user_1","name":"{name}",
                               "email":"ada@atlas.example","image":{image}}}}}"#
             ))],
         );
+    }
+
+    /// `GET /organization/list` — `(id, name)` pairs, carrying the extra fields
+    /// the real endpoint returns so the desktop is proven to ignore them.
+    fn org_list(&self, orgs: &[(&str, &str)]) {
+        let body = orgs
+            .iter()
+            .map(|(id, name)| {
+                format!(r#"{{"id":"{id}","name":"{name}","slug":"{id}","logo":null}}"#)
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        self.on("/organization/list", vec![Reply::ok(&format!("[{body}]"))]);
     }
 
     /// Absolute URL for a stub path, for use as a profile `image`.
@@ -283,8 +307,30 @@ fn signed_in(snapshot: &AuthSnapshot) -> bool {
 /// The identity on a signed-in snapshot, or a panic naming what we got instead.
 fn user_of(snapshot: &AuthSnapshot) -> AccountUser {
     match snapshot {
-        AuthSnapshot::SignedIn { user: Some(user) } => user.clone(),
+        AuthSnapshot::SignedIn {
+            user: Some(user), ..
+        } => user.clone(),
         other => panic!("expected a signed-in snapshot with an identity, got {other:?}"),
+    }
+}
+
+/// The organisation list on a signed-in snapshot (ATL-51).
+///
+/// Deliberately hands back the `Option` rather than defaulting it: `None`
+/// ("not known yet") and `Some([])` ("belongs to none") render differently, and
+/// a helper that flattened them would let a test pass while the menu lied.
+fn orgs_of(snapshot: &AuthSnapshot) -> Option<Vec<AccountOrg>> {
+    match snapshot {
+        AuthSnapshot::SignedIn { orgs, .. } => orgs.clone(),
+        other => panic!("expected a signed-in snapshot, got {other:?}"),
+    }
+}
+
+/// The organisation the desktop resolved as active, and nothing else about it.
+fn active_org_of(snapshot: &AuthSnapshot) -> Option<String> {
+    match snapshot {
+        AuthSnapshot::SignedIn { active_org_id, .. } => active_org_id.clone(),
+        other => panic!("expected a signed-in snapshot, got {other:?}"),
     }
 }
 
@@ -297,7 +343,29 @@ async fn sign_in(auth: &AuthCore) {
 const TOKEN_OK: &str = r#"{"access_token":"session-tok","token_type":"Bearer"}"#;
 /// A successful `/token` mint — the call [`AuthCore::validate_once`] takes its
 /// verdict from, so any test that validates has to script it.
+///
+/// Deliberately **not** a well-formed JWT. Every test that does not care about
+/// roles uses it, so each of them also proves that an unparseable token costs
+/// the roles and nothing else.
 const JWT_OK: &str = r#"{"token":"jwt-here"}"#;
+
+/// A `/token` reply whose JWT carries an `orgs` claim — `(organisationId, role)`
+/// pairs, exactly the `{ orgId: role }` shape of the real claim (API doc §5.1).
+///
+/// Three dot-separated segments, base64url without padding. The signature is
+/// gibberish on purpose: nothing verifies it, and a test that supplied a real
+/// one would imply otherwise.
+fn jwt_reply(orgs: &[(&str, &str)]) -> Reply {
+    use base64::Engine;
+    let claims = orgs
+        .iter()
+        .map(|(id, role)| format!(r#""{id}":"{role}""#))
+        .collect::<Vec<_>>()
+        .join(",");
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(format!(r#"{{"sub":"user_1","orgs":{{{claims}}}}}"#));
+    Reply::ok(&format!(r#"{{"token":"header.{payload}.signature"}}"#))
+}
 /// Stands in for image bytes. Content is irrelevant — nothing decodes it.
 const PIXELS: &str = "not-really-a-png-but-nothing-here-decodes-it";
 
@@ -1152,8 +1220,13 @@ async fn a_credential_stored_before_identities_existed_still_loads() {
     let auth = core(&stub, &dir);
     assert_eq!(
         auth.snapshot(),
-        AuthSnapshot::SignedIn { user: None },
-        "signed in, just not yet identified"
+        AuthSnapshot::SignedIn {
+            user: None,
+            orgs: None,
+            active_org_id: None
+        },
+        "signed in, just not yet identified — and not yet knowing anything \
+         about organisations either, which is not the same as belonging to none"
     );
 
     stub.profile("Ada Lovelace", None);
@@ -1162,6 +1235,340 @@ async fn a_credential_stored_before_identities_existed_still_loads() {
         user_of(&validated(&auth).await).name,
         "Ada Lovelace",
         "the first validation after upgrade fills the identity in"
+    );
+}
+
+// ----------------------------------------------------------- organisations
+//
+// ATL-51. Two calls, joined, because neither answers alone: `/organization/list`
+// carries the names and no roles, and the access token's `orgs` claim carries
+// the roles and no names. Everything below is about that join surviving the
+// ways either half can be missing.
+
+/// A grant whose `/token` mint carries real roles, so signing in alone lands a
+/// populated organisation section — no validation pass required.
+fn scripted_grant_with_roles(stub: &Stub, roles: &[(&str, &str)]) {
+    stub.grant_ready(600);
+    stub.on("/device/token", vec![Reply::ok(TOKEN_OK)]);
+    stub.on("/token", vec![jwt_reply(roles)]);
+}
+
+fn org(id: &str, name: &str, role: Option<Role>) -> AccountOrg {
+    AccountOrg {
+        id: id.into(),
+        name: name.into(),
+        role,
+    }
+}
+
+#[tokio::test]
+async fn organisation_names_and_roles_are_joined_from_the_two_sources() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "admin"), ("org_2", "developer")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas"), ("org_2", "Side Project")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    let snapshot = auth.snapshot();
+    assert_eq!(
+        orgs_of(&snapshot),
+        Some(vec![
+            org("org_1", "Atlas", Some(Role::Admin)),
+            org("org_2", "Side Project", Some(Role::Developer)),
+        ]),
+        "every name came from the list and every role from the claim — \
+         neither source could have produced this alone"
+    );
+    assert_eq!(
+        active_org_of(&snapshot).as_deref(),
+        Some("org_1"),
+        "with nothing set on the web, the first organisation is the active one"
+    );
+
+    // The contract ATL-44 proved: the desktop has no cookie, so the list is
+    // only reachable with the session token as a Bearer.
+    let seen = stub.seen("/organization/list");
+    assert_eq!(seen.len(), 1, "one list call per refresh");
+    assert_eq!(seen[0].method, "GET");
+    assert_eq!(seen[0].bearer.as_deref(), Some("session-tok"));
+}
+
+#[tokio::test]
+async fn an_account_in_no_organisation_yields_a_deliberate_empty_state() {
+    // The user belongs to none — a real answer, not a failure. It has to be
+    // distinguishable from every degraded state, because the menu renders a
+    // plain line for it rather than a blank row, a spinner, or an error.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    let snapshot = auth.snapshot();
+    assert!(signed_in(&snapshot), "no organisation is not a failed sign-in");
+    assert_eq!(
+        orgs_of(&snapshot),
+        Some(Vec::new()),
+        "`Some([])` — the server answered, and the answer is none. The menu \
+         only states that because it can tell this from having never asked"
+    );
+    assert_eq!(active_org_of(&snapshot), None);
+    assert_eq!(
+        user_of(&snapshot).name,
+        "Ada Lovelace",
+        "the identity is unaffected by having joined nothing"
+    );
+}
+
+#[tokio::test]
+async fn the_organisation_list_survives_a_restart_and_renders_with_the_server_unreachable() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "product_owner")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    let known = orgs_of(&auth.snapshot());
+    assert_eq!(
+        known,
+        Some(vec![org("org_1", "Atlas", Some(Role::ProductOwner))])
+    );
+
+    // A relaunch on a plane: same config directory, nothing listening.
+    let offline = AuthCore::new("http://127.0.0.1:1", dir.path(), reqwest::Client::new());
+    assert_eq!(
+        orgs_of(&offline.snapshot()),
+        known,
+        "the section renders from the snapshot before any call is made"
+    );
+
+    offline.validate_once().await;
+    assert_eq!(
+        orgs_of(&offline.snapshot()),
+        known,
+        "a call that never landed says nothing about membership, so it must \
+         not empty the menu"
+    );
+    assert_eq!(active_org_of(&offline.snapshot()).as_deref(), Some("org_1"));
+}
+
+#[tokio::test]
+async fn a_failed_organisation_list_keeps_the_one_already_stored() {
+    // Distinct from being offline: the server answered, just not with a list.
+    // The old one is still the best thing known about this user's membership.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "admin")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    let known = orgs_of(&auth.snapshot());
+
+    stub.on("/organization/list", vec![Reply::err(500, "boom")]);
+    assert_eq!(auth.validate_once().await, Validation::Confirmed);
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        known,
+        "an outage on one endpoint must not trade a known-good list for an \
+         empty one"
+    );
+}
+
+#[tokio::test]
+async fn an_organisation_the_claim_does_not_mention_is_listed_without_a_role() {
+    // The two calls are not atomic with respect to each other: an invitation
+    // accepted between the mint and the list lands here. A name with no role
+    // beats an organisation that silently disappears.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "admin")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas"), ("org_2", "Joined Just Now")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        Some(vec![
+            org("org_1", "Atlas", Some(Role::Admin)),
+            org("org_2", "Joined Just Now", None),
+        ])
+    );
+}
+
+#[tokio::test]
+async fn a_role_this_build_does_not_know_is_dropped_but_its_organisation_is_not() {
+    // A fifth role added server-side after this build shipped. There is no
+    // label to render, but the organisation is still real.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "auditor")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        Some(vec![org("org_1", "Atlas", None)])
+    );
+}
+
+#[tokio::test]
+async fn an_unreadable_access_token_costs_the_roles_and_nothing_else() {
+    // `scripted_grant` mints a `token` that is not a JWT at all. Nothing here
+    // authorises anything, so an unparseable claim is a missing label — never
+    // an error, and never a reason to doubt the credential.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant(&stub);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        Some(vec![org("org_1", "Atlas", None)]),
+        "nothing was ever known about this role, so there is nothing to show"
+    );
+    assert_eq!(active_org_of(&auth.snapshot()).as_deref(), Some("org_1"));
+    assert!(auth.stored().is_some());
+}
+
+#[tokio::test]
+async fn an_unreadable_access_token_keeps_the_role_already_known() {
+    // The other half of the case above, and the one that matters: a role was
+    // known, and a later refresh could not read the claim. Downgrading "Admin"
+    // to nothing over one unreadable token is the same mistake as trading a
+    // known-good photo for initials over one timeout.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "admin")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    let known = orgs_of(&auth.snapshot());
+    assert_eq!(known, Some(vec![org("org_1", "Atlas", Some(Role::Admin))]));
+
+    // The mint still succeeds — the credential is fine — but the token is not
+    // one this build can read.
+    stub.on("/token", vec![Reply::ok(JWT_OK)]);
+    assert_eq!(auth.validate_once().await, Validation::Confirmed);
+    assert_eq!(orgs_of(&auth.snapshot()), known);
+}
+
+#[tokio::test]
+async fn a_claim_that_places_the_user_nowhere_does_clear_the_role() {
+    // The distinction the tri-state exists for: an `orgs` claim of `{}` was
+    // *read*, and says this user holds no role here (API doc §5.1). Unlike an
+    // unreadable token, that is an answer, and it must land.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "admin")]);
+    stub.profile("Ada Lovelace", None);
+    stub.org_list(&[("org_1", "Atlas")]);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        Some(vec![org("org_1", "Atlas", Some(Role::Admin))])
+    );
+
+    stub.on("/token", vec![jwt_reply(&[])]);
+    assert_eq!(auth.validate_once().await, Validation::Confirmed);
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        Some(vec![org("org_1", "Atlas", None)]),
+        "a claim we could read outranks one we remember"
+    );
+}
+
+#[tokio::test]
+async fn organisations_that_were_never_fetched_are_unknown_rather_than_none() {
+    // Upgrading from a build that stored no organisations. Saying "no
+    // organisation" here would be a lie to a user who has one — and offline,
+    // a lie with no expiry, since the list call never lands to correct it.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    std::fs::write(
+        dir.path().join("atlas-session.json"),
+        r#"{"sessionToken":"session-tok","savedAt":"2026-07-22T00:00:00Z",
+            "identity":{"id":"user_1","name":"Ada Lovelace",
+                        "email":"ada@atlas.example","avatarUrl":null,
+                        "avatarPath":null}}"#,
+    )
+    .unwrap();
+
+    let auth = core(&stub, &dir);
+    assert_eq!(
+        user_of(&auth.snapshot()).name,
+        "Ada Lovelace",
+        "the identity from the old file still loads"
+    );
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        None,
+        "never asked is not the same answer as none"
+    );
+
+    // A launch where the list call fails must not resolve the question either.
+    stub.profile("Ada Lovelace", None);
+    stub.on("/token", vec![Reply::ok(JWT_OK)]);
+    stub.on("/organization/list", vec![Reply::err(500, "boom")]);
+    assert_eq!(auth.validate_once().await, Validation::Confirmed);
+    assert_eq!(orgs_of(&auth.snapshot()), None, "still unknown, still silent");
+
+    // And is settled the moment one lands.
+    stub.org_list(&[("org_1", "Atlas")]);
+    assert_eq!(auth.validate_once().await, Validation::Confirmed);
+    assert_eq!(
+        orgs_of(&auth.snapshot()),
+        Some(vec![org("org_1", "Atlas", None)])
+    );
+}
+
+#[tokio::test]
+async fn the_active_organisation_follows_the_web_and_falls_back_when_it_cannot() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_1", "member"), ("org_2", "admin")]);
+    stub.org_list(&[("org_1", "First"), ("org_2", "Chosen")]);
+    stub.profile_active_org("Ada Lovelace", None, Some("org_2"));
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    assert_eq!(
+        active_org_of(&auth.snapshot()).as_deref(),
+        Some("org_2"),
+        "a choice made on the web outranks list order"
+    );
+
+    // Membership in the active organisation removed on the web: the stored
+    // choice is no longer in the list, and must not resolve to nothing.
+    stub.profile_active_org("Ada Lovelace", None, Some("org_2"));
+    stub.org_list(&[("org_1", "First")]);
+    assert_eq!(auth.validate_once().await, Validation::Confirmed);
+    assert_eq!(
+        active_org_of(&auth.snapshot()).as_deref(),
+        Some("org_1"),
+        "an active id that is no longer a membership falls back to the first"
     );
 }
 

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -601,6 +601,32 @@ async fn a_second_start_resumes_the_same_grant_instead_of_minting_another() {
 }
 
 #[tokio::test]
+async fn the_browser_is_sent_to_the_plain_url_never_the_pre_filled_one() {
+    // The remote-phishing guard, pinned. A link carrying the code puts an
+    // already-signed-in user one click from approving someone else's grant;
+    // sending them to an empty box means the approved code is necessarily the
+    // one this window is showing. "Just pre-fill it" reads as a harmless UX
+    // win, so the property gets a test rather than only a comment.
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    stub.grant_ready(600);
+
+    let auth = core(&stub, &dir);
+    let grant = auth.start_grant().await.expect("start grant");
+
+    assert_eq!(grant.approval_url(), "https://app.example/device");
+    assert!(
+        !grant.approval_url().contains("user_code"),
+        "the code must not travel in the URL — that link is the attack"
+    );
+    assert!(
+        grant.verification_uri_complete.contains("user_code"),
+        "the pre-filled URL is still parsed off the wire; it is simply not opened, \
+         so this asserts the two are genuinely different values"
+    );
+}
+
+#[tokio::test]
 async fn the_connecting_snapshot_exposes_the_code_but_never_the_secret() {
     let stub = Stub::start().await;
     let dir = TempDir::new();

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -77,11 +77,13 @@ pub async fn auth_sign_in(
         .await
         .map_err(|e| e.user_message())?;
 
-    // The verification URI comes off the wire — never constructed here, so the
-    // desktop stays ignorant of the web app's routing.
+    // Never a URL built here — it comes off the wire, so the desktop stays
+    // ignorant of the web app's routing. *Which* of the two the server sent is
+    // a security decision, so it is `approval_url`'s to make and not this
+    // layer's: see the note there before changing it.
     let _ = app
         .opener()
-        .open_url(grant.verification_uri_complete.clone(), None::<&str>);
+        .open_url(grant.approval_url().to_string(), None::<&str>);
 
     let snapshot = core.snapshot();
     broadcast(&app, snapshot.clone());

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -5,18 +5,29 @@
 //! tests here — this layer holds no logic of its own.
 //!
 //! Events emitted to the frontend:
-//!   `atlas:auth-changed` — the full [`AuthSnapshot`], on every transition
-//!   `atlas:auth-error`   — `{ message }` when a grant ends without a token
+//!   `atlas:auth-changed`    — the full [`AuthSnapshot`], on every transition
+//!   `atlas:auth-error`      — `{ message }` when a grant ends without a token
+//!   `atlas:auth-signed-out` — `{ message }` when the server ended the session
 //!
-//! Both go out via `app.emit`, which broadcasts to **every** window, so a
+//! All go out via `app.emit`, which broadcasts to **every** window, so a
 //! multi-window install always agrees about who is signed in.
+//!
+//! `auth-error` and `auth-signed-out` are separate because they are read in
+//! different places: a grant failure belongs inside the connect dialog the user
+//! is already looking at, while a revoked session arrives with nothing on
+//! screen and has to reach them as a toast.
 
 use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_opener::OpenerExt;
 
-use crate::auth::{auth_base, AuthCore, AuthSnapshot, GrantError};
+use crate::auth::{auth_base, AuthCore, AuthSnapshot, GrantError, Validation};
+
+/// Shown when the server rejects the stored credential. Deliberately says what
+/// happened and what to do about it: a title bar that silently reverts to a
+/// signed-out icon reads as a bug.
+const SESSION_ENDED: &str = "Your Atlas session ended. Sign in again to reconnect.";
 
 /// Managed handle to the auth core.
 pub struct AuthState {
@@ -117,15 +128,32 @@ fn raise(app: &AppHandle) {
     }
 }
 
-/// Validate any stored credential at startup, then broadcast the result.
+/// Render the stored credential immediately, then validate it in the
+/// background for as long as it takes (ATL-48).
 ///
-/// Preserves the credential on every failure for now — see
-/// [`AuthCore::validate_stored`].
+/// The first broadcast is the whole offline story: a launch with no network
+/// shows a complete signed-in title bar — name and photo — from the stored
+/// snapshot, rather than waiting on a call that is going to time out.
+///
+/// The validation behind it runs unbounded, so a machine that boots offline
+/// reconnects on its own. Only a 401 ends it in a sign-out, and only then does
+/// the user hear about it.
 pub fn restore_on_launch(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
         let core = app.state::<AuthState>().core();
-        let snapshot = core.validate_stored().await;
-        broadcast(&app, snapshot);
+        broadcast(&app, core.snapshot());
+
+        let settled = {
+            let app = app.clone();
+            core.revalidate(move |snapshot| broadcast(&app, snapshot)).await
+        };
+
+        if settled == Validation::Rejected {
+            let _ = app.emit(
+                "atlas:auth-signed-out",
+                serde_json::json!({ "message": SESSION_ENDED }),
+            );
+        }
     });
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -23,6 +23,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_opener::OpenerExt;
 
 use crate::auth::{auth_base, AuthCore, AuthSnapshot, GrantError, Validation};
+use crate::telemetry::TelemetryClient;
 
 /// Shown when the server rejects the stored credential. Deliberately says what
 /// happened and what to do about it: a title bar that silently reverts to a
@@ -52,6 +53,14 @@ impl AuthState {
 
 fn broadcast(app: &AppHandle, snapshot: AuthSnapshot) {
     let _ = app.emit("atlas:auth-changed", snapshot);
+}
+
+/// The anonymous account events (ATL-52). Both are no-ops unless the user has
+/// already opted into telemetry, and neither carries a user id, email, or
+/// Organisation id — see [`TelemetryClient::capture_signed_in`] for why the
+/// payload is defined there rather than here.
+fn telemetry(app: &AppHandle) -> Arc<TelemetryClient> {
+    Arc::clone(&app.state::<Arc<TelemetryClient>>())
 }
 
 /// Current account state. Carries no credential — see [`AuthSnapshot`].
@@ -95,6 +104,7 @@ pub async fn auth_sign_in(
             Ok(()) => {
                 broadcast(&task_app, core.snapshot());
                 raise(&task_app);
+                telemetry(&task_app).capture_signed_in();
             }
             // Cancellation is a deliberate user action; it needs no error toast.
             Err(GrantError::Cancelled) => broadcast(&task_app, core.snapshot()),
@@ -141,9 +151,15 @@ pub async fn auth_sign_out(app: AppHandle, state: State<'_, AuthState>) -> Resul
     broadcast(&app, core.snapshot());
 
     Ok(match ticket {
-        Some(ticket) => core.revoke(ticket).await,
+        Some(ticket) => {
+            // Recorded on the local sign-out, not the revocation: the user has
+            // signed out either way, and whether the server could be reached is
+            // not what this event counts.
+            telemetry(&app).capture_signed_out();
+            core.revoke(ticket).await
+        }
         // Nothing was stored, so there is nothing the server could still be
-        // holding — no caveat is owed.
+        // holding — no caveat is owed, and nothing happened worth recording.
         None => true,
     })
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,0 +1,131 @@
+//! Tauri adapters over [`crate::auth::AuthCore`].
+//!
+//! Thin by design: translate arguments, spawn the poll task, emit events. Every
+//! decision worth testing lives in `crate::auth`, which is why there are no
+//! tests here — this layer holds no logic of its own.
+//!
+//! Events emitted to the frontend:
+//!   `atlas:auth-changed` — the full [`AuthSnapshot`], on every transition
+//!   `atlas:auth-error`   — `{ message }` when a grant ends without a token
+//!
+//! Both go out via `app.emit`, which broadcasts to **every** window, so a
+//! multi-window install always agrees about who is signed in.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter, Manager, State};
+use tauri_plugin_opener::OpenerExt;
+
+use crate::auth::{auth_base, AuthCore, AuthSnapshot, GrantError};
+
+/// Managed handle to the auth core.
+pub struct AuthState {
+    core: Arc<AuthCore>,
+}
+
+impl AuthState {
+    pub fn new(config_dir: std::path::PathBuf) -> Self {
+        Self {
+            core: Arc::new(AuthCore::new(
+                auth_base(),
+                config_dir,
+                reqwest::Client::new(),
+            )),
+        }
+    }
+
+    pub fn core(&self) -> Arc<AuthCore> {
+        Arc::clone(&self.core)
+    }
+}
+
+fn broadcast(app: &AppHandle, snapshot: AuthSnapshot) {
+    let _ = app.emit("atlas:auth-changed", snapshot);
+}
+
+/// Current account state. Carries no credential — see [`AuthSnapshot`].
+#[tauri::command]
+pub fn auth_snapshot(state: State<'_, AuthState>) -> AuthSnapshot {
+    state.core().snapshot()
+}
+
+/// Begin (or resume) sign-in.
+///
+/// Opens the approval page in the system browser and polls in the background.
+/// Returns immediately with the `connecting` snapshot so the dialog can render
+/// while the human is still in the browser.
+#[tauri::command]
+pub async fn auth_sign_in(
+    app: AppHandle,
+    state: State<'_, AuthState>,
+) -> Result<AuthSnapshot, String> {
+    let core = state.core();
+
+    let grant = core
+        .start_grant()
+        .await
+        .map_err(|e| e.user_message())?;
+
+    // The verification URI comes off the wire — never constructed here, so the
+    // desktop stays ignorant of the web app's routing.
+    let _ = app
+        .opener()
+        .open_url(grant.verification_uri_complete.clone(), None::<&str>);
+
+    let snapshot = core.snapshot();
+    broadcast(&app, snapshot.clone());
+
+    // Poll off the command so the frontend is not blocked for up to 10 minutes.
+    let task_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        match core.run_grant(&grant).await {
+            Ok(()) => {
+                broadcast(&task_app, core.snapshot());
+                raise(&task_app);
+            }
+            // Cancellation is a deliberate user action; it needs no error toast.
+            Err(GrantError::Cancelled) => broadcast(&task_app, core.snapshot()),
+            Err(err) => {
+                broadcast(&task_app, core.snapshot());
+                let _ = task_app.emit(
+                    "atlas:auth-error",
+                    serde_json::json!({ "message": err.user_message() }),
+                );
+            }
+        }
+    });
+
+    Ok(snapshot)
+}
+
+/// Abandon an in-flight grant. Idempotent.
+#[tauri::command]
+pub fn auth_cancel_sign_in(app: AppHandle, state: State<'_, AuthState>) -> AuthSnapshot {
+    let core = state.core();
+    core.cancel_grant();
+    let snapshot = core.snapshot();
+    broadcast(&app, snapshot.clone());
+    snapshot
+}
+
+/// Bring Atlas forward once approval lands, so the human does not have to hunt
+/// for the window they left behind in the browser.
+fn raise(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+/// Validate any stored credential at startup, then broadcast the result.
+///
+/// Preserves the credential on every failure for now — see
+/// [`AuthCore::validate_stored`].
+pub fn restore_on_launch(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let core = app.state::<AuthState>().core();
+        let snapshot = core.validate_stored().await;
+        broadcast(&app, snapshot);
+    });
+}

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -119,6 +119,33 @@ pub fn auth_cancel_sign_in(app: AppHandle, state: State<'_, AuthState>) -> AuthS
     snapshot
 }
 
+/// Sign out (ATL-50).
+///
+/// Local state is gone and the signed-out snapshot has been broadcast to every
+/// window **before** the server is contacted at all, so the UI flips with no
+/// spinner and no wait — and sign-out works with the network off, which is when
+/// it matters most.
+///
+/// Resolves to `true` when the server confirmed the session is revoked. The
+/// caller is already signed out either way; the value only decides whether they
+/// are told the server session may outlive the local one. It is returned rather
+/// than emitted because, unlike everything else here, it answers *this* window's
+/// click — broadcasting it would put the same caveat in front of two other
+/// windows that did nothing.
+#[tauri::command]
+pub async fn auth_sign_out(app: AppHandle, state: State<'_, AuthState>) -> Result<bool, String> {
+    let core = state.core();
+    let ticket = core.sign_out();
+    broadcast(&app, core.snapshot());
+
+    Ok(match ticket {
+        Some(ticket) => core.revoke(ticket).await,
+        // Nothing was stored, so there is nothing the server could still be
+        // holding — no caveat is owed.
+        None => true,
+    })
+}
+
 /// Bring Atlas forward once approval lands, so the human does not have to hunt
 /// for the window they left behind in the browser.
 fn raise(app: &AppHandle) {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_memory;
+pub mod auth;
 pub mod agents;
 pub mod analysis;
 pub mod app_state;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,7 @@ pub fn run() {
             commands::auth::auth_snapshot,
             commands::auth::auth_sign_in,
             commands::auth::auth_cancel_sign_in,
+            commands::auth::auth_sign_out,
             commands::window::window_zoom,
             commands::clipboard::clipboard_file_paths,
             commands::window::set_window_title,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod commands;
 mod logging;
 mod menu;
@@ -171,6 +172,19 @@ pub fn run() {
             // then run a non-blocking background check + a periodic re-check. The
             // download/verify/stage happens silently; the user is only prompted
             // once it's ready to restart. See `commands::updater`.
+            // Account auth (ATL-35). The config dir only resolves from the
+            // app handle, so this is managed here rather than in the builder
+            // chain. Restore runs off-thread: a signed-out launch touches the
+            // network not at all, and a signed-in one must never block boot.
+            {
+                let config_dir = app
+                    .path()
+                    .app_config_dir()
+                    .unwrap_or_else(|_| std::path::PathBuf::from("."));
+                app.manage(commands::auth::AuthState::new(config_dir));
+                commands::auth::restore_on_launch(&app.handle());
+            }
+
             commands::updater::init_on_startup(&app.handle());
             commands::updater::check_in_background(&app.handle());
             commands::updater::spawn_periodic(&app.handle());
@@ -227,6 +241,9 @@ pub fn run() {
             }
         })
         .invoke_handler(tauri::generate_handler![
+            commands::auth::auth_snapshot,
+            commands::auth::auth_sign_in,
+            commands::auth::auth_cancel_sign_in,
             commands::window::window_zoom,
             commands::clipboard::clipboard_file_paths,
             commands::window::set_window_title,

--- a/src-tauri/src/telemetry/mod.rs
+++ b/src-tauri/src/telemetry/mod.rs
@@ -1,12 +1,15 @@
 //! Consent-gated, privacy-preserving product telemetry (PostHog).
 //!
-//! Atlas ships with **zero** analytics enabled by default. Nothing leaves the
-//! machine until the user explicitly opts in (Settings → General → "Share
-//! anonymous usage data" or the first-run consent prompt). When enabled, this
-//! module emits coarse **usage / error metadata only** — never prompt or
-//! response text, file contents or absolute paths, KB/chat content, API keys,
-//! terminal I/O, or browser URLs. See `TELEMETRY.md` at the repo root for the
-//! full event catalog and the never-collected list.
+//! Consent is Settings → General → "Share anonymous usage data", which defaults
+//! **ON** — the opt-out posture of VS Code and Zed, and the reason `TELEMETRY.md`
+//! says so plainly rather than calling this opt-in. Switching it off takes effect
+//! immediately: [`capture`](TelemetryClient::capture) returns before anything is
+//! queued, and nothing is buffered for later. When enabled, this module emits
+//! coarse **usage / error metadata only** — never prompt or response text, file
+//! contents or absolute paths, KB/chat content, API keys, terminal I/O, or
+//! browser URLs. See `TELEMETRY.md` at the repo root for the full event catalogue
+//! and the never-collected list; an event added here belongs in that table in the
+//! same change.
 //!
 //! Identity is a single persisted anonymous UUID (`telemetry_anon_id` in
 //! `state.json`) used as the PostHog `distinct_id` by both this Rust emitter
@@ -321,6 +324,38 @@ impl TelemetryClient {
         });
     }
 
+    /// The account events, and the whole reason they are named here rather than
+    /// written inline at their call sites (ATL-52).
+    ///
+    /// Atlas's telemetry identity is the persisted anonymous install UUID above,
+    /// consented to under "Share anonymous usage data". Signing in must not
+    /// change that: there is no `identify` and no `alias` anywhere in this app,
+    /// and these two events carry **no user id, email, or Organisation id**.
+    /// Linking the install to a real user would retroactively de-anonymize every
+    /// event it has ever sent, under a consent string that promised the
+    /// opposite. ADR-0007 §8's identified analytics is satisfied server-side,
+    /// where session creation calls `identify` — the desktop must not duplicate
+    /// it.
+    ///
+    /// Defining the payload once, in the module that owns that promise, is what
+    /// lets a test hold it: a `json!({})` written at the call site could grow a
+    /// `user_id` without anything noticing.
+    ///
+    /// Both are no-ops unless consent was already granted, because
+    /// [`capture`](Self::capture) is — a user who has not opted in sends nothing
+    /// extra as a result of signing in.
+    pub fn capture_signed_in(&self) {
+        self.capture("auth_signed_in", json!({}));
+    }
+
+    /// Companion to [`capture_signed_in`](Self::capture_signed_in). Emitted only
+    /// when the *user* signs out, never when the server ends a session: folding
+    /// a revocation into this event would leave a count that means neither one
+    /// thing nor the other.
+    pub fn capture_signed_out(&self) {
+        self.capture("auth_signed_out", json!({}));
+    }
+
     /// Remember the latest cumulative usage for a session (stamped onto the
     /// next `agent_turn_finished`). No-op when inert.
     pub fn note_usage(&self, session_id: &str, usage: Value) {
@@ -557,5 +592,66 @@ mod tests {
         let ev2 = rx.try_recv().expect("finished event");
         assert_eq!(ev2.event, "agent_turn_finished");
         assert_eq!(ev2.properties["agent_kind"], json!("atlas"));
+    }
+
+    /// Build a non-inert client with `enabled` as given, plus the receiving end
+    /// of its queue.
+    fn client_with_consent(enabled: bool) -> (TelemetryClient, mpsc::Receiver<QueuedEvent>) {
+        let (tx, rx) = mpsc::channel(8);
+        let c = TelemetryClient {
+            enabled: AtomicBool::new(enabled),
+            inert: false,
+            api_key: Some("phc_test".into()),
+            host: DEFAULT_HOST.to_string(),
+            using_default_key: true,
+            distinct_id: "anon-install-uuid".into(),
+            app_version: "0.0.0",
+            os: "test",
+            arch: "test",
+            tx: Some(tx),
+            last_usage: DashMap::new(),
+        };
+        (c, rx)
+    }
+
+    /// ATL-52: signing in must not become a telemetry backdoor. A user who has
+    /// not opted in sends *nothing* extra as a result of signing in or out.
+    #[test]
+    fn auth_events_are_gated_by_consent() {
+        let (c, mut rx) = client_with_consent(false);
+        c.capture_signed_in();
+        c.capture_signed_out();
+        assert!(
+            rx.try_recv().is_err(),
+            "auth events must not be enqueued without consent"
+        );
+    }
+
+    /// ATL-52: the install stays anonymous after sign-in. These two events carry
+    /// nothing beyond the common properties every event gets — in particular no
+    /// user id, email, or Organisation id. This is the test the payload lives in
+    /// `capture_signed_in` / `capture_signed_out` to make possible.
+    #[test]
+    fn auth_events_carry_no_identity() {
+        let (c, mut rx) = client_with_consent(true);
+        c.capture_signed_in();
+        c.capture_signed_out();
+
+        // The four keys `inject_common` adds, and nothing else is permitted.
+        const COMMON: [&str; 4] = ["$lib", "app_version", "os", "arch"];
+
+        for expected in ["auth_signed_in", "auth_signed_out"] {
+            let ev = rx.try_recv().unwrap_or_else(|_| panic!("{expected} event"));
+            assert_eq!(ev.event, expected);
+            let props = ev.properties.as_object().expect("object properties");
+            let extra: Vec<&String> = props
+                .keys()
+                .filter(|k| !COMMON.contains(&k.as_str()))
+                .collect();
+            assert!(
+                extra.is_empty(),
+                "{expected} must carry no properties beyond the common ones, found {extra:?}"
+            );
+        }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,12 @@ import {
   listenUpdateChecking,
 } from "@/features/updater/lib/updater-api";
 import { Toaster, toast } from "sonner";
+import {
+  listenAuthChanged,
+  listenAuthError,
+} from "@/features/auth/lib/auth-api";
+import { useAuthStore } from "@/features/auth/stores/auth-store";
+import { ConnectDialog } from "@/features/auth/components/connect-dialog";
 import { clampScale, SCALE_STEP, DEFAULT_SCALE } from "@/features/settings/lib/ui-scale";
 
 // Interface-zoom helpers (⌘+/⌘-/⌘0). They read + write the persisted
@@ -162,6 +168,21 @@ export function App() {
         a.dismissModal();
       }
     });
+    return () => {
+      for (const p of offs) void p.then((off) => off());
+    };
+  }, []);
+
+  // Account auth (ATL-35). Rust owns the credential and every transition; this
+  // only mirrors `atlas:auth-changed` into the store. Broadcast (not per-window)
+  // so two open windows always agree on who is signed in.
+  useEffect(() => {
+    const a = useAuthStore.getState().actions;
+    const offs: Array<Promise<() => void>> = [
+      listenAuthChanged((snapshot) => a.setSnapshot(snapshot)),
+      listenAuthError((e) => a.setError(e.message)),
+    ];
+    void a.hydrate();
     return () => {
       for (const p of offs) void p.then((off) => off());
     };
@@ -1221,6 +1242,7 @@ export function App() {
       <HintOverlay />
       <NotificationPanel />
       <UpdateAvailableModal />
+      <ConnectDialog />
       <BrowserOverlayWatcher />
       <Toaster
         position="bottom-right"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import { Toaster, toast } from "sonner";
 import {
   listenAuthChanged,
   listenAuthError,
+  listenAuthSignedOut,
 } from "@/features/auth/lib/auth-api";
 import { useAuthStore } from "@/features/auth/stores/auth-store";
 import { ConnectDialog } from "@/features/auth/components/connect-dialog";
@@ -181,6 +182,10 @@ export function App() {
     const offs: Array<Promise<() => void>> = [
       listenAuthChanged((snapshot) => a.setSnapshot(snapshot)),
       listenAuthError((e) => a.setError(e.message)),
+      // A revoked or expired session arrives with nothing on screen, so the
+      // only place it can land is a toast — the title bar quietly reverting to
+      // a signed-out icon reads as a bug rather than an explanation.
+      listenAuthSignedOut((e) => toast.error(e.message)),
     ];
     void a.hydrate();
     return () => {

--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import type { Window as TauriWindow } from "@tauri-apps/api/window";
 import { useUpdaterStore } from "@/features/updater/stores/updater-store";
 import { updater } from "@/features/updater/lib/updater-api";
+import { AccountButton } from "@/features/auth/components/account-button";
 
 function useTauriWindow() {
   const windowRef = useRef<TauriWindow | null>(null);
@@ -107,13 +108,19 @@ export function Titlebar() {
         <ProjectLabel name={displayName} path={currentProject?.path} />
       </div>
 
-      {currentProject && (
-        <div className="flex items-center gap-1.5">
-          <UpdateButton />
-          <NotificationButton />
-          <RightPanelToggle />
-        </div>
-      )}
+      {/* The account button sits OUTSIDE the `currentProject` guard on purpose:
+          a fresh install has no project open, and sign-in must be reachable
+          from that empty state rather than hidden behind opening a folder. */}
+      <div className="flex items-center gap-1.5">
+        {currentProject && (
+          <>
+            <UpdateButton />
+            <NotificationButton />
+            <RightPanelToggle />
+          </>
+        )}
+        <AccountButton />
+      </div>
     </div>
   );
 }

--- a/src/features/auth/components/account-avatar.tsx
+++ b/src/features/auth/components/account-avatar.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+import type { AccountUser } from "../lib/auth-api";
+
+/**
+ * The signed-in user's face: their cached photo, or their initial on a colour
+ * derived from their user id.
+ *
+ * There is no third "broken photo" state — every failure path, in Rust and
+ * here, lands on the initial, because a missing avatar is not something the
+ * user can act on.
+ *
+ * Sized by prop rather than by class so the title-bar button (18px) and the
+ * account-menu header (28px) stay the same component: the initial's colour is
+ * identity, and two implementations of it would eventually disagree.
+ */
+export function AccountAvatar({
+  user,
+  size,
+}: {
+  user: AccountUser;
+  size: number;
+}) {
+  // Keyed by path rather than a bare boolean, so a photo that changes gets a
+  // fresh attempt instead of inheriting the previous one's failure.
+  const [failedPath, setFailedPath] = useState<string | null>(null);
+
+  if (user.avatarPath && failedPath !== user.avatarPath) {
+    return (
+      <img
+        src={convertFileSrc(user.avatarPath)}
+        alt=""
+        draggable={false}
+        onError={() => setFailedPath(user.avatarPath)}
+        style={{ width: size, height: size }}
+        className="rounded-full object-cover shrink-0"
+      />
+    );
+  }
+  return <Initial user={user} size={size} />;
+}
+
+/**
+ * A single letter on a colour derived from the user id.
+ *
+ * Deriving rather than picking keeps the same person the same colour on every
+ * machine and every launch, which is what makes the circle read as *their*
+ * badge rather than decoration.
+ */
+function Initial({ user, size }: { user: AccountUser; size: number }) {
+  const source = user.name.trim() || user.email.trim();
+  // `Array.from` rather than `[0]`, so a name starting outside the BMP does not
+  // render as half a character.
+  const letter = (Array.from(source)[0] ?? "?").toUpperCase();
+
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.55),
+        backgroundColor: `hsl(${hueFor(user.id)} 42% 40%)`,
+      }}
+      className="flex items-center justify-center shrink-0 rounded-full font-medium leading-none text-white/90 select-none"
+    >
+      {letter}
+    </span>
+  );
+}
+
+/** Stable hue in [0, 360) for a string. */
+function hueFor(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
+}

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -68,6 +68,8 @@ export function AccountButton() {
     </button>
   );
 
-  if (!signedIn) return button;
-  return <AccountMenu user={user}>{button}</AccountMenu>;
+  // Narrowed on `snapshot` rather than the `signedIn` boolean, so the menu is
+  // handed one coherent account state instead of pieces pulled out separately.
+  if (snapshot.status !== "signed-in") return button;
+  return <AccountMenu account={snapshot}>{button}</AccountMenu>;
 }

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -1,0 +1,63 @@
+import { CircleUser, Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useAuthStore } from "../stores/auth-store";
+
+/**
+ * The account control at the right of the title bar.
+ *
+ * Rendered unconditionally — deliberately **outside** the title bar's
+ * "a project is open" guard, so a fresh install can connect an account from the
+ * empty state rather than having to open a folder first.
+ *
+ * ATL-47 replaces the icon with the user's profile photo. Until then signed-in
+ * is shown as a filled state rather than a face.
+ */
+export function AccountButton() {
+  const snapshot = useAuthStore.use.snapshot();
+  const starting = useAuthStore.use.starting();
+  const { beginSignIn, closeDialog } = useAuthStore.use.actions();
+  const dialogOpen = useAuthStore.use.dialogOpen();
+
+  const connecting = snapshot.status === "connecting";
+  const signedIn = snapshot.status === "signed-in";
+
+  const onClick = () => {
+    // While connecting, the button toggles the dialog rather than starting
+    // anything — the grant is already running.
+    if (connecting) {
+      if (dialogOpen) closeDialog();
+      else void beginSignIn();
+      return;
+    }
+    if (signedIn) return; // ATL-49 opens the account menu from here.
+    void beginSignIn();
+  };
+
+  const title = signedIn
+    ? "Atlas account — connected"
+    : connecting
+      ? "Waiting for approval in your browser…"
+      : "Connect your Atlas account";
+
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      className={cn(
+        "relative flex items-center justify-center w-6 h-6 rounded transition-all duration-150",
+        "hover:bg-[#ffffff08] outline-none focus:outline-none",
+        signedIn || connecting
+          ? "text-[#ccc]"
+          : "text-[#555] hover:text-[#aaa]",
+      )}
+    >
+      {starting || connecting ? (
+        <Loader2 size={14} className="animate-spin" />
+      ) : (
+        <CircleUser size={14} />
+      )}
+    </button>
+  );
+}

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -54,7 +54,10 @@ export function AccountButton() {
       aria-label={title}
       className={cn(
         "relative flex items-center justify-center w-6 h-6 rounded transition-all duration-150",
-        "hover:bg-[#ffffff08] outline-none focus:outline-none",
+        // A `<button>` still gets the arrow by default, and this one carries no
+        // label or border — the pointer is most of what says it is pressable.
+        // Matches the title bar's project-name button beside it.
+        "cursor-pointer hover:bg-[#ffffff08] outline-none focus:outline-none",
         signedIn || connecting ? "text-[#ccc]" : "text-[#555] hover:text-[#aaa]",
       )}
     >

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -1,10 +1,9 @@
-import { useState } from "react";
-import { convertFileSrc } from "@tauri-apps/api/core";
 import { CircleUser, Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import type { AccountUser } from "../lib/auth-api";
 import { useAuthStore } from "../stores/auth-store";
+import { AccountAvatar } from "./account-avatar";
+import { AccountMenu } from "./account-menu";
 
 /**
  * The account control at the right of the title bar.
@@ -13,10 +12,9 @@ import { useAuthStore } from "../stores/auth-store";
  * "a project is open" guard, so a fresh install can connect an account from the
  * empty state rather than having to open a folder first.
  *
- * Signed in, it is the user's face: the photo when we have one cached, their
- * initial in a coloured circle when we do not. There is no third "broken photo"
- * state — every failure path in Rust and here lands on the initial, because a
- * missing avatar is not something the user can act on.
+ * Signed in, it is the user's face and the trigger for the account menu.
+ * Signed out or mid-grant it is a plain button that starts (or reopens)
+ * sign-in — the menu has nothing to say in either state.
  */
 export function AccountButton() {
   const snapshot = useAuthStore.use.snapshot();
@@ -36,7 +34,6 @@ export function AccountButton() {
       else void beginSignIn();
       return;
     }
-    if (signedIn) return; // ATL-49 opens the account menu from here.
     void beginSignIn();
   };
 
@@ -48,9 +45,11 @@ export function AccountButton() {
         ? "Waiting for approval in your browser…"
         : "Connect your Atlas account";
 
-  return (
+  const button = (
+    // Signed in the click is Radix's to handle, so no `onClick` of our own —
+    // one that also ran would fight the trigger it is wrapped in.
     <button
-      onClick={onClick}
+      onClick={signedIn ? undefined : onClick}
       title={title}
       aria-label={title}
       className={cn(
@@ -62,63 +61,13 @@ export function AccountButton() {
       {starting || connecting ? (
         <Loader2 size={14} className="animate-spin" />
       ) : user ? (
-        <Avatar user={user} />
+        <AccountAvatar user={user} size={18} />
       ) : (
         <CircleUser size={14} />
       )}
     </button>
   );
-}
 
-/** The user's photo, or their initial. */
-function Avatar({ user }: { user: AccountUser }) {
-  // Keyed by path rather than a bare boolean, so a photo that changes gets a
-  // fresh attempt instead of inheriting the previous one's failure.
-  const [failedPath, setFailedPath] = useState<string | null>(null);
-
-  if (user.avatarPath && failedPath !== user.avatarPath) {
-    return (
-      <img
-        src={convertFileSrc(user.avatarPath)}
-        alt=""
-        draggable={false}
-        onError={() => setFailedPath(user.avatarPath)}
-        className="w-[18px] h-[18px] rounded-full object-cover"
-      />
-    );
-  }
-  return <Initial user={user} />;
-}
-
-/**
- * A single letter on a colour derived from the user id.
- *
- * Deriving rather than picking keeps the same person the same colour on every
- * machine and every launch, which is what makes the circle read as *their*
- * badge rather than decoration.
- */
-function Initial({ user }: { user: AccountUser }) {
-  const source = user.name.trim() || user.email.trim();
-  // `Array.from` rather than `[0]`, so a name starting outside the BMP does not
-  // render as half a character.
-  const letter = (Array.from(source)[0] ?? "?").toUpperCase();
-
-  return (
-    <span
-      aria-hidden
-      style={{ backgroundColor: `hsl(${hueFor(user.id)} 42% 40%)` }}
-      className="flex items-center justify-center w-[18px] h-[18px] rounded-full text-[10px] font-medium leading-none text-white/90 select-none"
-    >
-      {letter}
-    </span>
-  );
-}
-
-/** Stable hue in [0, 360) for a string. */
-function hueFor(seed: string): number {
-  let hash = 0;
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
-  }
-  return hash % 360;
+  if (!signedIn) return button;
+  return <AccountMenu user={user}>{button}</AccountMenu>;
 }

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -26,15 +26,12 @@ export function AccountButton() {
   const signedIn = snapshot.status === "signed-in";
   const user = snapshot.status === "signed-in" ? snapshot.user : null;
 
-  const onClick = () => {
-    // While connecting, the button toggles the dialog rather than starting
-    // anything — the grant is already running.
-    if (connecting) {
-      if (dialogOpen) closeDialog();
-      else void beginSignIn();
-      return;
-    }
-    void beginSignIn();
+  // Only reachable while connecting — every other state opens the menu. Toggles
+  // the dialog rather than starting anything, since the grant is already
+  // running; reopening it resumes that grant and reopens the browser.
+  const toggleDialog = () => {
+    if (dialogOpen) closeDialog();
+    else void beginSignIn();
   };
 
   const title = user
@@ -43,13 +40,14 @@ export function AccountButton() {
       ? "Atlas account — connected"
       : connecting
         ? "Waiting for approval in your browser…"
-        : "Connect your Atlas account";
+        : "Account and settings";
 
   const button = (
-    // Signed in the click is Radix's to handle, so no `onClick` of our own —
-    // one that also ran would fight the trigger it is wrapped in.
+    // Only the connecting state keeps a click of its own. In the other two the
+    // click is Radix's to handle, and one that also ran would fight the trigger
+    // it is wrapped in.
     <button
-      onClick={signedIn ? undefined : onClick}
+      onClick={connecting ? toggleDialog : undefined}
       title={title}
       aria-label={title}
       className={cn(
@@ -71,8 +69,15 @@ export function AccountButton() {
     </button>
   );
 
-  // Narrowed on `snapshot` rather than the `signedIn` boolean, so the menu is
-  // handed one coherent account state instead of pieces pulled out separately.
-  if (snapshot.status !== "signed-in") return button;
+  // The menu opens signed out as well as signed in. Settings, Keybindings,
+  // Themes, Skills and Layouts live behind this avatar and are not account
+  // features — gating them on having an account contradicts the rule that
+  // authentication is additive and nothing becomes gated. Signing in is simply
+  // the first item when there is no account yet.
+  //
+  // `connecting` is the exception and keeps its plain click: a grant is already
+  // running, the only thing the user wants is the dialog they closed, and
+  // putting that behind a menu adds a step to a state that lasts seconds.
+  if (snapshot.status === "connecting") return button;
   return <AccountMenu account={snapshot}>{button}</AccountMenu>;
 }

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { CircleUser, Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import type { AccountUser } from "../lib/auth-api";
 import { useAuthStore } from "../stores/auth-store";
 
 /**
@@ -10,8 +13,10 @@ import { useAuthStore } from "../stores/auth-store";
  * "a project is open" guard, so a fresh install can connect an account from the
  * empty state rather than having to open a folder first.
  *
- * ATL-47 replaces the icon with the user's profile photo. Until then signed-in
- * is shown as a filled state rather than a face.
+ * Signed in, it is the user's face: the photo when we have one cached, their
+ * initial in a coloured circle when we do not. There is no third "broken photo"
+ * state — every failure path in Rust and here lands on the initial, because a
+ * missing avatar is not something the user can act on.
  */
 export function AccountButton() {
   const snapshot = useAuthStore.use.snapshot();
@@ -21,6 +26,7 @@ export function AccountButton() {
 
   const connecting = snapshot.status === "connecting";
   const signedIn = snapshot.status === "signed-in";
+  const user = snapshot.status === "signed-in" ? snapshot.user : null;
 
   const onClick = () => {
     // While connecting, the button toggles the dialog rather than starting
@@ -34,11 +40,13 @@ export function AccountButton() {
     void beginSignIn();
   };
 
-  const title = signedIn
-    ? "Atlas account — connected"
-    : connecting
-      ? "Waiting for approval in your browser…"
-      : "Connect your Atlas account";
+  const title = user
+    ? `${user.name} (${user.email})`
+    : signedIn
+      ? "Atlas account — connected"
+      : connecting
+        ? "Waiting for approval in your browser…"
+        : "Connect your Atlas account";
 
   return (
     <button
@@ -48,16 +56,69 @@ export function AccountButton() {
       className={cn(
         "relative flex items-center justify-center w-6 h-6 rounded transition-all duration-150",
         "hover:bg-[#ffffff08] outline-none focus:outline-none",
-        signedIn || connecting
-          ? "text-[#ccc]"
-          : "text-[#555] hover:text-[#aaa]",
+        signedIn || connecting ? "text-[#ccc]" : "text-[#555] hover:text-[#aaa]",
       )}
     >
       {starting || connecting ? (
         <Loader2 size={14} className="animate-spin" />
+      ) : user ? (
+        <Avatar user={user} />
       ) : (
         <CircleUser size={14} />
       )}
     </button>
   );
+}
+
+/** The user's photo, or their initial. */
+function Avatar({ user }: { user: AccountUser }) {
+  // Keyed by path rather than a bare boolean, so a photo that changes gets a
+  // fresh attempt instead of inheriting the previous one's failure.
+  const [failedPath, setFailedPath] = useState<string | null>(null);
+
+  if (user.avatarPath && failedPath !== user.avatarPath) {
+    return (
+      <img
+        src={convertFileSrc(user.avatarPath)}
+        alt=""
+        draggable={false}
+        onError={() => setFailedPath(user.avatarPath)}
+        className="w-[18px] h-[18px] rounded-full object-cover"
+      />
+    );
+  }
+  return <Initial user={user} />;
+}
+
+/**
+ * A single letter on a colour derived from the user id.
+ *
+ * Deriving rather than picking keeps the same person the same colour on every
+ * machine and every launch, which is what makes the circle read as *their*
+ * badge rather than decoration.
+ */
+function Initial({ user }: { user: AccountUser }) {
+  const source = user.name.trim() || user.email.trim();
+  // `Array.from` rather than `[0]`, so a name starting outside the BMP does not
+  // render as half a character.
+  const letter = (Array.from(source)[0] ?? "?").toUpperCase();
+
+  return (
+    <span
+      aria-hidden
+      style={{ backgroundColor: `hsl(${hueFor(user.id)} 42% 40%)` }}
+      className="flex items-center justify-center w-[18px] h-[18px] rounded-full text-[10px] font-medium leading-none text-white/90 select-none"
+    >
+      {letter}
+    </span>
+  );
+}
+
+/** Stable hue in [0, 360) for a string. */
+function hueFor(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
 }

--- a/src/features/auth/components/account-menu.tsx
+++ b/src/features/auth/components/account-menu.tsx
@@ -13,7 +13,12 @@ import { toast } from "sonner";
 import { KbdCombo } from "@/ui/kbd";
 import { openSettingsSection } from "@/features/settings/lib/open-settings";
 import type { SettingsSection } from "@/features/settings/stores/settings-nav-store";
-import type { AccountUser } from "../lib/auth-api";
+import {
+  ROLE_LABELS,
+  type AccountOrg,
+  type AccountUser,
+  type SignedIn,
+} from "../lib/auth-api";
 import { useAuthStore } from "../stores/auth-store";
 import { AccountAvatar } from "./account-avatar";
 
@@ -64,6 +69,10 @@ const ITEM_CLASS =
   "text-[var(--text-secondary)] data-[highlighted]:bg-[var(--bg-hover)] " +
   "data-[highlighted]:text-[var(--text-primary)]";
 
+// Hoisted for the same reason as the two above: this menu now has three
+// separators, and a rule one of them disagreed with would be visible.
+const SEPARATOR_CLASS = "my-1 h-px bg-[var(--border-default)]";
+
 /**
  * The menu behind the title bar's avatar — who you are, the parts of Settings
  * people actually reach for, and the way out.
@@ -74,21 +83,26 @@ const ITEM_CLASS =
  * same primitive every other Atlas menu uses.
  */
 export function AccountMenu({
-  user,
+  account,
   children,
 }: {
   /**
-   * `null` in the narrow window between holding a credential and the first
-   * successful profile fetch (see `SignedIn.user`). The menu still opens, and
-   * Sign Out still works — neither depends on identity, and a credential we
-   * cannot put a name to is still one the user must be able to disconnect.
-   * There is simply no header to render, and inventing a placeholder name would
-   * be worse than the gap it fills.
+   * The whole signed-in snapshot rather than its pieces, so the menu cannot be
+   * handed an identity and a set of organisations that came from different
+   * moments.
+   *
+   * `account.user` is `null` in the narrow window between holding a credential
+   * and the first successful profile fetch (see `SignedIn.user`). The menu still
+   * opens, and Sign Out still works — neither depends on identity, and a
+   * credential we cannot put a name to is still one the user must be able to
+   * disconnect. There is simply no header to render, and inventing a placeholder
+   * name would be worse than the gap it fills.
    */
-  user: AccountUser | null;
+  account: SignedIn;
   children: ReactNode;
 }) {
   const { signOut } = useAuthStore.use.actions();
+  const { user, orgs, activeOrgId } = account;
 
   // Not awaited by anything on screen: the title bar has already flipped by the
   // time this promise settles, off the state event Rust emits before it touches
@@ -107,6 +121,13 @@ export function AccountMenu({
           className={CONTENT_CLASS}
         >
           {user && <Header user={user} />}
+          {/* Omitted entirely while the organisations are unknown — see
+              `SignedIn.orgs`. Same reasoning as the header above it. */}
+          {orgs && (
+            <Organisation
+              active={orgs.find((org) => org.id === activeOrgId) ?? null}
+            />
+          )}
           {ITEMS.map((item) => (
             <DropdownMenu.Item
               key={item.section}
@@ -125,7 +146,7 @@ export function AccountMenu({
               menu navigates, and this one ends the session. Rendered whether or
               not there is an identity to show — a credential held with no
               profile yet is still one the user must be able to disconnect. */}
-          <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
+          <DropdownMenu.Separator className={SEPARATOR_CLASS} />
           <DropdownMenu.Item onSelect={() => void onSignOut()} className={ITEM_CLASS}>
             <LogOut size={13} className="shrink-0 text-[var(--text-tertiary)]" />
             <span className="flex-1 text-left">Sign Out</span>
@@ -133,6 +154,59 @@ export function AccountMenu({
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
+  );
+}
+
+/**
+ * Which organisation this device is acting for, and the role it carries there
+ * (ATL-51).
+ *
+ * A `Label`, not an `Item`: this section is read-only, and rendering it as an
+ * item would make it focusable, highlightable, and reachable by type-ahead —
+ * every affordance of something you can act on, for something you cannot.
+ * Switching organisations is ATL-36's.
+ *
+ * `active` is `null` for a user who belongs to none. That is a real answer and
+ * gets a plain sentence, not a blank row or a spinner: nothing is loading, and
+ * nothing is wrong.
+ *
+ * No plan or tier badge, deliberately. The mockup had one; the server has no
+ * billing, subscription, or plan concept anywhere, so a hardcoded "Free" would
+ * be untrue from the first commit and would quietly stay untrue after billing
+ * ships.
+ */
+function Organisation({ active }: { active: AccountOrg | null }) {
+  return (
+    <>
+      <DropdownMenu.Label className="px-3 pt-1 pb-1.5">
+        {/* Same caption shape as the provider picker's section labels, so
+            dropdown sections read alike across the app. */}
+        <div className="text-[9px] uppercase tracking-wider text-[var(--text-tertiary)]">
+          Organisation
+        </div>
+        {active ? (
+          // Name and role on one row, mirroring the shortcut rows below: the
+          // name takes the space and truncates, the role never wraps.
+          <div className="mt-0.5 flex items-baseline gap-2">
+            <span className="min-w-0 flex-1 truncate text-[11px] text-[var(--text-primary)]">
+              {active.name}
+            </span>
+            {/* Absent when the claim named no role, or one this build does not
+                know — the organisation is still real, so it is still shown. */}
+            {active.role && (
+              <span className="shrink-0 text-[10px] text-[var(--text-tertiary)]">
+                {ROLE_LABELS[active.role]}
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
+            No organisation
+          </div>
+        )}
+      </DropdownMenu.Label>
+      <DropdownMenu.Separator className={SEPARATOR_CLASS} />
+    </>
   );
 }
 
@@ -165,7 +239,7 @@ function Header({ user }: { user: AccountUser }) {
           )}
         </div>
       </DropdownMenu.Label>
-      <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
+      <DropdownMenu.Separator className={SEPARATOR_CLASS} />
     </>
   );
 }

--- a/src/features/auth/components/account-menu.tsx
+++ b/src/features/auth/components/account-menu.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Keyboard, LayoutTemplate, Palette, Settings, Zap } from "lucide-react";
+
+import { KbdCombo } from "@/ui/kbd";
+import { openSettingsSection } from "@/features/settings/lib/open-settings";
+import type { SettingsSection } from "@/features/settings/stores/settings-nav-store";
+import type { AccountUser } from "../lib/auth-api";
+import { AccountAvatar } from "./account-avatar";
+
+/**
+ * The account menu's destinations.
+ *
+ * `label` is what the user is looking for and `section` is where it lives —
+ * "Themes" is the Appearance section, not one of its own.
+ *
+ * `shortcut` is set only where Atlas really binds one, so a hint here always
+ * survives being pressed.
+ */
+const ITEMS: Array<{
+  label: string;
+  icon: typeof Settings;
+  section: SettingsSection;
+  shortcut?: string;
+}> = [
+  { label: "Settings", icon: Settings, section: "general", shortcut: "⌘," },
+  { label: "Keybindings", icon: Keyboard, section: "keybindings" },
+  { label: "Themes", icon: Palette, section: "appearance" },
+  { label: "Skills", icon: Zap, section: "skills" },
+  { label: "Layouts", icon: LayoutTemplate, section: "layouts" },
+];
+
+// Same shape as the composer's "+" menu, so every Atlas dropdown reads alike.
+// `--z-max` matches the sidebar's add-project menu: the content is portalled to
+// `body`, so it is not competing with the title bar, but it does share a
+// stacking context with every dialog and overlay in the app.
+const CONTENT_CLASS =
+  "z-[var(--z-max)] min-w-[228px] max-w-[300px] rounded-md border border-[var(--border-default)] " +
+  "bg-[var(--bg-secondary)] shadow-[var(--shadow-overlay)] py-1";
+
+const ITEM_CLASS =
+  "flex items-center gap-2 px-3 h-[26px] text-[11px] cursor-default outline-none " +
+  "text-[var(--text-secondary)] data-[highlighted]:bg-[var(--bg-hover)] " +
+  "data-[highlighted]:text-[var(--text-primary)]";
+
+/**
+ * The menu behind the title bar's avatar — who you are, and the parts of
+ * Settings people actually reach for.
+ *
+ * Wraps the account button rather than replacing it, so signed out the button
+ * keeps its plain click-to-sign-in behaviour and this component is simply not
+ * rendered. Escape, click-away, arrow keys and type-ahead come from Radix, the
+ * same primitive every other Atlas menu uses.
+ */
+export function AccountMenu({
+  user,
+  children,
+}: {
+  /**
+   * `null` in the narrow window between holding a credential and the first
+   * successful profile fetch (see `SignedIn.user`). The menu still opens — its
+   * destinations do not depend on identity, and this is where signing out will
+   * live — but there is no header to render, and inventing a placeholder name
+   * would be worse than the gap it fills.
+   */
+  user: AccountUser | null;
+  children: ReactNode;
+}) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>{children}</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={6}
+          className={CONTENT_CLASS}
+        >
+          {user && <Header user={user} />}
+          {ITEMS.map((item) => (
+            <DropdownMenu.Item
+              key={item.section}
+              onSelect={() => openSettingsSection(item.section)}
+              className={ITEM_CLASS}
+            >
+              <item.icon
+                size={13}
+                className="shrink-0 text-[var(--text-tertiary)]"
+              />
+              <span className="flex-1 text-left">{item.label}</span>
+              {item.shortcut && <KbdCombo combo={item.shortcut} />}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+/** Avatar, name and email — the "who am I signed in as" answer. */
+function Header({ user }: { user: AccountUser }) {
+  // A name is not guaranteed: some providers give us only an address. Falling
+  // back to the email keeps the primary line filled rather than showing a blank
+  // row above the address, and the second line is dropped when it would just
+  // repeat the first.
+  const name = user.name.trim();
+  const email = user.email.trim();
+  const primary = name || email;
+
+  return (
+    <>
+      {/* `Label`, not a bare div: inside `role="menu"` an unlabelled block is
+          announced as loose text between the items. This is the menu's title. */}
+      <DropdownMenu.Label className="flex items-center gap-2.5 px-3 py-1.5">
+        <AccountAvatar user={user} size={28} />
+        {/* `flex-1 min-w-0` against the content's max width is what makes a
+            long address truncate rather than stretch the whole menu. */}
+        <div className="flex-1 min-w-0">
+          <div className="truncate text-[11.5px] font-medium text-[var(--text-primary)]">
+            {primary}
+          </div>
+          {email && email !== primary && (
+            <div className="truncate text-[10.5px] text-[var(--text-tertiary)]">
+              {email}
+            </div>
+          )}
+        </div>
+      </DropdownMenu.Label>
+      <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
+    </>
+  );
+}

--- a/src/features/auth/components/account-menu.tsx
+++ b/src/features/auth/components/account-menu.tsx
@@ -1,11 +1,20 @@
 import type { ReactNode } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Keyboard, LayoutTemplate, Palette, Settings, Zap } from "lucide-react";
+import {
+  Keyboard,
+  LayoutTemplate,
+  LogOut,
+  Palette,
+  Settings,
+  Zap,
+} from "lucide-react";
+import { toast } from "sonner";
 
 import { KbdCombo } from "@/ui/kbd";
 import { openSettingsSection } from "@/features/settings/lib/open-settings";
 import type { SettingsSection } from "@/features/settings/stores/settings-nav-store";
 import type { AccountUser } from "../lib/auth-api";
+import { useAuthStore } from "../stores/auth-store";
 import { AccountAvatar } from "./account-avatar";
 
 /**
@@ -38,14 +47,26 @@ const CONTENT_CLASS =
   "z-[var(--z-max)] min-w-[228px] max-w-[300px] rounded-md border border-[var(--border-default)] " +
   "bg-[var(--bg-secondary)] shadow-[var(--shadow-overlay)] py-1";
 
+/**
+ * Shown when the background revocation did not land — offline, or an Atlas
+ * outage.
+ *
+ * States the residual risk instead of implying a clean revocation, because the
+ * session is a 7-day rolling credential: "may stay active until it expires" is
+ * a real window, and only the user can judge whether it matters on the machine
+ * they are walking away from.
+ */
+const RESIDUAL_SESSION =
+  "Signed out on this device. Your Atlas session may stay active on the server until it expires.";
+
 const ITEM_CLASS =
   "flex items-center gap-2 px-3 h-[26px] text-[11px] cursor-default outline-none " +
   "text-[var(--text-secondary)] data-[highlighted]:bg-[var(--bg-hover)] " +
   "data-[highlighted]:text-[var(--text-primary)]";
 
 /**
- * The menu behind the title bar's avatar — who you are, and the parts of
- * Settings people actually reach for.
+ * The menu behind the title bar's avatar — who you are, the parts of Settings
+ * people actually reach for, and the way out.
  *
  * Wraps the account button rather than replacing it, so signed out the button
  * keeps its plain click-to-sign-in behaviour and this component is simply not
@@ -58,14 +79,24 @@ export function AccountMenu({
 }: {
   /**
    * `null` in the narrow window between holding a credential and the first
-   * successful profile fetch (see `SignedIn.user`). The menu still opens — its
-   * destinations do not depend on identity, and this is where signing out will
-   * live — but there is no header to render, and inventing a placeholder name
-   * would be worse than the gap it fills.
+   * successful profile fetch (see `SignedIn.user`). The menu still opens, and
+   * Sign Out still works — neither depends on identity, and a credential we
+   * cannot put a name to is still one the user must be able to disconnect.
+   * There is simply no header to render, and inventing a placeholder name would
+   * be worse than the gap it fills.
    */
   user: AccountUser | null;
   children: ReactNode;
 }) {
+  const { signOut } = useAuthStore.use.actions();
+
+  // Not awaited by anything on screen: the title bar has already flipped by the
+  // time this promise settles, off the state event Rust emits before it touches
+  // the network. All that arrives here is whether a caveat is owed.
+  const onSignOut = async () => {
+    if (!(await signOut())) toast.warning(RESIDUAL_SESSION);
+  };
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>{children}</DropdownMenu.Trigger>
@@ -90,6 +121,15 @@ export function AccountMenu({
               {item.shortcut && <KbdCombo combo={item.shortcut} />}
             </DropdownMenu.Item>
           ))}
+          {/* Separated from the destinations above: everything else in this
+              menu navigates, and this one ends the session. Rendered whether or
+              not there is an identity to show — a credential held with no
+              profile yet is still one the user must be able to disconnect. */}
+          <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
+          <DropdownMenu.Item onSelect={() => void onSignOut()} className={ITEM_CLASS}>
+            <LogOut size={13} className="shrink-0 text-[var(--text-tertiary)]" />
+            <span className="flex-1 text-left">Sign Out</span>
+          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/src/features/auth/components/account-menu.tsx
+++ b/src/features/auth/components/account-menu.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   Keyboard,
   LayoutTemplate,
+  LogIn,
   LogOut,
   Palette,
   Settings,
@@ -18,6 +19,7 @@ import {
   type AccountOrg,
   type AccountUser,
   type SignedIn,
+  type SignedOut,
 } from "../lib/auth-api";
 import { useAuthStore } from "../stores/auth-store";
 import { AccountAvatar } from "./account-avatar";
@@ -103,11 +105,14 @@ export function AccountMenu({
    * disconnect. There is simply no header to render, and inventing a placeholder
    * name would be worse than the gap it fills.
    */
-  account: SignedIn;
+  account: SignedIn | SignedOut;
   children: ReactNode;
 }) {
-  const { signOut } = useAuthStore.use.actions();
-  const { user, orgs, activeOrgId } = account;
+  const { signOut, beginSignIn } = useAuthStore.use.actions();
+  const signedIn = account.status === "signed-in";
+  const user = signedIn ? account.user : null;
+  const orgs = signedIn ? account.orgs : null;
+  const activeOrgId = signedIn ? account.activeOrgId : null;
 
   // Not awaited by anything on screen: the title bar has already flipped by the
   // time this promise settles, off the state event Rust emits before it touches
@@ -125,7 +130,23 @@ export function AccountMenu({
           sideOffset={6}
           className={CONTENT_CLASS}
         >
+          {/* The account zone is always first, whichever state we are in: the
+              identity when there is one, the way to get one when there is not.
+              Keeping it in the same place means the destinations below never
+              move under the pointer as the user signs in or out. */}
           {user && <Header user={user} />}
+          {!signedIn && (
+            <>
+              <DropdownMenu.Item
+                onSelect={() => void beginSignIn()}
+                className={ITEM_CLASS}
+              >
+                <LogIn size={13} className="shrink-0 text-[var(--text-tertiary)]" />
+                <span className="flex-1 text-left">Sign In</span>
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator className={SEPARATOR_CLASS} />
+            </>
+          )}
           {/* Omitted entirely while the organisations are unknown — see
               `SignedIn.orgs`. Same reasoning as the header above it. */}
           {orgs && (
@@ -148,14 +169,21 @@ export function AccountMenu({
             </DropdownMenu.Item>
           ))}
           {/* Separated from the destinations above: everything else in this
-              menu navigates, and this one ends the session. Rendered whether or
-              not there is an identity to show — a credential held with no
-              profile yet is still one the user must be able to disconnect. */}
-          <DropdownMenu.Separator className={SEPARATOR_CLASS} />
-          <DropdownMenu.Item onSelect={() => void onSignOut()} className={ITEM_CLASS}>
-            <LogOut size={13} className="shrink-0 text-[var(--text-tertiary)]" />
-            <span className="flex-1 text-left">Sign Out</span>
-          </DropdownMenu.Item>
+              menu navigates, and this one ends the session. Rendered whenever a
+              credential is held, with or without a profile — one we cannot put
+              a name to is still one the user must be able to disconnect. */}
+          {signedIn && (
+            <>
+              <DropdownMenu.Separator className={SEPARATOR_CLASS} />
+              <DropdownMenu.Item
+                onSelect={() => void onSignOut()}
+                className={ITEM_CLASS}
+              >
+                <LogOut size={13} className="shrink-0 text-[var(--text-tertiary)]" />
+                <span className="flex-1 text-left">Sign Out</span>
+              </DropdownMenu.Item>
+            </>
+          )}
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/src/features/auth/components/account-menu.tsx
+++ b/src/features/auth/components/account-menu.tsx
@@ -64,8 +64,13 @@ const CONTENT_CLASS =
 const RESIDUAL_SESSION =
   "Signed out on this device. Your Atlas session may stay active on the server until it expires.";
 
+// `cursor-pointer`, not the `cursor-default` a native menu would use: every row
+// carrying this class does something when clicked, and the pointer says so.
+// It is deliberately on the class the *actionable* rows share — the identity
+// header and the Organisation section are `Label`s and keep the arrow, so the
+// cursor distinguishes what you can act on from what is only being reported.
 const ITEM_CLASS =
-  "flex items-center gap-2 px-3 h-[26px] text-[11px] cursor-default outline-none " +
+  "flex items-center gap-2 px-3 h-[26px] text-[11px] cursor-pointer outline-none " +
   "text-[var(--text-secondary)] data-[highlighted]:bg-[var(--bg-hover)] " +
   "data-[highlighted]:text-[var(--text-primary)]";
 

--- a/src/features/auth/components/connect-dialog.tsx
+++ b/src/features/auth/components/connect-dialog.tsx
@@ -130,17 +130,17 @@ export function ConnectDialog() {
                       </button>
                     </div>
 
-                    {/* "Connect device" is the literal button label on the web
-                        page. Naming it means the instruction ends at something
-                        the user can see, rather than at a step they have to
-                        recognise. */}
+                    {/* "Approve" is the literal button label on the web page.
+                        Naming it means the instruction ends at something the
+                        user can point at rather than at a step they have to
+                        recognise — and it has to be changed here whenever it
+                        changes there. */}
                     <p className="mt-3 px-1 text-[11px] leading-relaxed text-text-tertiary">
                       Paste this at{" "}
                       <span className="font-mono text-text-secondary">
                         {connecting.verificationUri}
                       </span>
-                      , which just opened in your browser, then press Connect
-                      device.
+                      , which just opened in your browser, then press Approve.
                     </p>
                   </>
                 ) : null}

--- a/src/features/auth/components/connect-dialog.tsx
+++ b/src/features/auth/components/connect-dialog.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { Check, ChevronRight, Loader2, MonitorSmartphone } from "lucide-react";
+import { Check, Copy, Loader2, MonitorSmartphone } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "../stores/auth-store";
@@ -8,15 +8,17 @@ import { useAuthStore } from "../stores/auth-store";
 /**
  * The connecting dialog.
  *
- * **The device code is not the headline.** RFC 8628 shows a code because it was
- * designed for TVs and printers, where the human carries it to a *second*
- * device. Atlas runs on a laptop with the browser one process away, and the URL
- * we open already has the code embedded — so on the happy path nobody needs to
- * read it. Leading with it imports a compare-these-two-screens ritual that
- * protects nothing the user can perceive and reads as unexplained friction.
+ * **The device code is the content.** It used to sit behind a "Trouble?"
+ * disclosure, on the reasoning that the URL Atlas opened already carried the
+ * code so nobody needed to read it. That reasoning was sound and the conclusion
+ * was wrong: a link that carries the code is exactly what lets someone else's
+ * grant be approved by a signed-in user who clicked a link. Atlas now opens the
+ * *plain* approval page, so this code is the only way the browser can learn
+ * which grant to approve — and the user reading it across is what guarantees
+ * the approved grant is this one.
  *
- * So: a waiting state up front, and the code behind a disclosure for whoever
- * lost the browser tab or is approving from their phone.
+ * So: the code up front, one button that copies it and says so, and the waiting
+ * state underneath.
  */
 export function ConnectDialog() {
   const open = useAuthStore.use.dialogOpen();
@@ -25,10 +27,29 @@ export function ConnectDialog() {
   const starting = useAuthStore.use.starting();
   const { cancelSignIn, closeDialog, beginSignIn } = useAuthStore.use.actions();
 
-  const [showCode, setShowCode] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const connecting = snapshot.status === "connecting" ? snapshot : null;
   const done = snapshot.status === "signed-in";
+
+  // Revert the button to "Copy" a moment after a copy, so a user who returns to
+  // this dialog to copy again is not looking at a tick that says it is done.
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  const copyCode = async () => {
+    if (!connecting) return;
+    try {
+      await navigator.clipboard.writeText(connecting.userCode);
+      setCopied(true);
+    } catch {
+      // Clipboard access can be refused. The code is on screen and selectable,
+      // so the fallback is the user reading it — no error worth raising.
+    }
+  };
 
   return (
     <Dialog.Root
@@ -78,42 +99,53 @@ export function ConnectDialog() {
               </div>
             ) : (
               <>
-                <div className="flex items-center gap-2 px-1 py-5 text-xs text-text-secondary">
+                {connecting ? (
+                  <>
+                    {/* `select-all` so a click-drag grabs the whole code and
+                        nothing else — the clipboard button is the fast path,
+                        not the only one, and it can be refused by the OS. */}
+                    <div className="rounded border border-border-default bg-[var(--bg-base)] px-3 py-4">
+                      <p className="select-all text-center font-mono text-[22px] tracking-[0.3em] text-text-primary">
+                        {connecting.userCode}
+                      </p>
+                      <button
+                        onClick={() => void copyCode()}
+                        className={cn(
+                          "mx-auto mt-3 flex items-center gap-1.5 rounded border border-border-default",
+                          "cursor-pointer px-2.5 py-1 text-[11px] transition-colors",
+                          "text-text-secondary hover:bg-[#ffffff08] hover:text-text-primary",
+                        )}
+                      >
+                        {copied ? (
+                          <>
+                            <Check size={12} className="text-[var(--status-success)]" />
+                            Copied
+                          </>
+                        ) : (
+                          <>
+                            <Copy size={12} />
+                            Copy code
+                          </>
+                        )}
+                      </button>
+                    </div>
+
+                    <p className="mt-3 px-1 text-[11px] leading-relaxed text-text-tertiary">
+                      Paste this at{" "}
+                      <span className="font-mono text-text-secondary">
+                        {connecting.verificationUri}
+                      </span>
+                      , which just opened in your browser, then approve.
+                    </p>
+                  </>
+                ) : null}
+
+                <div className="flex items-center gap-2 px-1 pt-4 text-xs text-text-secondary">
                   <Loader2 size={14} className="animate-spin" />
                   {starting
                     ? "Starting…"
-                    : "Continue in your browser, then come back here."}
+                    : "Waiting for you to approve in the browser…"}
                 </div>
-
-                {connecting ? (
-                  <div className="border-t border-border-default pt-2">
-                    <button
-                      onClick={() => setShowCode((v) => !v)}
-                      className="flex w-full items-center gap-1 px-1 py-1.5 text-[11px] text-text-tertiary transition-colors hover:text-text-secondary"
-                    >
-                      <ChevronRight
-                        size={12}
-                        className={cn("transition-transform", showCode && "rotate-90")}
-                      />
-                      Trouble? Enter the code manually
-                    </button>
-
-                    {showCode ? (
-                      <div className="mt-1 space-y-2 rounded border border-border-default bg-[var(--bg-base)] px-3 py-2.5">
-                        <p className="text-[11px] text-text-tertiary">
-                          Go to{" "}
-                          <span className="font-mono text-text-secondary">
-                            {connecting.verificationUri}
-                          </span>{" "}
-                          and enter:
-                        </p>
-                        <p className="text-center font-mono text-lg tracking-[0.3em] text-text-primary">
-                          {connecting.userCode}
-                        </p>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
               </>
             )}
           </div>

--- a/src/features/auth/components/connect-dialog.tsx
+++ b/src/features/auth/components/connect-dialog.tsx
@@ -130,12 +130,17 @@ export function ConnectDialog() {
                       </button>
                     </div>
 
+                    {/* "Connect device" is the literal button label on the web
+                        page. Naming it means the instruction ends at something
+                        the user can see, rather than at a step they have to
+                        recognise. */}
                     <p className="mt-3 px-1 text-[11px] leading-relaxed text-text-tertiary">
                       Paste this at{" "}
                       <span className="font-mono text-text-secondary">
                         {connecting.verificationUri}
                       </span>
-                      , which just opened in your browser, then approve.
+                      , which just opened in your browser, then press Connect
+                      device.
                     </p>
                   </>
                 ) : null}

--- a/src/features/auth/components/connect-dialog.tsx
+++ b/src/features/auth/components/connect-dialog.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Check, ChevronRight, Loader2, MonitorSmartphone } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useAuthStore } from "../stores/auth-store";
+
+/**
+ * The connecting dialog.
+ *
+ * **The device code is not the headline.** RFC 8628 shows a code because it was
+ * designed for TVs and printers, where the human carries it to a *second*
+ * device. Atlas runs on a laptop with the browser one process away, and the URL
+ * we open already has the code embedded — so on the happy path nobody needs to
+ * read it. Leading with it imports a compare-these-two-screens ritual that
+ * protects nothing the user can perceive and reads as unexplained friction.
+ *
+ * So: a waiting state up front, and the code behind a disclosure for whoever
+ * lost the browser tab or is approving from their phone.
+ */
+export function ConnectDialog() {
+  const open = useAuthStore.use.dialogOpen();
+  const snapshot = useAuthStore.use.snapshot();
+  const error = useAuthStore.use.error();
+  const starting = useAuthStore.use.starting();
+  const { cancelSignIn, closeDialog, beginSignIn } = useAuthStore.use.actions();
+
+  const [showCode, setShowCode] = useState(false);
+
+  const connecting = snapshot.status === "connecting" ? snapshot : null;
+  const done = snapshot.status === "signed-in";
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        // Closing the dialog abandons the attempt. Leaving a poll loop running
+        // against a request the user visibly cancelled would be dishonest.
+        if (!next) void cancelSignIn();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[var(--z-overlay)] bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-[24%] z-[var(--z-modal)] -translate-x-1/2",
+            "w-[440px] max-w-[92vw] rounded-lg border border-border-default bg-bg-elevated",
+            "shadow-[var(--shadow-overlay)] text-text-primary",
+          )}
+        >
+          <div className="flex items-start gap-2.5 border-b border-border-default px-4 py-3">
+            <MonitorSmartphone className="mt-0.5 size-4 text-text-tertiary" />
+            <div>
+              <Dialog.Title className="text-sm font-medium">
+                Connect your Atlas account
+              </Dialog.Title>
+              <Dialog.Description className="mt-0.5 text-xs text-text-secondary">
+                Approve this device in your browser to finish.
+              </Dialog.Description>
+            </div>
+          </div>
+
+          <div className="p-4">
+            {done ? (
+              <div className="flex items-center gap-2 px-1 py-5 text-xs text-text-secondary">
+                <Check size={14} className="text-[var(--status-success)]" />
+                Connected.
+              </div>
+            ) : error ? (
+              <div className="px-1 py-4">
+                <p className="text-xs text-[var(--status-error)]">{error}</p>
+                <button
+                  onClick={() => void beginSignIn()}
+                  className="mt-3 rounded border border-border-default px-2.5 py-1 text-xs text-text-primary transition-colors hover:bg-[#ffffff08]"
+                >
+                  Try again
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 px-1 py-5 text-xs text-text-secondary">
+                  <Loader2 size={14} className="animate-spin" />
+                  {starting
+                    ? "Starting…"
+                    : "Continue in your browser, then come back here."}
+                </div>
+
+                {connecting ? (
+                  <div className="border-t border-border-default pt-2">
+                    <button
+                      onClick={() => setShowCode((v) => !v)}
+                      className="flex w-full items-center gap-1 px-1 py-1.5 text-[11px] text-text-tertiary transition-colors hover:text-text-secondary"
+                    >
+                      <ChevronRight
+                        size={12}
+                        className={cn("transition-transform", showCode && "rotate-90")}
+                      />
+                      Trouble? Enter the code manually
+                    </button>
+
+                    {showCode ? (
+                      <div className="mt-1 space-y-2 rounded border border-border-default bg-[var(--bg-base)] px-3 py-2.5">
+                        <p className="text-[11px] text-text-tertiary">
+                          Go to{" "}
+                          <span className="font-mono text-text-secondary">
+                            {connecting.verificationUri}
+                          </span>{" "}
+                          and enter:
+                        </p>
+                        <p className="text-center font-mono text-lg tracking-[0.3em] text-text-primary">
+                          {connecting.userCode}
+                        </p>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 border-t border-border-default px-4 py-2.5">
+            <button
+              onClick={() => (done ? closeDialog() : void cancelSignIn())}
+              className="rounded px-2.5 py-1 text-xs text-text-secondary transition-colors hover:bg-[#ffffff08] hover:text-text-primary"
+            >
+              {done ? "Close" : "Cancel"}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/features/auth/lib/auth-api.ts
+++ b/src/features/auth/lib/auth-api.ts
@@ -83,3 +83,22 @@ export const listenAuthError = (
   handler: (e: { message: string }) => void,
 ): Promise<UnlistenFn> =>
   listen<{ message: string }>("atlas:auth-error", (e) => handler(e.payload));
+
+/**
+ * The server rejected the stored credential and Atlas signed out (ATL-48).
+ *
+ * Separate from `atlas:auth-error` because it is read somewhere else: a grant
+ * failure belongs inside the connect dialog the user is already looking at,
+ * while this one arrives unprompted — a session revoked from the web, or one
+ * that finally expired — and has to reach them as a toast.
+ *
+ * Only ever fires on an authoritative rejection. Being offline, an Atlas
+ * outage, or a rate limit never produces this: those preserve the credential
+ * and retry silently, which is the entire point of the classification.
+ */
+export const listenAuthSignedOut = (
+  handler: (e: { message: string }) => void,
+): Promise<UnlistenFn> =>
+  listen<{ message: string }>("atlas:auth-signed-out", (e) =>
+    handler(e.payload),
+  );

--- a/src/features/auth/lib/auth-api.ts
+++ b/src/features/auth/lib/auth-api.ts
@@ -70,6 +70,19 @@ export const auth = {
   signIn: () => invoke<AuthSnapshot>("auth_sign_in"),
   /** Abandon an in-flight grant. Idempotent. */
   cancelSignIn: () => invoke<AuthSnapshot>("auth_cancel_sign_in"),
+  /**
+   * Sign out (ATL-50).
+   *
+   * Nothing here waits: Rust clears the credential, the identity snapshot and
+   * the cached photo first and unconditionally, and the signed-out state
+   * arrives over `atlas:auth-changed` before the server is contacted at all.
+   *
+   * Resolves — later, once the background revocation settles — to whether the
+   * server confirmed the session is gone. `false` means this device is signed
+   * out but the server session may stay active until it expires, which is the
+   * one thing the user has to be told.
+   */
+  signOut: () => invoke<boolean>("auth_sign_out"),
 };
 
 /** Every auth transition, broadcast to every window. */

--- a/src/features/auth/lib/auth-api.ts
+++ b/src/features/auth/lib/auth-api.ts
@@ -44,6 +44,35 @@ export interface AccountUser {
   avatarPath: string | null;
 }
 
+/**
+ * A role in an organisation (API doc §6), highest privilege first.
+ *
+ * A union rather than `string` so `ROLE_LABELS` cannot silently lose a case:
+ * the only thing the desktop does with a role is render its label, and a value
+ * with no label renders as nothing at all.
+ */
+export type Role = "admin" | "product_owner" | "developer" | "member";
+
+/** What each role is called on screen. Matches the web dashboard's wording. */
+export const ROLE_LABELS: Record<Role, string> = {
+  admin: "Admin",
+  product_owner: "Product Owner",
+  developer: "Developer",
+  member: "Member",
+};
+
+/** One organisation the account belongs to (ATL-51). Read-only — see ATL-36. */
+export interface AccountOrg {
+  id: string;
+  name: string;
+  /**
+   * `null` when the access token's `orgs` claim did not place the user in this
+   * organisation, or named a role this build does not know. The organisation is
+   * still real; only its label is missing.
+   */
+  role: Role | null;
+}
+
 /** A credential is held. */
 export interface SignedIn {
   status: "signed-in";
@@ -54,6 +83,25 @@ export interface SignedIn {
    * button shows the generic icon rather than nothing.
    */
   user: AccountUser | null;
+  /**
+   * Every organisation the user belongs to, from the stored snapshot — so this
+   * is populated on an offline launch too.
+   *
+   * Three states, and the menu must render each differently:
+   * - a non-empty array — known, and shown.
+   * - `[]` — **known to be none.** The deliberate empty state.
+   * - `null` — **not known yet**, because no list call has ever succeeded on
+   *   this machine. Telling such a user they belong to no organisation would be
+   *   a lie, and offline it is one nothing would ever correct — so the section
+   *   is omitted, exactly as the identity header is when `user` is null.
+   */
+  orgs: AccountOrg[] | null;
+  /**
+   * Which of `orgs` this device is acting for, already resolved in Rust — the
+   * one the user made active on the web, or the first they belong to. `null`
+   * whenever `orgs` is empty or not yet known.
+   */
+  activeOrgId: string | null;
 }
 
 export type AuthSnapshot = SignedOut | Connecting | SignedIn;

--- a/src/features/auth/lib/auth-api.ts
+++ b/src/features/auth/lib/auth-api.ts
@@ -28,9 +28,32 @@ export interface Connecting {
   expiresAt: string;
 }
 
-/** A credential is held. ATL-47 adds the user identity here. */
+/** Who is signed in. Carries no credential — see the note at the top. */
+export interface AccountUser {
+  id: string;
+  name: string;
+  email: string;
+  /**
+   * Absolute path to the locally cached profile photo, or `null` when the user
+   * has none or the fetch failed. Render it through `convertFileSrc`.
+   *
+   * Deliberately a local path rather than the provider URL: an `<img>` pointed
+   * at Google or GitHub would tell them the user opened Atlas, every launch,
+   * for a photo already on disk — and would leave the title bar blank offline.
+   */
+  avatarPath: string | null;
+}
+
+/** A credential is held. */
 export interface SignedIn {
   status: "signed-in";
+  /**
+   * `null` only between holding a credential and the first successful profile
+   * fetch — a network blip right after approval, or an upgrade from a build
+   * that stored no identity. The next validation fills it in; until then the
+   * button shows the generic icon rather than nothing.
+   */
+  user: AccountUser | null;
 }
 
 export type AuthSnapshot = SignedOut | Connecting | SignedIn;

--- a/src/features/auth/lib/auth-api.ts
+++ b/src/features/auth/lib/auth-api.ts
@@ -1,0 +1,62 @@
+// Atlas account auth (ATL-35) — the frontend half.
+//
+// Every credential stays in Rust: the Better Auth session token and the access
+// JWT never cross this boundary. What arrives here is `AuthSnapshot`, which
+// carries identity and nothing secret. That split is deliberate — the renderer
+// runs with no CSP and also displays agent-authored markdown, so a token in
+// this heap would be one injection away from being exfiltrated.
+//
+// See src-tauri/src/auth for the state machine and src-tauri/src/commands/auth
+// for the adapters.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+/** No credential stored. */
+export interface SignedOut {
+  status: "signed-out";
+}
+
+/** A device grant is in flight, awaiting approval in the browser. */
+export interface Connecting {
+  status: "connecting";
+  /** Shown only behind the "enter the code manually" disclosure. */
+  userCode: string;
+  /** The plain approval URL, for that same manual fallback. */
+  verificationUri: string;
+  /** ISO-8601; the dialog stops offering a dead code past this. */
+  expiresAt: string;
+}
+
+/** A credential is held. ATL-47 adds the user identity here. */
+export interface SignedIn {
+  status: "signed-in";
+}
+
+export type AuthSnapshot = SignedOut | Connecting | SignedIn;
+
+export const auth = {
+  /** Current state, for hydrating on mount. */
+  snapshot: () => invoke<AuthSnapshot>("auth_snapshot"),
+  /**
+   * Begin or resume sign-in. Opens the approval page in the system browser and
+   * polls in the background; resolves as soon as the grant starts, not when it
+   * completes. Calling it again while one is in flight resumes the same grant
+   * and reopens the browser rather than minting a competing code.
+   */
+  signIn: () => invoke<AuthSnapshot>("auth_sign_in"),
+  /** Abandon an in-flight grant. Idempotent. */
+  cancelSignIn: () => invoke<AuthSnapshot>("auth_cancel_sign_in"),
+};
+
+/** Every auth transition, broadcast to every window. */
+export const listenAuthChanged = (
+  handler: (snapshot: AuthSnapshot) => void,
+): Promise<UnlistenFn> =>
+  listen<AuthSnapshot>("atlas:auth-changed", (e) => handler(e.payload));
+
+/** A grant that ended without a token (denied, expired, unreachable). */
+export const listenAuthError = (
+  handler: (e: { message: string }) => void,
+): Promise<UnlistenFn> =>
+  listen<{ message: string }>("atlas:auth-error", (e) => handler(e.payload));

--- a/src/features/auth/stores/auth-store.ts
+++ b/src/features/auth/stores/auth-store.ts
@@ -30,6 +30,13 @@ interface AuthStoreState {
     cancelSignIn: () => Promise<void>;
     /** Dismiss the dialog, leaving the grant running. */
     closeDialog: () => void;
+    /**
+     * Sign out. Resolves to whether the server session was revoked too —
+     * `false` means this device is signed out but the server session may
+     * outlive it. The signed-out state itself arrives as an event, not from
+     * this promise.
+     */
+    signOut: () => Promise<boolean>;
     /** Pull the current state from Rust (mount hydration). */
     hydrate: () => Promise<void>;
   };
@@ -76,6 +83,17 @@ const useAuthStoreBase = create<AuthStoreState>()((set, get) => ({
     },
 
     closeDialog: () => set({ dialogOpen: false }),
+
+    signOut: async () => {
+      try {
+        return await auth.signOut();
+      } catch {
+        // The local half cannot fail — Rust clears before it can return an
+        // error at all — so an IPC failure here says nothing about the server
+        // session, and the caveat is the honest thing to show.
+        return false;
+      }
+    },
 
     hydrate: async () => {
       try {

--- a/src/features/auth/stores/auth-store.ts
+++ b/src/features/auth/stores/auth-store.ts
@@ -1,0 +1,95 @@
+// Account state, mirrored from Rust.
+//
+// This store is a pure reflection of `atlas:auth-changed`. It never decides
+// anything: Rust owns the credential, the grant, and every transition, so the
+// only writer here is the event handler wired up once in App.tsx.
+//
+// `dialogOpen` is the one piece of genuinely local state — whether the connect
+// dialog is on screen. It is separate from `status` because a user can dismiss
+// the dialog while a grant is still valid, and reopening it must resume rather
+// than restart.
+
+import { create } from "zustand";
+import { createSelectors } from "@/lib/create-selectors";
+import { auth, type AuthSnapshot } from "../lib/auth-api";
+
+interface AuthStoreState {
+  snapshot: AuthSnapshot;
+  /** Whether the connect dialog is showing. */
+  dialogOpen: boolean;
+  /** Last grant failure, shown inside the dialog. Cleared on the next attempt. */
+  error: string | null;
+  /** True between clicking the button and Rust confirming the grant started. */
+  starting: boolean;
+  actions: {
+    setSnapshot: (snapshot: AuthSnapshot) => void;
+    setError: (message: string) => void;
+    /** Start (or resume) sign-in and show the dialog. */
+    beginSignIn: () => Promise<void>;
+    /** Dismiss the dialog and abandon the grant. */
+    cancelSignIn: () => Promise<void>;
+    /** Dismiss the dialog, leaving the grant running. */
+    closeDialog: () => void;
+    /** Pull the current state from Rust (mount hydration). */
+    hydrate: () => Promise<void>;
+  };
+}
+
+const useAuthStoreBase = create<AuthStoreState>()((set, get) => ({
+  snapshot: { status: "signed-out" },
+  dialogOpen: false,
+  error: null,
+  starting: false,
+
+  actions: {
+    setSnapshot: (snapshot) =>
+      set((s) => ({
+        snapshot,
+        starting: false,
+        // Signing in is the end of the flow — close the dialog for them.
+        dialogOpen: snapshot.status === "connecting" ? s.dialogOpen : false,
+        error: snapshot.status === "signed-in" ? null : s.error,
+      })),
+
+    setError: (message) => set({ error: message, starting: false }),
+
+    beginSignIn: async () => {
+      set({ dialogOpen: true, error: null, starting: true });
+      try {
+        const snapshot = await auth.signIn();
+        set({ snapshot, starting: false });
+      } catch (e) {
+        set({
+          error: e instanceof Error ? e.message : String(e),
+          starting: false,
+        });
+      }
+    },
+
+    cancelSignIn: async () => {
+      set({ dialogOpen: false, error: null, starting: false });
+      try {
+        set({ snapshot: await auth.cancelSignIn() });
+      } catch {
+        // Cancelling is best-effort; the dialog is already gone either way.
+      }
+    },
+
+    closeDialog: () => set({ dialogOpen: false }),
+
+    hydrate: async () => {
+      try {
+        const snapshot = await auth.snapshot();
+        // Never resurrect the dialog from hydration — if a grant is still in
+        // flight it belongs in the title bar, not popped over the workspace.
+        set({ snapshot });
+      } catch {
+        // A failed hydrate leaves the default signed-out state, which is the
+        // correct thing to show when we cannot tell.
+      }
+      void get();
+    },
+  },
+}));
+
+export const useAuthStore = createSelectors(useAuthStoreBase);

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -296,7 +296,7 @@ function GeneralSettings() {
       </SettingRow>
       <SettingRow
         label="Share anonymous usage data"
-        description="Anonymous, privacy-preserving usage data (app launches, agents/skills used, token counts, crashes) to help improve Atlas. Never your prompts, code, paths, or keys. See TELEMETRY.md."
+        description="Anonymous, privacy-preserving usage data (app launches, agents/skills used, token counts, crashes, and that a sign-in happened — never who signed in) to help improve Atlas. Never your prompts, code, paths, or keys. See TELEMETRY.md."
       >
         <Toggle
           checked={settings.shareTelemetry}

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -41,14 +41,21 @@ import { useProjectStore } from "@/features/project/stores/project-store";
 import { setEnabled as setTelemetryEnabled } from "@/features/telemetry/posthog-client";
 import { updater } from "@/features/updater/lib/updater-api";
 import { useUpdaterStore } from "@/features/updater/stores/updater-store";
-import { useSettingsNav } from "../stores/settings-nav-store";
+import {
+  useSettingsNav,
+  type SettingsSection,
+} from "../stores/settings-nav-store";
 import { isDev } from "@/lib/env";
 
 // Developer section is dev-build only — production users never see the
 // diagnostic toggles (they change app behavior and aren't useful outside
 // UI testing). `isDev` is a Vite build constant, so the production bundle
 // drops the entry entirely via dead-code elimination.
-const SECTIONS = [
+const SECTIONS: Array<{
+  id: SettingsSection;
+  label: string;
+  icon: typeof Settings;
+}> = [
   { id: "general", label: "General", icon: Settings },
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "layouts", label: "Layouts", icon: LayoutTemplate },
@@ -58,7 +65,7 @@ const SECTIONS = [
   { id: "updates", label: "Updates", icon: DownloadCloud },
   { id: "keybindings", label: "Keybindings", icon: Keyboard },
   ...(isDev
-    ? [{ id: "developer", label: "Developer", icon: FlaskConical }]
+    ? [{ id: "developer" as const, label: "Developer", icon: FlaskConical }]
     : []),
   { id: "about", label: "About", icon: Info },
 ];

--- a/src/features/settings/lib/open-settings.ts
+++ b/src/features/settings/lib/open-settings.ts
@@ -1,0 +1,31 @@
+import { useLayoutStore } from "@/features/layout/stores/layout-store";
+import {
+  useSettingsNav,
+  type SettingsSection,
+} from "../stores/settings-nav-store";
+
+/**
+ * Open the Settings tab already showing `section`.
+ *
+ * Both channels are used, because the panel has two ways of arriving at a
+ * section and only one of them covers each case:
+ *
+ * - `data.section` becomes the panel's initial state, so a tab opened fresh
+ *   *renders* on the right section. Without it the panel mounts on General and
+ *   swaps a frame later — a visible flash on the common path.
+ * - The nav store reaches a panel that is **already mounted** on another
+ *   section, where the initial state has long since been read.
+ *
+ * Setting one without the other leaves half the ticket's requirement working.
+ */
+export function openSettingsSection(section: SettingsSection): void {
+  useSettingsNav.getState().goTo(section);
+  useLayoutStore.getState().actions.addTab({
+    id: "settings",
+    type: "settings",
+    title: "Settings",
+    closable: true,
+    dirty: false,
+    data: { section },
+  });
+}

--- a/src/features/settings/stores/settings-nav-store.ts
+++ b/src/features/settings/stores/settings-nav-store.ts
@@ -1,12 +1,33 @@
 import { create } from "zustand";
 
+/**
+ * Every section the Settings panel can show.
+ *
+ * Named rather than left as `string` because the callers that navigate here
+ * (the sidebar's Skills button, the account menu) live nowhere near the panel:
+ * a typo would compile, open Settings, and silently land on nothing. The
+ * `SECTIONS` table in `settings-panel.tsx` is typed against this, so the two
+ * cannot drift apart.
+ */
+export type SettingsSection =
+  | "general"
+  | "appearance"
+  | "layouts"
+  | "providers"
+  | "skills"
+  | "models"
+  | "updates"
+  | "keybindings"
+  | "developer"
+  | "about";
+
 /** Cross-component signal to open the Settings tab on a specific section.
  *  Set `goTo(section)` before/after opening the (singleton, persistent) settings
  *  tab; `SettingsPanel` consumes it so the switch works whether the tab is
  *  freshly opened or already mounted on another section. */
 interface SettingsNavState {
-  section: string | null;
-  goTo: (section: string) => void;
+  section: SettingsSection | null;
+  goTo: (section: SettingsSection) => void;
   clear: () => void;
 }
 

--- a/src/features/workspaces/components/workspace-sidebar.tsx
+++ b/src/features/workspaces/components/workspace-sidebar.tsx
@@ -28,7 +28,7 @@ import {
   type Workspace,
   type WorkspaceGroup,
 } from "../stores/workspace-store";
-import { useSettingsNav } from "@/features/settings/stores/settings-nav-store";
+import { openSettingsSection } from "@/features/settings/lib/open-settings";
 import { pickAndAddWorkspace } from "../lib/pick-workspace";
 import { useRunningChatKeys } from "../lib/agent-activity";
 import { openAgentSession } from "@/features/chat/lib/open-agent-session";
@@ -573,10 +573,7 @@ export function WorkspaceSidebar() {
         <HeaderButton
           icon={<Zap size={13} />}
           label="Skills"
-          onClick={() => {
-            useSettingsNav.getState().goTo("skills");
-            openTabSingleton("settings", "Settings");
-          }}
+          onClick={() => openSettingsSection("skills")}
         />
         <HeaderButton icon={<Settings size={13} />} label="Settings" onClick={() => openTabSingleton("settings", "Settings")} />
       </div>


### PR DESCRIPTION
Implements the desktop half of Atlas accounts — **ATL-46 → ATL-52**, landing as one reviewable commit per ticket.

Server side is already merged (`tryatlas/server` #6 and the bearer-contract tests), so this PR is the client.



## Progress

| Ticket | What it delivers | Status |
| --- | --- | --- |
| **ATL-46** | Sign in from the desktop and stay signed in | ✅ committed |
| **ATL-47** | Show who is signed in (profile + avatar) | ✅ committed |
| **ATL-48** | Survive offline and transient failures | ✅ committed |
| **ATL-49** | Account menu | ✅ committed |
| **ATL-50** | Sign out | ✅ committed |
| **ATL-51** | Organisation and role in the menu | ✅ committed |
| **ATL-52** | Closeout: anonymous telemetry and documentation | ✅ committed |

---

## ATL-46 — Sign in from the desktop and stay signed in

Click the account icon → &#34;Continue in your browser…&#34; → approve → Atlas raises itself and shows connected. Quit, relaunch, still connected.

The tracer bullet: it establishes the spine everything else builds on — config resolution, the auth core, the device-grant state machine, credential storage, boot restore, and the app-level state broadcast. It deliberately stops short of identifying the user; that is ATL-47.

### Decisions worth reviewing

**All token material stays in Rust.** The session token is the user&#39;s whole account and every organisation they belong to. The renderer runs with `csp: null` *and* displays agent-authored markdown, so neither the session token nor the access JWT crosses the IPC boundary — the frontend gets a snapshot carrying no credentials, and the `device_code` (the actual secret) never leaves the module. This departs from the existing BYOK precedent, which hands raw provider keys to the frontend; an LLM key is one vendor&#39;s blast radius, this is the whole account.

**Credentials go to a `0600` file, not the OS keychain.** A knowing deviation from the server&#39;s API doc §12.5, for the reason `commands::byok` already documents: an unsigned, frequently-rebuilt binary prompts on *every* keychain access, and `tauri.conf.json` sets no signing identity while auto-update replaces the binary each release — so keychain would re-prompt every user after every update. It is worse in release than in development. Revisit once a Developer ID identity exists.

**Transient poll failures do not end a grant.** A dropped connection or a 5xx tells us nothing about whether the human approved, so ending there would discard an approval already given. Only denial, expiry, cancellation, and the deadline are terminal.

**A second sign-in click resumes the pending grant and reopens the browser** rather than minting a competing code. That is the recovery path for someone who lost their way signing in on the web — load-bearing, not an optimisation.

**Boot validation preserves the credential on every failure, including 401.** ATL-48 adds the authoritative-401 rule. Until then the safe default is to keep a credential we are unsure about: if that ticket slips, the worst case is a stale signed-in state rather than a destroyed valid session.

**The device code is not the headline of the dialog.** RFC 8628 surfaces a code because it was designed for TVs and printers, where a human carries it to a second device. Atlas has the browser one process away and the opened URL already embeds the code, so it sits behind a &#34;Trouble? Enter the code manually&#34; disclosure for whoever lost the tab.

**The account button renders outside the title bar&#39;s &#34;project is open&#34; guard**, so a fresh install can sign in from the empty state.

### Tests

18 tests drive `AuthCore` against a **stub HTTP server on loopback** with a temp config dir — the real reqwest client, real poll loop, real file I/O. Covers the full grant matrix (pending, `slow_down`, denied, expired, deadline, cancelled, transient), grant reuse, `0600` permissions, restart persistence, and the boot paths including offline.

---

## ATL-47 — Show who is signed in

The account button becomes the user&#39;s face: their cached photo, or their initial on a colour derived from their user id. The credential file grows an identity snapshot (id, name, email, remote photo URL, cached local path), refreshed on every successful validation.

Profile comes from `GET /get-session` with the session token as a Bearer, which ATL-44 proved generalises. Note it answers **200 with a `null` body** rather than 401 for a dead session — that is parsed, not inferred from the status.

### Decisions worth reviewing

**The remote photo URL never crosses to the frontend.** The photo is fetched once, when the URL first appears or changes, and read from disk every launch after. The point is not speed: the URL points at Google or GitHub, and re-fetching per launch hands one of them a beacon carrying the user&#39;s IP and a rough activity log, for a picture we already have. Exposing the URL would let a single `<img src>` put that request straight back, so the frontend only ever learns a local path.

**A failed re-fetch keeps the photo it already had, and deletes nothing.** A timeout tells us nothing about the *new* photo, so it must not cost the known-good old one — that file is the whole reason an offline launch renders a face. Leaving the **old URL** recorded is what makes the next launch notice the change and retry, instead of filing a new URL against an old file and never re-fetching. Same principle as the poll loop&#39;s transient handling, applied to the cache. (This was a real bug caught in review: the first cut pruned unconditionally, so one 5s blip cost the offline avatar permanently.)

**Failures are never cached, only successes.** A photo that has never downloaded is retried every launch, unbounded. Deliberate: caching a failure would let one CDN outage during sign-in cost the user their photo until they next changed it. The request only recurs while we have nothing to show, and a launch already talks to the Atlas auth server anyway. Flagging it as the explicit half of the trade rather than burying it.

**The fetch is bounded three ways** — a 5s timeout, a 2 MB cap enforced *while streaming* as well as against the declared length, and a content-type allowlist. The bytes land in a directory the asset protocol serves, so it is worth being narrow about what reaches it; SVG is excluded for that reason alone.

**One `authed_get` for every authenticated call**, so the rule the module turns on — 401 is the server rejecting us, unreachable is us never finding out — is written once rather than per endpoint. It also carries a 10s ceiling the shared `reqwest::Client` does not set: one of these sits on the sign-in path, and a server that accepts the connection then never answers would otherwise leave &#34;Continue in your browser…&#34; up forever, long after the credential was safely written. (Also a review finding.)

**The identity refresh runs inline on the grant path**, so the single state broadcast already carries the user&#39;s name and face. The alternative flashes a nameless signed-in title bar on *every* sign-in to save a few hundred milliseconds behind a spinner the user is already watching. Both calls are bounded, and the credential is persisted before either runs, so nothing about sign-in can be lost to a slow photo. Worth a reviewer&#39;s opinion — it is the one place I traded a rare slow path for a common-case flash.

**`signed-in` carries `user: null` in one narrow window** — a blip between approval and the profile call, or an upgrade from an ATL-46 build whose stored file has no identity. This deviates from the spec&#39;s `AuthState` shape, which has `user` unconditionally. Signed-in-but-nameless beats discarding a valid credential over a photo, and the next validation fills it in.

Organisations and the active org are **not** here — they are ATL-51, and the menu that displays them is ATL-49.

### Tests

12 new at the same auth-core seam (30 total in the module): snapshot persistence across restart, cache reuse asserted by hit-counting, changed-URL re-fetch, failed re-fetch preserving the old photo, failure falling back to initials without costing the credential, the size cap under both declared and undeclared lengths, non-image rejection, and an ATL-46-era credential file still loading after upgrade.

---

## ATL-48 — Survive offline and transient failures

Every authenticated call now sorts into exactly one class, and **only one of them may ever destroy a credential**:

```
AUTHORITATIVE  401              the server looked and refused -> sign out, toast, stop
DENIED         403, other 4xx   credential is fine -> neither sign out nor retry
INDETERMINATE  network, timeout, we learned NOTHING -> preserve everything,
               DNS, 5xx, 429     retry with backoff
```

ATL-46 preserved the credential on every failure *including* 401 — the right outcome with no rule behind it. This replaces the placeholder with the rule.

### Decisions worth reviewing

**The verdict is taken from `/token`, not `/get-session`.** Both answer for a dead session, but `/get-session` says so with **200 and a `null` body** (ATL-44) — a much weaker signal than a status code, and one an unrelated serialisation change could start emitting by accident. A misread here destroys a valid credential, so the reading that carries that power is the unambiguous one. The `null` body is still parsed; it just decides a name and a photo rather than a credential.

**`AuthFailure` is an enum, not a `String`.** The whole ticket exists to stop one specific confusion — treating "the server never answered" as "the server said no" — and a caller who cannot see the class cannot avoid it. The classification happens in exactly one place, `authed_get`, which every authenticated call already went through.

**Other 4xx join DENIED rather than earning a fourth class.** A 400 or a 404 is not a verdict on the credential either, and repeating the request will not change it — which is precisely how DENIED is handled.

**No attempt limit, by design.** Retry is exponential from 1s to a 5-minute ceiling. A cap would turn "offline for six hours" into a dead end indistinguishable from being signed out; instead the user is signed in the moment they reconnect, without restarting Atlas or redoing the grant. The ceiling holds the loop at 12 requests an hour, well clear of the auth worker's global 100-per-60s limit (the API doc's table lists only the narrower social sign-in limit — noted in the spec).

**Half jitter, not full jitter.** `[0, cap]` can put the tenth retry a millisecond after the ninth, throwing away the backoff exactly when the server is least able to absorb it. `[cap/2, cap]` still de-synchronises a fleet of clients that all lost connectivity at the same moment, which is the actual purpose.

**`Retry-After` is honoured but clamped into the same window.** It is a number off the network: taken verbatim, a `0` spins this loop against a server already asking for quiet, and an `86400` strands a signed-in user for a day over one bad header. The attempt counter advances either way.

**Boot broadcasts the stored snapshot *before* validating.** That is the whole offline story — a launch with no network renders a complete title bar, name and photo, instead of waiting on a call that is going to time out.

**Nothing is emitted between retries.** The signed-in state has no "verifying" variant, per the spec: a spinner or warning in the title bar every time a laptop lid opens only teaches people to ignore it.

**A rejection reaches the user on a new `atlas:auth-signed-out` event**, separate from `atlas:auth-error`, because they are read in different places — a grant failure belongs inside the connect dialog already on screen, while a revoked session arrives with nothing on screen at all and has to be a toast.

**The `/token` mint is deliberately *not* given the API doc §12.5 "single retry on 401 after a re-mint" treatment.** That advice is written for calls authenticated with the access JWT. Every call here uses the session token, where a 401 means the session itself is dead — following it literally loops forever against a credential that will never work.

**Sign-in from ATL-46 is untouched.** The grant keeps its own transient handling inside its fixed 10-minute deadline, and a failed profile fetch on the grant path still costs nothing.

**The retry base is a field on `AuthCore` with a `#[cfg(test)]` setter.** It exists so the loop can be driven through several failures in milliseconds; being `cfg(test)` means no production path can reach for it. Flagging it as a test-shaped seam rather than hiding it.

### Tests

9 new (37 in the module): a 401 clears and signs out; a 500, a refused connection and a 429 do not; an unreachable server at boot still yields a fully-populated signed-in state *with a face*; two failures then a success end signed in with no user action and no intermediate emission; a 403 neither signs out nor retries (asserted by hit-count); backoff grows and is bounded; a hostile `Retry-After` cannot escape the window.

```
cargo test --lib     145 passed  (108 pre-existing + 37 auth)
cargo clippy         clean across the auth module
tsc --noEmit         unchanged
```

---

## ATL-49 — Account menu

The avatar becomes the app's global entry point.

```
  [avatar]  Ahammad Nafiz
            nafiz@…
  ─────────────────────────
  Settings              ⌘,
  Keybindings
  Themes
  Skills
  Layouts
```

### Decisions worth reviewing

**Navigation writes two channels, and both are load-bearing.** `data.section` becomes the panel's initial state, so a *fresh* Settings tab renders on the right section; the nav store reaches a panel **already mounted** on another section, where the initial state was read long ago. The obvious implementation — nav store only — passes the already-open case and flashes General for a frame on the common one. That bug is live today in the sidebar's Skills button; routing it through the same helper fixes it there too, which is the whole reason `openSettingsSection` is not written inline. (Caught in review — the first cut had exactly that flash.)

**Only items that lead somewhere real.** The mockup was Zed's and three entries had nothing behind them here: **Icon Themes** does not exist and is omitted; **Extensions** is **Skills**, which is what the section is called; and the chords beside every other row are not bound in this app, so only `⌘,` is shown — verified against `App.tsx`, not assumed. A hint that does nothing when pressed is worse than no hint. "Themes" is the Appearance section rather than one of its own: the label is what the user is looking for, the id is where it lives.

**`SettingsSection` is a union rather than `string`.** The callers that navigate here live nowhere near the panel, so a typo would compile, open Settings, and land on nothing. `SECTIONS` in `settings-panel.tsx` is typed against the same union, so the table and its callers cannot drift.

**The menu opens even when `user` is `null`** — the narrow ATL-47 window between holding a credential and the first profile fetch. **This deviates from the ticket's acceptance criterion**, which states the header unconditionally. The destinations do not depend on identity and Sign Out (ATL-50) will live here, so a headerless menu beats no menu; inventing a placeholder name would be worse than the gap it fills. Worth a reviewer's opinion.

**The avatar moved out of the button into `AccountAvatar`**, sized by prop, so the 18px title-bar face and the 28px menu header stay one component. The initial's colour is derived identity — two implementations of it would eventually disagree.

The header is a `DropdownMenu.Label`, not a bare div: inside `role="menu"` an unlabelled block is announced as loose text between the items. Escape, click-away, arrow keys and type-ahead come from Radix, the same primitive the composer and sidebar menus use. Signed out the button is untouched; signed in it carries no `onClick` of its own, so nothing fights the trigger wrapping it.

### Known, and deliberately out of scope

- `⌘,` opens Settings on the **last-viewed** section while the menu's Settings row forces General. Making them agree means either yanking an already-open panel back to General on every `⌘,`, or breaking the criterion that all five rows land on their section. Both predate this change.
- `addTab` treats Settings as a **per-column** singleton, so a split layout with Settings open in the unfocused column gets a second tab. Shared with the sidebar and the shortcut.
- `ITEM_CLASS` / `CONTENT_CLASS` are near-copies of the composer menu's. This is the third Radix dropdown with hand-rolled classes and it wants a `src/ui/dropdown-menu.tsx` — migrating the other two is its own change, not this ticket's.

### Tests

**None — this repo has no frontend test harness** (no vitest, jest, or testing-library). Standing one up for one menu is a bigger decision than this ticket, so flagging it rather than smuggling it in. `tsc --noEmit` is clean and `cargo test --lib` still passes 145.

---

## ATL-50 — Sign out

```
  Settings              ⌘,
  Keybindings
  Themes
  Skills
  Layouts
  ─────────────────────────
  Sign Out
```

Click it and the title bar is a neutral outline before the pointer leaves the item. No spinner, no network on the path: the credential, the identity snapshot and the cached photo are cleared first and unconditionally, the signed-out snapshot broadcasts to every window, and only then is the server asked to revoke the session.

### Decisions worth reviewing

**The ordering is the whole ticket, so it is a type rather than a comment.** Revoking first and clearing second makes sign-out fail while offline — precisely when someone closing a borrowed laptop most needs it to work. `sign_out()` hands back a `RevocationTicket`, which is the *only* way to reach `revoke()`, so no caller can get the order wrong; `revoke()` consumes it, so "fired once and forgotten" falls out of the same construction rather than being a discipline someone has to keep. The ticket's `Debug` is hand-written to print `<redacted>`: it is the one type in the module whose entire content is a credential.

**The revocation is deliberately outside `authed_get` and the ATL-48 retry policy.** It cannot go through it — the credential store is already empty by the time it runs, which is why the token arrives on the ticket. And it should not: there is no backoff because the local state a retry would defend is already gone. One POST, one answer, done.

**A failed revocation is returned to the window that clicked, not broadcast.** Every other auth event goes to all windows because it is a fact about the app's identity. This one answers *this* window's click, and broadcasting it would put the same caveat in front of two other windows that did nothing. The message states the residual risk rather than implying a clean revocation — the session is a 7-day rolling credential, so "may stay active until it expires" is a real window and only the user can judge whether it matters on the machine they are walking away from.

**A 401 on revoke counts as success.** The server does not recognise the credential, so there is no live session left to caveat. Warning about one would be noise.

**Sign Out renders even when `user` is `null`.** That is the ATL-47 window where a credential is held but the profile has not landed — still a credential the user must be able to disconnect.

**Nothing pretends the unlink cannot fail.** A read-only config dir is not handled with a lie: `snapshot()` is derived from the file, so the state broadcast immediately after is whatever is really on disk.

### One bug this path made reachable, fixed here

The background identity refresh re-read the credential **before** its profile and photo calls and wrote it back **after** — so a sign-out landing in that window (up to a 10s profile call plus a 5s photo fetch, on the launch path) was silently undone. Signed out on screen, credential file back on disk, signed straight back in on the next launch. The re-read now happens after the network work, and a photo fetched into the gap is discarded with it. It predates this ticket, but sign-out is what makes a user likely to hit it, and it breaks this ticket's "relaunching after sign-out starts signed out".

### Not here

**No in-memory access token to clear.** Minting is lazy and uncached today, so the acceptance criterion is currently vacuous rather than met by code. Whatever ATL-51 adds to hold a JWT belongs in `sign_out`, and the doc comment says so at the site.

### Tests

6 new at the auth-core seam (43 in the module, 151 in the lib). The stub server grew two small capabilities to support them: it now records the **method and Bearer credential** of each request, and a reply can be **delayed** so a user action can be tested against a call that is provably still in flight.

- local state — credential, snapshot, cached photo — is gone *before* a single byte is sent, asserted by hit-count
- the same holds with a 500, and with the connection refused outright
- the revocation is one `POST /sign-out` carrying the session token as a Bearer (the contract ATL-44 proved)
- a failure is never retried, and never resurrects the credential
- a session the server has already forgotten (401) needs no caveat
- an already-signed-out device asks the server nothing
- a refresh in flight cannot resurrect a signed-out credential

```
cargo test --lib     151 passed  (108 pre-existing + 43 auth)
cargo clippy         clean across the auth module
tsc --noEmit         unchanged (two pre-existing missing-module errors, see below)
```

---

## ATL-51 — Organisation and role in the menu

```
  [avatar]  Ahammad Nafiz
            nafiz@…
  ─────────────────────────
  ORGANISATION
  Atlas                Admin
  ─────────────────────────
  Settings              ⌘,
  …
```

Read-only. Which organisation this device is acting for, and the role it carries there.

### Decisions worth reviewing

**Two calls, joined, because neither answers alone.** `GET /organization/list` has the names and no roles; the access token's `orgs` claim has the roles and no names. The claim is decoded **without verifying the signature** — we minted that token ourselves, over TLS, from the issuer, seconds earlier. JWKS verification exists for parties receiving tokens from untrusted sources; verifying our own proves nothing it did not already know, and nothing here authorises anything. Sanctioned by the spec's deviation table (§5.2), flagged here so it is reviewed deliberately rather than found by diff.

**"Active" needs a fallback, or the section is empty for every desktop user.** `session.activeOrganizationId` is set only by `POST /organization/set-active`, which only the web dashboard calls — and a device-granted session starts with it unset. So: the web's choice when there is one, the first organisation otherwise, and a stored id that is no longer a membership falls through rather than resolving to nothing. `apps/web/src/components/dashboard/org-panel.tsx` defaults identically (`list[0]`), so the two surfaces agree rather than each inventing a rule. ATL-36 makes it explicit and switchable.

**Three states, not two — this was the first cut's bug.** Empty is not the same as unknown. `Some([])` is the server saying this user belongs to nothing, and gets the deliberate empty state. `null` is a credential file written before the field existed, or one whose every list call has failed. Telling *that* user they belong to no organisation is a lie, and offline it is one nothing would ever correct, since the call that would fix it never lands. The section is omitted instead — exactly as the identity header is omitted when the profile has not arrived, and for the same stated reason. Caught in review; the first cut rendered "No organisation" for both.

**Nothing already known is downgraded by a call that failed.** A failed list keeps the stored list. A token whose claim cannot be read keeps the roles already known. This is the rule the module already runs on — the one that keeps a photo through a timeout and a credential through an outage — applied to a third thing. `org_roles` returns `Option` for precisely this: a claim of `{}` was *read*, and does clear the role (API doc §5.1: "`orgs` is `{}` until the user belongs to an Organisation"), while an unreadable token learned nothing and must not. Also a review finding — the first cut collapsed both into an empty map.

**`Role` is a closed set of four in both languages.** An unrecognised value leaves its organisation role-less rather than absent — membership can change between the mint and the list, and the two calls are not atomic. `Role::from_claim` routes through the same serde attribute that spells the role on disk, so a fifth variant cannot be accepted from the wire and written back as something else.

**The section is a `DropdownMenu.Label`, not an `Item`.** Read-only means not focusable, not highlightable, not reachable by type-ahead — rather than an item that merely has no handler attached.

**No plan or tier badge.** The mockup had one; the server has no billing, subscription, or plan concept anywhere. A hardcoded "Free" would be untrue from the first commit and would quietly stay untrue after billing ships.

### Deviations worth a reviewer's eye

- **`role` is optional** where the spec's `AuthState` has it required. A name with no label beats an organisation that silently disappears.
- **`orgs` is nullable** for the same reason `user` already is, and is not in the spec's shape either.
- **A 403 on the list is not surfaced**, deviating from "DENIED → surface in context". There is no honest context: this runs unprompted on the launch path, the endpoint is caller-scoped so a 403 on it indicates a server fault rather than anything the user can act on, and a toast every launch would be noise. The section stays as it was, or absent.

**Rate-limit ceiling re-checked**, as the spec asks of anyone changing the request count: +1 request per *successful* validation, plus one extra `/token` mint on the sign-in path. The retry path is untouched — `validate_once` only loops when `/token` itself fails, so `refresh_identity` never runs on the backoff schedule. A successful validation costs 3 requests and happens about once per launch, nowhere near the global 100/60s.

### Tests

11 new at the auth-core seam (54 in the module, 162 in the lib).

- names and roles joined from the two sources, with the Bearer contract ATL-44 proved asserted on the list call itself
- no organisation yields the empty state, distinguishably from never having asked
- the list survives a restart and renders with the server unreachable
- a failed list keeps the one already stored
- an unreadable token keeps the roles already known; a claim of `{}` clears them
- never-fetched stays unknown through a failed launch, and settles on the first success
- an organisation the claim does not mention, and a role this build does not know
- the active organisation follows the web's choice, and falls back when that id is no longer a membership

```
cargo test --lib     162 passed  (108 pre-existing + 54 auth)
cargo clippy         clean across the auth module
tsc --noEmit         unchanged (two pre-existing missing-module errors, see below)
```

No frontend tests — this repo still has no frontend test harness, and standing one up is not this ticket's job.

---

---

## ATL-52 — Closeout: anonymous auth telemetry and documentation

Two events, one new document, and a wording pass over everything in this repo that still claimed Atlas has no account.

### The install stays anonymous

`auth_signed_in` and `auth_signed_out`, carrying **no user id, no email, no Organisation id**. There is no `identify` and no `alias` call anywhere in the desktop app, and the persisted install UUID is untouched by signing in.

Not a preference — linking that id to a real user on sign-in would retroactively de-anonymize *every event the install has ever sent*, under a consent string that says "Share anonymous usage data". ADR-0007 §8's requirement for identified analytics is already satisfied server-side, where session creation calls `identify`; duplicating it here would buy nothing and cost the consent promise.

### Decisions worth reviewing

**The payload lives on `TelemetryClient`, not at the call sites, and that is the entire point.** A `json!({})` written inline in `commands::auth` could grow a `user_id` in a later change with nothing to stop it. Defining it once, in the module that owns the anonymity promise, is what lets a test hold the invariant — which is the difference between a claim in a README and a claim the build enforces.

**Sign-out is recorded on the local clear, not on the revocation.** The user has signed out either way; whether the server could be reached is not what this event counts, and the local clear is the thing that always happens.

**A session the *server* ended emits nothing.** Folding a revocation or an expiry into `auth_signed_out` would leave a number that means neither "users are leaving" nor "sessions are dying" — the two questions you would actually ask it. The 401 path in `restore_on_launch` is deliberately silent.

**An already-signed-out device asks for nothing and records nothing.** `auth_sign_out` with no stored credential is a no-op; emitting there would inflate the count with clicks that did nothing.

### Tests

2 new (6 in the telemetry module, 165 in the lib), both at the telemetry seam:

- an install that has **not** opted in enqueues nothing for either event — signing in is not a telemetry backdoor
- both events carry nothing beyond the four common properties (`$lib`, `app_version`, `os`, `arch`), asserted by diffing the enqueued property keys rather than by reading the call site

The second is the one that matters: it fails the moment someone adds a user id to either payload.

---

### TELEMETRY.md — new, and missing for a findable reason

`telemetry/mod.rs` and the Settings consent toggle have **both pointed at `TELEMETRY.md` since telemetry shipped**, and the file has never existed in this repo. The reason is one line: `.gitignore` ignores `*.md` with a single `!README.md` exception, so the file could not have been committed even if it had been written. Fixed with a second negation and a comment saying why.

It now carries the full event catalogue — every event, every property, across the Rust emitter and the renderer crash reporter — plus the never-collected list, and two disclosures the codebase was quietly carrying:

- **Consent defaults ON** (opt-out, like VS Code and Zed), not opt-in.
- **The auto-update check is deliberately outside the telemetry toggle** and has its own switch. An app that stops learning about security updates when you decline analytics is a worse deal than the one you thought you were making — but that is only defensible if it is written down.

While cataloguing, one property was documented as what it is rather than what it sounds like: `agent_kind` is the agent instance's internal `AgentId`, a random per-registration UUID. It identifies nothing outside the process and is useless as a "kind". Not renamed here — that is a telemetry-schema change with a live dashboard behind it.

**The module's own doc comment was corrected**, not left alone: it claimed "zero analytics enabled by default", "nothing leaves the machine until the user explicitly opts in", and a "first-run consent prompt" that does not exist anywhere in the codebase. Three false statements in the header of the file whose job is to be honest about this.

---

### README, landing page, consent string

The README claimed **no account, no server, no telemetry, no analytics, no auto-update pings**. The account and server become false with this feature; the telemetry claims were already false before this branch.

- A new **Accounts and privacy** section states what signing in does and does not do: optional, additive, nothing gated, nothing uploaded, credential never leaves Rust, telemetry stays anonymous after sign-in.
- **Local-first** is restated to be true rather than absolute — content never leaves, and the network calls Atlas does make are named.
- Contributing rule 3 changes from "no telemetry, no analytics" to the rule that actually applies: nothing leaves the machine that is not in the catalogue, and adding an event means adding it to the table in the same PR.
- `landing/index.html` carried the same two claims in the hero and the download CTA, and is fixed with it.
- The consent toggle's own description now says a sign-in is recorded and that *who* signed in is not. The string a user reads before consenting should be the one that is true.

---

### Fed back to the server repo — [tryatlas/server#11](https://github.com/tryatlas/server/pull/11)

Both corrections the spec asked for, as a docs-only PR:

1. **The status-code table listed the wrong rate limit.** It named only the social sign-in 20/60s and omitted the **global 100 requests / 60 s across every `/api/auth/*` path** — the limit that actually constrains a desktop client, shared by the device poll, `/get-session`, the org list, and every `/token` mint. New §16 states both and their relationship.
2. **§12.5's "single retry on 401 after a re-mint" is written for JWT calls without saying so.** Every call the desktop makes here carries the session token, where a 401 means the session is dead and the rule loops forever against a credential that will never work. Now split by which credential the call carries.

Plus the rule that policy assumed but never wrote down: a request that never reached the server tells you nothing about your credential — treating "no answer" as "rejected" is what signs out every user who launches offline.

```
cargo test --lib     165 passed  (2 new)
cargo clippy         clean across the changed files
tsc --noEmit         unchanged (two pre-existing missing-module errors, see below)
```

---

## Pre-existing breakage, not from this PR

Both reproduce on a stashed `main`:
- `tsc` cannot find `@tiptap/extension-bold` and `hast`
- `vite build` fails resolving `@lezer/common` from `@codemirror/language`

So `npm run build` is currently red on `main`. Flagging rather than fixing — out of scope here, but worth its own issue.



