### PR TITLE
fix: chat agent identity, workspace tab mounting, selection theme, CLI shim

### DIFF
--- a/src-tauri/bin/atlas-cli.sh
+++ b/src-tauri/bin/atlas-cli.sh
@@ -58,7 +58,7 @@ for candidate in \
   fi
 done
 if [ -z "$app" ] && command -v mdfind >/dev/null 2>&1; then
-  app="$(mdfind "kMDItemCFBundleIdentifier == 'com.atlas.ide'" 2>/dev/null | head -n 1)"
+  app="$(mdfind "kMDItemCFBundleIdentifier == 'dev.atlas.ide'" 2>/dev/null | head -n 1)"
 fi
 if [ -z "$app" ]; then
   app="Atlas.app"  # let `open` resolve via LaunchServices as a fallback

--- a/src-tauri/bin/atlas-cli.sh
+++ b/src-tauri/bin/atlas-cli.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # atlas-cli-version: {{VERSION}}
+# {{VERSION}} is substituted at install time from CARGO_PKG_VERSION
+# (src-tauri/Cargo.toml), not tauri.conf.json's `version` field —
+# the two can drift.
 #
 # Atlas CLI helper. Installed (and refreshed on every launch) by the
 # Atlas IDE at `~/.local/bin/atlas`. Mirrors the `code` (VS Code) and
@@ -48,6 +51,8 @@ abs="$(cd "$target" && pwd)"
 # Find Atlas.app. macOS first looks in /Applications, then
 # ~/Applications, then PATH-y locations via `mdfind`. The latter
 # covers DMG drag-installs to unusual locations.
+# "Atlas.app" (below and in the LaunchServices fallback) must match
+# `productName` in src-tauri/tauri.conf.json.
 app=""
 for candidate in \
   "/Applications/Atlas.app" \
@@ -58,6 +63,7 @@ for candidate in \
   fi
 done
 if [ -z "$app" ] && command -v mdfind >/dev/null 2>&1; then
+  # Identifier must match `identifier` in src-tauri/tauri.conf.json.
   app="$(mdfind "kMDItemCFBundleIdentifier == 'dev.atlas.ide'" 2>/dev/null | head -n 1)"
 fi
 if [ -z "$app" ]; then

--- a/src/features/chat/components/chat-input.tsx
+++ b/src/features/chat/components/chat-input.tsx
@@ -214,7 +214,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               backgroundColor: "transparent",
             },
             ".cm-selectionBackground, ::selection": {
-              background: "var(--bg-selected) !important",
+              background: "var(--selection-bg) !important",
             },
           },
           { dark: true }

--- a/src/features/chat/components/message-item.tsx
+++ b/src/features/chat/components/message-item.tsx
@@ -2,10 +2,10 @@ import { useState, memo } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { cn } from "@/lib/utils";
 import type { ChatMessage } from "@/types/agent";
