### PR TITLE
chore: issue + PR templates, dependabot, CONTRIBUTING pass

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Something is broken, or behaves in a way it shouldn't
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Write as much or as little as you have. A one-line note is a fine issue;
+        so is a long writeup with code references. Only the first box is required —
+        everything below it is optional, so skip anything that doesn't apply.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's going on?
+      description: >-
+        Markdown and code blocks render here, so this box can hold anything from a
+        single sentence to a full investigation. If you have them, useful things to
+        include: what you expected instead, how to see it in the app, screenshots or
+        a screen recording, relevant log lines, what you've already checked or ruled
+        out, and your Atlas version / OS + version / which agent was active if it's
+        relevant.
+      placeholder: |
+        Terminal tab loses scrollback when I switch away and back.
+
+        Only happens after the pane has been split. Probably around
+        src/features/terminal/stores/ — the buffer lives in the PTY, so
+        the remount may be dropping the subscription rather than the bytes.
+
+        Checked: the PTY process itself isn't dying (still shows in Activity
+        Monitor), so this looks like a frontend subscription issue, not a
+        backend one.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area is this in?
+      description: Optional — leave it alone if you're not sure.
+      multiple: true
+      options:
+        - "Not sure"
+        - "agents / chat"
+        - "editor"
+        - "terminal"
+        - "browser"
+        - "knowledge"
+        - "memory"
+        - "git / checkpoints"
+        - "canvas"
+        - "settings"
+        - "install / updates"
+        - "other"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: confidence
+    attributes:
+      label: How sure are you?
+      description: >-
+        Optional. "Not sure" is a real answer and won't get the issue closed —
+        it just tells us to reproduce before anyone starts fixing.
+      options:
+        - "I saw it happen and can trigger it again"
+        - "I saw it happen once, haven't reproduced it"
+        - "Not sure it's a bug — might be my setup, or my misunderstanding"
+    validations:
+      required: false
+
+  - type: input
+    id: prior_art
+    attributes:
+      label: Seen it handled well elsewhere?
+      description: >-
+        Optional, and only if it applies. If another app gets this right, naming it
+        is often more useful than a paragraph describing what you want.
+      placeholder: "The Next.js dev overlay — errors get a dismissible box with a copy button"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Kept enabled on purpose. Already-installed Atlas builds link to
+# /issues/new?title=…&body=… with no `template=` — disabling blank issues
+# redirects that to the template chooser and silently drops the prefilled
+# body, losing whatever the user typed in the feedback panel. It also gives
+# anything that fits neither form somewhere to go.
+blank_issues_enabled: true
+contact_links:
+  - name: Question about Atlas
+    url: https://discord.gg/GmnFggaPfP
+    about: Ask in #dev on Discord rather than opening an issue.
+  - name: Report a security vulnerability
+    url: https://github.com/pacifio/atlas/security/policy
+    about: Don't open a public issue for a vulnerability — see SECURITY.md for how to report it privately.

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,63 @@
+name: Feature Request / Feedback
+description: Suggest something, propose work, or tell us what feels clumsy
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Write as much or as little as you have. A one-line idea is a fine issue;
+        so is a long proposal with implementation notes. Only the first box is
+        required — everything below it is optional.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Tell us more
+      description: >-
+        What would you like Atlas to do, or what feels slow, clumsy, or confusing?
+        Markdown and code blocks render here, so this box can also hold a full
+        writeup — current behaviour, the ask, implementation notes, files to touch,
+        what you've already checked or ruled out, how you'd verify it — if you've
+        already thought it through that far.
+      placeholder: |
+        The send keybinding in chat should be configurable — Enter-to-send
+        fights muscle memory when composing multi-line prompts.
+
+        Notes: the keymap is registered in the chat composer; CodeMirror
+        keymap precedence matters here, so a user binding has to be added
+        with high precedence rather than appended.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area is this about?
+      description: Optional — leave it alone if you're not sure.
+      multiple: true
+      options:
+        - "Not sure"
+        - "agents / chat"
+        - "editor"
+        - "terminal"
+        - "browser"
+        - "knowledge"
+        - "memory"
+        - "git / checkpoints"
+        - "canvas"
+        - "settings"
+        - "install / updates"
+        - "other"
+    validations:
+      required: false
+
+  - type: input
+    id: prior_art
+    attributes:
+      label: Seen it done well elsewhere?
+      description: >-
+        Optional, and only if it applies. If another app already solves this,
+        naming it is often worth more than a paragraph describing what you want.
+      placeholder: "Zed — the model picker lives right in the chat panel"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Thanks for the PR. Please read CONTRIBUTING.md if you haven't already.
+
+## Which branch should this target?
+
+Atlas ships versioned installable builds, so `main` always equals the latest
+release — work collects on a version branch (e.g. `0.2.5`) first, and the
+merge of that branch into `main` is the release itself.
+
+- Target the **current version branch** for anything that isn't a small,
+  self-contained fix.
+- Target **`main`** directly only if the change has no version-branch
+  dependency and doesn't need to wait for the next release (a doc fix, a
+  one-line hotfix).
+
+See CONTRIBUTING.md's "Branching model" section if you're not sure which
+applies.
+-->
+
+### What?
+
+### Why?
+
+### How?
+
+Fixes #
+
+## Checklist
+
+Only the things CI can't check for you:
+
+- [ ] Targets the current version branch, unless it's a small standalone fix
+- [ ] `cd src-tauri && cargo check` passes
+- [ ] `cargo test` passes from inside every crate you touched (`cd crates/<crate> && cargo test`) — CI only covers `atlas-redact` and `atlas-checkpoint`
+- [ ] You've run the app and used the change in a window
+
+CI runs `bunx tsc --noEmit` on every PR, so there's no box for it.
+
+If this adds a top-level dependency or touches the telemetry pipeline, say so in **Why?** above — both need discussion, and telemetry changes need `TELEMETRY.md` updated to match.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,158 @@
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Every crates/* crate is a standalone package with its own Cargo.lock, not a
+  # workspace member — Dependabot doesn't discover them recursively from
+  # src-tauri, so each one needs its own entry. Limit kept low per-directory
+  # since a shared dep bump (e.g. a cersei-* pin) can fire across several of
+  # these at once.
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-acp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-agentkit"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-agents"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-bus"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-cersei"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-checkpoint"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-codeindex"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-embed"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-gitdiff"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-kb-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-memory"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-redact"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-review"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/crates/atlas-terminal"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,9 @@ Areas where help goes furthest right now:
 
 Check [open and closed issues](https://github.com/pacifio/atlas/issues?q=is%3Aissue) first. If one already covers it, a 👍 reaction is more useful than a duplicate.
 
-For a new report, include your Atlas version (Settings → About), your macOS version, and which agent was selected.
+The fastest way to report one is the **feedback button** in the app (status bar, or Settings) — its "Open a GitHub issue" link pre-fills the Bug Report form from whatever you typed. Filing directly on GitHub works the same way.
+
+The form only requires one field: a freeform description. Write as much or as little as you have — a one-line note is a fine issue, and so is a long writeup with source references. If you have them, your Atlas version (Settings → About), your OS and version, which agent was selected, and how to trigger it all help, but none of them block you from filing.
 
 ## Security issues
 
@@ -46,32 +48,41 @@ Share the proposal in the issue before implementing anything that changes UI or 
 
 Atlas has a lot of surfaces — a change that looks right in one panel often reads wrong across the other twelve. A design pass up front is faster than a rewrite after review.
 
-## Requirements
+## Quickstart
 
-**macOS is the supported platform.** Linux and Windows build from the same Tauri codebase but are untested, so expect to be the first person to hit whatever breaks. Reports from either are genuinely welcome.
+**macOS is the only currently-supported platform.** Linux and Windows build from the same Tauri codebase but are untested — a Windows build is planned, and reports from either OS are genuinely welcome in the meantime.
+
+You need:
 
 - [Bun](https://bun.sh/)
 - [Rust](https://rustup.rs/), stable
 - Xcode Command Line Tools
-- The `claude` CLI on your `PATH`, only if you're working on the Claude Code agent. The native agent needs nothing extra.
 
-## Local setup
+**No API keys, no `.env` file, no account.** Atlas builds and runs from a clean clone:
 
 ```bash
+git clone git@github.com:pacifio/atlas.git
+cd atlas
 bun install
 bun run dev:app
 ```
 
-The first Rust compile takes a few minutes. After that it's seconds.
+The first Rust compile takes a few minutes; after that, seconds. `bun run dev:app` hot-reloads the frontend on save — Rust changes need a restart.
 
-**No API keys are needed to build or run Atlas.** `.env` is optional — copy `.env.example` only if you want to point telemetry at your own PostHog project. Left blank, telemetry is permanently inert.
+That's enough to build and run Atlas. If you're planning to submit a change, clone your **fork** instead of `pacifio/atlas` directly — see "Fork, branch, PR" below.
+
+Other commands you'll use:
 
 ```bash
-bun run dev             # Vite only, no Tauri shell. Fast for pure UI work, but invoke() calls fail
+bun run dev             # Vite only, no Tauri shell — fast for pure UI work, but invoke() calls fail
 bun run format          # Prettier on src/
 ```
 
-`bun run lint` fails on a clean checkout — there's no ESLint 9 flat config in the repo yet. Use `bunx tsc --noEmit` as the frontend gate.
+`bun run lint` fails on a clean checkout — there's no ESLint 9 flat config in the repo yet. Use `bunx tsc --noEmit` as the frontend gate (see Verification below).
+
+If you're working on the **Claude Code** agent specifically, you also need the `claude` CLI on your `PATH`. The native Atlas agent needs nothing extra.
+
+`.env` is optional — copy `.env.example` only if you want to point telemetry at your own PostHog project. Left blank, telemetry is permanently inert.
 
 ## Fork, branch, PR
 
@@ -85,40 +96,48 @@ cd atlas
 # 2. Point `upstream` at the canonical repo
 git remote add upstream git@github.com:pacifio/atlas.git
 git fetch upstream
-
-# 3. Find the current version branch — the highest-numbered one
-git ls-remote --heads upstream \
-  | sed 's|.*refs/heads/||' \
-  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
-
-# 4. Branch from it, not from main
-git checkout -b <you>/atl-123-short-slug upstream/0.2.4
-
-# 5. Push to your fork, then open the PR against that same version branch
-git push -u origin <you>/atl-123-short-slug
 ```
 
-Linear generates branch names in the form `<you>/atl-<id>-<slug>`. Use them as given.
+Next, find the current version branch — check the [branch list on GitHub](https://github.com/pacifio/atlas/branches) and look for the highest-numbered one (e.g. `0.2.5`). Ask in `#dev` on Discord if it's not obvious.
+
+```bash
+# 3. Branch from it, not from main
+git checkout -b <you>/short-slug upstream/0.2.5
+
+# 4. Push to your fork, then open the PR against that same version branch
+git push -u origin <you>/short-slug
+```
+
+Name your branch `<you>/<short-slug>` — a few words describing the change, e.g. `alex/fix-sidebar-collapse`. If there's a GitHub issue for it, lead with the number: `alex/42-fix-sidebar-collapse`.
 
 To pick up changes made while you were working:
 
 ```bash
 git fetch upstream
-git rebase upstream/0.2.4
+git rebase upstream/0.2.5
 ```
 
 Leave **Allow edits from maintainers** checked when you open the PR. It lets small fixes land without another round trip.
 
 ## Branching model
 
-Atlas uses version branches, not trunk-based development.
+Most open-source projects merge every PR straight into `main`, because `main` is deployed continuously — there's no fixed "next release," just a constantly moving target. Atlas doesn't work that way: it ships as a numbered, installable build with an auto-updater, so `main` has to always equal exactly what's been released, nothing ahead of it. That means work needs somewhere to collect *before* it becomes a release, instead of landing on `main` directly.
+
+That somewhere is a version branch — one per upcoming release (`0.2.5`, `0.2.6`, …). PRs target the version branch, not `main`. Once the version branch is ready to ship, it gets merged into `main` in a single PR, and that merge *is* the release.
+
+```
+you/fix-sidebar-collapse ──┐
+you/add-vim-keybindings ───┼──►  0.2.5  ──►  main     (this merge = the 0.2.5 release)
+someone/fix-x ──────────────┘
+```
 
 | Branch | Purpose | Merges into |
 |---|---|---|
-| `main` | Release branch | — |
-| `0.2.4`, `0.2.5`, … | Integration branch for an upcoming release | `main`, and that merge is the release |
-| `<you>/atl-<id>-<slug>` | One issue's worth of work | The current version branch |
-| `feature-*`, `fix/*`, `mvc`, `ui` | Work spanning version cycles | `main` or the active version branch, depending on timing |
+| `main` | Always equals the latest release, nothing more | — |
+| `0.2.4`, `0.2.5`, … | Collects everything going into the next release | `main`, and that merge is the release |
+| `<you>/<short-slug>` | One issue's worth of work | The current version branch |
+
+PR straight into `main` only when the change has no version-branch dependency and doesn't need to wait for the next release — a doc fix or a one-line hotfix, say. When in doubt, target the version branch.
 
 Releases are tagged `alpha-X.Y.Z`, with occasional `exp-X.Y.Z-X.Y.Z` snapshots.
 
@@ -141,28 +160,21 @@ bunx tsc --noEmit                  # frontend typecheck
 cd src-tauri && cargo check        # Rust typecheck, including every crates/* dependency
 ```
 
-Rust tests run offline and need no API keys:
+Rust tests run offline and need no API keys. Each crate under `crates/` is its own standalone package (its own `Cargo.lock`, not a workspace member of `src-tauri`), so tests run from inside the crate's own directory — not with `-p <crate>` from `src-tauri`:
 
 ```bash
-cd src-tauri && cargo test -p atlas-cersei                      # the native agent
-cd src-tauri && cargo test -p atlas-cersei --test tools_eval    # a single file
-cd src-tauri && cargo run -p atlas-acp --example smoke          # ACP transport smoke test
+cd crates/atlas-cersei && cargo test                      # the native agent
+cd crates/atlas-cersei && cargo test --test tools_eval    # a single file
+cd crates/atlas-acp && cargo run --example smoke          # ACP transport smoke test
 ```
 
-Run `cargo test -p <crate>` for any workspace crate you touched.
+Run `cargo test` from inside the directory of any crate you touched.
 
 There's no frontend test runner. UI work is verified by running the app and using the feature in a window.
 
 ## Pull request checklist
 
-- [ ] PR targets the current version branch, unless it's a small standalone fix
-- [ ] `bunx tsc --noEmit` passes
-- [ ] `cd src-tauri && cargo check` passes
-- [ ] `cargo test -p <crate>` passes for every crate you touched
-- [ ] You have run the app and used the feature in a window
-- [ ] No commented-out code, no leftover `console.log`
-- [ ] No new top-level dependencies unless discussed in the issue
-- [ ] `TELEMETRY.md` updated, if you touched the telemetry pipeline
+Opening a PR pre-fills the checklist from the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — work through it before asking for review.
 
 ## Telemetry
 

--- a/src/features/feedback/lib/feedback-links.ts
+++ b/src/features/feedback/lib/feedback-links.ts
@@ -13,10 +13,24 @@ const PREFIX: Record<FeedbackCategory, string> = {
   other: "[Feedback]",
 };
 
+/** Which issue form each category opens. Both forms use a `description` field id. */
+const TEMPLATE: Record<FeedbackCategory, string> = {
+  issue: "bug_report.yml",
+  feature_request: "feedback.yml",
+  improvement: "feedback.yml",
+  other: "feedback.yml",
+};
+
 /** GitHub rejects very long URLs (~8k). Stay well inside it. */
 const MAX_BODY = 4000;
 
