### PR TITLE
fix: markdown preview for fileviewer

### DIFF
--- a/src/features/editor/components/editor-panel.tsx
+++ b/src/features/editor/components/editor-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { EditorView, keymap, lineNumbers, highlightActiveLine, drawSelection } from "@codemirror/view";
 import { EditorState, Compartment, Transaction, type Extension } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
@@ -17,6 +17,8 @@ import { diffGutter, applyDiffStatus } from "../lib/diff-gutter";
 import { gitDiffLineStatus } from "@/features/git/lib/git-diff-api";
 import { blameInline, applyBlame } from "../lib/blame-inline";
 import { gitBlameFile } from "@/features/git/lib/git-blame-api";
+import { MarkdownFile } from "@/lib/markdown-fileviewer";
+import { cn } from "@/lib/utils";
 
 const TOOLBAR_HEIGHT = 32;
 const DIRTY_CHECK_DEBOUNCE = 300; // ms — only check dirty state, not sync content
@@ -119,6 +121,10 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   const refreshGutterRef = useRef<() => void>(() => {});
   const refreshBlameRef = useRef<() => void>(() => {});
   const dirtyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [renderMode, setRenderMode] = useState<"editor" | "preview">("editor");
+  const resolvedFileType = (buffer?.language ?? path.split(".").pop()?.toLowerCase() ?? "").toLowerCase();
+  const isMarkdownFile = resolvedFileType === "markdown";
 
   // Load file content from disk — unless this is an untitled scratch
   // buffer (Cmd+N), in which case we seed an empty buffer in-memory
@@ -481,6 +487,34 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
         {buffer.dirty && (
           <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0 ml-2" />
         )}