+import { AGENT_LABEL } from "@/types/agent";
 import { isBashToolCall } from "../lib/tool-calls";
 import {
   User,
-  Sparkles,
   CheckCircle2,
   XCircle,
   Loader2,
@@ -25,6 +25,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
+import { useChatStore } from "@/features/chat/stores/chat-store";
+import { AgentIcons } from "@/components/agent-icons";
+import { AtlasIcon } from "@/components/atlas-icon";
 import { CachedMarkdown } from "@/lib/markdown-cache";
 import { StreamingMarkdown } from "./streaming-markdown";
 
@@ -113,6 +116,11 @@ export const MessageItem = memo(function MessageItem({
 }) {
   const isUser = message.role === "user";
   const isAssistant = message.role === "assistant";
+  const agentType = useChatStore((s) =>
+    tabId ? (s.sessions[tabId]?.agentType ?? "claude-code") : "claude-code",
+  );
+  const agentLabel =
+    AGENT_LABEL[agentType === "codex" ? "codex" : agentType === "cersei" ? "cersei" : "claude-code"];
 
   // Only user messages carry the @-mention "Atlas context" suffix.
   // `getAtlasSplit` reads from precomputed fields when present (set by
@@ -163,18 +171,15 @@ export const MessageItem = memo(function MessageItem({
             <div className="w-px h-full bg-[var(--border-subtle)]" />
           </div>
         ) : (
-          <div
-            className={cn(
-              "w-8 h-8 rounded-full flex items-center justify-center shrink-0 mt-0.5",
-              isUser
-                ? "bg-[var(--accent-primary-muted)]"
-                : "bg-[var(--bg-elevated)] border border-[var(--border-default)]",
-            )}
-          >
+          <div className="w-8 flex items-start justify-center shrink-0">
             {isUser ? (
-              <User size={14} className="text-[var(--accent-primary)]" />
+              <User size={20} className="text-[var(--accent-primary)]" />
+            ) : agentType === "codex" ? (
+              <AgentIcons.Codex className="size-5" />
+            ) : agentType === "cersei" ? (
+              <AtlasIcon size={20} />
             ) : (
-              <Sparkles size={14} className="text-[var(--text-secondary)]" />
+              <AgentIcons.Claude className="size-5" />
             )}
           </div>
         )}
@@ -195,7 +200,7 @@ export const MessageItem = memo(function MessageItem({
             {!compact && (
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-semibold text-[var(--text-secondary)] uppercase tracking-wide">
-                  {isUser ? "You" : isAssistant ? "Assistant" : message.role}
+                  {isUser ? "You" : isAssistant ? agentLabel : message.role}
                 </span>
                 <span className="text-[10px] text-[var(--text-tertiary)] font-mono">
                   {new Date(message.timestamp).toLocaleTimeString([], {

--- a/src/features/layout/components/center-panel.tsx
+++ b/src/features/layout/components/center-panel.tsx
@@ -150,11 +150,12 @@ export function CenterPanel() {
 
   if (!currentProject) return <WelcomeScreen />;
 
-  // Render EVERY open workspace's column-set in its own stable container
-  // (key=ws.id), only the active one visible. Background workspaces keep their
-  // editor/terminal/chat subtrees MOUNTED (display:none) so switching back is
-  // instant (no CodeMirror/xterm rebuild). A workspace with no view yet (never
-  // visited this session) renders nothing until its first cold load.
+  // Render every mounted workspace's shell in a stable container (key=ws.id),
+  // but only the ACTIVE workspace keeps heavyweight tab contents mounted. The
+  // old "display:none but still mounted" model left terminals, browser embeds,
+  // Pixi graphs, PDFs, and chat virtualizers alive across background
+  // workspaces, which could keep CPU/GPU busy even when those workspaces were
+  // completely hidden.
   return (
     <div className="h-full w-full bg-bg-surface relative">
       {workspaces.map((ws) => {
@@ -465,9 +466,13 @@ const TabContentContainer = memo(function TabContentContainer({
     return <div ref={ref} style={{ flex: "1 1 0%", minHeight: 0, overflow: "hidden" }} />;
   }
 
-  // Keep editor/terminal/browser/knowledge-graph/pdf mounted across tab
-  // switches *within this column* (expensive to rebuild).
-  const persistentTabs = tabs.filter((t) => PERSISTENT_TYPES.has(t.type));
+  // Keep expensive tabs mounted only for the ACTIVE workspace. Persisting them
+  // across tab switches is still valuable, but persisting them across hidden
+  // workspaces lets off-screen terminals/browser embeds/graphs keep running and
+  // is a major source of idle heat.
+  const persistentTabs = isActive
+    ? tabs.filter((t) => PERSISTENT_TYPES.has(t.type))
+    : [];
   const activeIsNonPersistent = !persistentTabs.find((t) => t.id === activeTab.id);
 
   return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -309,7 +309,7 @@
   }
 
   ::selection {
-    background: var(--accent-primary-muted);
+    background: var(--selection-bg);
     color: var(--text-primary);
   }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -16,6 +16,11 @@
   --bg-hover: rgba(255, 255, 255, 0.04);
   --bg-selected: rgba(255, 255, 255, 0.06);
   --bg-active: rgba(255, 255, 255, 0.08);
+  /* Text-selection highlight (::selection). Kept separate from --bg-selected
+     (list/row "selected" UI state) even though both started at 6% white —
+     they're unrelated concepts that happened to share a value, and text
+     selection needs more contrast to stay legible on near-black surfaces. */
+  --selection-bg: rgba(255, 255, 255, 0.18);
 
   /* Knowledge / editor surfaces from the Claude Design handoff
      (atlas-knowledge.jsx). Distinct from --bg-base so we get the


### PR DESCRIPTION
## Summary
- Chat messages now show the active session's actual agent icon/label (Claude, Codex, or Atlas) instead of a generic sparkle/"Assistant".
- Background workspaces no longer keep terminals, browser embeds, knowledge-graph, and PDF views mounted while hidden, cutting idle CPU/GPU usage.
- Text-selection highlight now uses its own token instead of sharing `--bg-selected` with row-selection state, restoring contrast on near-black surfaces.
- `atlas-cli.sh`'s mdfind fallback now looks up the real bundle identifier (`dev.atlas.ide`) instead of a stale `com.atlas.ide`, so Spotlight resolution works again; version/identifier sync notes added inline.

## Test plan
- [ ] `bunx tsc --noEmit`
- [ ] `cd src-tauri && cargo check`
- [ ] Manually verify chat message icons match the active agent per session
- [ ] Manually verify switching workspaces unmounts hidden terminal/browser/KG/PDF views
- [ ] Manually verify text selection contrast in chat input on dark theme
- [ ] Manually verify `atlas` CLI shim resolves the app via Spotlight