### PR TITLE
fix(source-control): layout blowout, branch-scoped history, and stale commit log

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -319,7 +319,14 @@ pub async fn git_log(
     all: Option<bool>,
 ) -> Result<Vec<GitLogEntry>, String> {
     let lim = limit.unwrap_or(50);
-    let all_flag = all.unwrap_or(true);
+    // Defaults to the checked-out branch, like `git log` itself. Every consumer
+    // of THIS command is branch-scoped: the Source-Control History list sits
+    // under a toolbar naming the current branch and offers reset/revert against
+    // what it shows, and the Review panel pre-selects its newest entry. Under
+    // `--all` both silently reach commits that are not on HEAD. The commit graph
+    // genuinely wants every ref, and asks for it explicitly via
+    // `git_graph_build(all: true)`.
+    let all_flag = all.unwrap_or(false);
     tokio::task::spawn_blocking(move || git_log_compute(&path, lim, all_flag))
         .await
         .map_err(|e| e.to_string())?
@@ -696,4 +703,66 @@ fn parse_line_porcelain(out: &str) -> Vec<BlameLine> {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn git(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@example.com")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@example.com")
+            .status()
+            .expect("git is on PATH");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// `git_log` is branch-scoped unless a caller opts in. The Source-Control
+    /// History list and the Review panel both act on what this returns —
+    /// reset/revert/cherry-pick and the pre-selected review target — so a
+    /// commit that is not on HEAD must not appear by default.
+    #[tokio::test]
+    async fn git_log_defaults_to_the_checked_out_branch() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("atlas-gitlog-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+
+        git(&root, &["init", "-q", "-b", "main"]);
+        fs::write(root.join("f"), "a").unwrap();
+        git(&root, &["add", "-A"]);
+        git(&root, &["commit", "-qm", "on main"]);
+        git(&root, &["checkout", "-qb", "feature"]);
+        fs::write(root.join("f"), "b").unwrap();
+        git(&root, &["commit", "-qam", "only on feature"]);
+        git(&root, &["checkout", "-q", "main"]);
+
+        let path = root.to_string_lossy().into_owned();
+
+        let default = git_log(path.clone(), Some(50), None).await.unwrap();
+        assert!(
+            !default.iter().any(|c| c.message == "only on feature"),
+            "default log leaked a commit that is not on HEAD: {:?}",
+            default.iter().map(|c| &c.message).collect::<Vec<_>>()
+        );
+        assert!(default.iter().any(|c| c.message == "on main"));
+
+        let all = git_log(path, Some(50), Some(true)).await.unwrap();
+        assert!(
+            all.iter().any(|c| c.message == "only on feature"),
+            "all: true must still reach every ref"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/src/features/git/stores/git-store.ts
+++ b/src/features/git/stores/git-store.ts
@@ -108,8 +108,9 @@ function ensureGitStatusFreshListener(): void {
 
   // Live updates from the git watcher — commit / checkout / branch / fetch /
   // stage / push all fire `atlas:git-changed`. Refresh status, the rich
-  // branch list, diff and in-progress state. Stashes/remotes/tags change
-  // rarely and are loaded on demand (mount + the action that mutates them).
+  // branch list, the log, diff and in-progress state. Stashes/remotes/tags
+  // change rarely and are loaded on demand (mount + the action that mutates
+  // them).
   void listen<{ project: string }>("atlas:git-changed", (e) => {
     const current = useGitStore.getState().repoPath;
     if (!current || current !== e.payload.project) return;
@@ -119,6 +120,14 @@ function ensureGitStatusFreshListener(): void {
     void actions.refreshStatusNow(current).catch(() => {});
     void actions.listBranches().catch(() => {});
     void actions.loadBranchesFull().catch(() => {});
+    // The log MUST refresh here. Every action that rewrites history —
+    // commit, reset, revert, cherry-pick, merge, pull — mutates `.git/refs`
+    // and so lands on this event, and none of them reload the log
+    // themselves. Without this the History list only ever loads on mount,
+    // so a commit made while the user is watching it (by an agent, the
+    // terminal, or History's own revert/reset buttons) leaves a list that
+    // silently describes a repo state that no longer exists.
+    void actions.loadLog(current).catch(() => {});
     void actions.loadDiff().catch(() => {});
     void actions.loadInProgress().catch(() => {});
   });

--- a/src/features/layout/components/app-layout.tsx
+++ b/src/features/layout/components/app-layout.tsx
@@ -74,7 +74,19 @@ export function AppLayout() {
        * place from an in-RAM snapshot (see workspace-snapshot.ts), so the shell
        * stays mounted and switching is near-instant.
        */}
-      <div className="flex flex-col flex-1 min-h-0">
+      {/* `min-w-0` is load-bearing, not decoration. This column is a flex item
+          of the row above, so without it its automatic minimum size is its
+          MIN-CONTENT width — and min-content propagates up from the deepest
+          `whitespace-nowrap` text in any panel (e.g. a 400-char commit subject
+          in the git History list). The column then grows PAST the window,
+          `PanelGroup`'s `width: 100%` resolves against that inflated width, and
+          every panel scales with it: the left panel balloons and the right
+          panel is pushed off-screen entirely. `overflow: hidden` on the panels
+          does NOT prevent this — it stops a panel's USED size being overridden
+          by its content, but the content still contributes to the group's
+          intrinsic width. Capping the column here is what keeps the shell
+          inside the window no matter what any panel renders. */}
+      <div className="flex flex-col flex-1 min-h-0 min-w-0">
         <Titlebar />
 
         <div className="flex-1 min-h-0">


### PR DESCRIPTION
Three bugs in the source-control panel. The first is what I set out to fix; the other two turned up while investigating it and are in the same code path.

| # | Bug | Severity |
|---|---|---|
| 1 | A long commit subject destroys the whole window layout | Visible breakage |
| 2 | History lists commits that aren't on your branch, and offers Reset/Revert against them | Data-loss risk |
| 3 | History never refreshes after a commit made while it's on screen | Silently stale UI |

---

# 1. Long commit subjects blow out the shell layout

Opening the git **History** tab destroyed the window layout on some projects: the left sidebar ballooned, the centre content was shoved right and clipped, and the right panel disappeared off-screen. The same project was fine on the **Changes** tab, and other projects were fine on both — which made it look like a git bug rather than a layout one.

### Root cause

`AppLayout`'s main column was `flex flex-col flex-1 min-h-0` — **missing `min-w-0`**.

It is a flex item of the app's root row, so without `min-w-0` its automatic minimum size resolves to its **min-content width**, and that min-content propagates up from the deepest `whitespace-nowrap` text in any panel. `HistoryView` renders every commit subject with `truncate`, which sets `white-space: nowrap` — so each row's min-content is the *entire unwrapped subject*. Once that exceeded the window:

1. the column grew past the viewport,
2. `PanelGroup`'s `width: 100%` resolved against that inflated width,
3. every panel scaled proportionally — left panel ballooned, right panel pushed off-screen.

Two things that look like they should have caught this, and don't:

- **`overflow: hidden` on `react-resizable-panels`' `Panel` does not help.** It stops a panel's *used* size being overridden by its content, but the content still contributes to the group's *intrinsic* width. Measured: adding `min-width: 0` to all three Panels while removing the column fix reproduces the blowout at exactly the same 1.82×.
- **`ChangesView` already carries `min-w-0`** (`changes-view.tsx:236`); `HistoryView` does not. That asymmetry is why only the History tab tripped it.

### Why only some repos

A threshold, not a per-project quirk — it shows only once min-content exceeds the window width:

| repo | longest commit subject | approx. min-content |
|---|---|---|
| atlas | 98 chars | ~540px — under the window, invisible |
| engram | 415 chars | ~2100px against a ~350px panel — blowout |

### Fix

`min-w-0` on the shell column, with a comment explaining why it's load-bearing so it doesn't get "cleaned up" later. This caps the shell at the window regardless of what *any* panel renders, rather than patching `HistoryView` specifically — the same bug was reachable from any panel with long unbreakable text.

### Verification

Isolated the exact computed-style chain (root row → column → `PanelGroup` → `Panel` → right panel → git manager → history list) and measured it in a browser at a 1200px viewport:

| case | column width | left panel | right panel |
|---|---|---|---|
| 98-char subject, no `min-w-0` | 1200 (= viewport) | 217 | on screen |
| **415-char subject, no `min-w-0`** | **2188 — 1.82× blowout** | **395** | **off screen** |
| 415-char subject, with `min-w-0` | 1200 | 217 | on screen |

1.82× matches the ~1.8× in the broken screenshot (left panel 340px → 625px). Dropping `nowrap` instead also cleared it, confirming `truncate` as the source. After the fix the message still ellipsizes and the list gains no horizontal overflow.

---

# 2. History showed commits that aren't on your branch

`git_log` defaulted `all` to **true**, and neither caller passed it — so the History list and the Review panel both ran `git log --all`.

```
HEAD on main, with an unmerged feature branch:

git log -100          →  on main: second / on main: first
git log -100 --all    →  ON FEATURE BRANCH - not on main / on main: second / on main: first
```

The list renders only message, hash, author and date — it drops the `refs` already present in the payload — so a foreign-branch commit is indistinguishable from one on HEAD. The toolbar directly above names the current branch, and selecting an entry offers **Reset (soft/mixed/hard)**, **Revert** and **Cherry-pick**, labelled *"Reset current branch to this commit"*. A `reset --hard` onto another branch's commit was reachable with no signal that's what you were doing.

The Review panel had it worse: it pre-selects `commits[0]`, and under `--topo-order --all` the newest commit across all refs need not be HEAD — so "review this commit" could default to a different branch's work.

### Fix

Default to the checked-out branch, matching `git log` itself. The commit graph is the one consumer that genuinely wants every ref, and already opts in explicitly via `git_graph_build(all: true)`.

Pinned by a test that fails on the old default:

```
default log leaked a commit that is not on HEAD: ["only on feature", "on main"]
```

Latent in this repo today (all branches merged within the first 100 commits — 0 divergence), but it triggers the moment an unmerged branch exists.

---

# 3. History never refreshed after a commit

`loadLog` had exactly two call sites, both mount-scoped: `HistoryView`'s effect and `refreshAll`, itself only called from `GitManagerPanel`'s mount effect. The `atlas:git-changed` watcher refreshed status, branch lists, diff and in-progress state — but not the log — and none of commit / reset / revert / cherry-pick / merge / pull reloaded it either.

So the History list only ever reflected the repo as it was when the view mounted. Committing in Changes and *then* opening History happened to be safe, because that mounts the view. The broken cases:

- a commit lands while History is already on screen (an agent, the terminal) → nothing appears;
- you hit **Revert** or **Reset** in the commit detail and go Back → the list still shows the pre-mutation state.

For a tool where agents commit in the background, the first is the common case.

### Fix

Refresh the log in the `atlas:git-changed` watcher. Every one of those actions writes `.git/refs`, which the watcher already observes, so one line covers all of them rather than bolting a refresh onto each mutation.

---

## Verification

- `cargo test --lib` — 194 passed, 0 failed (193 pre-existing + 1 new)
- New test red-green checked: fails on the old `--all` default, passes on the fix
- `tsc --noEmit` — clean
- `npm run build` — clean
- Layout fix confirmed in the running app against `engram` and other projects

## Notes for review

- The `--all` default was arguably deliberate, since cherry-picking from another branch is a real use case. If so, the alternative fix is ref badges in the list rather than changing the query — happy to switch.
- Two pre-existing issues found but deliberately left alone: `center-panel.tsx:229` carries a `min-w-0` on a `Panel` that by the measurement above is likely also a no-op, and `npm run lint` is broken repo-wide (ESLint 9 with no `eslint.config.js`).