+        {isMarkdownFile && (
+          <div className="ml-2 inline-flex items-center h-[20px] rounded-full border border-border-default bg-bg-elevated p-[2px] text-[10px] font-medium shrink-0">
+              <button
+                type="button"
+                onClick={() => setRenderMode("editor")}
+                className={cn(
+                  "px-2 h-full rounded-full transition-colors",
+                  renderMode === "editor"
+                    ? "bg-bg-hover text-text-primary"
+                    : "text-text-secondary hover:text-text-primary"
+                )}
+                >
+                  Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => setRenderMode("preview")}
+                className={cn(
+                  "px-2 h-full rounded-full transition-colors",
+                  renderMode === "preview"
+                    ? "bg-bg-hover text-text-primary"
+                    : "text-text-secondary hover:text-text-primary"
+                )}
+              >
+                Preview
+              </button>
+          </div>
+        )}
         {buffer.externallyChanged && (
           <button
             type="button"
@@ -495,9 +529,19 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
 
       {/* CodeMirror container */}
       <div
-        ref={containerRef}
-        style={{ height: editorHeight, overflow: "hidden" }}
-      />
+        style={{height:editorHeight, overflow:"hidden"}}
+      >
+        <div
+          ref={containerRef}
+          style={{display: renderMode === "editor" ? "block" : "none", height: editorHeight, overflow: "hidden" }}
+        />
+        <div
+          style={{ display: renderMode === "preview" ? "block" : "none", height: editorHeight }}
+          className="overflow-auto bg-bg-primary px-4 py-3"
+        >
+          {buffer && <MarkdownFile trusted={true} className="max-w-none">{buffer.originalContent}</MarkdownFile>}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/lib/markdown-fileviewer.tsx
+++ b/src/lib/markdown-fileviewer.tsx
@@ -1,0 +1,190 @@
+import { memo } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
+import "highlight.js/styles/github-dark.css";
+
+
+
+interface Props {
+  children: string;
+   /**
+   * Enables rendering of raw HTML (e.g. <details>, <img align>, etc.).
+   * Should only be enabled for trusted/local Markdown documents.
+   */
+  trusted?: boolean;
+  className?: string;
+}
+export const MarkdownFile = memo(function MarkdownFile({
+  children,  
+  trusted = false,
+}: Props) {
+  return (
+    <div className="atlas-markdown text-[14px] leading-relaxed text-[var(--text-primary)] break-words select-text">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[
+          ...(trusted ? [rehypeRaw] : []),
+          rehypeHighlight,
+        ]}
+        components={{
+          h1: (p) => (
+            <h1 className="mt-8 mb-3 border-b border-[var(--border-default)] pb-2 text-[26px] font-bold tracking-tight">
+              {p.children}
+            </h1>
+          ),
+
+          h2: (p) => (
+            <h2 className="mt-7 mb-3 border-b border-[var(--border-subtle)] pb-1.5 text-[20px] font-semibold tracking-tight">
+              {p.children}
+            </h2>
+          ),
+
+          h3: (p) => (
+            <h3 className="mt-6 mb-2 text-[16px] font-semibold">
+              {p.children}
+            </h3>
+          ),
+
+          h4: (p) => (
+            <h4 className="mt-4 mb-1.5 text-[14px] font-semibold">
+              {p.children}
+            </h4>
+          ),
+
+          p: (p) => <p className="my-3">{p.children}</p>,
+
+          a: (p) => (
+            <a
+              {...p}
+              target="_blank"
+              rel="noreferrer"
+              className="text-[var(--accent-primary)] underline hover:opacity-80"
+            />
+          ),
+
+          ul: (p) => (
+            <ul className="my-3 list-disc space-y-1 pl-6">
+              {p.children}
+            </ul>
+          ),
+
+          ol: (p) => (
+            <ol className="my-3 list-decimal space-y-1 pl-6">
+              {p.children}
+            </ol>
+          ),
+
+          li: (p) => (
+            <li className="leading-relaxed">{p.children}</li>
+          ),
+
+          img: (p) => (
+            // eslint-disable-next-line jsx-a11y/alt-text
+            <img
+              {...p}
+              className="my-1 inline-block h-auto max-w-full rounded align-middle"
+            />
+          ),
+
+          code(props) {
+            const { className, children, ...rest } = props as {
+              className?: string;
+              children?: React.ReactNode;
+            };
+
+            const isInline = !className;
+
+            if (isInline) {
+              return (
+                <code
+                  className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 font-mono text-[12.5px] text-[var(--text-primary)]"
+                  {...rest}
+                >
+                  {children}
+                </code>
+              );
+            }
+
+            return (
+              <code className={className} {...rest}>
+                {children}
+              </code>
+            );
+          },
+
+          pre: (p) => (
+            <pre
+              className="my-4 overflow-x-auto rounded-md border border-[var(--border-default)] bg-[var(--bg-secondary)] p-4 text-[12.5px]"
+              style={{
+                whiteSpace: "pre",
+                wordBreak: "normal",
+              }}
+            >
+              {p.children}
+            </pre>
+          ),
+
+          blockquote: (p) => (
+            <blockquote className="my-3 border-l-2 border-[var(--border-default)] pl-4 text-[var(--text-secondary)]">
+              {p.children}
+            </blockquote>
+          ),
+
+          hr: () => (
+            <hr className="my-6 border-[var(--border-subtle)]" />
+          ),
+
+          table: (p) => (
+            <div className="my-4 overflow-x-auto rounded-md border border-[var(--border-default)]">
+              <table className="min-w-max border-collapse text-[13px]">
+                {p.children}
+              </table>
+            </div>
+          ),
+
+          thead: (p) => (
+            <thead className="bg-[var(--bg-elevated)]">
+              {p.children}
+            </thead>
+          ),
+
+          tr: (p) => (
+            <tr className="border-b border-[var(--border-subtle)] last:border-b-0">
+              {p.children}
+            </tr>
+          ),
+
+          th: (p) => (
+            <th className="border-r border-[var(--border-default)] border-b border-[var(--border-default)] px-3 py-2 text-left text-[12px] font-semibold whitespace-nowrap text-[var(--text-secondary)] last:border-r-0">
+              {p.children}
+            </th>
+          ),
+
+          td: (p) => (
+            <td className="border-r border-[var(--border-subtle)] px-3 py-2 align-top whitespace-nowrap text-[13px] text-[var(--text-primary)] last:border-r-0">
+              {p.children}
+            </td>
+          ),
+
+          ...(trusted && {
+            details: (p) => (
+              <details className="my-3 rounded-md border border-[var(--border-default)] bg-[var(--bg-secondary)] px-3 py-2">
+                {p.children}
+              </details>
+            ),
+
+            summary: (p) => (
+              <summary className="cursor-pointer py-1 font-medium text-[var(--text-primary)]">
+                {p.children}
+              </summary>
+            ),
+          }),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+});


### PR DESCRIPTION
#32  

**changes**

1.  Added a dedicated `MarkdownFile` component in `src/lib/` for Markdown document previews.
2. Added an explicit trusted prop to control raw HTML rendering.
3. Trusted/local documents will render perfectly.
4. Untrusted content can be rendered without enabling raw HTML.

**Improved table rendering**

1. Tables now use their intrinsic width (min-w-max).
2. Wide tables scroll horizontally within their container.
3. Prevents content from collapsing into unreadably narrow columns.
4. Integrated the preview into the Atlas editor by rendering Markdown when Preview mode is selected.

<img width="1389" height="934" alt="pr1" src="https://github.com/user-attachments/assets/8977310e-0af3-4346-9aa7-46a5ee589d23" />
<img width="1319" height="558" alt="scrollable tables" src="https://github.com/user-attachments/assets/5c3c1cdb-025e-4d31-bddc-1d232c1c440c" />
