### PR TITLE
fix: use non interactive login shell for resolution

### DIFF
--- a/crates/atlas-acp/src/spawn.rs
+++ b/crates/atlas-acp/src/spawn.rs
@@ -90,7 +90,7 @@ fn resolve_program_abs(program: &str) -> Option<String> {
     resolved
 }
 
-/// Run `$SHELL -lic <script>` with an OWNED timeout: on expiry the probe child
+/// Run `$SHELL -lc <script>` with an OWNED timeout: on expiry the probe child
 /// is killed (so its reader thread exits promptly) instead of being abandoned
 /// to run forever — the old `recv_timeout`-only pattern leaked one thread AND
 /// one login shell per timed-out probe.
@@ -100,7 +100,7 @@ fn probe_shell(
     timeout: std::time::Duration,
 ) -> Option<std::process::Output> {
     let child = std::process::Command::new(shell)
-        .args(["-lic", script])
+        .args(["-lc", script])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -259,8 +259,8 @@ fn enrich_path() {
     //    happen synchronously so the very first `acp_spawn_agent` call can
     //    already resolve `npx`/`node` from a Homebrew install.
     //
-    // 2. The user's REAL interactive-shell PATH, queried synchronously via
-    //    `$SHELL -lic 'echo $PATH'` (bounded by a short timeout). This is the
+    // 2. The user's REAL shell PATH, queried synchronously via
+    //    `$SHELL -lc 'echo $PATH'` (bounded by a short timeout). This is the
     //    authoritative fix: macOS GUI apps launched from Finder/the Dock only
     //    inherit `/usr/bin:/bin:/usr/sbin:/sbin`, so `npx`/`node` installed via
     //    nvm/fnm/volta/asdf or a custom npm prefix are invisible — the hardcoded
@@ -285,7 +285,7 @@ fn enrich_path() {
 fn merge_login_shell_path() {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
 
-    // `-lic` loads the user's full login + interactive config (where
+    // `-lc` loads the user's full login config (where
     // nvm/fnm/etc. mutate PATH). Owned timeout: the probe child is killed on
     // expiry instead of leaking (see `probe_shell`).
     let Some(out) = probe_shell(

--- a/src-tauri/src/commands/claude_setup.rs
+++ b/src-tauri/src/commands/claude_setup.rs
@@ -26,19 +26,20 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as AsyncCommand;
 use tokio::time::timeout;
 
-/// Resolve a CLI's absolute path via the user's LOGIN+INTERACTIVE shell.
+/// Resolve a CLI's absolute path via the user's login shell.
 ///
 /// macOS GUI apps launched from Finder/the Dock inherit only a minimal PATH
 /// (`/usr/bin:/bin:/usr/sbin:/sbin`), so a bare `claude` spawn fails even when
 /// the user has it on their interactive-shell PATH (`~/.local/bin`, nvm, a
-/// custom npm prefix, Homebrew, etc.). Asking their own `$SHELL -lic` resolves
-/// the binary the same way their terminal would. Falls back to the bare name
-/// (relying on the process-wide PATH enrichment in `atlas_acp::sanitize_host_env`)
-/// if the shell probe fails or times out.
-async fn resolve_cli(name: &str) -> String {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+/// custom npm prefix, Homebrew, etc.). Asking their own `$SHELL -lc` resolves
+/// the binary the same way their terminal would — login-shell PATH sourcing
+/// without interactive-shell job-control init, which self-stops via SIGTTOU
+/// when this process has a real controlling terminal attached (e.g. any
+/// dev-mode launch from a terminal, vs. a Finder/Dock-launched build).
+/// Falls back to the bare name (relying on the process-wide PATH enrichment
+/// in `atlas_acp::sanitize_host_env`) if the shell probe fails or times out.    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let probe = AsyncCommand::new(&shell)
-        .args(["-lic", &format!("command -v {name} 2>/dev/null")])
+        .args(["-lc", &format!("command -v {name} 2>/dev/null")])
         .output();
     if let Ok(Ok(out)) = timeout(Duration::from_secs(5), probe).await {
         if out.status.success() {

--- a/src-tauri/src/commands/node_setup.rs
+++ b/src-tauri/src/commands/node_setup.rs
@@ -52,12 +52,12 @@ pub struct NodeStatus {
     pub min_major: u32,
 }
 
-/// Resolve a CLI to an absolute path via the user's login+interactive shell
+/// Resolve a CLI to an absolute path via the user's login shell
 /// (covers nvm/fnm/volta/brew). Mirrors `claude_setup::resolve_cli`.
 async fn resolve_cli(name: &str) -> Option<String> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let probe = AsyncCommand::new(&shell)
-        .args(["-lic", &format!("command -v {name} 2>/dev/null")])
+        .args(["-lc", &format!("command -v {name} 2>/dev/null")])
         .output();
     if let Ok(Ok(out)) = timeout(Duration::from_secs(5), probe).await {
         if out.status.success() {


### PR DESCRIPTION
Problem: 
Running bun run dev:app (or any dev mode launch via tauri-cli) would open the window, show the initial skeleton UI and then become completely unresponsive no errors. This was reproducible on Linux and is likely reachable on macOS too when running dev builds from an actual terminal (as opposed to a Finder/Dock launched production build).

Root cause:
claude_setup.rs::resolve_cli and node_setup.rs's mirrored copy both resolve a CLI's path by spawning the user's shell:
```rust
AsyncCommand::new(&shell)
    .args(["-lic", &format!("command -v {name} 2>/dev/null")])
    .output();
```
The -i (interactive) flag was unnecessary and is the actual bug. An interactive shell on startup runs job control initialization. It checks whether it's the terminal's current foreground process group and, if not, tries to claim it via tcsetpgrp(). That's fine when there's no controlling terminal at all (a Finder-launched GUI app the ioctl just fails with ENOTTY and the shell moves on silently). But when this probe is spawned from a real terminal session  or any dev-mode run via bun run dev:app,  the process inherits a real controlling terminal and tokio::process::Command spawns children into the parent's process group by default (no new pgroup, no pty). So the shell's job-control bootstrap collides with the terminal's actual foreground group and gets sent SIGTTOU. Default disposition: stop. Because it shares its process group with atlas, cargo, and everything above it in the tree, the stop signal hits the whole group at once which is why the entire app froze, not just one subprocess.

Fix:
Drop -i, keep -l

```rust
AsyncCommand::new(&shell)
    .args(["-lc", &format!("command -v {name} 2>/dev/null")])
    .output();
```
-l alone still sources login shell PATH configuration which is the only thing this lookup actually needs command -v doesn't require interactive shell behavior (job control, prompts). Non interactive shells skip job control init entirely so there's no terminal claim attempted and no SIGTTOU.