-/** A prefilled "new issue" URL carrying whatever the user has typed so far. */
+/**
+ * A prefilled "new issue" URL carrying whatever the user has typed so far.
+ *
+ * Issue forms don't have a single body box, so `body=` is ignored once a
+ * template is specified — text has to target a field by its `id` instead
+ * (here, `description`, which both bug_report.yml and feedback.yml declare).
+ */
 export function issueUrl(
   category: FeedbackCategory,
   message: string,
@@ -24,11 +38,16 @@ export function issueUrl(
   const text = message.trim();
   const first = text.split("\n")[0]?.slice(0, 90) || "Feedback";
   const title = `${PREFIX[category]} ${first}`;
-  const body =
+  const description =
     `${text.slice(0, MAX_BODY)}\n\n---\n` +
     `_Filed from Atlas → Send feedback._\n` +
     `_Attached a screenshot? Drag it in here — a link can't carry it._`;
-  return `${ISSUE_BASE}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+  const params = new URLSearchParams({
+    template: TEMPLATE[category],
+    title,
+    description,
+  });
+  return `${ISSUE_BASE}?${params.toString()}`;
 }
 
 /** Open in the system browser, with the repo's usual `window.open` fallback. */


### PR DESCRIPTION
### What?

Adds the GitHub contribution surface the repo was missing: two issue forms, a PR template, and a Dependabot config. Also reworks the parts of `CONTRIBUTING.md` that were out of date, and points the in-app feedback panel at the new forms.

### Why?

Issues were arriving in wildly different shapes — some one-line notes, some full writeups, some with invented "Steps to Reproduce" sections that nobody had actually walked. A heavy template makes people fabricate the fields it demands; no template makes reports unroutable. These two forms require exactly one field (a freeform description) and make everything else optional, so a one-line note and a long investigation are both valid submissions.

`crates/*` packages aren't `src-tauri` workspace members, so Dependabot doesn't discover them recursively — each needs its own entry.

### How?

**Issue forms** — `bug_report.yml` (description · area · confidence · prior art) and `feedback.yml` (description · area · prior art). Only `description` is required on either. The optional fields are ones where leaving them blank is an honest answer: "Not sure" is a real option for area, and prior art ("Zed puts the model picker in the panel") is often more implementable than a paragraph of description.

**`config.yml`** — deliberately keeps blank issues **enabled**. Already-installed Atlas builds link to `/issues/new?title=…&body=…` with no `template=`; disabling blank issues redirects that to the chooser and silently drops the prefilled body, losing whatever the user typed in the feedback panel. The reasoning is recorded in a comment in the file so it doesn't get flipped back.

**PR template** — branch-targeting guidance up top, and a checklist trimmed to only what CI can't verify (`cargo check`, per-crate `cargo test`, running the app). CI already runs `bunx tsc --noEmit`, so there's no box for it.

**`feedback-links.ts`** — each feedback category now opens the matching form and prefills the `description` field. No dropdown prefill: matching an option by exact string is a cross-file contract nothing typechecks, and the title prefix already carries the category.

**`CONTRIBUTING.md`** — quickstart now shows the clone/install/run path and states that no API keys or `.env` are needed; fork/branch/PR and bug-reporting sections updated to match.

Note that issue templates only take effect once they reach the default branch, so none of this is user-visible until `0.2.5` merges to `main`.

### Verification

- `bunx tsc --noEmit` — clean
- All three issue templates parse as YAML; each declares exactly one required field
- Rebased onto current `upstream/0.2.5` (`da5dd5b`); no file overlap with the timeline/linux commits

Fixes #

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] `cd src-tauri && cargo check` passes — no Rust touched
- [x] `cargo test` passes from inside every crate you touched — no crates touched
- [x] You've run the app and used the change in a window — **not done.** The only runtime change is `issueUrl()`, and the forms it targets don't resolve on GitHub until this reaches the default branch, so the link can't be exercised end-to-end yet. Worth a manual click-through from the feedback panel after the release merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
