### PR TITLE
chore: format src/ with prettier

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,11 @@ import { SWITCHABLE_AGENTS } from "@/types/agent";
 import { FilePicker } from "@/features/file-picker/components/file-picker";
 import { HintOverlay } from "@/features/hint-nav/components/hint-overlay";
 import { BrowserOverlayWatcher } from "@/features/browser/components/browser-overlay-watcher";
-import { fileIndex, openFileIndex, markFileIndexClosed } from "@/features/file-picker/lib/file-picker-api";
+import {
+  fileIndex,
+  openFileIndex,
+  markFileIndexClosed,
+} from "@/features/file-picker/lib/file-picker-api";
 import { activeWorkspaceId } from "@/features/workspaces/lib/active-workspace";
 import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store";
 import { pickAndAddWorkspace } from "@/features/workspaces/lib/pick-workspace";
@@ -73,7 +77,11 @@ import {
 } from "@/features/auth/lib/auth-api";
 import { useAuthStore } from "@/features/auth/stores/auth-store";
 import { ConnectDialog } from "@/features/auth/components/connect-dialog";
-import { clampScale, SCALE_STEP, DEFAULT_SCALE } from "@/features/settings/lib/ui-scale";
+import {
+  clampScale,
+  SCALE_STEP,
+  DEFAULT_SCALE,
+} from "@/features/settings/lib/ui-scale";
 
 // Interface-zoom helpers (⌘+/⌘-/⌘0). They read + write the persisted
 // `uiScale` setting; `updateSettings` applies it to the native WebView zoom.
@@ -154,7 +162,9 @@ export function App() {
   useEffect(() => {
     const a = useUpdaterStore.getState().actions;
     const offs: Array<Promise<() => void>> = [
-      listenUpdateProgress((e) => a.setDownloading(e.version, e.downloaded, e.total, e.phase)),
+      listenUpdateProgress((e) =>
+        a.setDownloading(e.version, e.downloaded, e.total, e.phase),
+      ),
       listenUpdateReady((e) => a.setReady(e.version)),
       listenUpdateApplied((e) => {
         a.reset();
@@ -241,9 +251,9 @@ export function App() {
       // both clobber the CLI workspace and swallow the CLI switch (`switching`
       // guard). So we suppress hydrate's auto-switch when a CLI path is present
       // and perform the CLI open as the sole, final switch.
-      const cliPath = await invoke<string | null>("cli_take_initial_project_path").catch(
-        () => null,
-      );
+      const cliPath = await invoke<string | null>(
+        "cli_take_initial_project_path",
+      ).catch(() => null);
       try {
         const payload = await invoke<AppStateWire>("bootstrap_app_state");
         if (cancelled) return;
@@ -446,7 +456,8 @@ export function App() {
     // first interaction (e.g. scrolling the chat) eats the catch-up. Firing this
     // on the focus/visibility RISING edge lets listeners (chat virtualizer,
     // markdown worker) warm the pipeline before the user touches anything.
-    const signalActive = () => window.dispatchEvent(new CustomEvent("atlas:window-active"));
+    const signalActive = () =>
+      window.dispatchEvent(new CustomEvent("atlas:window-active"));
     void appWindow
       .onFocusChanged(({ payload: focused }) => {
         if (focused && !windowFocused) signalActive();
@@ -564,7 +575,9 @@ export function App() {
       const deltas = pendingDeltas.slice();
       pendingDeltas.length = 0;
       toolDeltaPos.clear();
-      useChatStore.getState().actions.applyAgentBatch({ texts: [], thoughts: [], deltas });
+      useChatStore
+        .getState()
+        .actions.applyAgentBatch({ texts: [], thoughts: [], deltas });
     };
     // Coalesce a streaming text/thinking chunk into the trailing pendingDeltas
     // entry when it's the same kind + session; otherwise append in order. Keeps
@@ -632,7 +645,10 @@ export function App() {
       for (const [tabId, s] of Object.entries(sessions)) {
         if (s.acpSessionId === acpSessionId) return { tabId, title: s.title };
       }
-      return { tabId: undefined as string | undefined, title: undefined as string | undefined };
+      return {
+        tabId: undefined as string | undefined,
+        title: undefined as string | undefined,
+      };
     };
     const notify = () => useNotificationsStore.getState().actions;
 
@@ -643,7 +659,9 @@ export function App() {
     const indexTimers = new Map<string, ReturnType<typeof setTimeout>>();
     const autoIndexAfterTurn = (acpSessionId: string) => {
       const sessions = useChatStore.getState().sessions;
-      const sess = Object.values(sessions).find((s) => s.acpSessionId === acpSessionId);
+      const sess = Object.values(sessions).find(
+        (s) => s.acpSessionId === acpSessionId,
+      );
       if (sess?.agentType !== "cersei") return;
       const path = sess.workingDirectory;
       if (!path) return;
@@ -657,7 +675,9 @@ export function App() {
           // "Indexing…" then refresh its status.
           const emit = (active: boolean) =>
             window.dispatchEvent(
-              new CustomEvent("atlas:cersei-index", { detail: { path, active } }),
+              new CustomEvent("atlas:cersei-index", {
+                detail: { path, active },
+              }),
             );
           emit(true);
           void invoke("codebase_index_build", {
@@ -786,7 +806,8 @@ export function App() {
           // the "done" notification, memory reindex, and log too.
           if (isStaleAgentTurn(env.session_id, env.turn_seq)) return;
           // Keep the native agent's project memory fresh (debounced, cheap).
-          if (env.stop_reason !== "cancelled") autoIndexAfterTurn(env.session_id);
+          if (env.stop_reason !== "cancelled")
+            autoIndexAfterTurn(env.session_id);
           logEvent({
             source: "atlas",
             kind: "agent-turn-finished",
@@ -870,7 +891,11 @@ export function App() {
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
-    type Payload = { workspaceId?: string; dirs: string[]; fullRefresh: boolean };
+    type Payload = {
+      workspaceId?: string;
+      dirs: string[];
+      fullRefresh: boolean;
+    };
     listen<Payload>("atlas:explorer:changed", (e) => {
       if (cancelled) return;
       // Ignore changes from a backgrounded workspace's resident watcher —
@@ -920,16 +945,15 @@ export function App() {
     for (const t of tabs) {
       if (t.type !== "editor" && t.type !== "media" && t.type !== "unsupported")
         continue;
-      const absPath = (t.data as Record<string, unknown> | undefined)?.filePath as
-        | string
-        | undefined;
+      const absPath = (t.data as Record<string, unknown> | undefined)
+        ?.filePath as string | undefined;
       if (!absPath) continue;
       if (seenFileTabsRef.current.has(absPath)) continue;
       seenFileTabsRef.current.add(absPath);
       const rel =
         projectPath && absPath.startsWith(projectPath + "/")
           ? absPath.slice(projectPath.length + 1)
-          : absPath.split("/").pop() ?? absPath;
+          : (absPath.split("/").pop() ?? absPath);
       useRecentFilesStore.getState().actions.push({ absPath, rel });
     }
   }, [tabs, currentProject?.path]);
@@ -967,8 +991,8 @@ export function App() {
     // Capture: a bound Workspace just became active — open its store (which
     // also heals a folder rename) and kick its transcript import and drain.
     // A no-op for Workspaces that never enabled capture.
-    void invoke("capture_activate", { projectPath: currentProject.path }).catch((e) =>
-      console.warn("capture activate failed:", e),
+    void invoke("capture_activate", { projectPath: currentProject.path }).catch(
+      (e) => console.warn("capture activate failed:", e),
     );
     // Clear the global recents mirror SYNCHRONOUSLY before the async reload so
     // there's no window where it still shows the previous project's files
@@ -1107,7 +1131,8 @@ export function App() {
       // ⌘9 always jumps to the LAST tab (browser convention), regardless
       // of how many tabs there are; ⌘1–8 select by index.
       // ⌘9 = last tab in the focused column (the store treats i<0 as "last").
-      action: i === 8 ? () => activateTabByIndex(-1) : () => activateTabByIndex(i),
+      action:
+        i === 8 ? () => activateTabByIndex(-1) : () => activateTabByIndex(i),
     })),
     {
       combo: { key: "w", meta: true },
@@ -1164,9 +1189,13 @@ export function App() {
         const chat = useChatStore.getState();
         const sess = chat.sessions[tab.id];
         const curIdx = SWITCHABLE_AGENTS.indexOf(
-          (sess?.agentType ?? "claude-code") as (typeof SWITCHABLE_AGENTS)[number]
+          (sess?.agentType ??
+            "claude-code") as (typeof SWITCHABLE_AGENTS)[number],
         );
-        const next = SWITCHABLE_AGENTS[(Math.max(curIdx, 0) + 1) % SWITCHABLE_AGENTS.length];
+        const next =
+          SWITCHABLE_AGENTS[
+            (Math.max(curIdx, 0) + 1) % SWITCHABLE_AGENTS.length
+          ];
         // Empty chat flips agent in place. A started chat always starts a fresh
         // session in the SAME tab bound to the next agent (singleton model —
         // never a new tab, even mid-stream; the abandoned turn persists to the
@@ -1254,7 +1283,10 @@ export function App() {
   return (
     <>
       <AppContextMenu>
-        <div className="h-screen w-screen" onContextMenu={(e) => e.preventDefault()}>
+        <div
+          className="h-screen w-screen"
+          onContextMenu={(e) => e.preventDefault()}
+        >
           <AppLayout />
         </div>
       </AppContextMenu>

--- a/src/components/agent-mark.tsx
+++ b/src/components/agent-mark.tsx
@@ -15,12 +15,19 @@ const AGENT_CLASS: Record<AgentType, string> = {
   custom: "",
 };
 
-function AgentGlyph({ agentType, size }: { agentType: AgentType; size: "sm" | "lg" }) {
+function AgentGlyph({
+  agentType,
+  size,
+}: {
+  agentType: AgentType;
+  size: "sm" | "lg";
+}) {
   const cls = size === "lg" ? "size-[18px]" : "size-3.5";
   if (agentType === "claude-code") return <AgentIcons.Claude className={cls} />;
   if (agentType === "codex") return <AgentIcons.Codex className={cls} />;
   // Atlas's native agent — its own brand mark.
-  if (agentType === "cersei") return <AtlasIcon size={size === "lg" ? 18 : 14} />;
+  if (agentType === "cersei")
+    return <AtlasIcon size={size === "lg" ? 18 : 14} />;
   return <span className="font-mono">?</span>;
 }
 
@@ -35,7 +42,12 @@ export function AgentMark({
 }) {
   return (
     <span
-      className={cn("amark", size === "lg" && "amark-lg", AGENT_CLASS[agentType], className)}
+      className={cn(
+        "amark",
+        size === "lg" && "amark-lg",
+        AGENT_CLASS[agentType],
+        className,
+      )}
       aria-hidden
     >
       <AgentGlyph agentType={agentType} size={size} />

--- a/src/components/app-context-menu.tsx
+++ b/src/components/app-context-menu.tsx
@@ -18,9 +18,7 @@ export function AppContextMenu({ children }: { children: React.ReactNode }) {
 
   return (
     <ContextMenu.Root>
-      <ContextMenu.Trigger asChild>
-        {children}
-      </ContextMenu.Trigger>
+      <ContextMenu.Trigger asChild>{children}</ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content
           className="w-[180px] rounded-lg border border-[#1a1a1a] bg-[#0f0f0f] shadow-xl py-1"
@@ -38,17 +36,44 @@ export function AppContextMenu({ children }: { children: React.ReactNode }) {
                 icon={<Terminal size={12} />}
                 label="New Terminal"
                 shortcut="⌘⇧T"
-                onClick={() => addTab({ id: `terminal-${Date.now()}`, type: "terminal", title: "Terminal", closable: true, dirty: false, data: {} })}
+                onClick={() =>
+                  addTab({
+                    id: `terminal-${Date.now()}`,
+                    type: "terminal",
+                    title: "Terminal",
+                    closable: true,
+                    dirty: false,
+                    data: {},
+                  })
+                }
               />
               <MenuItem
                 icon={<Globe size={12} />}
                 label="New Browser"
-                onClick={() => addTab({ id: `browser-${Date.now()}`, type: "browser", title: "Browser", closable: true, dirty: false, data: {} })}
+                onClick={() =>
+                  addTab({
+                    id: `browser-${Date.now()}`,
+                    type: "browser",
+                    title: "Browser",
+                    closable: true,
+                    dirty: false,
+                    data: {},
+                  })
+                }
               />
               <MenuItem
                 icon={<BookOpen size={12} />}
                 label="Research"
-                onClick={() => addTab({ id: `research-${Date.now()}`, type: "research", title: "Research", closable: true, dirty: false, data: {} })}
+                onClick={() =>
+                  addTab({
+                    id: `research-${Date.now()}`,
+                    type: "research",
+                    title: "Research",
+                    closable: true,
+                    dirty: false,
+                    data: {},
+                  })
+                }
               />
               <ContextMenu.Separator className="h-px bg-[#1a1a1a] my-1" />
             </>
@@ -70,7 +95,16 @@ export function AppContextMenu({ children }: { children: React.ReactNode }) {
               icon={<Settings size={12} />}
               label="Settings"
               shortcut="⌘,"
-              onClick={() => addTab({ id: "settings", type: "settings", title: "Settings", closable: true, dirty: false, data: {} })}
+              onClick={() =>
+                addTab({
+                  id: "settings",
+                  type: "settings",
+                  title: "Settings",
+                  closable: true,
+                  dirty: false,
+                  data: {},
+                })
+              }
             />
           )}
         </ContextMenu.Content>
@@ -79,7 +113,17 @@ export function AppContextMenu({ children }: { children: React.ReactNode }) {
   );
 }
 
-function MenuItem({ icon, label, shortcut, onClick }: { icon: React.ReactNode; label: string; shortcut?: string; onClick: () => void }) {
+function MenuItem({
+  icon,
+  label,
+  shortcut,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  shortcut?: string;
+  onClick: () => void;
+}) {
   return (
     <ContextMenu.Item
       onClick={onClick}
@@ -87,7 +131,9 @@ function MenuItem({ icon, label, shortcut, onClick }: { icon: React.ReactNode; l
     >
       <span className="text-[#555]">{icon}</span>
       <span className="flex-1">{label}</span>
-      {shortcut && <span className="text-[9px] text-[#444] font-mono">{shortcut}</span>}
+      {shortcut && (
+        <span className="text-[9px] text-[#444] font-mono">{shortcut}</span>
+      )}
     </ContextMenu.Item>
   );
 }

--- a/src/components/atlas-icon.tsx
+++ b/src/components/atlas-icon.tsx
@@ -7,7 +7,11 @@ interface AtlasIconProps {
   alt?: string;
 }
 
-export function AtlasIcon({ size = 32, className, alt = "Atlas" }: AtlasIconProps) {
+export function AtlasIcon({
+  size = 32,
+  className,
+  alt = "Atlas",
+}: AtlasIconProps) {
   return (
     <img
       src={atlasIconUrl}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,4 +1,11 @@
-import { useState, useMemo, useRef, useEffect, useLayoutEffect, Fragment } from "react";
+import {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  Fragment,
+} from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { cn } from "@/lib/utils";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
@@ -118,47 +125,248 @@ export function CommandPalette({
   const commands = useMemo<Command[]>(
     () => [
       // ── Project ──
-      { id: "open-folder", label: "Open Folder", icon: FolderOpen, category: "Project", action: handleOpenFolder },
+      {
+        id: "open-folder",
+        label: "Open Folder",
+        icon: FolderOpen,
+        category: "Project",
+        action: handleOpenFolder,
+      },
 
       // ── Open tabs ──
-      { id: "new-agents-chat", label: "New Agents Chat", shortcut: "⌘T", icon: AtlasIcon, category: "Open", action: () => openTab("chat", "Agents") },
-      { id: "new-model-chat", label: "New Chat", icon: MessageSquare, category: "Open", action: () => openTab("model-chat", "Chat") },
-      { id: "new-terminal", label: "New Terminal", shortcut: "⌘⇧T", icon: Terminal, category: "Open", action: () => openTab("terminal", "Terminal") },
-      { id: "new-editor", label: "New Untitled Editor", shortcut: "⌘N", icon: Code, category: "Open", action: () => openTab("editor", "Untitled") },
-      { id: "new-canvas", label: "New Spaces", icon: Map, category: "Open", action: () => openTab("canvas", "Spaces") },
-      { id: "new-browser", label: "Open Browser", icon: Globe, category: "Open", action: () => openTab("browser", "Browser") },
-      { id: "new-tasks", label: "Task Board", icon: CheckSquare, category: "Open", action: () => openTab("tasks", "Tasks") },
-      { id: "new-research", label: "Research", icon: BookOpen, category: "Open", action: () => openTab("research", "Research") },
-      { id: "new-knowledge", label: "Knowledge Base", icon: Brain, category: "Open", action: () => openTab("knowledge", "Knowledge") },
-      { id: "new-knowledge-graph", label: "Knowledge Graph", icon: Network, category: "Open", action: () => openTab("knowledge-graph", "Graph") },
-      { id: "new-memory", label: "Memory", icon: BrainCircuit, category: "Open", action: () => openTab("memory", "Memory") },
-      { id: "new-log", label: "Log", icon: ScrollText, category: "Open", action: () => openTab("log", "Log") },
-      { id: "new-pomodoro", label: "Pomodoro", icon: Timer, category: "Open", action: () => openTab("pomodoro", "Pomodoro") },
+      {
+        id: "new-agents-chat",
+        label: "New Agents Chat",
+        shortcut: "⌘T",
+        icon: AtlasIcon,
+        category: "Open",
+        action: () => openTab("chat", "Agents"),
+      },
+      {
+        id: "new-model-chat",
+        label: "New Chat",
+        icon: MessageSquare,
+        category: "Open",
+        action: () => openTab("model-chat", "Chat"),
+      },
+      {
+        id: "new-terminal",
+        label: "New Terminal",
+        shortcut: "⌘⇧T",
+        icon: Terminal,
+        category: "Open",
+        action: () => openTab("terminal", "Terminal"),
+      },
+      {
+        id: "new-editor",
+        label: "New Untitled Editor",
+        shortcut: "⌘N",
+        icon: Code,
+        category: "Open",
+        action: () => openTab("editor", "Untitled"),
+      },
+      {
+        id: "new-canvas",
+        label: "New Spaces",
+        icon: Map,
+        category: "Open",
+        action: () => openTab("canvas", "Spaces"),
+      },
+      {
+        id: "new-browser",
+        label: "Open Browser",
+        icon: Globe,
+        category: "Open",
+        action: () => openTab("browser", "Browser"),
+      },
+      {
+        id: "new-tasks",
+        label: "Task Board",
+        icon: CheckSquare,
+        category: "Open",
+        action: () => openTab("tasks", "Tasks"),
+      },
+      {
+        id: "new-research",
+        label: "Research",
+        icon: BookOpen,
+        category: "Open",
+        action: () => openTab("research", "Research"),
+      },
+      {
+        id: "new-knowledge",
+        label: "Knowledge Base",
+        icon: Brain,
+        category: "Open",
+        action: () => openTab("knowledge", "Knowledge"),
+      },
+      {
+        id: "new-knowledge-graph",
+        label: "Knowledge Graph",
+        icon: Network,
+        category: "Open",
+        action: () => openTab("knowledge-graph", "Graph"),
+      },
+      {
+        id: "new-memory",
+        label: "Memory",
+        icon: BrainCircuit,
+        category: "Open",
+        action: () => openTab("memory", "Memory"),
+      },
+      {
+        id: "new-log",
+        label: "Log",
+        icon: ScrollText,
+        category: "Open",
+        action: () => openTab("log", "Log"),
+      },
+      {
+        id: "new-pomodoro",
+        label: "Pomodoro",
+        icon: Timer,
+        category: "Open",
+        action: () => openTab("pomodoro", "Pomodoro"),
+      },
 
       // ── Layout toggles ──
-      { id: "toggle-left", label: "Toggle Left Panel", shortcut: "⌘B", icon: PanelLeft, category: "Layout", action: toggleLeftPanel },
-      { id: "toggle-right", label: "Toggle Right Panel", shortcut: "⌘⇧B", icon: PanelRight, category: "Layout", action: toggleRightPanel },
-      { id: "toggle-bottom", label: "Toggle Bottom Panel", shortcut: "⌘⌥B", icon: PanelBottom, category: "Layout", action: toggleBottomPanel },
-      { id: "toggle-chat-sidebar", label: "Toggle Chat Sidebar", shortcut: "⌘⌥J", icon: Sidebar, category: "Layout", action: toggleChatSidebar },
-      { id: "toggle-model-chat-sidebar", label: "Toggle Chat History Sidebar", shortcut: "⌘⌥K", icon: Sidebar, category: "Layout", action: toggleModelChatSidebar },
-      { id: "toggle-tab-bar", label: "Toggle Tab Bar", shortcut: "⌘⌥T", icon: PanelTop, category: "Layout", action: toggleTabBar },
-      { id: "toggle-usage", label: "Toggle Usage Report", icon: Activity, category: "Layout", action: toggleUsagePanel },
-      { id: "toggle-zen", label: "Toggle Zen Mode", shortcut: "⌥Z", icon: Maximize2, category: "Layout", action: toggleZenMode },
+      {
+        id: "toggle-left",
+        label: "Toggle Left Panel",
+        shortcut: "⌘B",
+        icon: PanelLeft,
+        category: "Layout",
+        action: toggleLeftPanel,
+      },
+      {
+        id: "toggle-right",
+        label: "Toggle Right Panel",
+        shortcut: "⌘⇧B",
+        icon: PanelRight,
+        category: "Layout",
+        action: toggleRightPanel,
+      },
+      {
+        id: "toggle-bottom",
+        label: "Toggle Bottom Panel",
+        shortcut: "⌘⌥B",
+        icon: PanelBottom,
+        category: "Layout",
+        action: toggleBottomPanel,
+      },
+      {
+        id: "toggle-chat-sidebar",
+        label: "Toggle Chat Sidebar",
+        shortcut: "⌘⌥J",
+        icon: Sidebar,
+        category: "Layout",
+        action: toggleChatSidebar,
+      },
+      {
+        id: "toggle-model-chat-sidebar",
+        label: "Toggle Chat History Sidebar",
+        shortcut: "⌘⌥K",
+        icon: Sidebar,
+        category: "Layout",
+        action: toggleModelChatSidebar,
+      },
+      {
+        id: "toggle-tab-bar",
+        label: "Toggle Tab Bar",
+        shortcut: "⌘⌥T",
+        icon: PanelTop,
+        category: "Layout",
+        action: toggleTabBar,
+      },
+      {
+        id: "toggle-usage",
+        label: "Toggle Usage Report",
+        icon: Activity,
+        category: "Layout",
+        action: toggleUsagePanel,
+      },
+      {
+        id: "toggle-zen",
+        label: "Toggle Zen Mode",
+        shortcut: "⌥Z",
+        icon: Maximize2,
+        category: "Layout",
+        action: toggleZenMode,
+      },
 
       // ── Splits ──
-      { id: "split-new", label: "Split: New Column", shortcut: "⌘\\", icon: Columns2, category: "Split", action: () => addGroup() },
-      { id: "split-focus-left", label: "Split: Focus Left", shortcut: "⌥;", icon: ArrowLeftToLine, category: "Split", action: () => focusAdjacentGroup(-1) },
-      { id: "split-focus-right", label: "Split: Focus Right", shortcut: "⌥'", icon: ArrowRightToLine, category: "Split", action: () => focusAdjacentGroup(1) },
-      { id: "split-close", label: "Split: Close Column", shortcut: "⌥W", icon: Columns2, category: "Split", action: () => closeGroup(useLayoutStore.getState().focusedGroupId) },
+      {
+        id: "split-new",
+        label: "Split: New Column",
+        shortcut: "⌘\\",
+        icon: Columns2,
+        category: "Split",
+        action: () => addGroup(),
+      },
+      {
+        id: "split-focus-left",
+        label: "Split: Focus Left",
+        shortcut: "⌥;",
+        icon: ArrowLeftToLine,
+        category: "Split",
+        action: () => focusAdjacentGroup(-1),
+      },
+      {
+        id: "split-focus-right",
+        label: "Split: Focus Right",
+        shortcut: "⌥'",
+        icon: ArrowRightToLine,
+        category: "Split",
+        action: () => focusAdjacentGroup(1),
+      },
+      {
+        id: "split-close",
+        label: "Split: Close Column",
+        shortcut: "⌥W",
+        icon: Columns2,
+        category: "Split",
+        action: () => closeGroup(useLayoutStore.getState().focusedGroupId),
+      },
 
       // ── Views (reveal the panel, then switch its section) ──
-      { id: "view-files", label: "Show File Explorer", icon: PanelLeft, category: "View", action: () => showLeft("files") },
-      { id: "view-knowledge", label: "Show Knowledge Sidebar", icon: Brain, category: "View", action: () => showLeft("knowledge") },
-      { id: "view-changes", label: "Show Source Control", icon: PanelRight, category: "View", action: () => showRight("changes") },
-      { id: "view-git-graph", label: "Show Git Graph", icon: GitBranch, category: "View", action: () => showRight("git-graph") },
+      {
+        id: "view-files",
+        label: "Show File Explorer",
+        icon: PanelLeft,
+        category: "View",
+        action: () => showLeft("files"),
+      },
+      {
+        id: "view-knowledge",
+        label: "Show Knowledge Sidebar",
+        icon: Brain,
+        category: "View",
+        action: () => showLeft("knowledge"),
+      },
+      {
+        id: "view-changes",
+        label: "Show Source Control",
+        icon: PanelRight,
+        category: "View",
+        action: () => showRight("changes"),
+      },
+      {
+        id: "view-git-graph",
+        label: "Show Git Graph",
+        icon: GitBranch,
+        category: "View",
+        action: () => showRight("git-graph"),
+      },
 
       // ── App ──
-      { id: "settings", label: "Open Settings", shortcut: "⌘,", icon: Settings, category: "App", action: () => openTab("settings", "Settings") },
+      {
+        id: "settings",
+        label: "Open Settings",
+        shortcut: "⌘,",
+        icon: Settings,
+        category: "App",
+        action: () => openTab("settings", "Settings"),
+      },
     ],
     [
       addTab,
@@ -175,7 +383,7 @@ export function CommandPalette({
       addGroup,
       focusAdjacentGroup,
       closeGroup,
-    ]
+    ],
   );
 
   const filtered = useMemo(() => {
@@ -184,7 +392,7 @@ export function CommandPalette({
     return commands.filter(
       (c) =>
         c.label.toLowerCase().includes(q) ||
-        c.category.toLowerCase().includes(q)
+        c.category.toLowerCase().includes(q),
     );
   }, [query, commands]);
 
@@ -230,7 +438,7 @@ export function CommandPalette({
             "w-[520px] max-h-[400px] rounded-xl overflow-hidden",
             "bg-[var(--bg-secondary)] border border-[var(--border-default)]",
             "shadow-[var(--shadow-overlay)]",
-            "flex flex-col"
+            "flex flex-col",
           )}
           onOpenAutoFocus={(e) => {
             e.preventDefault();
@@ -242,7 +450,10 @@ export function CommandPalette({
               search bar when the list overflows `max-h` (the command list is
               long), making it render at half height. */}
           <div className="flex items-center gap-2 px-4 h-[44px] shrink-0 border-b border-[var(--border-default)]">
-            <Search size={14} className="text-[var(--text-tertiary)] shrink-0" />
+            <Search
+              size={14}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
             <input
               ref={inputRef}
               value={query}
@@ -263,7 +474,8 @@ export function CommandPalette({
               const Icon = cmd.icon;
               // Section header before the first item of each category — breaks
               // the long flat list into scannable groups.
-              const showHeader = i === 0 || filtered[i - 1].category !== cmd.category;
+              const showHeader =
+                i === 0 || filtered[i - 1].category !== cmd.category;
               return (
                 <Fragment key={cmd.id}>
                   {showHeader && (
@@ -279,10 +491,13 @@ export function CommandPalette({
                       "w-full flex items-center gap-3 px-4 h-[36px] text-left text-sm transition-colors",
                       i === selectedIndex
                         ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
-                        : "text-[var(--text-secondary)]"
+                        : "text-[var(--text-secondary)]",
                     )}
                   >
-                    <Icon size={14} className="shrink-0 text-[var(--text-tertiary)]" />
+                    <Icon
+                      size={14}
+                      className="shrink-0 text-[var(--text-tertiary)]"
+                    />
                     <span className="flex-1 truncate">{cmd.label}</span>
                     {cmd.shortcut && <KbdCombo combo={cmd.shortcut} />}
                   </button>

--- a/src/components/graph-ruler.tsx
+++ b/src/components/graph-ruler.tsx
@@ -53,13 +53,12 @@ export function GraphRuler({
 
     const { x: vx, y: vy, scale } = viewport;
     // Target ~70px between major ticks on screen.
-    const step = niceStep((70 / scale) || 1);
+    const step = niceStep(70 / scale || 1);
     const screenStep = step * scale;
     const worldToScreenX = (wx: number) => wx * scale + vx;
     const worldToScreenY = (wy: number) => wy * scale + vy;
 
-    ctx.font =
-      "9px Inter, -apple-system, system-ui, sans-serif";
+    ctx.font = "9px Inter, -apple-system, system-ui, sans-serif";
     ctx.textBaseline = "middle";
 
     // ── Band backgrounds ──
@@ -68,7 +67,7 @@ export function GraphRuler({
     ctx.fillRect(0, 0, BAND, height); // left
 
     // ── Top ruler (X) ──
-    const firstX = Math.ceil((-vx / scale) / step) * step;
+    const firstX = Math.ceil(-vx / scale / step) * step;
     const lastX = (width - vx) / scale;
     ctx.fillStyle = LABEL_COL;
     ctx.textAlign = "left";
@@ -93,7 +92,7 @@ export function GraphRuler({
     }
 
     // ── Left ruler (Y) — rotated labels ──
-    const firstY = Math.ceil((-vy / scale) / step) * step;
+    const firstY = Math.ceil(-vy / scale / step) * step;
     const lastY = (height - vy) / scale;
     for (let wy = firstY; wy <= lastY; wy += step) {
       const sy = worldToScreenY(wy);

--- a/src/components/new-tab-palette.tsx
+++ b/src/components/new-tab-palette.tsx
@@ -1,4 +1,11 @@
-import { useState, useMemo, useRef, useEffect, useLayoutEffect, type ElementType } from "react";
+import {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  type ElementType,
+} from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
   MessageSquare,
@@ -39,20 +46,54 @@ interface ModuleEntry {
  * palettes read as one consistent system.
  */
 const MODULES: ModuleEntry[] = [
-  { id: "chat", type: "chat", label: "New Agents Chat", icon: AtlasIcon as ElementType<LucideProps>, shortcut: "⌘T" },
-  { id: "model-chat", type: "model-chat", label: "New Chat", icon: MessageSquare },
-  { id: "terminal", type: "terminal", label: "New Terminal", icon: Terminal, shortcut: "⌘⇧T" },
+  {
+    id: "chat",
+    type: "chat",
+    label: "New Agents Chat",
+    icon: AtlasIcon as ElementType<LucideProps>,
+    shortcut: "⌘T",
+  },
+  {
+    id: "model-chat",
+    type: "model-chat",
+    label: "New Chat",
+    icon: MessageSquare,
+  },
+  {
+    id: "terminal",
+    type: "terminal",
+    label: "New Terminal",
+    icon: Terminal,
+    shortcut: "⌘⇧T",
+  },
   { id: "knowledge", type: "knowledge", label: "Knowledge", icon: Brain },
-  { id: "knowledge-graph", type: "knowledge-graph", label: "Knowledge Graph", icon: Network },
+  {
+    id: "knowledge-graph",
+    type: "knowledge-graph",
+    label: "Knowledge Graph",
+    icon: Network,
+  },
   { id: "memory", type: "memory", label: "Memory", icon: BrainCircuit },
   { id: "research", type: "research", label: "Research", icon: BookOpen },
   { id: "canvas", type: "canvas", label: "Spaces", icon: Map },
   { id: "diff", type: "diff", label: "Git Diff", icon: GitCompare },
   { id: "browser", type: "browser", label: "Browser", icon: Globe },
-  { id: "editor", type: "editor", label: "Untitled Editor", icon: Code, shortcut: "⌘N" },
+  {
+    id: "editor",
+    type: "editor",
+    label: "Untitled Editor",
+    icon: Code,
+    shortcut: "⌘N",
+  },
   { id: "log", type: "log", label: "Log", icon: ScrollText },
   { id: "pomodoro", type: "pomodoro", label: "Pomodoro", icon: Timer },
-  { id: "settings", type: "settings", label: "Settings", icon: Settings, shortcut: "⌘," },
+  {
+    id: "settings",
+    type: "settings",
+    label: "Settings",
+    icon: Settings,
+    shortcut: "⌘,",
+  },
 ];
 
 export function NewTabPalette({
@@ -80,8 +121,7 @@ export function NewTabPalette({
     if (!q) return MODULES;
     return MODULES.filter(
       (m) =>
-        m.label.toLowerCase().includes(q) ||
-        m.type.toLowerCase().includes(q),
+        m.label.toLowerCase().includes(q) || m.type.toLowerCase().includes(q),
     );
   }, [query]);
 
@@ -195,7 +235,10 @@ export function NewTabPalette({
         >
           <Dialog.Title className="sr-only">Open module</Dialog.Title>
           <div className="flex items-center gap-2 px-4 h-[44px] shrink-0 border-b border-[var(--border-default)]">
-            <Search size={14} className="text-[var(--text-tertiary)] shrink-0" />
+            <Search
+              size={14}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
             <input
               ref={inputRef}
               value={query}
@@ -228,7 +271,10 @@ export function NewTabPalette({
                       : "text-[var(--text-secondary)]",
                   )}
                 >
-                  <Icon size={14} className="shrink-0 text-[var(--text-tertiary)]" />
+                  <Icon
+                    size={14}
+                    className="shrink-0 text-[var(--text-tertiary)]"
+                  />
                   <span className="flex-1 truncate">{item.label}</span>
                   {item.shortcut && <KbdCombo combo={item.shortcut} />}
                 </button>

--- a/src/components/panel-skeleton.tsx
+++ b/src/components/panel-skeleton.tsx
@@ -14,7 +14,11 @@ interface PanelSkeletonProps {
  * sees structure rather than a spinner while a panel's chunk + initial
  * data load.
  */
-export function PanelSkeleton({ rows = 6, label, className }: PanelSkeletonProps) {
+export function PanelSkeleton({
+  rows = 6,
+  label,
+  className,
+}: PanelSkeletonProps) {
   return (
     <div className={cn("h-full flex flex-col gap-2 p-3", className)}>
       {label && (

--- a/src/components/search-overlay.tsx
+++ b/src/components/search-overlay.tsx
@@ -32,7 +32,12 @@ export function SearchOverlay({
   const rootPath = useExplorerStore.use.rootPath();
   const { addTab } = useLayoutStore.use.actions();
   const session = useSessionStore.use.session();
-  const { addSearchHistory, removeSearchHistory, clearSearchHistory, saveSession } = useSessionStore.use.actions();
+  const {
+    addSearchHistory,
+    removeSearchHistory,
+    clearSearchHistory,
+    saveSession,
+  } = useSessionStore.use.actions();
   const currentProject = useProjectStore.use.currentProject();
 
   useEffect(() => {
@@ -65,7 +70,9 @@ export function SearchOverlay({
   };
 
   const openResult = (result: SearchResult) => {
-    const fullPath = rootPath ? `${rootPath}/${result.file_path}` : result.file_path;
+    const fullPath = rootPath
+      ? `${rootPath}/${result.file_path}`
+      : result.file_path;
     addTab({
       id: `editor-${fullPath}`,
       type: "editor",
@@ -97,14 +104,17 @@ export function SearchOverlay({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/60" style={{ zIndex: 99998 }} />
+        <Dialog.Overlay
+          className="fixed inset-0 bg-black/60"
+          style={{ zIndex: 99998 }}
+        />
         <Dialog.Content
           className={cn(
             "fixed top-[15%] left-1/2 -translate-x-1/2",
             "w-[600px] max-h-[500px] rounded-xl overflow-hidden",
             "bg-[var(--bg-secondary)] border border-[var(--border-default)]",
             "shadow-[var(--shadow-overlay)]",
-            "flex flex-col"
+            "flex flex-col",
           )}
           style={{ zIndex: 99999 }}
           onOpenAutoFocus={(e) => {
@@ -113,7 +123,10 @@ export function SearchOverlay({
           }}
         >
           <div className="flex items-center gap-2 px-4 h-[44px] shrink-0 border-b border-[var(--border-default)]">
-            <Search size={14} className="text-[var(--text-tertiary)] shrink-0" />
+            <Search
+              size={14}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
             <input
               ref={inputRef}
               value={query}
@@ -123,7 +136,9 @@ export function SearchOverlay({
               className="flex-1 bg-transparent border-none outline-none text-sm text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]"
             />
             {searching && (
-              <span className="text-[10px] text-[var(--text-tertiary)]">Searching...</span>
+              <span className="text-[10px] text-[var(--text-tertiary)]">
+                Searching...
+              </span>
             )}
           </div>
 
@@ -133,44 +148,64 @@ export function SearchOverlay({
                 No results found
               </div>
             )}
-            {!query.trim() && !hasSearched && session.searchHistory.length > 0 && (
-              <div className="py-1">
-                <div className="flex items-center justify-between px-4 py-1">
-                  <span className="text-[10px] text-[var(--text-tertiary)] uppercase tracking-wide font-semibold">Recent searches</span>
-                  <button
-                    onClick={() => { clearSearchHistory(); if (currentProject) saveSession(currentProject.path); }}
-                    className="text-[9px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] cursor-pointer"
-                  >
-                    Clear all
-                  </button>
-                </div>
-                {session.searchHistory.slice(0, 8).map((q, i) => (
-                  <div
-                    key={`${q}-${i}`}
-                    className="flex items-center px-4 py-1.5 hover:bg-[var(--bg-hover)] group"
-                  >
+            {!query.trim() &&
+              !hasSearched &&
+              session.searchHistory.length > 0 && (
+                <div className="py-1">
+                  <div className="flex items-center justify-between px-4 py-1">
+                    <span className="text-[10px] text-[var(--text-tertiary)] uppercase tracking-wide font-semibold">
+                      Recent searches
+                    </span>
                     <button
-                      onClick={() => { setQuery(q); performSearch(q); }}
-                      className="flex items-center gap-2 flex-1 min-w-0 text-left"
+                      onClick={() => {
+                        clearSearchHistory();
+                        if (currentProject) saveSession(currentProject.path);
+                      }}
+                      className="text-[9px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] cursor-pointer"
                     >
-                      <Clock size={11} className="text-[var(--text-tertiary)] shrink-0" />
-                      <span className="text-[11px] text-[var(--text-secondary)] font-mono truncate">{q}</span>
-                    </button>
-                    <button
-                      onClick={() => { removeSearchHistory(q); if (currentProject) saveSession(currentProject.path); }}
-                      className="opacity-0 group-hover:opacity-100 p-0.5 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] shrink-0"
-                    >
-                      <X size={9} />
+                      Clear all
                     </button>
                   </div>
-                ))}
-              </div>
-            )}
-            {!query.trim() && !hasSearched && session.searchHistory.length === 0 && (
-              <div className="px-4 py-6 text-center text-xs text-[var(--text-tertiary)]">
-                Type to search across all files
-              </div>
-            )}
+                  {session.searchHistory.slice(0, 8).map((q, i) => (
+                    <div
+                      key={`${q}-${i}`}
+                      className="flex items-center px-4 py-1.5 hover:bg-[var(--bg-hover)] group"
+                    >
+                      <button
+                        onClick={() => {
+                          setQuery(q);
+                          performSearch(q);
+                        }}
+                        className="flex items-center gap-2 flex-1 min-w-0 text-left"
+                      >
+                        <Clock
+                          size={11}
+                          className="text-[var(--text-tertiary)] shrink-0"
+                        />
+                        <span className="text-[11px] text-[var(--text-secondary)] font-mono truncate">
+                          {q}
+                        </span>
+                      </button>
+                      <button
+                        onClick={() => {
+                          removeSearchHistory(q);
+                          if (currentProject) saveSession(currentProject.path);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 p-0.5 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] shrink-0"
+                      >
+                        <X size={9} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            {!query.trim() &&
+              !hasSearched &&
+              session.searchHistory.length === 0 && (
+                <div className="px-4 py-6 text-center text-xs text-[var(--text-tertiary)]">
+                  Type to search across all files
+                </div>
+              )}
             {results.map((result, i) => (
               <button
                 key={`${result.file_path}:${result.line}:${i}`}
@@ -178,11 +213,14 @@ export function SearchOverlay({
                 onMouseEnter={() => setSelectedIndex(i)}
                 className={cn(
                   "w-full text-left px-4 py-1.5 transition-colors",
-                  i === selectedIndex ? "bg-[var(--bg-hover)]" : ""
+                  i === selectedIndex ? "bg-[var(--bg-hover)]" : "",
                 )}
               >
                 <div className="flex items-center gap-2">
-                  <FileCode size={12} className="text-[var(--text-tertiary)] shrink-0" />
+                  <FileCode
+                    size={12}
+                    className="text-[var(--text-tertiary)] shrink-0"
+                  />
                   <span className="text-[11px] text-[var(--accent-primary)] font-mono truncate">
                     {result.file_path}
                   </span>

--- a/src/components/status-bar.tsx
+++ b/src/components/status-bar.tsx
@@ -11,7 +11,10 @@ export function StatusBar() {
   const showUsage = activeTab?.type === "chat";
 
   return (
-    <div className="h-7 flex items-center justify-between px-3 shrink-0 bg-[#000] border-t border-border-default text-[11px] font-mono text-[#555] select-none relative" style={{ zIndex: "var(--z-max)" as unknown as number }}>
+    <div
+      className="h-7 flex items-center justify-between px-3 shrink-0 bg-[#000] border-t border-border-default text-[11px] font-mono text-[#555] select-none relative"
+      style={{ zIndex: "var(--z-max)" as unknown as number }}
+    >
       <div className="flex items-center gap-3">
         <BranchPopover />
       </div>

--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -4,7 +4,14 @@ import { useProjectStore } from "@/features/project/stores/project-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
 import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store";
 import { useNotificationsStore } from "@/features/notifications/stores/notifications-store";
-import { PanelLeft, PanelRight, Bell, Layers, ArrowDownToLine, Loader2 } from "lucide-react";
+import {
+  PanelLeft,
+  PanelRight,
+  Bell,
+  Layers,
+  ArrowDownToLine,
+  Loader2,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
@@ -76,7 +83,9 @@ export function Titlebar() {
 
   const isTitlebarSurface = (target: EventTarget | null) => {
     const el = target as HTMLElement | null;
-    return !el?.closest("button, a, input, select, textarea, [role='menuitem']");
+    return !el?.closest(
+      "button, a, input, select, textarea, [role='menuitem']",
+    );
   };
 
   // Drag the window manually (the `data-tauri-drag-region` CSS hook
@@ -214,7 +223,9 @@ function ProjectLabel({
                 <span className="min-w-0 shrink truncate text-[var(--text-tertiary)]">
                   {orgName}
                 </span>
-                <span className="shrink-0 text-[var(--text-tertiary)] opacity-50">/</span>
+                <span className="shrink-0 text-[var(--text-tertiary)] opacity-50">
+                  /
+                </span>
               </>
             )}
             <span className="min-w-0 truncate text-[var(--text-secondary)] transition-colors group-hover:text-[var(--text-primary)]">
@@ -222,7 +233,9 @@ function ProjectLabel({
             </span>
             {/* Only once capture is on. An always-present grey dot on every
                 project reads as a defect indicator rather than a state. */}
-            {binding?.enabled && <StatusDot binding={binding} health={health} />}
+            {binding?.enabled && (
+              <StatusDot binding={binding} health={health} />
+            )}
           </button>
         </Popover.Trigger>
         {path && (
@@ -305,7 +318,15 @@ function ArcProgress({ value }: { value: number }) {
   const off = c * (1 - Math.max(0, Math.min(1, value)));
   return (
     <svg width={14} height={14} viewBox="0 0 16 16" className="-rotate-90">
-      <circle cx="8" cy="8" r={r} fill="none" stroke="currentColor" strokeOpacity={0.25} strokeWidth={2} />
+      <circle
+        cx="8"
+        cy="8"
+        r={r}
+        fill="none"
+        stroke="currentColor"
+        strokeOpacity={0.25}
+        strokeWidth={2}
+      />
       <circle
         cx="8"
         cy="8"
@@ -347,10 +368,16 @@ function UpdateButton() {
       .checkNow()
       .then((status) => {
         if (!status.available) {
-          toast.success(`You're on the latest version (${status.currentVersion}).`);
+          toast.success(
+            `You're on the latest version (${status.currentVersion}).`,
+          );
         }
       })
-      .catch((e) => toast.error(`Update check failed: ${e instanceof Error ? e.message : String(e)}`));
+      .catch((e) =>
+        toast.error(
+          `Update check failed: ${e instanceof Error ? e.message : String(e)}`,
+        ),
+      );
   };
 
   const title = checking
@@ -376,7 +403,11 @@ function UpdateButton() {
       {checking ? (
         <Loader2 size={14} className="animate-spin" />
       ) : downloading ? (
-        progress != null ? <ArcProgress value={progress} /> : <Loader2 size={14} className="animate-spin" />
+        progress != null ? (
+          <ArcProgress value={progress} />
+        ) : (
+          <Loader2 size={14} className="animate-spin" />
+        )
       ) : (
         <ArrowDownToLine size={14} />
       )}
@@ -431,7 +462,10 @@ function RightPanelToggle() {
       className="flex items-center justify-center w-6 h-6 rounded text-[#555] hover:text-[#aaa] hover:bg-[#ffffff08] transition-all duration-150"
       title={rightPanel.visible ? "Hide right panel" : "Show right panel"}
     >
-      <PanelRight size={14} className={rightPanel.visible ? "" : "opacity-40"} />
+      <PanelRight
+        size={14}
+        className={rightPanel.visible ? "" : "opacity-40"}
+      />
     </button>
   );
 }

--- a/src/features/artifacts/components/artifacts-panel.tsx
+++ b/src/features/artifacts/components/artifacts-panel.tsx
@@ -49,7 +49,9 @@ export function ArtifactsPanel() {
   const activeOrganisationId = useOrgStore.use.activeOrganisationId();
   const projects = useMemo(
     () =>
-      allWorkspaces.filter((w) => w.orgId === activeOrganisationId || w.orgId == null),
+      allWorkspaces.filter(
+        (w) => w.orgId === activeOrganisationId || w.orgId == null,
+      ),
     [allWorkspaces, activeOrganisationId],
   );
   // A stable key, so the read effect does not re-fire on unrelated workspace
@@ -84,7 +86,8 @@ export function ArtifactsPanel() {
   // A filter naming a project that is no longer open would hide everything with
   // no way back, so it is dropped rather than left dangling.
   useEffect(() => {
-    if (projectFilter && !projectPaths.includes(projectFilter)) setProjectFilter(null);
+    if (projectFilter && !projectPaths.includes(projectFilter))
+      setProjectFilter(null);
   }, [projectFilter, projectPaths, setProjectFilter]);
 
   const refresh = useCallback(async () => {
@@ -206,7 +209,9 @@ export function ArtifactsPanel() {
           </button>
         ) : (
           <>
-            <span className="text-[12px] font-medium text-[var(--text-primary)]">Timeline</span>
+            <span className="text-[12px] font-medium text-[var(--text-primary)]">
+              Timeline
+            </span>
             {filterable.length > 0 && (
               <ProjectFilter
                 projects={filterable}
@@ -257,15 +262,17 @@ export function ArtifactsPanel() {
               <SessionList
                 sessions={sessions}
                 loading={!loaded}
-                onOpen={(sessionId, projectPath) => openSession({ sessionId, projectPath })}
+                onOpen={(sessionId, projectPath) =>
+                  openSession({ sessionId, projectPath })
+                }
               />
             </div>
             {/* Say what is being left out. A board that silently stops at the
              *  newest few hundred reads as "this is everything". */}
             {capped && (
               <p className="shrink-0 border-t border-[var(--border-subtle)] px-4 py-1.5 text-[11px] text-[var(--text-tertiary)]">
-                Showing the newest {BOARD_LIMIT} sessions — filter by project to see a
-                project&apos;s full history.
+                Showing the newest {BOARD_LIMIT} sessions — filter by project to
+                see a project&apos;s full history.
               </p>
             )}
           </div>
@@ -343,9 +350,9 @@ function NotEnabled() {
         Nothing captured yet
       </h2>
       <p className="mt-1.5 max-w-[420px] text-[12px] leading-relaxed text-[var(--text-tertiary)]">
-        Turn capture on for a project and Atlas records what you asked, what the agent did, and
-        which commits came out of it — stored on this machine, with secrets scrubbed before
-        anything is written.
+        Turn capture on for a project and Atlas records what you asked, what the
+        agent did, and which commits came out of it — stored on this machine,
+        with secrets scrubbed before anything is written.
       </p>
       {/* The control is deliberately not repeated here. Capture is per project
        *  and this board spans all of them, so the honest place to switch it on
@@ -362,7 +369,9 @@ function NotEnabled() {
 function NotFound({ onBack }: { onBack: () => void }) {
   return (
     <div className="flex h-full flex-col items-center justify-center px-8 text-center">
-      <p className="text-[13px] text-[var(--text-secondary)]">This session no longer exists.</p>
+      <p className="text-[13px] text-[var(--text-secondary)]">
+        This session no longer exists.
+      </p>
       <button
         type="button"
         onClick={onBack}

--- a/src/features/artifacts/components/session-detail.tsx
+++ b/src/features/artifacts/components/session-detail.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
   Bot,
@@ -148,7 +155,8 @@ export function SessionDetail({ detail, projectPath, focusCommitSha }: Props) {
       // which row was the destination. The ring says "this one", then gets out
       // of the way.
       setLanded(pendingJump);
-      if (visible[index]?.kind === "checkpoint") setActiveCheckpoint(pendingJump);
+      if (visible[index]?.kind === "checkpoint")
+        setActiveCheckpoint(pendingJump);
       setPendingJump(null);
     }
   }, [pendingJump, visible, renderCount]);
@@ -172,7 +180,8 @@ export function SessionDetail({ detail, projectPath, focusCommitSha }: Props) {
     const arrival = `${detail.summary.id}:${focusCommitSha}`;
     if (honouredFocus.current === arrival) return;
     const target = detail.entries.find(
-      (entry) => entry.kind === "checkpoint" && entry.commitSha === focusCommitSha,
+      (entry) =>
+        entry.kind === "checkpoint" && entry.commitSha === focusCommitSha,
     );
     if (target) {
       honouredFocus.current = arrival;
@@ -182,7 +191,11 @@ export function SessionDetail({ detail, projectPath, focusCommitSha }: Props) {
 
   return (
     <div className="flex h-full min-h-0">
-      <div ref={scrollRef} onScroll={onScroll} className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="min-h-0 flex-1 overflow-y-auto px-6 py-4"
+      >
         <Header detail={detail} />
 
         {visible.length === 0 ? (
@@ -236,11 +249,14 @@ export function SessionDetail({ detail, projectPath, focusCommitSha }: Props) {
               <button
                 type="button"
                 onClick={() =>
-                  setRenderCount((count) => Math.min(count + WINDOW_CHUNK, visible.length))
+                  setRenderCount((count) =>
+                    Math.min(count + WINDOW_CHUNK, visible.length),
+                  )
                 }
                 className="mt-4 w-full rounded border border-[var(--border-default)] py-1.5 text-[11px] text-[var(--text-tertiary)] transition-colors duration-150 hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)] focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] active:scale-[0.99]"
               >
-                {visible.length - renderCount} more entries — scroll or click to load
+                {visible.length - renderCount} more entries — scroll or click to
+                load
               </button>
             )}
           </>
@@ -269,7 +285,8 @@ export function SessionDetail({ detail, projectPath, focusCommitSha }: Props) {
  *  themselves carry their names and failure chips in their own rows. */
 function GutterNode({ entry }: { entry: TimelineEntry }) {
   const failed = entry.kind === "tool_call" && entry.toolStatus === "failed";
-  const orphaned = entry.kind === "checkpoint" && entry.linkState === "orphaned";
+  const orphaned =
+    entry.kind === "checkpoint" && entry.linkState === "orphaned";
   const Icon =
     entry.kind === "prompt"
       ? User
@@ -343,7 +360,9 @@ function Header({ detail }: { detail: Detail }) {
               <span className="text-[var(--stat-added)]">+{s.insertions}</span>
             )}
             {s.insertions > 0 && s.deletions > 0 && " / "}
-            {s.deletions > 0 && <span className="text-[var(--stat-removed)]">-{s.deletions}</span>}
+            {s.deletions > 0 && (
+              <span className="text-[var(--stat-removed)]">-{s.deletions}</span>
+            )}
           </span>
         )}
       </div>
@@ -354,8 +373,8 @@ function Header({ detail }: { detail: Detail }) {
         <p className="mt-2 flex items-start gap-1.5 rounded bg-[var(--status-warning-muted)] px-2 py-1.5 text-[11px] text-[var(--status-warning)]">
           <TriangleAlert size={12} className="mt-px shrink-0" />
           <span>
-            {s.attentionReason ?? "Part of this session could not be recorded."} Content that
-            could not be scrubbed was not stored.
+            {s.attentionReason ?? "Part of this session could not be recorded."}{" "}
+            Content that could not be scrubbed was not stored.
           </span>
         </p>
       )}
@@ -383,7 +402,13 @@ function Entry({
     case "thinking":
       return <Thinking entry={entry} projectPath={projectPath} />;
     case "tool_call":
-      return <ToolCall entry={entry} projectPath={projectPath} expandAll={expandAllTools} />;
+      return (
+        <ToolCall
+          entry={entry}
+          projectPath={projectPath}
+          expandAll={expandAllTools}
+        />
+      );
     case "checkpoint":
       return <Checkpoint entry={entry} />;
   }
@@ -459,7 +484,10 @@ function Prompt({
   projectPath: string;
   calls: number;
 }) {
-  const meta = [relative(entry.at), calls > 0 ? `${calls} call${calls === 1 ? "" : "s"}` : null]
+  const meta = [
+    relative(entry.at),
+    calls > 0 ? `${calls} call${calls === 1 ? "" : "s"}` : null,
+  ]
     .filter((part): part is string => part !== null)
     .join(" · ");
 
@@ -474,7 +502,9 @@ function Prompt({
           />
         </Clamp>
       </div>
-      {meta && <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">{meta}</p>}
+      {meta && (
+        <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">{meta}</p>
+      )}
     </div>
   );
 }
@@ -482,7 +512,13 @@ function Prompt({
 /** What the agent said back. Unboxed, so the conversation reads as prose —
  *  and through the app's cached markdown renderer, so code fences and lists
  *  in agent output stop reading as prose soup. */
-function Response({ entry, projectPath }: { entry: TimelineEntry; projectPath: string }) {
+function Response({
+  entry,
+  projectPath,
+}: {
+  entry: TimelineEntry;
+  projectPath: string;
+}) {
   return (
     <div className="py-0.5">
       <Clamp>
@@ -504,7 +540,13 @@ function Response({ entry, projectPath }: { entry: TimelineEntry; projectPath: s
  * never what someone opened the timeline to read — but throwing it away would
  * lose the only record of *why* the agent did what it did.
  */
-function Thinking({ entry, projectPath }: { entry: TimelineEntry; projectPath: string }) {
+function Thinking({
+  entry,
+  projectPath,
+}: {
+  entry: TimelineEntry;
+  projectPath: string;
+}) {
   const [open, setOpen] = useState(false);
   return (
     <div>
@@ -582,15 +624,23 @@ function ToolCall({
           </span>
         )}
         {open ? (
-          <ChevronDown size={12} className="shrink-0 text-[var(--text-tertiary)]" />
+          <ChevronDown
+            size={12}
+            className="shrink-0 text-[var(--text-tertiary)]"
+          />
         ) : (
-          <ChevronRight size={12} className="shrink-0 text-[var(--text-tertiary)]" />
+          <ChevronRight
+            size={12}
+            className="shrink-0 text-[var(--text-tertiary)]"
+          />
         )}
       </button>
 
       {open && (
         <div className="mt-1 space-y-1.5 border-l border-[var(--border-default)] pl-3">
-          {entry.paths.length > 1 && <Block label="Files" text={entry.paths.join("\n")} />}
+          {entry.paths.length > 1 && (
+            <Block label="Files" text={entry.paths.join("\n")} />
+          )}
           {entry.arguments && (
             <Block
               label="Arguments"
@@ -644,12 +694,18 @@ function Block({
   const [full, setFull] = useState<string | null>(null);
   return (
     <div>
-      <p className="text-[10px] uppercase tracking-wide text-[var(--text-tertiary)]">{label}</p>
+      <p className="text-[10px] uppercase tracking-wide text-[var(--text-tertiary)]">
+        {label}
+      </p>
       <pre className="mt-0.5 max-h-[280px] overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--bg-raised)] px-2 py-1.5 font-mono text-[11px] text-[var(--text-secondary)]">
         {full ?? text}
       </pre>
       {blobRef && projectPath && full === null && (
-        <ShowFull projectPath={projectPath} blobRef={blobRef} onLoaded={setFull} />
+        <ShowFull
+          projectPath={projectPath}
+          blobRef={blobRef}
+          onLoaded={setFull}
+        />
       )}
     </div>
   );
@@ -682,57 +738,63 @@ function Checkpoint({ entry }: { entry: TimelineEntry }) {
             : "border-[var(--border-default)] bg-[var(--bg-raised)]",
         )}
       >
-      <span className="shrink-0 font-mono text-[11px] text-[var(--text-tertiary)]">
-        {entry.commitSha?.slice(0, 7)}
-      </span>
+        <span className="shrink-0 font-mono text-[11px] text-[var(--text-tertiary)]">
+          {entry.commitSha?.slice(0, 7)}
+        </span>
 
-      <span
-        className={cn(
-          "min-w-0 flex-1 truncate text-[12px]",
-          orphaned ? "text-[var(--text-secondary)]" : "text-[var(--text-primary)]",
-        )}
-      >
-        {entry.commitSubject ?? (
-          // The Checkpoint is a real record even when git can no longer resolve
-          // it — a moved repository or a pruned commit must not erase it.
-          <span className="text-[var(--text-tertiary)]">
-            {orphaned ? "Commit no longer reachable" : "Subject unavailable"}
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate text-[12px]",
+            orphaned
+              ? "text-[var(--text-secondary)]"
+              : "text-[var(--text-primary)]",
+          )}
+        >
+          {entry.commitSubject ?? (
+            // The Checkpoint is a real record even when git can no longer resolve
+            // it — a moved repository or a pruned commit must not erase it.
+            <span className="text-[var(--text-tertiary)]">
+              {orphaned ? "Commit no longer reachable" : "Subject unavailable"}
+            </span>
+          )}
+        </span>
+
+        {/* A squash or a conflict-resolved rebase leaves the subject and the diff
+         *  stat intact, so without saying so outright an orphaned Checkpoint reads
+         *  exactly like a live one — the "wrong link" this whole subsystem exists
+         *  to avoid. The state is named on the row, not inferred from a border. */}
+        {orphaned && (
+          <span
+            className="shrink-0 rounded bg-[var(--status-warning-muted)] px-1.5 py-px text-[10px] text-[var(--status-warning)]"
+            title="This commit is no longer in history — rewritten or squashed. The Session record is kept."
+          >
+            orphaned
           </span>
         )}
-      </span>
 
-      {/* A squash or a conflict-resolved rebase leaves the subject and the diff
-       *  stat intact, so without saying so outright an orphaned Checkpoint reads
-       *  exactly like a live one — the "wrong link" this whole subsystem exists
-       *  to avoid. The state is named on the row, not inferred from a border. */}
-      {orphaned && (
-        <span
-          className="shrink-0 rounded bg-[var(--status-warning-muted)] px-1.5 py-px text-[10px] text-[var(--status-warning)]"
-          title="This commit is no longer in history — rewritten or squashed. The Session record is kept."
-        >
-          orphaned
-        </span>
-      )}
+        {/* Suppressed when orphaned: the branch no longer contains this commit,
+         *  so showing it would assert exactly the link that was lost. */}
+        {entry.branch && !orphaned && (
+          <span className="hidden shrink-0 font-mono text-[10px] text-[var(--text-tertiary)] md:block">
+            {entry.branch}
+          </span>
+        )}
 
-      {/* Suppressed when orphaned: the branch no longer contains this commit,
-       *  so showing it would assert exactly the link that was lost. */}
-      {entry.branch && !orphaned && (
-        <span className="hidden shrink-0 font-mono text-[10px] text-[var(--text-tertiary)] md:block">
-          {entry.branch}
-        </span>
-      )}
-
-      {(entry.insertions > 0 || entry.deletions > 0) && (
-        <span className="shrink-0 font-mono text-[11px]">
-          {entry.insertions > 0 && (
-            <span className="text-[var(--stat-added)]">+{entry.insertions}</span>
-          )}
-          {entry.insertions > 0 && entry.deletions > 0 && (
-            <span className="text-[var(--text-ghost)]"> / </span>
-          )}
-          {entry.deletions > 0 && (
-            <span className="text-[var(--stat-removed)]">-{entry.deletions}</span>
-          )}
+        {(entry.insertions > 0 || entry.deletions > 0) && (
+          <span className="shrink-0 font-mono text-[11px]">
+            {entry.insertions > 0 && (
+              <span className="text-[var(--stat-added)]">
+                +{entry.insertions}
+              </span>
+            )}
+            {entry.insertions > 0 && entry.deletions > 0 && (
+              <span className="text-[var(--text-ghost)]"> / </span>
+            )}
+            {entry.deletions > 0 && (
+              <span className="text-[var(--stat-removed)]">
+                -{entry.deletions}
+              </span>
+            )}
           </span>
         )}
       </div>
@@ -764,7 +826,11 @@ function Body({
         … {compact(entry.bodyBytes)} bytes not shown
       </span>
       {entry.bodyRef && (
-        <ShowFull projectPath={projectPath} blobRef={entry.bodyRef} onLoaded={setFull} />
+        <ShowFull
+          projectPath={projectPath}
+          blobRef={entry.bodyRef}
+          onLoaded={setFull}
+        />
       )}
     </>
   );
@@ -772,7 +838,10 @@ function Body({
   if (markdown) {
     return (
       <div className="break-words">
-        <CachedMarkdown source={full ?? entry.text ?? ""} className={className} />
+        <CachedMarkdown
+          source={full ?? entry.text ?? ""}
+          className={className}
+        />
         {truncated && <p className="mt-1 -ml-1">{notice}</p>}
       </div>
     );
@@ -822,7 +891,11 @@ function ShowFull({
   };
 
   if (error) {
-    return <span className="ml-1.5 text-[11px] text-[var(--text-tertiary)]">{error}</span>;
+    return (
+      <span className="ml-1.5 text-[11px] text-[var(--text-tertiary)]">
+        {error}
+      </span>
+    );
   }
   return (
     <button
@@ -869,7 +942,11 @@ function Rail({
   return (
     <aside className="w-[240px] shrink-0 overflow-y-auto border-l border-[var(--border-default)] px-4 py-4">
       {checkpoints.length > 0 ? (
-        <JumpTo checkpoints={checkpoints} activeId={activeCheckpoint} onJump={onJump} />
+        <JumpTo
+          checkpoints={checkpoints}
+          activeId={activeCheckpoint}
+          onJump={onJump}
+        />
       ) : (
         /* Zero is a fact worth one quiet sentence, not an empty rail — the
          * difference between "imported, so never linked" and "nothing was
@@ -882,7 +959,9 @@ function Rail({
       )}
 
       <section>
-        <h3 className="pb-1.5 text-[11px] font-medium text-[var(--text-primary)]">Filters</h3>
+        <h3 className="pb-1.5 text-[11px] font-medium text-[var(--text-primary)]">
+          Filters
+        </h3>
         <Toggle
           label="Prompts"
           count={detail.counts.prompts}
@@ -930,8 +1009,12 @@ function Rail({
               onChange={(e) => onFailedOnlyChange(e.target.checked)}
               className="size-3 accent-[var(--status-error)]"
             />
-            <span className="flex-1 text-[12px] text-[var(--status-error)]">Failed</span>
-            <span className="text-[11px] text-[var(--status-error)]">{failedCount}</span>
+            <span className="flex-1 text-[12px] text-[var(--status-error)]">
+              Failed
+            </span>
+            <span className="text-[11px] text-[var(--status-error)]">
+              {failedCount}
+            </span>
           </label>
         )}
 
@@ -954,7 +1037,9 @@ function Rail({
       </section>
 
       <section className="mt-5">
-        <h3 className="pb-1.5 text-[11px] font-medium text-[var(--text-primary)]">View</h3>
+        <h3 className="pb-1.5 text-[11px] font-medium text-[var(--text-primary)]">
+          View
+        </h3>
         <label className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 transition-colors duration-150 hover:bg-[var(--bg-hover)]">
           <input
             type="checkbox"
@@ -1004,14 +1089,19 @@ function JumpTo({
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center justify-between gap-2 rounded border border-[var(--border-default)] px-2 py-1.5 transition-colors duration-150 hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] active:bg-[var(--bg-active)]"
       >
-        <span className="text-[11px] font-medium text-[var(--text-primary)]">Jump to</span>
+        <span className="text-[11px] font-medium text-[var(--text-primary)]">
+          Jump to
+        </span>
         <span className="flex items-center gap-1.5 text-[11px] text-[var(--text-tertiary)]">
           {activeIndex >= 0 && checkpoints.length > 1
             ? `${activeIndex + 1} of ${checkpoints.length}`
             : `${checkpoints.length} checkpoint${checkpoints.length === 1 ? "" : "s"}`}
           <ChevronDown
             size={11}
-            className={cn("transition-transform duration-150 ease-out", open && "rotate-180")}
+            className={cn(
+              "transition-transform duration-150 ease-out",
+              open && "rotate-180",
+            )}
           />
         </span>
       </button>
@@ -1049,7 +1139,9 @@ function JumpTo({
                   <span
                     className={cn(
                       "mt-px w-3 shrink-0 text-right font-mono text-[10px] tabular-nums",
-                      active ? "text-[var(--text-secondary)]" : "text-[var(--text-ghost)]",
+                      active
+                        ? "text-[var(--text-secondary)]"
+                        : "text-[var(--text-ghost)]",
                     )}
                   >
                     {index + 1}
@@ -1101,13 +1193,19 @@ function Toggle({
         onChange={(e) => onChange(e.target.checked)}
         className="size-3 accent-[var(--accent-primary)]"
       />
-      <span className="flex-1 text-[12px] text-[var(--text-secondary)]">{label}</span>
+      <span className="flex-1 text-[12px] text-[var(--text-secondary)]">
+        {label}
+      </span>
       <span className="text-[11px] text-[var(--text-tertiary)]">{count}</span>
     </label>
   );
 }
 
-function passes(entry: TimelineEntry, filters: TimelineFilters, failedOnly: boolean): boolean {
+function passes(
+  entry: TimelineEntry,
+  filters: TimelineFilters,
+  failedOnly: boolean,
+): boolean {
   switch (entry.kind) {
     case "prompt":
       return filters.prompts;
@@ -1116,7 +1214,9 @@ function passes(entry: TimelineEntry, filters: TimelineFilters, failedOnly: bool
     case "thinking":
       return filters.thinking;
     case "tool_call":
-      return filters.toolCalls && (!failedOnly || entry.toolStatus === "failed");
+      return (
+        filters.toolCalls && (!failedOnly || entry.toolStatus === "failed")
+      );
     case "checkpoint":
       return filters.checkpoints;
   }

--- a/src/features/artifacts/components/session-list.tsx
+++ b/src/features/artifacts/components/session-list.tsx
@@ -1,5 +1,11 @@
 import { useMemo, useState } from "react";
-import { ChevronDown, ChevronRight, GitBranch, Search, TriangleAlert } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  Search,
+  TriangleAlert,
+} from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -40,7 +46,8 @@ export function SessionList({ sessions, loading, onOpen }: Props) {
 
   const branches = useMemo(() => {
     const all = new Set<string>();
-    for (const session of sessions) for (const b of session.branches) all.add(b);
+    for (const session of sessions)
+      for (const b of session.branches) all.add(b);
     return [...all].sort();
   }, [sessions]);
 
@@ -109,7 +116,9 @@ export function SessionList({ sessions, loading, onOpen }: Props) {
           groups.map(([day, rows]) => (
             <section key={day}>
               <header className="sticky top-0 z-10 flex items-baseline justify-between bg-[var(--bg-surface)] py-2">
-                <h2 className="text-[12px] font-medium text-[var(--text-primary)]">{day}</h2>
+                <h2 className="text-[12px] font-medium text-[var(--text-primary)]">
+                  {day}
+                </h2>
                 <span className="text-[11px] text-[var(--text-tertiary)]">
                   {rows.length} session{rows.length === 1 ? "" : "s"}
                 </span>
@@ -117,7 +126,11 @@ export function SessionList({ sessions, loading, onOpen }: Props) {
               <ul>
                 {clusterRows(rows).map((item) =>
                   item.kind === "single" ? (
-                    <SessionRow key={item.session.id} session={item.session} onOpen={onOpen} />
+                    <SessionRow
+                      key={item.session.id}
+                      session={item.session}
+                      onOpen={onOpen}
+                    />
                   ) : (
                     <ClusterRow
                       key={`${day}:${item.title}`}
@@ -204,9 +217,15 @@ function ClusterRow({
         className="group flex w-full items-center gap-2 rounded px-2 py-2 text-left transition-colors duration-150 hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] active:bg-[var(--bg-active)]"
       >
         {expanded ? (
-          <ChevronDown size={12} className="shrink-0 text-[var(--text-tertiary)]" />
+          <ChevronDown
+            size={12}
+            className="shrink-0 text-[var(--text-tertiary)]"
+          />
         ) : (
-          <ChevronRight size={12} className="shrink-0 text-[var(--text-tertiary)]" />
+          <ChevronRight
+            size={12}
+            className="shrink-0 text-[var(--text-tertiary)]"
+          />
         )}
         <span className="min-w-0 flex-1 truncate text-[13px] text-[var(--text-secondary)]">
           {item.title}
@@ -244,7 +263,11 @@ function SessionRow({
         className="group flex w-full items-center gap-3 rounded px-2 py-2 text-left transition-colors duration-150 hover:bg-[var(--bg-hover)] focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] active:bg-[var(--bg-active)]"
       >
         <span className="min-w-0 flex-1 truncate text-[13px] text-[var(--text-primary)]">
-          {session.title ?? <span className="text-[var(--text-tertiary)]">Untitled session</span>}
+          {session.title ?? (
+            <span className="text-[var(--text-tertiary)]">
+              Untitled session
+            </span>
+          )}
         </span>
 
         {/* The board spans every project, so a row that does not name its own
@@ -323,7 +346,13 @@ export function prettyModel(model: string | null): string | null {
   return raw;
 }
 
-export function AgentBadge({ agent, className }: { agent: string; className?: string }) {
+export function AgentBadge({
+  agent,
+  className,
+}: {
+  agent: string;
+  className?: string;
+}) {
   const tone = agent.includes("claude")
     ? "text-[var(--agent-claude-chip)] bg-[var(--agent-claude-chip-bg)]"
     : agent.includes("codex")
@@ -356,7 +385,9 @@ function Empty({ filtered }: { filtered: boolean }) {
   return (
     <div className="py-12 text-center">
       <p className="text-[12px] text-[var(--text-secondary)]">
-        {filtered ? "No sessions match this filter." : "No sessions captured yet."}
+        {filtered
+          ? "No sessions match this filter."
+          : "No sessions captured yet."}
       </p>
       {!filtered && (
         <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">
@@ -385,8 +416,11 @@ function groupByDay(sessions: BoardSession[]): Array<[string, BoardSession[]]> {
 }
 
 function dayLabel(date: Date): string {
-  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-  const days = Math.round((startOfDay(new Date()) - startOfDay(date)) / 86_400_000);
+  const startOfDay = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const days = Math.round(
+    (startOfDay(new Date()) - startOfDay(date)) / 86_400_000,
+  );
   if (days === 0) return "Today";
   if (days === 1) return "Yesterday";
   return date.toLocaleDateString(undefined, {
@@ -394,6 +428,7 @@ function dayLabel(date: Date): string {
     day: "numeric",
     month: "short",
     // The year only earns its space once it is ambiguous.
-    year: date.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+    year:
+      date.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
   });
 }

--- a/src/features/artifacts/types.ts
+++ b/src/features/artifacts/types.ts
@@ -8,7 +8,12 @@
  * is the failure mode to watch for.
  */
 
-export type EntryKind = "prompt" | "response" | "thinking" | "tool_call" | "checkpoint";
+export type EntryKind =
+  | "prompt"
+  | "response"
+  | "thinking"
+  | "tool_call"
+  | "checkpoint";
 
 export type ToolStatus = "pending" | "running" | "completed" | "failed";
 

--- a/src/features/auth/components/account-button.tsx
+++ b/src/features/auth/components/account-button.tsx
@@ -56,7 +56,9 @@ export function AccountButton() {
         // label or border — the pointer is most of what says it is pressable.
         // Matches the title bar's project-name button beside it.
         "cursor-pointer hover:bg-[#ffffff08] outline-none focus:outline-none",
-        signedIn || connecting ? "text-[#ccc]" : "text-[#555] hover:text-[#aaa]",
+        signedIn || connecting
+          ? "text-[#ccc]"
+          : "text-[#555] hover:text-[#aaa]",
       )}
     >
       {starting || connecting ? (

--- a/src/features/auth/components/account-menu.tsx
+++ b/src/features/auth/components/account-menu.tsx
@@ -137,7 +137,10 @@ export function AccountMenu({
                 onSelect={() => void beginSignIn()}
                 className={ITEM_CLASS}
               >
-                <LogIn size={13} className="shrink-0 text-[var(--text-tertiary)]" />
+                <LogIn
+                  size={13}
+                  className="shrink-0 text-[var(--text-tertiary)]"
+                />
                 <span className="flex-1 text-left">Sign In</span>
               </DropdownMenu.Item>
               <DropdownMenu.Separator className={SEPARATOR_CLASS} />
@@ -168,7 +171,10 @@ export function AccountMenu({
                 onSelect={() => void onSignOut()}
                 className={ITEM_CLASS}
               >
-                <LogOut size={13} className="shrink-0 text-[var(--text-tertiary)]" />
+                <LogOut
+                  size={13}
+                  className="shrink-0 text-[var(--text-tertiary)]"
+                />
                 <span className="flex-1 text-left">Sign Out</span>
               </DropdownMenu.Item>
             </>

--- a/src/features/auth/components/connect-dialog.tsx
+++ b/src/features/auth/components/connect-dialog.tsx
@@ -118,7 +118,10 @@ export function ConnectDialog() {
                       >
                         {copied ? (
                           <>
-                            <Check size={12} className="text-[var(--status-success)]" />
+                            <Check
+                              size={12}
+                              className="text-[var(--status-success)]"
+                            />
                             Copied
                           </>
                         ) : (

--- a/src/features/browser/components/browser-panel.tsx
+++ b/src/features/browser/components/browser-panel.tsx
@@ -64,14 +64,21 @@ function toNavUrl(input: string): string {
   if (/^https?:\/\//i.test(t)) return t;
   // A bare host (has a dot, no spaces) or localhost → treat as a URL.
   const looksLikeUrl =
-    /^localhost(:\d+)?(\/.*)?$/i.test(t) || /^[^\s]+\.[^\s]{2,}(\/.*)?$/.test(t);
+    /^localhost(:\d+)?(\/.*)?$/i.test(t) ||
+    /^[^\s]+\.[^\s]{2,}(\/.*)?$/.test(t);
   if (looksLikeUrl) return `https://${t}`;
   return `https://www.google.com/search?q=${encodeURIComponent(t)}`;
 }
 
-export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) {
+export function BrowserPanel({
+  tabId,
+  initialUrl,
+  groupId,
+}: BrowserPanelProps) {
   // Stable embed id for the native child webview. One per browser tab.
-  const embedId = useRef(tabId || `browser-${Math.random().toString(36).slice(2)}`).current;
+  const embedId = useRef(
+    tabId || `browser-${Math.random().toString(36).slice(2)}`,
+  ).current;
 
   const [mode, setMode] = useState<BrowserMode>("live");
   const [inputUrl, setInputUrl] = useState(initialUrl || "");
@@ -86,7 +93,8 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   // The native child webview floats above the DOM and can't be occluded, so it
   // must hide while any DOM overlay is open (see BrowserOverlayWatcher).
   const overlayOpen = useBrowserOverlayStore.use.overlayOpen();
-  const { registerEmbed, unregisterEmbed } = useBrowserOverlayStore.use.actions();
+  const { registerEmbed, unregisterEmbed } =
+    useBrowserOverlayStore.use.actions();
   const overlayOpenRef = useRef(overlayOpen);
   overlayOpenRef.current = overlayOpen;
 
@@ -116,7 +124,12 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
 
   // ── Live: geometry + lifecycle ──────────────────────────────────────────
 
-  const currentRect = useCallback((): { x: number; y: number; width: number; height: number } | null => {
+  const currentRect = useCallback((): {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null => {
     const el = placeholderRef.current;
     if (!el) return null;
     const r = el.getBoundingClientRect();
@@ -159,7 +172,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       setInputUrl(e.payload.url);
       // In-page navigation means the user is driving THIS pane — but only steal
       // keyboard focus if this is the visible/active tab in its column.
-      if (groupId && useLayoutStore.getState().activeByGroup[groupId] === (tabId ?? embedId)) {
+      if (
+        groupId &&
+        useLayoutStore.getState().activeByGroup[groupId] === (tabId ?? embedId)
+      ) {
         focusThisGroup();
       }
     });
@@ -179,7 +195,9 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
     }
     const visible = !!rect && !overlayOpenRef.current;
-    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
+    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(
+      () => {},
+    );
   }, [embedId, currentRect]);
 
   // Track geometry + visibility. ResizeObserver fires both when the panel
@@ -206,7 +224,9 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   useEffect(() => {
     if (mode !== "live") return;
     if (createdRef.current || !initialUrl) return;
-    const raf = requestAnimationFrame(() => ensureLive(normalizeUrl(initialUrl)));
+    const raf = requestAnimationFrame(() =>
+      ensureLive(normalizeUrl(initialUrl)),
+    );
     return () => cancelAnimationFrame(raf);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, initialUrl]);
@@ -219,7 +239,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     if (mode === "live") {
       syncVisibility();
     } else {
-      invoke("browser_embed_set_visible", { id: embedId, visible: false }).catch(() => {});
+      invoke("browser_embed_set_visible", {
+        id: embedId,
+        visible: false,
+      }).catch(() => {});
     }
   }, [mode, embedId, syncVisibility]);
 
@@ -234,23 +257,26 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   }, [embedId, unregisterEmbed]);
 
   // ── Reader: sanitized fetch ─────────────────────────────────────────────
-  const fetchPage = useCallback(async (url: string) => {
-    url = normalizeUrl(url);
-    setInputUrl(url);
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await invoke<ReadableContent>("fetch_readable", { url });
-      setPage(result);
-      setInputUrl(result.url);
-      setHistory((h) => [...h.slice(0, historyIndex + 1), result]);
-      setHistoryIndex((i) => i + 1);
-    } catch (e) {
-      setError(String(e));
-      setPage(null);
-    }
-    setLoading(false);
-  }, [historyIndex]);
+  const fetchPage = useCallback(
+    async (url: string) => {
+      url = normalizeUrl(url);
+      setInputUrl(url);
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await invoke<ReadableContent>("fetch_readable", { url });
+        setPage(result);
+        setInputUrl(result.url);
+        setHistory((h) => [...h.slice(0, historyIndex + 1), result]);
+        setHistoryIndex((i) => i + 1);
+      } catch (e) {
+        setError(String(e));
+        setPage(null);
+      }
+      setLoading(false);
+    },
+    [historyIndex],
+  );
 
   // ── Unified navigation (dispatches by mode) ─────────────────────────────
   const navigate = useCallback(
@@ -286,30 +312,48 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   };
 
   const reload = () => {
-    if (mode === "live") invoke("browser_embed_reload", { id: embedId }).catch(() => {});
+    if (mode === "live")
+      invoke("browser_embed_reload", { id: embedId }).catch(() => {});
     else if (page) fetchPage(page.url);
   };
 
-  const handleContentClick = useCallback((e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    const anchor = target.closest("a");
-    if (!anchor) return;
-    e.preventDefault();
-    const href = anchor.getAttribute("href");
-    if (!href || href.startsWith("#") || href.startsWith("javascript:")) return;
-    fetchPage(href);
-  }, [fetchPage]);
+  const handleContentClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const anchor = target.closest("a");
+      if (!anchor) return;
+      e.preventDefault();
+      const href = anchor.getAttribute("href");
+      if (!href || href.startsWith("#") || href.startsWith("javascript:"))
+        return;
+      fetchPage(href);
+    },
+    [fetchPage],
+  );
 
-  const currentUrl = () => (mode === "live" ? liveNav?.url || inputUrl : page?.url || inputUrl);
+  const currentUrl = () =>
+    mode === "live" ? liveNav?.url || inputUrl : page?.url || inputUrl;
 
   // Open the current URL in a separate native WebKit browser window.
   const openBrowserWindow = async () => {
     const url = currentUrl();
     try {
       await invoke("browser_open_window", { url });
-      logEvent({ source: "atlas", kind: "browser-open-window", summary: `Opened ${url} in a browser window`, status: "success", payload: { url } });
+      logEvent({
+        source: "atlas",
+        kind: "browser-open-window",
+        summary: `Opened ${url} in a browser window`,
+        status: "success",
+        payload: { url },
+      });
     } catch (e) {
-      logEvent({ source: "atlas", kind: "browser-open-window", summary: `Failed to open browser window: ${url}`, status: "failure", payload: { url, error: String(e) } });
+      logEvent({
+        source: "atlas",
+        kind: "browser-open-window",
+        summary: `Failed to open browser window: ${url}`,
+        status: "failure",
+        payload: { url, error: String(e) },
+      });
     }
   };
 
@@ -318,10 +362,22 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     try {
       const { openUrl } = await import("@tauri-apps/plugin-opener");
       await openUrl(url);
-      logEvent({ source: "atlas", kind: "browser-open-external", summary: `Opened ${url} in system browser`, status: "success", payload: { url } });
+      logEvent({
+        source: "atlas",
+        kind: "browser-open-external",
+        summary: `Opened ${url} in system browser`,
+        status: "success",
+        payload: { url },
+      });
     } catch (e) {
       window.open(url, "_blank");
-      logEvent({ source: "atlas", kind: "browser-open-external-fallback", summary: `Tauri opener failed; fell back to window.open: ${url}`, status: "failure", payload: { url, error: String(e) } });
+      logEvent({
+        source: "atlas",
+        kind: "browser-open-external-fallback",
+        summary: `Tauri opener failed; fell back to window.open: ${url}`,
+        status: "failure",
+        payload: { url, error: String(e) },
+      });
     }
   };
 
@@ -334,7 +390,8 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
         id: `web-${Date.now()}`,
         content: `# ${page.title}\n\nSource: ${page.url}\n\n${textContent.slice(0, 50000)}`,
       });
-      const { useKnowledgeStore } = await import("@/features/knowledge/stores/knowledge-store");
+      const { useKnowledgeStore } =
+        await import("@/features/knowledge/stores/knowledge-store");
       useKnowledgeStore.getState().actions.loadEntries(currentProject.path);
     } catch {}
   };
@@ -354,7 +411,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     const sel = window.getSelection();
     if (!sel) return;
     sel.removeAllRanges();
-    const walker = document.createTreeWalker(contentRef.current, NodeFilter.SHOW_TEXT);
+    const walker = document.createTreeWalker(
+      contentRef.current,
+      NodeFilter.SHOW_TEXT,
+    );
     const query = searchQuery.toLowerCase();
     let node: Node | null;
     while ((node = walker.nextNode())) {
@@ -365,7 +425,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
         range.setStart(node, idx);
         range.setEnd(node, idx + searchQuery.length);
         sel.addRange(range);
-        (node as HTMLElement).parentElement?.scrollIntoView({ behavior: "smooth", block: "center" });
+        (node as HTMLElement).parentElement?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
         return;
       }
     }
@@ -387,21 +450,42 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   // ── Derived chrome state ────────────────────────────────────────────────
   const isLive = mode === "live";
   const canBack = isLive ? !!liveNav?.canGoBack : historyIndex > 0;
-  const canFwd = isLive ? !!liveNav?.canGoForward : historyIndex < history.length - 1;
+  const canFwd = isLive
+    ? !!liveNav?.canGoForward
+    : historyIndex < history.length - 1;
   const isLoading = isLive ? !!liveNav?.loading : loading;
 
   return (
-    <div className="h-full flex flex-col bg-bg-base" onMouseDownCapture={focusThisGroup}>
+    <div
+      className="h-full flex flex-col bg-bg-base"
+      onMouseDownCapture={focusThisGroup}
+    >
       {/* Address bar */}
       <div className="flex items-center gap-1.5 px-2 h-[36px] shrink-0 border-b border-border-default bg-bg-primary">
-        <button onClick={goBack} disabled={!canBack} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer disabled:opacity-30">
+        <button
+          onClick={goBack}
+          disabled={!canBack}
+          className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer disabled:opacity-30"
+        >
           <ArrowLeft size={12} />
         </button>
-        <button onClick={goForward} disabled={!canFwd} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer disabled:opacity-30">
+        <button
+          onClick={goForward}
+          disabled={!canFwd}
+          className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer disabled:opacity-30"
+        >
           <ArrowRight size={12} />
         </button>
-        <button onClick={reload} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer" title="Reload">
-          {isLoading ? <Loader2 size={12} className="animate-spin" /> : <RotateCw size={12} />}
+        <button
+          onClick={reload}
+          className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer"
+          title="Reload"
+        >
+          {isLoading ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <RotateCw size={12} />
+          )}
         </button>
 
         <div className="flex-1 flex items-center gap-2 h-7 rounded border border-border-default bg-bg-secondary px-2 focus-within:ring-1 focus-within:ring-border-focus">
@@ -409,7 +493,9 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
           <input
             value={inputUrl}
             onChange={(e) => setInputUrl(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") navigate(inputUrl); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") navigate(inputUrl);
+            }}
             className="flex-1 bg-transparent outline-none text-[11px] text-text-primary font-mono placeholder:text-text-tertiary"
             placeholder="Search or enter URL"
           />
@@ -425,26 +511,46 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
               ? "bg-bg-hover text-text-primary"
               : "hover:bg-bg-hover text-text-tertiary",
           )}
-          title={mode === "reader" ? "Back to live page" : "Reader view of this page"}
+          title={
+            mode === "reader" ? "Back to live page" : "Reader view of this page"
+          }
         >
           {mode === "reader" ? <Zap size={11} /> : <BookText size={11} />}
-          <span className="text-[10px]">{mode === "reader" ? "Live" : "Reader"}</span>
+          <span className="text-[10px]">
+            {mode === "reader" ? "Live" : "Reader"}
+          </span>
         </button>
 
         {!isLive && page && currentProject && (
-          <button onClick={saveToKnowledge} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer" title="Save to knowledge base">
+          <button
+            onClick={saveToKnowledge}
+            className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer"
+            title="Save to knowledge base"
+          >
             <Save size={12} />
           </button>
         )}
         {!isLive && (
-          <button onClick={() => setSearchOpen(!searchOpen)} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer" title="Find in page">
+          <button
+            onClick={() => setSearchOpen(!searchOpen)}
+            className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer"
+            title="Find in page"
+          >
             <Search size={12} />
           </button>
         )}
-        <button onClick={openBrowserWindow} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer" title="Open in browser window">
+        <button
+          onClick={openBrowserWindow}
+          className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer"
+          title="Open in browser window"
+        >
           <AppWindow size={12} />
         </button>
-        <button onClick={openExternal} className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer" title="Open in system browser">
+        <button
+          onClick={openExternal}
+          className="p-1 rounded hover:bg-bg-hover text-text-tertiary transition-colors cursor-pointer"
+          title="Open in system browser"
+        >
           <ExternalLink size={12} />
         </button>
       </div>
@@ -456,7 +562,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
           <input
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") handleSearch(); if (e.key === "Escape") setSearchOpen(false); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSearch();
+              if (e.key === "Escape") setSearchOpen(false);
+            }}
             className="flex-1 bg-transparent outline-none text-[11px] text-text-primary placeholder:text-text-tertiary"
             placeholder="Find in page..."
             autoFocus
@@ -476,9 +585,12 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
                   <Globe size={22} className="text-text-tertiary" />
                 </div>
                 <div className="space-y-1.5">
-                  <p className="text-sm font-medium text-text-primary">Browser paused</p>
+                  <p className="text-sm font-medium text-text-primary">
+                    Browser paused
+                  </p>
                   <p className="text-xs leading-relaxed text-text-tertiary">
-                    A menu or dialog is open on top. Keep browsing without interruption:
+                    A menu or dialog is open on top. Keep browsing without
+                    interruption:
                   </p>
                   {(liveNav?.title || currentUrl()) && (
                     <p className="truncate pt-1 font-mono text-[10px] text-text-secondary">
@@ -509,12 +621,22 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
             <div className="absolute inset-0 flex items-center justify-center">
               <div className="text-center space-y-3">
                 <Globe size={32} className="text-text-tertiary mx-auto" />
-                <p className="text-sm text-text-secondary">Enter a URL to browse</p>
+                <p className="text-sm text-text-secondary">
+                  Enter a URL to browse
+                </p>
                 <div className="flex flex-wrap gap-2 justify-center max-w-[320px] pt-2">
-                  {["google.com", "youtube.com", "github.com", "news.ycombinator.com"].map((site) => (
+                  {[
+                    "google.com",
+                    "youtube.com",
+                    "github.com",
+                    "news.ycombinator.com",
+                  ].map((site) => (
                     <button
                       key={site}
-                      onClick={() => { setInputUrl(`https://${site}`); navigate(site); }}
+                      onClick={() => {
+                        setInputUrl(`https://${site}`);
+                        navigate(site);
+                      }}
                       className="px-2.5 py-1 rounded border border-border-default bg-bg-secondary text-[10px] text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors font-mono cursor-pointer"
                     >
                       {site}
@@ -531,7 +653,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       {!isLive && (
         <ContextMenu.Root>
           <ContextMenu.Trigger asChild>
-            <div className="flex-1 overflow-auto hide-scrollbar" onContextMenu={(e) => e.stopPropagation()}>
+            <div
+              className="flex-1 overflow-auto hide-scrollbar"
+              onContextMenu={(e) => e.stopPropagation()}
+            >
               {loading && (
                 <div className="flex items-center justify-center py-16">
                   <Loader2 size={20} className="animate-spin text-accent" />
@@ -541,15 +666,24 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
               {error && (
                 <div className="px-6 py-8 text-center">
                   <p className="text-[12px] text-error">{error}</p>
-                  <button onClick={() => fetchPage(inputUrl)} className="mt-2 text-[11px] text-accent underline cursor-pointer">Retry</button>
+                  <button
+                    onClick={() => fetchPage(inputUrl)}
+                    className="mt-2 text-[11px] text-accent underline cursor-pointer"
+                  >
+                    Retry
+                  </button>
                 </div>
               )}
 
               {!loading && !error && page && (
                 <div className="select-text">
                   <div className="px-4 py-3 border-b border-border-default">
-                    <h1 className="text-[15px] font-semibold text-text-primary leading-snug">{page.title}</h1>
-                    <span className="text-[10px] text-text-tertiary font-mono">{page.url}</span>
+                    <h1 className="text-[15px] font-semibold text-text-primary leading-snug">
+                      {page.title}
+                    </h1>
+                    <span className="text-[10px] text-text-tertiary font-mono">
+                      {page.url}
+                    </span>
                   </div>
                   <div
                     ref={contentRef}
@@ -563,10 +697,20 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
               {!loading && !error && !page && (
                 <div className="h-full flex items-center justify-center py-16">
                   <div className="text-center space-y-3">
-                    <BookText size={32} className="text-text-tertiary mx-auto" />
-                    <p className="text-sm text-text-secondary">Reader mode — enter a URL for a clean, JS-free view</p>
+                    <BookText
+                      size={32}
+                      className="text-text-tertiary mx-auto"
+                    />
+                    <p className="text-sm text-text-secondary">
+                      Reader mode — enter a URL for a clean, JS-free view
+                    </p>
                     <div className="flex flex-wrap gap-2 justify-center max-w-[300px] pt-2">
-                      {["arxiv.org", "github.com", "news.ycombinator.com", "developer.mozilla.org"].map((site) => (
+                      {[
+                        "arxiv.org",
+                        "github.com",
+                        "news.ycombinator.com",
+                        "developer.mozilla.org",
+                      ].map((site) => (
                         <button
                           key={site}
                           onClick={() => fetchPage(`https://${site}`)}
@@ -582,28 +726,52 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
             </div>
           </ContextMenu.Trigger>
           <ContextMenu.Portal>
-            <ContextMenu.Content className="w-[180px] rounded-lg border border-[#1a1a1a] bg-[#0f0f0f] shadow-xl py-1" style={{ zIndex: 99999 }}>
-              <ContextMenu.Item onClick={copySelection} className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none">
+            <ContextMenu.Content
+              className="w-[180px] rounded-lg border border-[#1a1a1a] bg-[#0f0f0f] shadow-xl py-1"
+              style={{ zIndex: 99999 }}
+            >
+              <ContextMenu.Item
+                onClick={copySelection}
+                className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none"
+              >
                 <Copy size={11} className="text-[#555]" /> Copy Selection
               </ContextMenu.Item>
-              <ContextMenu.Item onClick={copyLink} className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none">
+              <ContextMenu.Item
+                onClick={copyLink}
+                className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none"
+              >
                 <Globe size={11} className="text-[#555]" /> Copy Link
               </ContextMenu.Item>
               <ContextMenu.Separator className="h-px bg-[#1a1a1a] my-1" />
-              <ContextMenu.Item onClick={() => setSearchOpen(true)} className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none">
+              <ContextMenu.Item
+                onClick={() => setSearchOpen(true)}
+                className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none"
+              >
                 <Search size={11} className="text-[#555]" /> Find in Page
               </ContextMenu.Item>
-              <ContextMenu.Item onClick={openBrowserWindow} className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none">
-                <AppWindow size={11} className="text-[#555]" /> Open in Browser Window
+              <ContextMenu.Item
+                onClick={openBrowserWindow}
+                className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none"
+              >
+                <AppWindow size={11} className="text-[#555]" /> Open in Browser
+                Window
               </ContextMenu.Item>
-              <ContextMenu.Item onClick={openExternal} className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none">
-                <ExternalLink size={11} className="text-[#555]" /> Open in System Browser
+              <ContextMenu.Item
+                onClick={openExternal}
+                className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none"
+              >
+                <ExternalLink size={11} className="text-[#555]" /> Open in
+                System Browser
               </ContextMenu.Item>
               {page && currentProject && (
                 <>
                   <ContextMenu.Separator className="h-px bg-[#1a1a1a] my-1" />
-                  <ContextMenu.Item onClick={saveToKnowledge} className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none">
-                    <BookOpen size={11} className="text-[#555]" /> Save to Knowledge
+                  <ContextMenu.Item
+                    onClick={saveToKnowledge}
+                    className="flex items-center gap-2 px-3 h-[28px] text-[11px] text-[#aaa] hover:bg-[#1a1a1a] hover:text-[#fff] cursor-default outline-none"
+                  >
+                    <BookOpen size={11} className="text-[#555]" /> Save to
+                    Knowledge
                   </ContextMenu.Item>
                 </>
               )}

--- a/src/features/browser/stores/browser-overlay-store.ts
+++ b/src/features/browser/stores/browser-overlay-store.ts
@@ -43,6 +43,6 @@ export const useBrowserOverlayStore = createSelectors(
             if (s.embedCount === 0) s.overlayOpen = false;
           }),
       },
-    }))
-  )
+    })),
+  ),
 );

--- a/src/features/canvas/components/ai-group-marker.tsx
+++ b/src/features/canvas/components/ai-group-marker.tsx
@@ -17,17 +17,26 @@ export function AiGroupMarkers({
 }) {
   const nodes = useCanvasStore.use.nodes();
   const aiGroups = useCanvasStore.use.aiGroups();
-  const { moveGroup, selectGroup, beginInteraction } = useCanvasStore.use.actions();
+  const { moveGroup, selectGroup, beginInteraction } =
+    useCanvasStore.use.actions();
   const streamingGroupId = useCanvasAiStore.use.streamingGroupId();
   const vp = useViewport(); // { x, y, zoom } — re-renders on pan/zoom
 
   // Per-drag bookkeeping (module-free; one active pin at a time).
-  const drag = useRef<{ id: string; lastX: number; lastY: number; moved: boolean } | null>(null);
+  const drag = useRef<{
+    id: string;
+    lastX: number;
+    lastY: number;
+    moved: boolean;
+  } | null>(null);
 
   const groupIds = Object.keys(aiGroups);
   if (groupIds.length === 0) return null;
 
-  const toScreen = (fx: number, fy: number) => ({ x: fx * vp.zoom + vp.x, y: fy * vp.zoom + vp.y });
+  const toScreen = (fx: number, fy: number) => ({
+    x: fx * vp.zoom + vp.x,
+    y: fy * vp.zoom + vp.y,
+  });
 
   return (
     <>
@@ -52,7 +61,12 @@ export function AiGroupMarkers({
               onPointerDown={(e) => {
                 e.stopPropagation();
                 (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-                drag.current = { id: gid, lastX: e.clientX, lastY: e.clientY, moved: false };
+                drag.current = {
+                  id: gid,
+                  lastX: e.clientX,
+                  lastY: e.clientY,
+                  moved: false,
+                };
               }}
               onPointerMove={(e) => {
                 const d = drag.current;
@@ -75,7 +89,11 @@ export function AiGroupMarkers({
                 }
               }}
             >
-              {generating ? <Loader2 size={12} className="animate-spin" /> : <Sparkles size={12} />}
+              {generating ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Sparkles size={12} />
+              )}
             </div>
           </div>
         );

--- a/src/features/canvas/components/ai-input-float.tsx
+++ b/src/features/canvas/components/ai-input-float.tsx
@@ -44,7 +44,14 @@ export function AiInputFloat({
     const prompt = text.trim();
     if (!prompt || !provider || !model) return;
     const groupId = createAiGroup(flow, provider, model);
-    void generate({ groupId, anchor: flow, prompt, provider, model, projectPath });
+    void generate({
+      groupId,
+      anchor: flow,
+      prompt,
+      provider,
+      model,
+      projectPath,
+    });
     onClose();
   };
 

--- a/src/features/canvas/components/ai-thread-panel.tsx
+++ b/src/features/canvas/components/ai-thread-panel.tsx
@@ -62,19 +62,33 @@ export function AiThreadPanel({
     const prompt = text.trim();
     if (!prompt || !provider || !model || generating) return;
     setText("");
-    void generate({ groupId, anchor: group.anchor, prompt, provider, model, projectPath });
+    void generate({
+      groupId,
+      anchor: group.anchor,
+      prompt,
+      provider,
+      model,
+      projectPath,
+    });
   };
 
   return (
     <div
       className="fixed z-[9999] flex flex-col rounded-xl border border-border-default bg-[var(--bg-elevated)]/90 backdrop-blur-2xl shadow-[var(--shadow-overlay)]"
-      style={{ left: Math.max(12, left), top: Math.max(12, top), width: PANEL_W, maxHeight: 420 }}
+      style={{
+        left: Math.max(12, left),
+        top: Math.max(12, top),
+        width: PANEL_W,
+        maxHeight: 420,
+      }}
       onPointerDown={(e) => e.stopPropagation()}
     >
       {/* Header */}
       <div className="flex items-center gap-1.5 border-b border-white/10 px-3 h-[34px] shrink-0">
         <Sparkles size={12} className="text-[var(--accent-primary)]" />
-        <span className="flex-1 text-[11px] font-semibold text-text-primary">AI diagram</span>
+        <span className="flex-1 text-[11px] font-semibold text-text-primary">
+          AI diagram
+        </span>
         <button
           type="button"
           title="Delete diagram"
@@ -97,12 +111,23 @@ export function AiThreadPanel({
       </div>
 
       {/* Messages */}
-      <div ref={listRef} className="flex-1 min-h-0 overflow-y-auto hide-scrollbar px-3 py-2 space-y-2">
+      <div
+        ref={listRef}
+        className="flex-1 min-h-0 overflow-y-auto hide-scrollbar px-3 py-2 space-y-2"
+      >
         {group.messages.length === 0 && (
-          <div className="text-[11px] text-text-tertiary italic">No messages yet.</div>
+          <div className="text-[11px] text-text-tertiary italic">
+            No messages yet.
+          </div>
         )}
         {group.messages.map((m, i) => (
-          <div key={i} className={cn("text-[11px] leading-relaxed", m.role === "user" ? "text-text-primary" : "text-text-secondary")}>
+          <div
+            key={i}
+            className={cn(
+              "text-[11px] leading-relaxed",
+              m.role === "user" ? "text-text-primary" : "text-text-secondary",
+            )}
+          >
             <span className="text-[9px] uppercase tracking-wide text-text-tertiary mr-1.5">
               {m.role === "user" ? "You" : "AI"}
             </span>
@@ -110,7 +135,9 @@ export function AiThreadPanel({
           </div>
         ))}
         {generating && (
-          <div className="text-[11px] text-text-tertiary italic">Generating…</div>
+          <div className="text-[11px] text-text-tertiary italic">
+            Generating…
+          </div>
         )}
       </div>
 

--- a/src/features/canvas/components/canvas-export-toolbar.tsx
+++ b/src/features/canvas/components/canvas-export-toolbar.tsx
@@ -1,6 +1,12 @@
 import { useState } from "react";
 import { useReactFlow } from "@xyflow/react";
-import { Download, Loader2, FileImage, FileType2, FileText } from "lucide-react";
+import {
+  Download,
+  Loader2,
+  FileImage,
+  FileType2,
+  FileText,
+} from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useCanvasStore } from "../stores/canvas-store";
@@ -34,9 +40,12 @@ export function CanvasExportToolbar() {
     try {
       const res = await exportCanvas(format, rf);
       if (res === "ok") toast.success(`Exported ${format.toUpperCase()}`);
-      else if (res === "empty") toast("Nothing to export — the canvas is empty.");
+      else if (res === "empty")
+        toast("Nothing to export — the canvas is empty.");
     } catch (e) {
-      toast.error(`Export failed: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Export failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
     } finally {
       setBusy(null);
     }
@@ -54,13 +63,21 @@ export function CanvasExportToolbar() {
           "text-[11px] font-medium text-text-secondary hover:text-text-primary transition-colors cursor-pointer disabled:opacity-60",
         )}
       >
-        {busy ? <Loader2 size={13} className="animate-spin" /> : <Download size={13} />}
+        {busy ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <Download size={13} />
+        )}
         Export
       </button>
 
       {open && !busy && (
         <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} aria-hidden />
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
           <div className="absolute right-0 top-full z-50 mt-1 w-[140px] overflow-hidden rounded-lg border border-border-default bg-[var(--bg-elevated)] py-1 shadow-[var(--shadow-overlay)]">
             {FORMATS.map((f) => (
               <button

--- a/src/features/canvas/components/canvas-panel.tsx
+++ b/src/features/canvas/components/canvas-panel.tsx
@@ -16,7 +16,12 @@ import "@xyflow/react/dist/style.css";
 import * as Dialog from "@radix-ui/react-dialog";
 import { StickyNote } from "lucide-react";
 import { useProjectStore } from "@/features/project/stores/project-store";
-import { useCanvasStore, groupBounds, type CanvasNode, type ShapeType } from "../stores/canvas-store";
+import {
+  useCanvasStore,
+  groupBounds,
+  type CanvasNode,
+  type ShapeType,
+} from "../stores/canvas-store";
 import { canvasMediaUpload } from "../lib/canvas-api";
 import { NoteNode } from "./note-node";
 import { TextNode } from "./text-node";
@@ -49,7 +54,10 @@ export function CanvasPanel() {
   // never have two ReactFlow instances competing for state at once.
   const surface = (
     <ReactFlowProvider>
-      <CanvasSurface fullscreen={fullscreen} onToggleFullscreen={() => setFullscreen(!fullscreen)} />
+      <CanvasSurface
+        fullscreen={fullscreen}
+        onToggleFullscreen={() => setFullscreen(!fullscreen)}
+      />
     </ReactFlowProvider>
   );
 
@@ -128,8 +136,14 @@ function CanvasSurface({
   // double-click; text edits inline; media has no editor.
   const [editingId, setEditingId] = useState<string | null>(null);
   // AI: floating composer position (after an "Ask AI" click) + open thread.
-  const [aiInput, setAiInput] = useState<{ screen: { x: number; y: number }; flow: { x: number; y: number } } | null>(null);
-  const [threadFor, setThreadFor] = useState<{ groupId: string; at: { x: number; y: number } } | null>(null);
+  const [aiInput, setAiInput] = useState<{
+    screen: { x: number; y: number };
+    flow: { x: number; y: number };
+  } | null>(null);
+  const [threadFor, setThreadFor] = useState<{
+    groupId: string;
+    at: { x: number; y: number };
+  } | null>(null);
   const [pagesOpen, setPagesOpen] = useState<boolean>(() => {
     try {
       return localStorage.getItem("atlas:canvas:pagesOpen") === "1";
@@ -172,7 +186,10 @@ function CanvasSurface({
     consumePendingAiThread();
     if (!group) return;
     try {
-      rf.setCenter(group.anchor.x, group.anchor.y, { zoom: 0.9, duration: 400 });
+      rf.setCenter(group.anchor.x, group.anchor.y, {
+        zoom: 0.9,
+        duration: 400,
+      });
     } catch {
       /* view not ready yet — the thread still opens below */
     }
@@ -194,10 +211,17 @@ function CanvasSurface({
         position: { x: n.x, y: n.y },
         selected: selectedSet.has(n.id),
         // Shapes are resizable, so React Flow owns their box dimensions.
-        ...(n.kind === "shape" ? { width: n.width ?? 160, height: n.height ?? 90 } : {}),
+        ...(n.kind === "shape"
+          ? { width: n.width ?? 160, height: n.height ?? 90 }
+          : {}),
         data:
           n.kind === "note"
-            ? { title: n.title, body: n.body, updatedAt: n.updatedAt, icon: n.icon }
+            ? {
+                title: n.title,
+                body: n.body,
+                updatedAt: n.updatedAt,
+                icon: n.icon,
+              }
             : n.kind === "text"
               ? { text: n.text ?? "" }
               : n.kind === "shape"
@@ -209,7 +233,7 @@ function CanvasSurface({
                   },
         draggable: true,
       })),
-    [nodes, selectedSet, projectPath]
+    [nodes, selectedSet, projectPath],
   );
   const rfEdges = useMemo<Edge[]>(
     () =>
@@ -222,7 +246,7 @@ function CanvasSurface({
         type: "smoothstep",
         style: { stroke: "rgba(255,255,255,0.25)", strokeWidth: 1.5 },
       })),
-    [edges]
+    [edges],
   );
 
   // Subtle dashed frame per AI group, as a NON-interactive background node placed
@@ -250,9 +274,12 @@ function CanvasSurface({
           },
         ];
       }),
-    [aiGroups, nodes]
+    [aiGroups, nodes],
   );
-  const allNodes = useMemo(() => [...frameNodes, ...rfNodes], [frameNodes, rfNodes]);
+  const allNodes = useMemo(
+    () => [...frameNodes, ...rfNodes],
+    [frameNodes, rfNodes],
+  );
 
   // Apply position/remove/selection changes back to the store. Selection is
   // multi (marquee): fold every select change into the current set.
@@ -273,7 +300,7 @@ function CanvasSurface({
       }
       if (selChanged) setSelectedIds([...sel]);
     },
-    [moveNote, deleteNote, setSelectedIds]
+    [moveNote, deleteNote, setSelectedIds],
   );
 
   const onEdgesChange = useCallback(
@@ -282,14 +309,15 @@ function CanvasSurface({
         if (c.type === "remove") deleteEdge(c.id);
       }
     },
-    [deleteEdge]
+    [deleteEdge],
   );
 
   const onConnect = useCallback(
     (c: Connection) => {
-      if (c.source && c.target) addEdge(c.source, c.target, c.sourceHandle, c.targetHandle);
+      if (c.source && c.target)
+        addEdge(c.source, c.target, c.sourceHandle, c.targetHandle);
     },
-    [addEdge]
+    [addEdge],
   );
 
   const viewportCenter = useCallback(
@@ -303,7 +331,7 @@ function CanvasSurface({
       });
       return { x: c.x + dx, y: c.y + dy };
     },
-    [rf]
+    [rf],
   );
 
   // Empty-canvas click just clears selection. Create-tools are handled by the
@@ -313,10 +341,18 @@ function CanvasSurface({
   // ── Drag-to-create (Excalidraw-style) ──────────────────────────────────────
   // While a create-tool is armed, an overlay captures pointer drags: press+drag
   // sizes the shape (Shift = 1:1 square), a plain click drops a default size.
-  const [preview, setPreview] = useState<{ left: number; top: number; w: number; h: number } | null>(
-    null
-  );
-  const dragStart = useRef<{ sx: number; sy: number; fx: number; fy: number } | null>(null);
+  const [preview, setPreview] = useState<{
+    left: number;
+    top: number;
+    w: number;
+    h: number;
+  } | null>(null);
+  const dragStart = useRef<{
+    sx: number;
+    sy: number;
+    fx: number;
+    fy: number;
+  } | null>(null);
 
   const overlayDown = useCallback(
     (e: React.PointerEvent) => {
@@ -324,11 +360,16 @@ function CanvasSurface({
       if (!wrap) return;
       const r = wrap.getBoundingClientRect();
       const flow = rf.screenToFlowPosition({ x: e.clientX, y: e.clientY });
-      dragStart.current = { sx: e.clientX - r.left, sy: e.clientY - r.top, fx: flow.x, fy: flow.y };
+      dragStart.current = {
+        sx: e.clientX - r.left,
+        sy: e.clientY - r.top,
+        fx: flow.x,
+        fy: flow.y,
+      };
       (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
       setPreview(null);
     },
-    [rf]
+    [rf],
   );
 
   const overlayMove = useCallback((e: React.PointerEvent) => {
@@ -373,7 +414,10 @@ function CanvasSurface({
       const tiny = w < 8 && h < 8; // treat as a click → default size
       if (tool === "ai") {
         // Open the AI composer at the click point (screen = wrapper-relative).
-        setAiInput({ screen: { x: st.sx, y: st.sy }, flow: { x: st.fx, y: st.fy } });
+        setAiInput({
+          screen: { x: st.sx, y: st.sy },
+          flow: { x: st.fx, y: st.fy },
+        });
         setTool("select");
         return;
       }
@@ -388,7 +432,7 @@ function CanvasSurface({
       }
       setTool("select");
     },
-    [rf, addShape, addNote, addText, setTool]
+    [rf, addShape, addNote, addText, setTool],
   );
 
   // Escape disarms a create-tool (back to the default pointer/pan mode).
@@ -409,7 +453,13 @@ function CanvasSurface({
       const w = wrapperRef.current;
       if (!w || w.offsetParent === null) return;
       const ae = document.activeElement as HTMLElement | null;
-      if (ae && (ae.tagName === "INPUT" || ae.tagName === "TEXTAREA" || ae.isContentEditable)) return;
+      if (
+        ae &&
+        (ae.tagName === "INPUT" ||
+          ae.tagName === "TEXTAREA" ||
+          ae.isContentEditable)
+      )
+        return;
       const key = e.key.toLowerCase();
       if (key === "z" && !e.shiftKey) {
         e.preventDefault();
@@ -429,7 +479,10 @@ function CanvasSurface({
     const sel = await open({
       multiple: false,
       filters: [
-        { name: "Image", extensions: ["png", "jpg", "jpeg", "gif", "webp", "avif", "svg"] },
+        {
+          name: "Image",
+          extensions: ["png", "jpg", "jpeg", "gif", "webp", "avif", "svg"],
+        },
       ],
     });
     if (!sel || Array.isArray(sel)) return;
@@ -451,16 +504,18 @@ function CanvasSurface({
     (_: unknown, vp: { x: number; y: number; zoom: number }) => {
       setViewport(vp);
     },
-    [setViewport]
+    [setViewport],
   );
 
   const jumpToNode = useCallback(
     (id: string) => {
-      const n = (useCanvasStore.getState().nodes as CanvasNode[]).find((nn) => nn.id === id);
+      const n = (useCanvasStore.getState().nodes as CanvasNode[]).find(
+        (nn) => nn.id === id,
+      );
       if (!n) return;
       rf.setCenter(n.x + 160, n.y + 60, { duration: 350, zoom: rf.getZoom() });
     },
-    [rf]
+    [rf],
   );
 
   // Open the slide-in editor on a note double-click (text/media aren't notes).
@@ -474,7 +529,9 @@ function CanvasSurface({
       <div className="h-full flex flex-col items-center justify-center text-[12px] text-text-tertiary gap-2 px-6 text-center">
         <StickyNote size={18} className="opacity-60" />
         <div>No project open.</div>
-        <div className="text-[10px]">Spaces are per-project. Open a folder to start a board.</div>
+        <div className="text-[10px]">
+          Spaces are per-project. Open a folder to start a board.
+        </div>
       </div>
     );
   }
@@ -482,114 +539,124 @@ function CanvasSurface({
   return (
     <div className="flex h-full min-h-0">
       {pagesOpen && <PagesPanel />}
-      <div ref={wrapperRef} className="relative min-h-0 min-w-0 flex-1 bg-bg-base overflow-hidden">
-      {!loaded && (
-        <div className="absolute inset-0 flex items-center justify-center text-[11px] text-text-tertiary z-30">
-          Loading…
-        </div>
-      )}
-
-      <ReactFlow
-        nodes={allNodes}
-        edges={rfEdges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-        onNodeDragStart={() => beginInteraction()}
-        onNodeDoubleClick={onNodeDoubleClick}
-        onPaneClick={onPaneClick}
-        onMoveEnd={onMoveEnd}
-        nodeTypes={nodeTypes}
-        connectionMode={ConnectionMode.Loose}
-        connectionRadius={40}
-        minZoom={0.2}
-        maxZoom={2}
-        fitView={false}
-        defaultViewport={useCanvasStore.getState().viewport}
-        deleteKeyCode={["Backspace", "Delete"]}
-        proOptions={{ hideAttribution: true }}
-        // Drag empty canvas to pan (hold Space also pans); click selects a node;
-        // Shift-click multi-selects. No marquee tool (it fought Space-to-pan).
-        panOnScroll
+      <div
+        ref={wrapperRef}
+        className="relative min-h-0 min-w-0 flex-1 bg-bg-base overflow-hidden"
       >
-        <Background
-          variant={BackgroundVariant.Dots}
-          gap={20}
-          size={1.2}
-          color="rgba(255,255,255,0.18)"
-        />
-      </ReactFlow>
+        {!loaded && (
+          <div className="absolute inset-0 flex items-center justify-center text-[11px] text-text-tertiary z-30">
+            Loading…
+          </div>
+        )}
 
-      {/* Drag-to-create overlay — only mounted while a create-tool is armed. */}
-      {armed && (
-        <div
-          className="absolute inset-0 z-10 cursor-crosshair"
-          onPointerDown={overlayDown}
-          onPointerMove={overlayMove}
-          onPointerUp={overlayUp}
+        <ReactFlow
+          nodes={allNodes}
+          edges={rfEdges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onNodeDragStart={() => beginInteraction()}
+          onNodeDoubleClick={onNodeDoubleClick}
+          onPaneClick={onPaneClick}
+          onMoveEnd={onMoveEnd}
+          nodeTypes={nodeTypes}
+          connectionMode={ConnectionMode.Loose}
+          connectionRadius={40}
+          minZoom={0.2}
+          maxZoom={2}
+          fitView={false}
+          defaultViewport={useCanvasStore.getState().viewport}
+          deleteKeyCode={["Backspace", "Delete"]}
+          proOptions={{ hideAttribution: true }}
+          // Drag empty canvas to pan (hold Space also pans); click selects a node;
+          // Shift-click multi-selects. No marquee tool (it fought Space-to-pan).
+          panOnScroll
         >
-          {preview && (
-            <div
-              className="absolute rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)]/10 pointer-events-none"
-              style={{ left: preview.left, top: preview.top, width: preview.w, height: preview.h }}
-            />
-          )}
-        </div>
-      )}
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={20}
+            size={1.2}
+            color="rgba(255,255,255,0.18)"
+          />
+        </ReactFlow>
 
-      {/* Floating overlays (Miro-style) */}
-      <CanvasHeader
-        pageName={pageName}
-        pageIcon={pageIcon}
-        pagesOpen={pagesOpen}
-        onTogglePages={togglePages}
-        fullscreen={fullscreen}
-        onFit={handleFit}
-        onToggleFullscreen={onToggleFullscreen}
-      />
-      <CanvasExportToolbar />
-      <CanvasToolbar
-        activeTool={activeTool}
-        onTool={setTool}
-        onInsertMedia={handleInsertMedia}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        onUndo={undo}
-        onRedo={redo}
-      />
+        {/* Drag-to-create overlay — only mounted while a create-tool is armed. */}
+        {armed && (
+          <div
+            className="absolute inset-0 z-10 cursor-crosshair"
+            onPointerDown={overlayDown}
+            onPointerMove={overlayMove}
+            onPointerUp={overlayUp}
+          >
+            {preview && (
+              <div
+                className="absolute rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)]/10 pointer-events-none"
+                style={{
+                  left: preview.left,
+                  top: preview.top,
+                  width: preview.w,
+                  height: preview.h,
+                }}
+              />
+            )}
+          </div>
+        )}
 
-      {editingId && (
-        <NoteEditorPanel
-          key={editingId}
-          noteId={editingId}
-          projectPath={projectPath}
-          onClose={() => setEditingId(null)}
-          onJumpToNode={(id) => {
-            setEditingId(id);
-            jumpToNode(id);
-          }}
+        {/* Floating overlays (Miro-style) */}
+        <CanvasHeader
+          pageName={pageName}
+          pageIcon={pageIcon}
+          pagesOpen={pagesOpen}
+          onTogglePages={togglePages}
+          fullscreen={fullscreen}
+          onFit={handleFit}
+          onToggleFullscreen={onToggleFullscreen}
         />
-      )}
+        <CanvasExportToolbar />
+        <CanvasToolbar
+          activeTool={activeTool}
+          onTool={setTool}
+          onInsertMedia={handleInsertMedia}
+          canUndo={canUndo}
+          canRedo={canRedo}
+          onUndo={undo}
+          onRedo={redo}
+        />
 
-      {/* AI copilot: ✨ group pins, floating composer, and thread popover. */}
-      <AiGroupMarkers onOpenThread={(groupId, at) => setThreadFor({ groupId, at })} />
-      {aiInput && (
-        <AiInputFloat
-          screen={aiInput.screen}
-          flow={aiInput.flow}
-          projectPath={projectPath}
-          onClose={() => setAiInput(null)}
+        {editingId && (
+          <NoteEditorPanel
+            key={editingId}
+            noteId={editingId}
+            projectPath={projectPath}
+            onClose={() => setEditingId(null)}
+            onJumpToNode={(id) => {
+              setEditingId(id);
+              jumpToNode(id);
+            }}
+          />
+        )}
+
+        {/* AI copilot: ✨ group pins, floating composer, and thread popover. */}
+        <AiGroupMarkers
+          onOpenThread={(groupId, at) => setThreadFor({ groupId, at })}
         />
-      )}
-      {threadFor && (
-        <AiThreadPanel
-          key={threadFor.groupId}
-          groupId={threadFor.groupId}
-          at={threadFor.at}
-          projectPath={projectPath}
-          onClose={() => setThreadFor(null)}
-        />
-      )}
+        {aiInput && (
+          <AiInputFloat
+            screen={aiInput.screen}
+            flow={aiInput.flow}
+            projectPath={projectPath}
+            onClose={() => setAiInput(null)}
+          />
+        )}
+        {threadFor && (
+          <AiThreadPanel
+            key={threadFor.groupId}
+            groupId={threadFor.groupId}
+            at={threadFor.at}
+            projectPath={projectPath}
+            onClose={() => setThreadFor(null)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/features/canvas/components/canvas-toolbar.tsx
+++ b/src/features/canvas/components/canvas-toolbar.tsx
@@ -23,7 +23,11 @@ interface ToolDef {
 // pan, click selects) is always active; create-tools auto-revert to it. Connect
 // nodes by dragging between their edge handles (no tool needed).
 const TOOLS: ToolDef[] = [
-  { tool: "ai", icon: Sparkles, label: "Ask AI — click the canvas to generate a diagram" },
+  {
+    tool: "ai",
+    icon: Sparkles,
+    label: "Ask AI — click the canvas to generate a diagram",
+  },
   { tool: "note", icon: StickyNote, label: "Note" },
   { tool: "text", icon: Type, label: "Text" },
 ];
@@ -31,7 +35,11 @@ const TOOLS: ToolDef[] = [
 /** Flowchart shapes — each drops that geometry on the next canvas click. */
 const SHAPES: ToolDef[] = [
   { tool: "shape:rectangle", icon: Square, label: "Rectangle" },
-  { tool: "shape:rounded", icon: RectangleHorizontal, label: "Rounded rectangle" },
+  {
+    tool: "shape:rounded",
+    icon: RectangleHorizontal,
+    label: "Rounded rectangle",
+  },
   { tool: "shape:ellipse", icon: Circle, label: "Ellipse / circle" },
   { tool: "shape:diamond", icon: Diamond, label: "Diamond" },
 ];
@@ -66,13 +74,23 @@ export function CanvasToolbar({
       )}
     >
       {TOOLS.map((t) => (
-        <ToolButton key={t.tool} def={t} active={activeTool === t.tool} onClick={() => onTool(t.tool)} />
+        <ToolButton
+          key={t.tool}
+          def={t}
+          active={activeTool === t.tool}
+          onClick={() => onTool(t.tool)}
+        />
       ))}
 
       <div className="my-0.5 h-px w-5 bg-white/10" />
 
       {SHAPES.map((t) => (
-        <ToolButton key={t.tool} def={t} active={activeTool === t.tool} onClick={() => onTool(t.tool)} />
+        <ToolButton
+          key={t.tool}
+          def={t}
+          active={activeTool === t.tool}
+          onClick={() => onTool(t.tool)}
+        />
       ))}
 
       <div className="my-0.5 h-px w-5 bg-white/10" />

--- a/src/features/canvas/components/group-frame-node.tsx
+++ b/src/features/canvas/components/group-frame-node.tsx
@@ -4,5 +4,7 @@ import { memo } from "react";
  *  non-interactive React Flow node placed FIRST in the node array (and thus
  *  painted below every real node), so nodes always sit above the border. */
 export const GroupFrameNode = memo(function GroupFrameNode() {
-  return <div className="h-full w-full rounded-lg border border-dashed border-white/30" />;
+  return (
+    <div className="h-full w-full rounded-lg border border-dashed border-white/30" />
+  );
 });

--- a/src/features/canvas/components/media-node.tsx
+++ b/src/features/canvas/components/media-node.tsx
@@ -13,7 +13,10 @@ export interface MediaNodeData extends Record<string, unknown> {
 /** Image node. (Video was dropped — it made the canvas very slow.) Media lives
  *  under `.atlas/canvas-media/`, which the asset protocol 403s, so we fetch a
  *  base64 data URL via `canvas_media_data_url`. */
-export const MediaNode = memo(function MediaNode({ data, selected }: NodeProps) {
+export const MediaNode = memo(function MediaNode({
+  data,
+  selected,
+}: NodeProps) {
   const d = data as MediaNodeData;
   const [url, setUrl] = useState<string | null>(null);
 
@@ -38,7 +41,9 @@ export const MediaNode = memo(function MediaNode({ data, selected }: NodeProps) 
       <div
         className={cn(
           "rounded-xl overflow-hidden border shadow-2xl bg-[var(--bg-secondary)]/40",
-          selected ? "border-[var(--accent-primary)]/60" : "border-white/10 hover:border-white/20",
+          selected
+            ? "border-[var(--accent-primary)]/60"
+            : "border-white/10 hover:border-white/20",
         )}
       >
         {url ? (

--- a/src/features/canvas/components/note-editor-panel.tsx
+++ b/src/features/canvas/components/note-editor-panel.tsx
@@ -23,7 +23,11 @@ interface NoteEditorPanelProps {
  * emoji. Save follows the KB lesson: gate on the editor's live `isDirty()` and
  * flush on close / blur / unmount — never on a store-content baseline.
  */
-export function NoteEditorPanel({ noteId, projectPath, onClose }: NoteEditorPanelProps) {
+export function NoteEditorPanel({
+  noteId,
+  projectPath,
+  onClose,
+}: NoteEditorPanelProps) {
   const nodes = useCanvasStore.use.nodes();
   const { updateNote, deleteNote } = useCanvasStore.use.actions();
   const note = nodes.find((n) => n.id === noteId) ?? null;
@@ -97,7 +101,9 @@ export function NoteEditorPanel({ noteId, projectPath, onClose }: NoteEditorPane
           <button
             type="button"
             title="Change icon"
-            onClick={(e) => setIconAnchor(e.currentTarget.getBoundingClientRect())}
+            onClick={(e) =>
+              setIconAnchor(e.currentTarget.getBoundingClientRect())
+            }
             className="flex h-5 w-5 items-center justify-center rounded-md bg-white/10 hover:bg-white/15 transition-colors cursor-pointer shrink-0"
           >
             {note.icon ? (

--- a/src/features/canvas/components/note-node.tsx
+++ b/src/features/canvas/components/note-node.tsx
@@ -27,7 +27,7 @@ export const NoteNode = memo(function NoteNode({ data, selected }: NodeProps) {
         "border shadow-2xl transition-colors",
         selected
           ? "border-[var(--accent-primary)]/60"
-          : "border-white/10 hover:border-white/20"
+          : "border-white/10 hover:border-white/20",
       )}
     >
       {/* Inner glow */}

--- a/src/features/canvas/components/pages-panel.tsx
+++ b/src/features/canvas/components/pages-panel.tsx
@@ -15,18 +15,27 @@ export const DEFAULT_PAGE_ICON = "📜";
 export function PagesPanel({ width = 240 }: { width?: number }) {
   const tree = useCanvasStore.use.tree();
   const activePageId = useCanvasStore.use.activePageId();
-  const { createPage, setActivePage, renameTreeEntry, setTreeEntryIcon, deleteTreeEntry } =
-    useCanvasStore.use.actions();
+  const {
+    createPage,
+    setActivePage,
+    renameTreeEntry,
+    setTreeEntryIcon,
+    deleteTreeEntry,
+  } = useCanvasStore.use.actions();
 
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [iconFor, setIconFor] = useState<{ id: string; rect: DOMRect } | null>(null);
+  const [iconFor, setIconFor] = useState<{ id: string; rect: DOMRect } | null>(
+    null,
+  );
 
   const pages = tree
     .filter((e) => e.kind === "page")
     .slice()
     .sort((a, b) => a.order - b.order);
 
-  const iconEntry = iconFor ? tree.find((e) => e.id === iconFor.id) ?? null : null;
+  const iconEntry = iconFor
+    ? (tree.find((e) => e.id === iconFor.id) ?? null)
+    : null;
 
   const renderEntry = (entry: PageTreeEntry): React.ReactNode => {
     const active = entry.id === activePageId;
@@ -35,7 +44,9 @@ export function PagesPanel({ width = 240 }: { width?: number }) {
         key={entry.id}
         className={cn(
           "group/row flex h-[26px] items-center gap-1.5 rounded px-1.5 text-[11px] cursor-pointer",
-          active ? "bg-bg-selected text-text-primary" : "text-text-secondary hover:bg-bg-hover",
+          active
+            ? "bg-bg-selected text-text-primary"
+            : "text-text-secondary hover:bg-bg-hover",
         )}
         onClick={() => setActivePage(entry.id)}
       >
@@ -45,11 +56,16 @@ export function PagesPanel({ width = 240 }: { width?: number }) {
           title="Change icon"
           onClick={(e) => {
             e.stopPropagation();
-            setIconFor({ id: entry.id, rect: e.currentTarget.getBoundingClientRect() });
+            setIconFor({
+              id: entry.id,
+              rect: e.currentTarget.getBoundingClientRect(),
+            });
           }}
           className="flex h-4 w-4 shrink-0 items-center justify-center rounded hover:bg-white/10"
         >
-          <span className="text-[11px] leading-none">{entry.icon || DEFAULT_PAGE_ICON}</span>
+          <span className="text-[11px] leading-none">
+            {entry.icon || DEFAULT_PAGE_ICON}
+          </span>
         </button>
 
         {/* Name / inline rename */}
@@ -64,7 +80,8 @@ export function PagesPanel({ width = 240 }: { width?: number }) {
               setEditingId(null);
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter") (e.currentTarget as HTMLInputElement).blur();
+              if (e.key === "Enter")
+                (e.currentTarget as HTMLInputElement).blur();
               else if (e.key === "Escape") setEditingId(null);
             }}
             className="min-w-0 flex-1 rounded bg-bg-input px-1 text-[11px] text-text-primary outline-none"

--- a/src/features/canvas/components/shape-node.tsx
+++ b/src/features/canvas/components/shape-node.tsx
@@ -32,7 +32,14 @@ function ShapeSvg({ type, stroke }: { type: ShapeType; stroke: string }) {
       ) : type === "diamond" ? (
         <polygon points="50,1 99,50 50,99 1,50" {...common} />
       ) : (
-        <rect x={1} y={1} width={98} height={98} rx={type === "rounded" ? 14 : 0} {...common} />
+        <rect
+          x={1}
+          y={1}
+          width={98}
+          height={98}
+          rx={type === "rounded" ? 14 : 0}
+          {...common}
+        />
       )}
     </svg>
   );
@@ -40,9 +47,14 @@ function ShapeSvg({ type, stroke }: { type: ShapeType; stroke: string }) {
 
 /** Geometric flowchart shape. Connectable from any side (shared handles); the
  *  only editable content is a centered text label (double-click to edit). */
-export const ShapeNode = memo(function ShapeNode({ id, data, selected }: NodeProps) {
+export const ShapeNode = memo(function ShapeNode({
+  id,
+  data,
+  selected,
+}: NodeProps) {
   const d = data as ShapeNodeData;
-  const { updateNote, moveNote, beginInteraction } = useCanvasStore.use.actions();
+  const { updateNote, moveNote, beginInteraction } =
+    useCanvasStore.use.actions();
   const ref = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
 
@@ -71,7 +83,10 @@ export const ShapeNode = memo(function ShapeNode({ id, data, selected }: NodePro
   return (
     // React Flow owns the box size (so NodeResizer can drive it); the shape fills
     // it. Size is persisted to the store via onResize.
-    <div className="group relative h-full w-full" onDoubleClick={() => setEditing(true)}>
+    <div
+      className="group relative h-full w-full"
+      onDoubleClick={() => setEditing(true)}
+    >
       <NodeResizer
         isVisible={selected}
         minWidth={40}
@@ -96,7 +111,9 @@ export const ShapeNode = memo(function ShapeNode({ id, data, selected }: NodePro
             // An empty contentEditable has no line box, so the caret can't render;
             // a min line-height gives it one when the shape has no text yet.
             "min-h-[1.25em] min-w-[2px]",
-            editing ? "nodrag cursor-text select-text" : "cursor-default select-none",
+            editing
+              ? "nodrag cursor-text select-text"
+              : "cursor-default select-none",
           )}
           contentEditable={editing}
           suppressContentEditableWarning

--- a/src/features/canvas/components/text-node.tsx
+++ b/src/features/canvas/components/text-node.tsx
@@ -11,7 +11,11 @@ export interface TextNodeData extends Record<string, unknown> {
 /** Chrome-less free text. Single-click selects / drag moves; double-click edits
  *  inline (contentEditable + `nodrag` so editing doesn't drag the node), commit
  *  on blur. Not editable while idle, so the node stays draggable. */
-export const TextNode = memo(function TextNode({ id, data, selected }: NodeProps) {
+export const TextNode = memo(function TextNode({
+  id,
+  data,
+  selected,
+}: NodeProps) {
   const d = data as TextNodeData;
   const { updateNote } = useCanvasStore.use.actions();
   const ref = useRef<HTMLDivElement>(null);
@@ -51,7 +55,9 @@ export const TextNode = memo(function TextNode({ id, data, selected }: NodeProps
         className={cn(
           "whitespace-pre-wrap break-words min-w-[40px] min-h-[1.25em] px-1 py-0.5 outline-none",
           "text-[15px] leading-snug text-[var(--text-primary)] caret-[var(--accent-primary)]",
-          editing ? "nodrag cursor-text select-text" : "cursor-default select-none",
+          editing
+            ? "nodrag cursor-text select-text"
+            : "cursor-default select-none",
         )}
         contentEditable={editing}
         suppressContentEditableWarning

--- a/src/features/canvas/lib/canvas-ai.ts
+++ b/src/features/canvas/lib/canvas-ai.ts
@@ -3,7 +3,12 @@
 // with any BYOK text model); the model only ever emits ops, never prose that we
 // render. Mirrors the diagram-DSL approach: tempIds + relative coords.
 
-import type { AiOp, CanvasEdge, CanvasNode, ShapeType } from "../stores/canvas-store";
+import type {
+  AiOp,
+  CanvasEdge,
+  CanvasNode,
+  ShapeType,
+} from "../stores/canvas-store";
 
 /** System prompt handed to the BYOK model on every generate/modify turn. */
 export const CANVAS_AI_SYSTEM = `You are Atlas's diagramming copilot for an infinite canvas. You turn a request into a diagram/flowchart/notes by emitting a STRICT JSON program of operations — never prose.
@@ -39,12 +44,17 @@ export function parseOps(reply: string): AiOp[] {
   // Last resort: the widest {...} span.
   const first = reply.indexOf("{");
   const last = reply.lastIndexOf("}");
-  if (first !== -1 && last > first) candidates.push(reply.slice(first, last + 1));
+  if (first !== -1 && last > first)
+    candidates.push(reply.slice(first, last + 1));
 
   for (const c of candidates) {
     try {
       const obj = JSON.parse(c) as { ops?: unknown };
-      const ops = Array.isArray(obj?.ops) ? obj.ops : Array.isArray(obj) ? obj : null;
+      const ops = Array.isArray(obj?.ops)
+        ? obj.ops
+        : Array.isArray(obj)
+          ? obj
+          : null;
       if (ops) return sanitize(ops as unknown[]);
     } catch {
       /* try next candidate */
@@ -63,7 +73,8 @@ function sanitize(raw: unknown[]): AiOp[] {
     const o = r as Record<string, unknown>;
     switch (o.op) {
       case "add_node": {
-        if (typeof o.tempId !== "string" || !NODE_KINDS.has(o.kind as string)) break;
+        if (typeof o.tempId !== "string" || !NODE_KINDS.has(o.kind as string))
+          break;
         const shapeType = SHAPES.has(o.shapeType as string)
           ? (o.shapeType as ShapeType)
           : undefined;
@@ -95,7 +106,9 @@ function sanitize(raw: unknown[]): AiOp[] {
             text: str(o.text),
             title: str(o.title),
             body: str(o.body),
-            shapeType: SHAPES.has(o.shapeType as string) ? (o.shapeType as ShapeType) : undefined,
+            shapeType: SHAPES.has(o.shapeType as string)
+              ? (o.shapeType as ShapeType)
+              : undefined,
           });
         break;
       case "delete_node":
@@ -117,10 +130,16 @@ function num(v: unknown): number | undefined {
 }
 
 /** Current members of a group, compacted for a "modify this diagram" prompt. */
-export function serializeGroup(nodes: CanvasNode[], edges: CanvasEdge[], groupId: string): string {
+export function serializeGroup(
+  nodes: CanvasNode[],
+  edges: CanvasEdge[],
+  groupId: string,
+): string {
   const members = nodes.filter((n) => n.groupId === groupId);
   const ids = new Set(members.map((n) => n.id));
-  const es = edges.filter((e) => e.groupId === groupId || (ids.has(e.source) && ids.has(e.target)));
+  const es = edges.filter(
+    (e) => e.groupId === groupId || (ids.has(e.source) && ids.has(e.target)),
+  );
   const shape = {
     nodes: members.map((n) => ({
       id: n.id,

--- a/src/features/canvas/lib/canvas-api.ts
+++ b/src/features/canvas/lib/canvas-api.ts
@@ -4,23 +4,35 @@ export function loadCanvas(projectPath: string): Promise<string> {
   return invoke<string>("load_canvas", { projectPath });
 }
 
-export function saveCanvas(projectPath: string, payload: string): Promise<void> {
+export function saveCanvas(
+  projectPath: string,
+  payload: string,
+): Promise<void> {
   return invoke<void>("save_canvas", { projectPath, payload });
 }
 
 /** Copy a picked image/video into `.atlas/canvas-media/`; returns its rel name. */
-export function canvasMediaUpload(projectPath: string, srcPath: string): Promise<string> {
+export function canvasMediaUpload(
+  projectPath: string,
+  srcPath: string,
+): Promise<string> {
   return invoke<string>("canvas_media_upload", { projectPath, srcPath });
 }
 
 /** Resolve a canvas media rel name to a base64 data URL (asset protocol 403s .atlas). */
-export function canvasMediaDataUrl(projectPath: string, src: string): Promise<string> {
+export function canvasMediaDataUrl(
+  projectPath: string,
+  src: string,
+): Promise<string> {
   return invoke<string>("canvas_media_data_url", { projectPath, src });
 }
 
 /** Compact codebase-structure summary (top files by dependency rank) for the AI
  *  copilot's architecture prompts. Empty string if the codebase index isn't built. */
-export function canvasCodebaseContext(projectPath: string, maxFiles?: number): Promise<string> {
+export function canvasCodebaseContext(
+  projectPath: string,
+  maxFiles?: number,
+): Promise<string> {
   return invoke<string>("canvas_codebase_context", { projectPath, maxFiles });
 }
 

--- a/src/features/canvas/lib/canvas-export.ts
+++ b/src/features/canvas/lib/canvas-export.ts
@@ -14,12 +14,19 @@ import {
 export type ExportFormat = "png" | "jpeg" | "svg" | "pdf";
 export type ExportResult = "ok" | "empty" | "cancelled";
 
-const EXT: Record<ExportFormat, string> = { png: "png", jpeg: "jpg", svg: "svg", pdf: "pdf" };
+const EXT: Record<ExportFormat, string> = {
+  png: "png",
+  jpeg: "jpg",
+  svg: "svg",
+  pdf: "pdf",
+};
 const MAX_DIM = 4096; // cap the longest side (px) to keep files/memory sane
 
 /** Canvas background (matches the app) — used for formats without alpha. */
 function canvasBg(): string {
-  const v = getComputedStyle(document.documentElement).getPropertyValue("--bg-base").trim();
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue("--bg-base")
+    .trim();
   return v || "#0a0a0a";
 }
 
@@ -33,10 +40,16 @@ function base64FromDataUrl(dataUrl: string): string {
 function filterChrome(el: HTMLElement): boolean {
   const cl = el.classList;
   if (!cl) return true;
-  return !cl.contains("react-flow__handle") && !cl.contains("react-flow__resize-control");
+  return (
+    !cl.contains("react-flow__handle") &&
+    !cl.contains("react-flow__resize-control")
+  );
 }
 
-export async function exportCanvas(format: ExportFormat, rf: ReactFlowInstance): Promise<ExportResult> {
+export async function exportCanvas(
+  format: ExportFormat,
+  rf: ReactFlowInstance,
+): Promise<ExportResult> {
   const nodes = rf.getNodes();
   if (nodes.length === 0) return "empty";
   // Load the heavy export libs (jspdf ~390KB + html-to-image) ONLY when an
@@ -45,7 +58,9 @@ export async function exportCanvas(format: ExportFormat, rf: ReactFlowInstance):
     import("html-to-image"),
     import("jspdf"),
   ]);
-  const viewportEl = document.querySelector<HTMLElement>(".react-flow__viewport");
+  const viewportEl = document.querySelector<HTMLElement>(
+    ".react-flow__viewport",
+  );
   if (!viewportEl) return "empty";
 
   const bounds = getNodesBounds(nodes);
@@ -88,15 +103,25 @@ export async function exportCanvas(format: ExportFormat, rf: ReactFlowInstance):
 
   if (format === "png") {
     const dataUrl = await toPng(viewportEl, baseOpts);
-    await invoke("write_file_base64", { path, contents: base64FromDataUrl(dataUrl) });
+    await invoke("write_file_base64", {
+      path,
+      contents: base64FromDataUrl(dataUrl),
+    });
     return "ok";
   }
 
   // JPEG + PDF both need an opaque background (no alpha).
   const png = await toPng(viewportEl, { ...baseOpts, backgroundColor: bg });
   if (format === "jpeg") {
-    const dataUrl = await toJpeg(viewportEl, { ...baseOpts, backgroundColor: bg, quality: 0.95 });
-    await invoke("write_file_base64", { path, contents: base64FromDataUrl(dataUrl) });
+    const dataUrl = await toJpeg(viewportEl, {
+      ...baseOpts,
+      backgroundColor: bg,
+      quality: 0.95,
+    });
+    await invoke("write_file_base64", {
+      path,
+      contents: base64FromDataUrl(dataUrl),
+    });
     return "ok";
   }
 

--- a/src/features/canvas/stores/canvas-ai-store.ts
+++ b/src/features/canvas/stores/canvas-ai-store.ts
@@ -6,7 +6,11 @@
 import { create } from "zustand";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { createSelectors } from "@/lib/create-selectors";
-import { modelchat, listenModelChat, type WireMsg } from "@/features/model-chat/lib/model-chat-api";
+import {
+  modelchat,
+  listenModelChat,
+  type WireMsg,
+} from "@/features/model-chat/lib/model-chat-api";
 import { useCanvasStore } from "./canvas-store";
 import { CANVAS_AI_SYSTEM, parseOps, serializeGroup } from "../lib/canvas-ai";
 import { canvasCodebaseContext, memoryChatRetrieve } from "../lib/canvas-api";
@@ -41,10 +45,15 @@ let active: {
 
 /** Wants codebase structure folded in (architecture/system/dependency asks). */
 function wantsCodebase(prompt: string): boolean {
-  return /\b(architecture|codebase|system|module|dependenc|repo|structure)\b/i.test(prompt);
+  return /\b(architecture|codebase|system|module|dependenc|repo|structure)\b/i.test(
+    prompt,
+  );
 }
 
-async function buildContext(projectPath: string, prompt: string): Promise<string> {
+async function buildContext(
+  projectPath: string,
+  prompt: string,
+): Promise<string> {
   const parts: string[] = [];
   try {
     const { prompt: augmented } = await memoryChatRetrieve(projectPath, prompt);
@@ -68,11 +77,22 @@ export const useCanvasAiStore = createSelectors(
     streamingGroupId: null,
     error: null,
     actions: {
-      generate: async ({ groupId, anchor, prompt, provider, model, projectPath }) => {
+      generate: async ({
+        groupId,
+        anchor,
+        prompt,
+        provider,
+        model,
+        projectPath,
+      }) => {
         if (get().streamingGroupId) return; // one generation at a time
         const canvas = useCanvasStore.getState().actions;
         const ts = Date.now();
-        canvas.appendGroupMessage(groupId, { role: "user", content: prompt, ts });
+        canvas.appendGroupMessage(groupId, {
+          role: "user",
+          content: prompt,
+          ts,
+        });
         set({ streamingGroupId: groupId, error: null });
 
         const context = await buildContext(projectPath, prompt);
@@ -100,7 +120,9 @@ export const useCanvasAiStore = createSelectors(
           if (!a) return;
           const ops = parseOps(a.text);
           if (ops.length > 0) {
-            useCanvasStore.getState().actions.applyAiOps(a.groupId, ops, a.anchor);
+            useCanvasStore
+              .getState()
+              .actions.applyAiOps(a.groupId, ops, a.anchor);
             useCanvasStore.getState().actions.appendGroupMessage(a.groupId, {
               role: "assistant",
               content: `Applied ${ops.length} change${ops.length === 1 ? "" : "s"} to the diagram.`,

--- a/src/features/canvas/stores/canvas-store.ts
+++ b/src/features/canvas/stores/canvas-store.ts
@@ -109,7 +109,14 @@ export type AiOp =
       height?: number;
       icon?: string;
     }
-  | { op: "update_node"; id: string; text?: string; title?: string; body?: string; shapeType?: ShapeType }
+  | {
+      op: "update_node";
+      id: string;
+      text?: string;
+      title?: string;
+      body?: string;
+      shapeType?: ShapeType;
+    }
   | { op: "delete_node"; id: string }
   | { op: "connect"; from: string; to: string }
   | { op: "delete_edge"; id: string };
@@ -174,7 +181,15 @@ interface CanvasState {
 type NodePatch = Partial<
   Pick<
     CanvasNode,
-    "title" | "body" | "width" | "height" | "icon" | "text" | "src" | "mediaKind" | "shapeType"
+    | "title"
+    | "body"
+    | "width"
+    | "height"
+    | "icon"
+    | "text"
+    | "src"
+    | "mediaKind"
+    | "shapeType"
   >
 >;
 
@@ -184,7 +199,12 @@ interface CanvasActions {
     addNote: (at?: { x: number; y: number }) => string;
     addText: (at?: { x: number; y: number }) => string;
     addMedia: (
-      opts: { src: string; mediaKind: MediaKind; width?: number; height?: number },
+      opts: {
+        src: string;
+        mediaKind: MediaKind;
+        width?: number;
+        height?: number;
+      },
       at?: { x: number; y: number },
     ) => string;
     addShape: (
@@ -230,12 +250,20 @@ interface CanvasActions {
     deleteTreeEntry: (id: string) => void;
     // ── AI groups ──
     /** Create an empty AI group anchored at `at`; returns its id. */
-    createAiGroup: (at: { x: number; y: number }, provider?: string, model?: string) => string;
+    createAiGroup: (
+      at: { x: number; y: number },
+      provider?: string,
+      model?: string,
+    ) => string;
     /** Append a message to a group's thread. */
     appendGroupMessage: (groupId: string, msg: AiGroupMessage) => void;
     /** Apply a batch of AI ops to a group (one undo step). New nodes are placed at
      *  `anchor` + their relative coords; missing coords get force-laid-out. */
-    applyAiOps: (groupId: string, ops: AiOp[], anchor: { x: number; y: number }) => void;
+    applyAiOps: (
+      groupId: string,
+      ops: AiOp[],
+      anchor: { x: number; y: number },
+    ) => void;
     /** Delete a group: its member nodes + edges + the thread. */
     deleteGroup: (groupId: string) => void;
     /** Translate all of a group's member nodes by (dx, dy). */
@@ -261,7 +289,13 @@ function nowIso(): string {
 const emptyViewport: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 
 function emptyPage(id: string): CanvasPage {
-  return { id, viewport: { ...emptyViewport }, nodes: [], edges: [], aiGroups: {} };
+  return {
+    id,
+    viewport: { ...emptyViewport },
+    nodes: [],
+    edges: [],
+    aiGroups: {},
+  };
 }
 
 /** Fold the active page's live working copy (top-level fields) back into `pages`
@@ -289,7 +323,10 @@ function scheduleSave() {
     if (!s.projectPath || !s.loaded || !s.activePageId) return;
     // Fold the live active page into the pages map for a complete snapshot.
     const active = activePageSnapshot(s);
-    const pages = Object.values({ ...s.pages, ...(active ? { [active.id]: active } : {}) });
+    const pages = Object.values({
+      ...s.pages,
+      ...(active ? { [active.id]: active } : {}),
+    });
     const payload: CanvasFile = {
       version: 4,
       pages,
@@ -356,12 +393,16 @@ function parseFile(raw: string): CanvasFile {
         viewport: p.viewport ?? { ...emptyViewport },
         nodes: normalizeNodes(p.nodes),
         edges: Array.isArray(p.edges) ? p.edges : [],
-        aiGroups: p.aiGroups && typeof p.aiGroups === "object" ? p.aiGroups : {},
+        aiGroups:
+          p.aiGroups && typeof p.aiGroups === "object" ? p.aiGroups : {},
       }));
       if (pages.length === 0) return freshFile();
-      const tree = Array.isArray(parsed.tree) ? (parsed.tree as PageTreeEntry[]) : [];
+      const tree = Array.isArray(parsed.tree)
+        ? (parsed.tree as PageTreeEntry[])
+        : [];
       const activePageId =
-        typeof parsed.activePageId === "string" && pages.some((p) => p.id === parsed.activePageId)
+        typeof parsed.activePageId === "string" &&
+        pages.some((p) => p.id === parsed.activePageId)
           ? (parsed.activePageId as string)
           : pages[0].id;
       return { version: 4, pages, tree, activePageId };
@@ -406,581 +447,668 @@ export const useCanvasStore = createSelectors(
         });
       };
       return {
-      projectPath: null,
-      loaded: false,
-      nodes: [],
-      edges: [],
-      aiGroups: {},
-      viewport: emptyViewport,
-      pages: {},
-      tree: [],
-      activePageId: null,
-      selectedIds: [],
-      pendingAiThreadGroupId: null,
-      fullscreen: false,
-      activeTool: "select",
-      canUndo: false,
-      canRedo: false,
-      actions: {
-        loadProject: async (path) => {
-          if (saveTimer) {
-            clearTimeout(saveTimer);
-            saveTimer = null;
-          }
-          set((s) => {
-            s.projectPath = path;
-            s.loaded = false;
-            s.nodes = [];
-            s.edges = [];
-            s.aiGroups = {};
-            s.pages = {};
-            s.tree = [];
-            s.activePageId = null;
-            s.selectedIds = [];
-            s.viewport = emptyViewport;
-          });
-          try {
-            const raw = await loadCanvas(path);
-            const parsed = parseFile(raw);
-            resetHistory();
-            set((s) => {
-              if (s.projectPath !== path) return; // user switched projects mid-load
-              const pagesMap: Record<string, CanvasPage> = {};
-              for (const p of parsed.pages) pagesMap[p.id] = p;
-              s.pages = pagesMap;
-              s.tree = parsed.tree;
-              s.activePageId = parsed.activePageId;
-              // Mirror the active page into the working fields.
-              const active = pagesMap[parsed.activePageId];
-              s.nodes = active?.nodes ?? [];
-              s.edges = active?.edges ?? [];
-              s.aiGroups = active?.aiGroups ?? {};
-              s.viewport = active?.viewport ?? { ...emptyViewport };
-              s.loaded = true;
-              s.canUndo = false;
-              s.canRedo = false;
-            });
-          } catch {
-            set((s) => {
-              if (s.projectPath !== path) return;
-              s.loaded = true;
-            });
-          }
-        },
-        addNote: (at) => {
-          takeSnapshot();
-          const id = genId("n");
-          const stamp = nowIso();
-          const x = at?.x ?? 0;
-          const y = at?.y ?? 0;
-          set((s) => {
-            s.nodes.push({
-              id,
-              kind: "note",
-              x,
-              y,
-              width: 320,
-              title: "Untitled",
-              body: "",
-              createdAt: stamp,
-              updatedAt: stamp,
-            });
-            s.selectedIds = [id];
-          });
-          scheduleSave();
-          logEvent({ source: "canvas", kind: "note-add", summary: "New note", payload: { id } });
-          return id;
-        },
-        addText: (at) => {
-          takeSnapshot();
-          const id = genId("n");
-          const stamp = nowIso();
-          set((s) => {
-            s.nodes.push({
-              id,
-              kind: "text",
-              x: at?.x ?? 0,
-              y: at?.y ?? 0,
-              width: 200,
-              title: "",
-              body: "",
-              text: "Text",
-              createdAt: stamp,
-              updatedAt: stamp,
-            });
-            s.selectedIds = [id];
-          });
-          scheduleSave();
-          logEvent({ source: "canvas", kind: "text-add", summary: "New text", payload: { id } });
-          return id;
-        },
-        addShape: (shapeType, at, size) => {
-          takeSnapshot();
-          const id = genId("n");
-          const stamp = nowIso();
-          // Default sizes when placed with a click; drag-to-create passes `size`.
-          const [defW, defH] =
-            shapeType === "ellipse" || shapeType === "diamond" ? [130, 130] : [160, 90];
-          const w = size ? Math.max(20, Math.round(size.width)) : defW;
-          const h = size ? Math.max(20, Math.round(size.height)) : defH;
-          set((s) => {
-            s.nodes.push({
-              id,
-              kind: "shape",
-              shapeType,
-              x: at?.x ?? 0,
-              y: at?.y ?? 0,
-              width: w,
-              height: h,
-              title: "",
-              body: "",
-              text: "",
-              createdAt: stamp,
-              updatedAt: stamp,
-            });
-            s.selectedIds = [id];
-          });
-          scheduleSave();
-          logEvent({ source: "canvas", kind: "shape-add", summary: shapeType, payload: { id } });
-          return id;
-        },
-        addMedia: ({ src, mediaKind, width, height }, at) => {
-          takeSnapshot();
-          const id = genId("n");
-          const stamp = nowIso();
-          set((s) => {
-            s.nodes.push({
-              id,
-              kind: "media",
-              x: at?.x ?? 0,
-              y: at?.y ?? 0,
-              width: width ?? 320,
-              height,
-              title: "",
-              body: "",
-              src,
-              mediaKind,
-              createdAt: stamp,
-              updatedAt: stamp,
-            });
-            s.selectedIds = [id];
-          });
-          scheduleSave();
-          logEvent({ source: "canvas", kind: "media-add", summary: mediaKind, payload: { id } });
-          return id;
-        },
-        updateNote: (id, patch) =>
-          set((s) => {
-            const n = s.nodes.find((n) => n.id === id);
-            if (!n) return;
-            if (patch.title !== undefined) n.title = patch.title;
-            if (patch.body !== undefined) n.body = patch.body;
-            if (patch.width !== undefined) n.width = patch.width;
-            if (patch.height !== undefined) n.height = patch.height;
-            if (patch.icon !== undefined) n.icon = patch.icon;
-            if (patch.text !== undefined) n.text = patch.text;
-            if (patch.src !== undefined) n.src = patch.src;
-            if (patch.mediaKind !== undefined) n.mediaKind = patch.mediaKind;
-            n.updatedAt = nowIso();
-            scheduleSave();
-          }),
-        deleteNote: (id) => {
-          takeSnapshot();
-          const removed = get().nodes.find((n) => n.id === id);
-          set((s) => {
-            s.nodes = s.nodes.filter((n) => n.id !== id);
-            s.edges = s.edges.filter((e) => e.source !== id && e.target !== id);
-            s.selectedIds = s.selectedIds.filter((x) => x !== id);
-            scheduleSave();
-          });
-          if (removed) {
-            logEvent({
-              source: "canvas",
-              kind: "note-delete",
-              summary: removed.title || "Untitled",
-              payload: { id },
-            });
-          }
-        },
-        moveNote: (id, x, y) =>
-          set((s) => {
-            const n = s.nodes.find((n) => n.id === id);
-            if (!n) return;
-            n.x = x;
-            n.y = y;
-            scheduleSave();
-          }),
-        addEdge: (source, target, sourceHandle, targetHandle) => {
-          if (source === target) return;
-          const exists = get().edges.some(
-            (e) =>
-              (e.source === source && e.target === target) ||
-              (e.source === target && e.target === source)
-          );
-          if (exists) return;
-          takeSnapshot();
-          set((s) => {
-            s.edges.push({ id: genId("e"), source, target, sourceHandle, targetHandle });
-            scheduleSave();
-          });
-          logEvent({
-            source: "canvas",
-            kind: "edge-add",
-            summary: "Connection added",
-            payload: { source, target },
-          });
-        },
-        deleteEdge: (id) => {
-          takeSnapshot();
-          set((s) => {
-            s.edges = s.edges.filter((e) => e.id !== id);
-            scheduleSave();
-          });
-          logEvent({ source: "canvas", kind: "edge-delete", summary: "Connection removed", payload: { id } });
-        },
-        setSelected: (id) =>
-          set((s) => {
-            s.selectedIds = id ? [id] : [];
-          }),
-        setSelectedIds: (ids) =>
-          set((s) => {
-            s.selectedIds = ids;
-          }),
-        setViewport: (vp) =>
-          set((s) => {
-            s.viewport = vp;
-            scheduleSave();
-          }),
-        setFullscreen: (open) =>
-          set((s) => {
-            s.fullscreen = open;
-          }),
-        toggleFullscreen: () =>
-          set((s) => {
-            s.fullscreen = !s.fullscreen;
-          }),
-        setTool: (tool) =>
-          set((s) => {
-            s.activeTool = tool;
-          }),
-        beginInteraction: () => takeSnapshot(),
-        undo: () => {
-          if (past.length === 0) return;
-          future.push({ nodes: get().nodes, edges: get().edges });
-          const prev = past.pop()!;
-          set((s) => {
-            s.nodes = prev.nodes;
-            s.edges = prev.edges;
-            s.canUndo = past.length > 0;
-            s.canRedo = true;
-          });
-          scheduleSave();
-        },
-        redo: () => {
-          if (future.length === 0) return;
-          past.push({ nodes: get().nodes, edges: get().edges });
-          const next = future.pop()!;
-          set((s) => {
-            s.nodes = next.nodes;
-            s.edges = next.edges;
-            s.canUndo = true;
-            s.canRedo = future.length > 0;
-          });
-          scheduleSave();
-        },
-
-        // ── Pages ──────────────────────────────────────────────────────────
-        createPage: (parentId = null) => {
-          const id = genId("p");
-          set((s) => {
-            s.pages[id] = emptyPage(id);
-            const order = s.tree.filter((e) => e.parentId === parentId).length;
-            s.tree.push({ id, kind: "page", parentId, name: "Untitled", order });
-            // Fold the outgoing page back, then switch to the new (empty) page.
-            const active = activePageSnapshot(s);
-            if (active) s.pages[active.id] = active;
-            s.activePageId = id;
-            s.nodes = [];
-            s.edges = [];
-            s.aiGroups = {};
-            s.viewport = { ...emptyViewport };
-            s.selectedIds = [];
-          });
-          resetHistory();
-          set((s) => {
-            s.canUndo = false;
-            s.canRedo = false;
-          });
-          scheduleSave();
-          logEvent({ source: "canvas", kind: "page-add", summary: "New page", payload: { id } });
-          return id;
-        },
-
-        createPageFolder: (parentId = null) => {
-          const id = genId("f");
-          set((s) => {
-            const order = s.tree.filter((e) => e.parentId === parentId).length;
-            s.tree.push({ id, kind: "folder", parentId, name: "New folder", order });
-          });
-          scheduleSave();
-          return id;
-        },
-
-        setActivePage: (id) => {
-          if (get().activePageId === id) return;
-          set((s) => {
-            const target = s.pages[id];
-            if (!target) return;
-            // Fold the current working copy back into pages, then load the target.
-            const active = activePageSnapshot(s);
-            if (active) s.pages[active.id] = active;
-            s.activePageId = id;
-            s.nodes = target.nodes;
-            s.edges = target.edges;
-            s.aiGroups = target.aiGroups;
-            s.viewport = target.viewport;
-            s.selectedIds = [];
-          });
-          resetHistory();
-          set((s) => {
-            s.canUndo = false;
-            s.canRedo = false;
-          });
-          scheduleSave();
-        },
-
-        renameTreeEntry: (id, name) =>
-          set((s) => {
-            const e = s.tree.find((t) => t.id === id);
-            if (!e) return;
-            e.name = name;
-            scheduleSave();
-          }),
-
-        setTreeEntryIcon: (id, icon) =>
-          set((s) => {
-            const e = s.tree.find((t) => t.id === id);
-            if (!e) return;
-            e.icon = icon ?? undefined;
-            scheduleSave();
-          }),
-
-        deleteTreeEntry: (id) => {
-          set((s) => {
-            // Collect the entry + all descendants (folders cascade).
-            const toRemove = new Set<string>([id]);
-            let grew = true;
-            while (grew) {
-              grew = false;
-              for (const e of s.tree) {
-                if (e.parentId && toRemove.has(e.parentId) && !toRemove.has(e.id)) {
-                  toRemove.add(e.id);
-                  grew = true;
-                }
-              }
+        projectPath: null,
+        loaded: false,
+        nodes: [],
+        edges: [],
+        aiGroups: {},
+        viewport: emptyViewport,
+        pages: {},
+        tree: [],
+        activePageId: null,
+        selectedIds: [],
+        pendingAiThreadGroupId: null,
+        fullscreen: false,
+        activeTool: "select",
+        canUndo: false,
+        canRedo: false,
+        actions: {
+          loadProject: async (path) => {
+            if (saveTimer) {
+              clearTimeout(saveTimer);
+              saveTimer = null;
             }
-            const removedPageIds = s.tree
-              .filter((e) => toRemove.has(e.id) && e.kind === "page")
-              .map((e) => e.id);
-            const remainingPages = s.tree.filter(
-              (e) => e.kind === "page" && !toRemove.has(e.id),
-            );
-            // Never delete the last page.
-            if (remainingPages.length === 0) return;
-
-            s.tree = s.tree.filter((e) => !toRemove.has(e.id));
-            for (const pid of removedPageIds) delete s.pages[pid];
-
-            // If the active page was removed, switch to another page.
-            if (s.activePageId && removedPageIds.includes(s.activePageId)) {
-              const next = remainingPages[0];
-              const target = s.pages[next.id];
-              s.activePageId = next.id;
-              s.nodes = target?.nodes ?? [];
-              s.edges = target?.edges ?? [];
-              s.aiGroups = target?.aiGroups ?? {};
-              s.viewport = target?.viewport ?? { ...emptyViewport };
+            set((s) => {
+              s.projectPath = path;
+              s.loaded = false;
+              s.nodes = [];
+              s.edges = [];
+              s.aiGroups = {};
+              s.pages = {};
+              s.tree = [];
+              s.activePageId = null;
               s.selectedIds = [];
+              s.viewport = emptyViewport;
+            });
+            try {
+              const raw = await loadCanvas(path);
+              const parsed = parseFile(raw);
+              resetHistory();
+              set((s) => {
+                if (s.projectPath !== path) return; // user switched projects mid-load
+                const pagesMap: Record<string, CanvasPage> = {};
+                for (const p of parsed.pages) pagesMap[p.id] = p;
+                s.pages = pagesMap;
+                s.tree = parsed.tree;
+                s.activePageId = parsed.activePageId;
+                // Mirror the active page into the working fields.
+                const active = pagesMap[parsed.activePageId];
+                s.nodes = active?.nodes ?? [];
+                s.edges = active?.edges ?? [];
+                s.aiGroups = active?.aiGroups ?? {};
+                s.viewport = active?.viewport ?? { ...emptyViewport };
+                s.loaded = true;
+                s.canUndo = false;
+                s.canRedo = false;
+              });
+            } catch {
+              set((s) => {
+                if (s.projectPath !== path) return;
+                s.loaded = true;
+              });
             }
-            scheduleSave();
-          });
-        },
-
-        // ── AI groups ──────────────────────────────────────────────────────
-        createAiGroup: (at, provider, model) => {
-          const id = genId("g");
-          const stamp = nowIso();
-          set((s) => {
-            s.aiGroups[id] = {
-              id,
-              anchor: { x: at.x, y: at.y },
-              title: "AI diagram",
-              messages: [],
-              provider,
-              model,
-              createdAt: stamp,
-              updatedAt: stamp,
-            };
-          });
-          scheduleSave();
-          return id;
-        },
-
-        appendGroupMessage: (groupId, msg) =>
-          set((s) => {
-            const g = s.aiGroups[groupId];
-            if (!g) return;
-            g.messages.push(msg);
-            g.updatedAt = nowIso();
-            scheduleSave();
-          }),
-
-        applyAiOps: (groupId, ops, anchor) => {
-          takeSnapshot(); // whole batch = one undo step
-          const stamp = nowIso();
-          set((s) => {
-            const temp = new Map<string, string>(); // tempId → real node id
-            const addedIds: string[] = [];
-            let allHaveCoords = true;
-
-            for (const op of ops) {
-              if (op.op !== "add_node") continue;
-              const id = genId("n");
-              temp.set(op.tempId, id);
-              addedIds.push(id);
-              if (op.x === undefined || op.y === undefined) allHaveCoords = false;
-              const [dw, dh] =
-                op.kind === "shape" && (op.shapeType === "ellipse" || op.shapeType === "diamond")
-                  ? [130, 130]
-                  : op.kind === "shape"
-                    ? [160, 90]
-                    : op.kind === "note"
-                      ? [320, undefined as number | undefined]
-                      : [200, undefined as number | undefined];
+          },
+          addNote: (at) => {
+            takeSnapshot();
+            const id = genId("n");
+            const stamp = nowIso();
+            const x = at?.x ?? 0;
+            const y = at?.y ?? 0;
+            set((s) => {
               s.nodes.push({
                 id,
-                kind: op.kind,
-                groupId,
-                x: anchor.x + (op.x ?? 0),
-                y: anchor.y + (op.y ?? 0),
-                width: op.width ?? dw,
-                height: op.height ?? dh,
-                title: op.title ?? (op.kind === "note" ? "Untitled" : ""),
-                body: op.body ?? "",
-                text: op.text ?? (op.kind === "text" ? "Text" : op.kind === "shape" ? op.title ?? "" : ""),
-                shapeType: op.kind === "shape" ? op.shapeType ?? "rectangle" : undefined,
-                icon: op.icon,
+                kind: "note",
+                x,
+                y,
+                width: 320,
+                title: "Untitled",
+                body: "",
                 createdAt: stamp,
                 updatedAt: stamp,
               });
+              s.selectedIds = [id];
+            });
+            scheduleSave();
+            logEvent({
+              source: "canvas",
+              kind: "note-add",
+              summary: "New note",
+              payload: { id },
+            });
+            return id;
+          },
+          addText: (at) => {
+            takeSnapshot();
+            const id = genId("n");
+            const stamp = nowIso();
+            set((s) => {
+              s.nodes.push({
+                id,
+                kind: "text",
+                x: at?.x ?? 0,
+                y: at?.y ?? 0,
+                width: 200,
+                title: "",
+                body: "",
+                text: "Text",
+                createdAt: stamp,
+                updatedAt: stamp,
+              });
+              s.selectedIds = [id];
+            });
+            scheduleSave();
+            logEvent({
+              source: "canvas",
+              kind: "text-add",
+              summary: "New text",
+              payload: { id },
+            });
+            return id;
+          },
+          addShape: (shapeType, at, size) => {
+            takeSnapshot();
+            const id = genId("n");
+            const stamp = nowIso();
+            // Default sizes when placed with a click; drag-to-create passes `size`.
+            const [defW, defH] =
+              shapeType === "ellipse" || shapeType === "diamond"
+                ? [130, 130]
+                : [160, 90];
+            const w = size ? Math.max(20, Math.round(size.width)) : defW;
+            const h = size ? Math.max(20, Math.round(size.height)) : defH;
+            set((s) => {
+              s.nodes.push({
+                id,
+                kind: "shape",
+                shapeType,
+                x: at?.x ?? 0,
+                y: at?.y ?? 0,
+                width: w,
+                height: h,
+                title: "",
+                body: "",
+                text: "",
+                createdAt: stamp,
+                updatedAt: stamp,
+              });
+              s.selectedIds = [id];
+            });
+            scheduleSave();
+            logEvent({
+              source: "canvas",
+              kind: "shape-add",
+              summary: shapeType,
+              payload: { id },
+            });
+            return id;
+          },
+          addMedia: ({ src, mediaKind, width, height }, at) => {
+            takeSnapshot();
+            const id = genId("n");
+            const stamp = nowIso();
+            set((s) => {
+              s.nodes.push({
+                id,
+                kind: "media",
+                x: at?.x ?? 0,
+                y: at?.y ?? 0,
+                width: width ?? 320,
+                height,
+                title: "",
+                body: "",
+                src,
+                mediaKind,
+                createdAt: stamp,
+                updatedAt: stamp,
+              });
+              s.selectedIds = [id];
+            });
+            scheduleSave();
+            logEvent({
+              source: "canvas",
+              kind: "media-add",
+              summary: mediaKind,
+              payload: { id },
+            });
+            return id;
+          },
+          updateNote: (id, patch) =>
+            set((s) => {
+              const n = s.nodes.find((n) => n.id === id);
+              if (!n) return;
+              if (patch.title !== undefined) n.title = patch.title;
+              if (patch.body !== undefined) n.body = patch.body;
+              if (patch.width !== undefined) n.width = patch.width;
+              if (patch.height !== undefined) n.height = patch.height;
+              if (patch.icon !== undefined) n.icon = patch.icon;
+              if (patch.text !== undefined) n.text = patch.text;
+              if (patch.src !== undefined) n.src = patch.src;
+              if (patch.mediaKind !== undefined) n.mediaKind = patch.mediaKind;
+              n.updatedAt = nowIso();
+              scheduleSave();
+            }),
+          deleteNote: (id) => {
+            takeSnapshot();
+            const removed = get().nodes.find((n) => n.id === id);
+            set((s) => {
+              s.nodes = s.nodes.filter((n) => n.id !== id);
+              s.edges = s.edges.filter(
+                (e) => e.source !== id && e.target !== id,
+              );
+              s.selectedIds = s.selectedIds.filter((x) => x !== id);
+              scheduleSave();
+            });
+            if (removed) {
+              logEvent({
+                source: "canvas",
+                kind: "note-delete",
+                summary: removed.title || "Untitled",
+                payload: { id },
+              });
             }
+          },
+          moveNote: (id, x, y) =>
+            set((s) => {
+              const n = s.nodes.find((n) => n.id === id);
+              if (!n) return;
+              n.x = x;
+              n.y = y;
+              scheduleSave();
+            }),
+          addEdge: (source, target, sourceHandle, targetHandle) => {
+            if (source === target) return;
+            const exists = get().edges.some(
+              (e) =>
+                (e.source === source && e.target === target) ||
+                (e.source === target && e.target === source),
+            );
+            if (exists) return;
+            takeSnapshot();
+            set((s) => {
+              s.edges.push({
+                id: genId("e"),
+                source,
+                target,
+                sourceHandle,
+                targetHandle,
+              });
+              scheduleSave();
+            });
+            logEvent({
+              source: "canvas",
+              kind: "edge-add",
+              summary: "Connection added",
+              payload: { source, target },
+            });
+          },
+          deleteEdge: (id) => {
+            takeSnapshot();
+            set((s) => {
+              s.edges = s.edges.filter((e) => e.id !== id);
+              scheduleSave();
+            });
+            logEvent({
+              source: "canvas",
+              kind: "edge-delete",
+              summary: "Connection removed",
+              payload: { id },
+            });
+          },
+          setSelected: (id) =>
+            set((s) => {
+              s.selectedIds = id ? [id] : [];
+            }),
+          setSelectedIds: (ids) =>
+            set((s) => {
+              s.selectedIds = ids;
+            }),
+          setViewport: (vp) =>
+            set((s) => {
+              s.viewport = vp;
+              scheduleSave();
+            }),
+          setFullscreen: (open) =>
+            set((s) => {
+              s.fullscreen = open;
+            }),
+          toggleFullscreen: () =>
+            set((s) => {
+              s.fullscreen = !s.fullscreen;
+            }),
+          setTool: (tool) =>
+            set((s) => {
+              s.activeTool = tool;
+            }),
+          beginInteraction: () => takeSnapshot(),
+          undo: () => {
+            if (past.length === 0) return;
+            future.push({ nodes: get().nodes, edges: get().edges });
+            const prev = past.pop()!;
+            set((s) => {
+              s.nodes = prev.nodes;
+              s.edges = prev.edges;
+              s.canUndo = past.length > 0;
+              s.canRedo = true;
+            });
+            scheduleSave();
+          },
+          redo: () => {
+            if (future.length === 0) return;
+            past.push({ nodes: get().nodes, edges: get().edges });
+            const next = future.pop()!;
+            set((s) => {
+              s.nodes = next.nodes;
+              s.edges = next.edges;
+              s.canUndo = true;
+              s.canRedo = future.length > 0;
+            });
+            scheduleSave();
+          },
 
-            const resolve = (ref: string) => temp.get(ref) ?? ref;
-            const nodeExists = (nid: string) => s.nodes.some((n) => n.id === nid);
+          // ── Pages ──────────────────────────────────────────────────────────
+          createPage: (parentId = null) => {
+            const id = genId("p");
+            set((s) => {
+              s.pages[id] = emptyPage(id);
+              const order = s.tree.filter(
+                (e) => e.parentId === parentId,
+              ).length;
+              s.tree.push({
+                id,
+                kind: "page",
+                parentId,
+                name: "Untitled",
+                order,
+              });
+              // Fold the outgoing page back, then switch to the new (empty) page.
+              const active = activePageSnapshot(s);
+              if (active) s.pages[active.id] = active;
+              s.activePageId = id;
+              s.nodes = [];
+              s.edges = [];
+              s.aiGroups = {};
+              s.viewport = { ...emptyViewport };
+              s.selectedIds = [];
+            });
+            resetHistory();
+            set((s) => {
+              s.canUndo = false;
+              s.canRedo = false;
+            });
+            scheduleSave();
+            logEvent({
+              source: "canvas",
+              kind: "page-add",
+              summary: "New page",
+              payload: { id },
+            });
+            return id;
+          },
 
-            for (const op of ops) {
-              if (op.op === "connect") {
-                const from = resolve(op.from);
-                const to = resolve(op.to);
-                if (from === to || !nodeExists(from) || !nodeExists(to)) continue;
-                const dup = s.edges.some(
-                  (e) =>
-                    (e.source === from && e.target === to) ||
-                    (e.source === to && e.target === from),
-                );
-                if (dup) continue;
-                s.edges.push({ id: genId("e"), source: from, target: to, groupId });
-              } else if (op.op === "update_node") {
-                const n = s.nodes.find((x) => x.id === op.id);
-                if (!n) continue;
-                if (op.text !== undefined) n.text = op.text;
-                if (op.title !== undefined) n.title = op.title;
-                if (op.body !== undefined) n.body = op.body;
-                if (op.shapeType !== undefined) n.shapeType = op.shapeType;
-                n.updatedAt = stamp;
-              } else if (op.op === "delete_node") {
-                s.nodes = s.nodes.filter((n) => n.id !== op.id);
-                s.edges = s.edges.filter((e) => e.source !== op.id && e.target !== op.id);
-              } else if (op.op === "delete_edge") {
-                s.edges = s.edges.filter((e) => e.id !== op.id);
-              }
-            }
+          createPageFolder: (parentId = null) => {
+            const id = genId("f");
+            set((s) => {
+              const order = s.tree.filter(
+                (e) => e.parentId === parentId,
+              ).length;
+              s.tree.push({
+                id,
+                kind: "folder",
+                parentId,
+                name: "New folder",
+                order,
+              });
+            });
+            scheduleSave();
+            return id;
+          },
 
-            // If the model didn't give coordinates for every new node, force-lay
-            // them out (over the group's own edges) in a box seeded at the anchor.
-            if (addedIds.length > 1 && !allHaveCoords) {
-              const deg = new Map<string, number>();
-              for (const e of s.edges) {
-                if (e.groupId !== groupId) continue;
-                deg.set(e.source, (deg.get(e.source) ?? 0) + 1);
-                deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
-              }
-              const layoutNodes = addedIds.map((nid) => ({ id: nid, degree: deg.get(nid) ?? 0 }));
-              const layoutEdges = s.edges
-                .filter((e) => e.groupId === groupId)
-                .map((e) => ({ from: e.source, to: e.target }));
-              const pos = forceLayout(layoutNodes, layoutEdges, 720, 480, { spacing: 1.1 });
-              for (const nid of addedIds) {
-                const p = pos[nid];
-                const n = s.nodes.find((x) => x.id === nid);
-                if (p && n) {
-                  n.x = anchor.x + p.x;
-                  n.y = anchor.y + p.y;
+          setActivePage: (id) => {
+            if (get().activePageId === id) return;
+            set((s) => {
+              const target = s.pages[id];
+              if (!target) return;
+              // Fold the current working copy back into pages, then load the target.
+              const active = activePageSnapshot(s);
+              if (active) s.pages[active.id] = active;
+              s.activePageId = id;
+              s.nodes = target.nodes;
+              s.edges = target.edges;
+              s.aiGroups = target.aiGroups;
+              s.viewport = target.viewport;
+              s.selectedIds = [];
+            });
+            resetHistory();
+            set((s) => {
+              s.canUndo = false;
+              s.canRedo = false;
+            });
+            scheduleSave();
+          },
+
+          renameTreeEntry: (id, name) =>
+            set((s) => {
+              const e = s.tree.find((t) => t.id === id);
+              if (!e) return;
+              e.name = name;
+              scheduleSave();
+            }),
+
+          setTreeEntryIcon: (id, icon) =>
+            set((s) => {
+              const e = s.tree.find((t) => t.id === id);
+              if (!e) return;
+              e.icon = icon ?? undefined;
+              scheduleSave();
+            }),
+
+          deleteTreeEntry: (id) => {
+            set((s) => {
+              // Collect the entry + all descendants (folders cascade).
+              const toRemove = new Set<string>([id]);
+              let grew = true;
+              while (grew) {
+                grew = false;
+                for (const e of s.tree) {
+                  if (
+                    e.parentId &&
+                    toRemove.has(e.parentId) &&
+                    !toRemove.has(e.id)
+                  ) {
+                    toRemove.add(e.id);
+                    grew = true;
+                  }
                 }
               }
-            }
+              const removedPageIds = s.tree
+                .filter((e) => toRemove.has(e.id) && e.kind === "page")
+                .map((e) => e.id);
+              const remainingPages = s.tree.filter(
+                (e) => e.kind === "page" && !toRemove.has(e.id),
+              );
+              // Never delete the last page.
+              if (remainingPages.length === 0) return;
 
-            const g = s.aiGroups[groupId];
-            if (g) g.updatedAt = stamp;
-            scheduleSave();
-          });
-        },
+              s.tree = s.tree.filter((e) => !toRemove.has(e.id));
+              for (const pid of removedPageIds) delete s.pages[pid];
 
-        deleteGroup: (groupId) => {
-          takeSnapshot();
-          set((s) => {
-            s.nodes = s.nodes.filter((n) => n.groupId !== groupId);
-            s.edges = s.edges.filter((e) => e.groupId !== groupId);
-            delete s.aiGroups[groupId];
-            s.selectedIds = [];
-            scheduleSave();
-          });
-        },
-
-        moveGroup: (groupId, dx, dy) =>
-          set((s) => {
-            for (const n of s.nodes) {
-              if (n.groupId === groupId) {
-                n.x += dx;
-                n.y += dy;
+              // If the active page was removed, switch to another page.
+              if (s.activePageId && removedPageIds.includes(s.activePageId)) {
+                const next = remainingPages[0];
+                const target = s.pages[next.id];
+                s.activePageId = next.id;
+                s.nodes = target?.nodes ?? [];
+                s.edges = target?.edges ?? [];
+                s.aiGroups = target?.aiGroups ?? {};
+                s.viewport = target?.viewport ?? { ...emptyViewport };
+                s.selectedIds = [];
               }
-            }
-            const g = s.aiGroups[groupId];
-            if (g) {
-              g.anchor.x += dx;
-              g.anchor.y += dy;
-            }
+              scheduleSave();
+            });
+          },
+
+          // ── AI groups ──────────────────────────────────────────────────────
+          createAiGroup: (at, provider, model) => {
+            const id = genId("g");
+            const stamp = nowIso();
+            set((s) => {
+              s.aiGroups[id] = {
+                id,
+                anchor: { x: at.x, y: at.y },
+                title: "AI diagram",
+                messages: [],
+                provider,
+                model,
+                createdAt: stamp,
+                updatedAt: stamp,
+              };
+            });
             scheduleSave();
-          }),
+            return id;
+          },
 
-        selectGroup: (groupId) =>
-          set((s) => {
-            s.selectedIds = s.nodes.filter((n) => n.groupId === groupId).map((n) => n.id);
-          }),
+          appendGroupMessage: (groupId, msg) =>
+            set((s) => {
+              const g = s.aiGroups[groupId];
+              if (!g) return;
+              g.messages.push(msg);
+              g.updatedAt = nowIso();
+              scheduleSave();
+            }),
 
-        requestOpenAiThread: (groupId) =>
-          set((s) => {
-            s.pendingAiThreadGroupId = groupId;
-          }),
+          applyAiOps: (groupId, ops, anchor) => {
+            takeSnapshot(); // whole batch = one undo step
+            const stamp = nowIso();
+            set((s) => {
+              const temp = new Map<string, string>(); // tempId → real node id
+              const addedIds: string[] = [];
+              let allHaveCoords = true;
 
-        consumePendingAiThread: () =>
-          set((s) => {
-            s.pendingAiThreadGroupId = null;
-          }),
-      },
+              for (const op of ops) {
+                if (op.op !== "add_node") continue;
+                const id = genId("n");
+                temp.set(op.tempId, id);
+                addedIds.push(id);
+                if (op.x === undefined || op.y === undefined)
+                  allHaveCoords = false;
+                const [dw, dh] =
+                  op.kind === "shape" &&
+                  (op.shapeType === "ellipse" || op.shapeType === "diamond")
+                    ? [130, 130]
+                    : op.kind === "shape"
+                      ? [160, 90]
+                      : op.kind === "note"
+                        ? [320, undefined as number | undefined]
+                        : [200, undefined as number | undefined];
+                s.nodes.push({
+                  id,
+                  kind: op.kind,
+                  groupId,
+                  x: anchor.x + (op.x ?? 0),
+                  y: anchor.y + (op.y ?? 0),
+                  width: op.width ?? dw,
+                  height: op.height ?? dh,
+                  title: op.title ?? (op.kind === "note" ? "Untitled" : ""),
+                  body: op.body ?? "",
+                  text:
+                    op.text ??
+                    (op.kind === "text"
+                      ? "Text"
+                      : op.kind === "shape"
+                        ? (op.title ?? "")
+                        : ""),
+                  shapeType:
+                    op.kind === "shape"
+                      ? (op.shapeType ?? "rectangle")
+                      : undefined,
+                  icon: op.icon,
+                  createdAt: stamp,
+                  updatedAt: stamp,
+                });
+              }
+
+              const resolve = (ref: string) => temp.get(ref) ?? ref;
+              const nodeExists = (nid: string) =>
+                s.nodes.some((n) => n.id === nid);
+
+              for (const op of ops) {
+                if (op.op === "connect") {
+                  const from = resolve(op.from);
+                  const to = resolve(op.to);
+                  if (from === to || !nodeExists(from) || !nodeExists(to))
+                    continue;
+                  const dup = s.edges.some(
+                    (e) =>
+                      (e.source === from && e.target === to) ||
+                      (e.source === to && e.target === from),
+                  );
+                  if (dup) continue;
+                  s.edges.push({
+                    id: genId("e"),
+                    source: from,
+                    target: to,
+                    groupId,
+                  });
+                } else if (op.op === "update_node") {
+                  const n = s.nodes.find((x) => x.id === op.id);
+                  if (!n) continue;
+                  if (op.text !== undefined) n.text = op.text;
+                  if (op.title !== undefined) n.title = op.title;
+                  if (op.body !== undefined) n.body = op.body;
+                  if (op.shapeType !== undefined) n.shapeType = op.shapeType;
+                  n.updatedAt = stamp;
+                } else if (op.op === "delete_node") {
+                  s.nodes = s.nodes.filter((n) => n.id !== op.id);
+                  s.edges = s.edges.filter(
+                    (e) => e.source !== op.id && e.target !== op.id,
+                  );
+                } else if (op.op === "delete_edge") {
+                  s.edges = s.edges.filter((e) => e.id !== op.id);
+                }
+              }
+
+              // If the model didn't give coordinates for every new node, force-lay
+              // them out (over the group's own edges) in a box seeded at the anchor.
+              if (addedIds.length > 1 && !allHaveCoords) {
+                const deg = new Map<string, number>();
+                for (const e of s.edges) {
+                  if (e.groupId !== groupId) continue;
+                  deg.set(e.source, (deg.get(e.source) ?? 0) + 1);
+                  deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
+                }
+                const layoutNodes = addedIds.map((nid) => ({
+                  id: nid,
+                  degree: deg.get(nid) ?? 0,
+                }));
+                const layoutEdges = s.edges
+                  .filter((e) => e.groupId === groupId)
+                  .map((e) => ({ from: e.source, to: e.target }));
+                const pos = forceLayout(layoutNodes, layoutEdges, 720, 480, {
+                  spacing: 1.1,
+                });
+                for (const nid of addedIds) {
+                  const p = pos[nid];
+                  const n = s.nodes.find((x) => x.id === nid);
+                  if (p && n) {
+                    n.x = anchor.x + p.x;
+                    n.y = anchor.y + p.y;
+                  }
+                }
+              }
+
+              const g = s.aiGroups[groupId];
+              if (g) g.updatedAt = stamp;
+              scheduleSave();
+            });
+          },
+
+          deleteGroup: (groupId) => {
+            takeSnapshot();
+            set((s) => {
+              s.nodes = s.nodes.filter((n) => n.groupId !== groupId);
+              s.edges = s.edges.filter((e) => e.groupId !== groupId);
+              delete s.aiGroups[groupId];
+              s.selectedIds = [];
+              scheduleSave();
+            });
+          },
+
+          moveGroup: (groupId, dx, dy) =>
+            set((s) => {
+              for (const n of s.nodes) {
+                if (n.groupId === groupId) {
+                  n.x += dx;
+                  n.y += dy;
+                }
+              }
+              const g = s.aiGroups[groupId];
+              if (g) {
+                g.anchor.x += dx;
+                g.anchor.y += dy;
+              }
+              scheduleSave();
+            }),
+
+          selectGroup: (groupId) =>
+            set((s) => {
+              s.selectedIds = s.nodes
+                .filter((n) => n.groupId === groupId)
+                .map((n) => n.id);
+            }),
+
+          requestOpenAiThread: (groupId) =>
+            set((s) => {
+              s.pendingAiThreadGroupId = groupId;
+            }),
+
+          consumePendingAiThread: () =>
+            set((s) => {
+              s.pendingAiThreadGroupId = null;
+            }),
+        },
       };
-    })
-  )
+    }),
+  ),
 );
 
 /** Bounding box (flow space) of a group's member nodes, or null if none. Used to

--- a/src/features/capture/components/capture-popover.tsx
+++ b/src/features/capture/components/capture-popover.tsx
@@ -61,15 +61,30 @@ interface Props {
 type View =
   | { kind: "main" }
   /** Cloud create: the import disclosure, with the registration still pending. */
-  | { kind: "cloud-confirm"; orgId: string; slug: string; preview: ImportPreview }
+  | {
+      kind: "cloud-confirm";
+      orgId: string;
+      slug: string;
+      preview: ImportPreview;
+    }
   /** Bound Cloud Workspace whose history import awaits approval. */
   | { kind: "import-confirm"; preview: ImportPreview }
   /** Local→Cloud promotion: pick the destination. */
   | { kind: "promote-form" }
   /** Local→Cloud promotion: the disclosure. */
-  | { kind: "promote-confirm"; orgId: string; slug: string; preview: PromotionPreview };
+  | {
+      kind: "promote-confirm";
+      orgId: string;
+      slug: string;
+      preview: PromotionPreview;
+    };
 
-export function CapturePopover({ projectPath, health, onChanged, onClose }: Props) {
+export function CapturePopover({
+  projectPath,
+  health,
+  onChanged,
+  onClose,
+}: Props) {
   const signedIn = useAuthStore.use.snapshot().status === "signed-in";
   const organisations = useOrgStore.use.organisations();
   // Cloud talks to the server, so only server-linked Organisations qualify.
@@ -81,7 +96,9 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
   const [detection, setDetection] = useState<Detection | null>(null);
   /** `undefined` while the read is in flight, `null` once it failed — the
    *  Cloud "Continue" button needs the difference to gate honestly. */
-  const [importPreview, setImportPreview] = useState<ImportPreview | null | undefined>(undefined);
+  const [importPreview, setImportPreview] = useState<
+    ImportPreview | null | undefined
+  >(undefined);
   const [view, setView] = useState<View>({ kind: "main" });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -94,7 +111,9 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
         // Read-only and cheap — the "history N sessions on disk" row and both
         // disclosure steps feed off it. A failure lands as `null`, which the
         // Cloud path surfaces with a retry instead of silently no-opping.
-        invoke<ImportPreview>("capture_import_preview", { projectPath }).catch(() => null),
+        invoke<ImportPreview>("capture_import_preview", { projectPath }).catch(
+          () => null,
+        ),
       ]);
       setBinding(current);
       setDetection(detected);
@@ -112,7 +131,9 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
   const retryPreview = useCallback(async () => {
     setImportPreview(undefined);
     try {
-      setImportPreview(await invoke<ImportPreview>("capture_import_preview", { projectPath }));
+      setImportPreview(
+        await invoke<ImportPreview>("capture_import_preview", { projectPath }),
+      );
     } catch {
       setImportPreview(null);
     }
@@ -147,7 +168,9 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
   return (
     <div className="w-[340px] rounded-lg border border-[var(--border-default)] bg-[var(--bg-overlay)] p-3 text-[12px] shadow-[var(--shadow-overlay)]">
       <header className="flex items-center justify-between pb-2">
-        <span className="font-medium text-[var(--text-primary)]">Session capture</span>
+        <span className="font-medium text-[var(--text-primary)]">
+          Session capture
+        </span>
         <StatusPill binding={binding} />
       </header>
 
@@ -166,7 +189,8 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
             busy={busy}
             run={run}
             onReviewImport={() =>
-              importPreview && setView({ kind: "import-confirm", preview: importPreview })
+              importPreview &&
+              setView({ kind: "import-confirm", preview: importPreview })
             }
             onPromote={() => setView({ kind: "promote-form" })}
           />
@@ -185,7 +209,12 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
               // Belt to the button's braces — Continue is disabled until the
               // preview is in, so this guard should never fire.
               if (!importPreview) return;
-              setView({ kind: "cloud-confirm", orgId, slug, preview: importPreview });
+              setView({
+                kind: "cloud-confirm",
+                orgId,
+                slug,
+                preview: importPreview,
+              });
             }}
           />
         ))}
@@ -223,7 +252,9 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
           busy={busy}
           onCancel={() => setView({ kind: "main" })}
           onConfirm={async () => {
-            const ok = await run(() => invoke("capture_import_confirm", { projectPath }));
+            const ok = await run(() =>
+              invoke("capture_import_confirm", { projectPath }),
+            );
             if (ok) setView({ kind: "main" });
           }}
         />
@@ -240,9 +271,12 @@ export function CapturePopover({ projectPath, health, onChanged, onClose }: Prop
             setBusy(true);
             setError(null);
             try {
-              const preview = await invoke<PromotionPreview>("capture_promotion_preview", {
-                projectPath,
-              });
+              const preview = await invoke<PromotionPreview>(
+                "capture_promotion_preview",
+                {
+                  projectPath,
+                },
+              );
               setView({ kind: "promote-confirm", orgId, slug, preview });
             } catch (e) {
               setError(String(e));
@@ -319,7 +353,9 @@ function DisclosureStep({
 }) {
   return (
     <div className="space-y-2">
-      <p className="text-[12px] font-medium text-[var(--text-primary)]">{title}</p>
+      <p className="text-[12px] font-medium text-[var(--text-primary)]">
+        {title}
+      </p>
       <ul className="space-y-0.5 rounded bg-[var(--bg-raised)] px-2 py-1.5">
         {lines.map((line) => (
           <li key={line} className="text-[11px] text-[var(--text-secondary)]">
@@ -328,7 +364,8 @@ function DisclosureStep({
         ))}
       </ul>
       <p className="text-[11px] text-[var(--text-tertiary)]">
-        This makes the above visible to your Organisation. Nothing is sent until you confirm.
+        This makes the above visible to your Organisation. Nothing is sent until
+        you confirm.
       </p>
       <div className="flex justify-end gap-2 pt-1">
         <GhostButton label="Cancel" onClick={onCancel} disabled={busy} />
@@ -352,7 +389,9 @@ function HealthDetail({ health }: { health: CaptureHealth | null }) {
     <ul
       className={cn(
         "mb-2 space-y-1.5 rounded px-2 py-1.5",
-        stopped ? "bg-[var(--status-error-muted)]" : "bg-[var(--status-warning-muted)]",
+        stopped
+          ? "bg-[var(--status-error-muted)]"
+          : "bg-[var(--status-warning-muted)]",
       )}
     >
       {health.issues.map((issue, index) => (
@@ -367,7 +406,9 @@ function HealthDetail({ health }: { health: CaptureHealth | null }) {
           >
             {issue.reason}
           </p>
-          {issue.nextStep && <p className="text-[var(--text-tertiary)]">{issue.nextStep}</p>}
+          {issue.nextStep && (
+            <p className="text-[var(--text-tertiary)]">{issue.nextStep}</p>
+          )}
         </li>
       ))}
     </ul>
@@ -383,9 +424,14 @@ function StatusPill({ binding }: { binding: Binding | null }) {
     <span className="flex items-center gap-1 text-[11px] text-[var(--text-secondary)]">
       <CircleDot
         size={11}
-        className={binding.enabled ? "text-[var(--status-info)]" : "text-[var(--text-tertiary)]"}
+        className={
+          binding.enabled
+            ? "text-[var(--status-info)]"
+            : "text-[var(--text-tertiary)]"
+        }
       />
-      {binding.enabled ? "Capturing" : "Paused"} · {binding.mode === "cloud" ? "Cloud" : "Local"}
+      {binding.enabled ? "Capturing" : "Paused"} ·{" "}
+      {binding.mode === "cloud" ? "Cloud" : "Local"}
     </span>
   );
 }
@@ -427,8 +473,16 @@ function BoundState({
     <div className="space-y-2">
       {binding.mode === "cloud" && binding.slug && (
         <dl className="space-y-0.5 rounded bg-[var(--bg-raised)] px-2 py-1.5 text-[11px]">
-          <Row label="Shared as" value={orgName ? `${orgName} / ${binding.slug}` : binding.slug} />
-          {pending > 0 && <Row label="Queue" value={`${pending} pending — sends when online`} />}
+          <Row
+            label="Shared as"
+            value={orgName ? `${orgName} / ${binding.slug}` : binding.slug}
+          />
+          {pending > 0 && (
+            <Row
+              label="Queue"
+              value={`${pending} pending — sends when online`}
+            />
+          )}
         </dl>
       )}
 
@@ -439,7 +493,9 @@ function BoundState({
       {detection && !detection.isGitRepository && (
         <GitInitOffer
           busy={busy}
-          onGitInit={() => void run(() => invoke("capture_git_init", { projectPath }))}
+          onGitInit={() =>
+            void run(() => invoke("capture_git_init", { projectPath }))
+          }
         />
       )}
 
@@ -470,7 +526,9 @@ function BoundState({
           <button
             type="button"
             disabled={busy}
-            onClick={() => void run(() => invoke("capture_retry_failed", { projectPath }))}
+            onClick={() =>
+              void run(() => invoke("capture_retry_failed", { projectPath }))
+            }
             className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-[var(--text-primary)] underline underline-offset-2 transition-colors duration-150 hover:no-underline focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] active:scale-[0.97] disabled:opacity-50"
           >
             <RefreshCw size={10} />
@@ -495,14 +553,20 @@ function BoundState({
           <GhostButton
             label="Pause capture"
             disabled={busy}
-            onClick={() => void run(() => invoke("capture_disable", { projectPath }))}
+            onClick={() =>
+              void run(() => invoke("capture_disable", { projectPath }))
+            }
           />
         ) : (
           <PrimaryButton
             busy={busy}
             // Always "local": the command rejects "cloud" outright, and an
             // existing Cloud binding keeps its mode on re-enable regardless.
-            onClick={() => void run(() => invoke("capture_enable", { projectPath, mode: "local" }))}
+            onClick={() =>
+              void run(() =>
+                invoke("capture_enable", { projectPath, mode: "local" }),
+              )
+            }
             label="Resume capture"
           />
         )}
@@ -584,7 +648,11 @@ function UnboundState({
 
       {tab === "create" ? (
         <>
-          <div role="radiogroup" aria-label="Where sessions are stored" className="space-y-1">
+          <div
+            role="radiogroup"
+            aria-label="Where sessions are stored"
+            className="space-y-1"
+          >
             <ModeOption
               selected={mode === "local"}
               disabled={false}
@@ -620,7 +688,9 @@ function UnboundState({
           {detection && !detection.isGitRepository && (
             <GitInitOffer
               busy={busy}
-              onGitInit={() => void run(() => invoke("capture_git_init", { projectPath }))}
+              onGitInit={() =>
+                void run(() => invoke("capture_git_init", { projectPath }))
+              }
             />
           )}
 
@@ -649,7 +719,9 @@ function UnboundState({
               disabled={!cloudReady}
               onClick={() => {
                 if (mode === "local") {
-                  void run(() => invoke("capture_enable", { projectPath, mode: "local" }));
+                  void run(() =>
+                    invoke("capture_enable", { projectPath, mode: "local" }),
+                  );
                 } else {
                   // No mutation yet — the disclosure step owns all of them.
                   onCloudEnable(orgId, slug.trim());
@@ -721,7 +793,11 @@ type SlugState =
  * name is gone when the network merely blinked is a lie they will act on — so
  * it reads as "couldn't check" with a retry, and it never blocks submitting.
  */
-function useSlugAvailability(projectPath: string, orgId: string, slug: string): SlugState {
+function useSlugAvailability(
+  projectPath: string,
+  orgId: string,
+  slug: string,
+): SlugState {
   const [state, setState] = useState<SlugState>({ kind: "idle" });
   const [nonce, setNonce] = useState(0);
   const seq = useRef(0);
@@ -735,12 +811,17 @@ function useSlugAvailability(projectPath: string, orgId: string, slug: string): 
     setState({ kind: "checking" });
     const mine = ++seq.current;
     const timer = setTimeout(() => {
-      invoke<SlugAvailability>("capture_slug_available", { projectPath, orgId, slug: trimmed })
+      invoke<SlugAvailability>("capture_slug_available", {
+        projectPath,
+        orgId,
+        slug: trimmed,
+      })
         .then((availability) => {
           if (mine !== seq.current) return;
           if (availability === "available") setState({ kind: "available" });
           else if (availability === "taken") setState({ kind: "taken" });
-          else setState({ kind: "unknown", retry: () => setNonce((n) => n + 1) });
+          else
+            setState({ kind: "unknown", retry: () => setNonce((n) => n + 1) });
         })
         .catch(() => {
           if (mine === seq.current) {
@@ -801,7 +882,9 @@ function CloudFields({
       )}
 
       <label className="flex items-center gap-2">
-        <span className="w-[70px] shrink-0 text-[11px] text-[var(--text-tertiary)]">Slug</span>
+        <span className="w-[70px] shrink-0 text-[11px] text-[var(--text-tertiary)]">
+          Slug
+        </span>
         <input
           value={slug}
           onChange={(e) => onSlugChange(e.target.value)}
@@ -823,7 +906,10 @@ function SlugStatus({ state }: { state: SlugState }) {
     <p className="flex items-center gap-1 pl-[78px] text-[11px]">
       {state.kind === "checking" && (
         <>
-          <Loader2 size={10} className="animate-spin text-[var(--text-tertiary)]" />
+          <Loader2
+            size={10}
+            className="animate-spin text-[var(--text-tertiary)]"
+          />
           <span className="text-[var(--text-tertiary)]">checking…</span>
         </>
       )}
@@ -836,7 +922,9 @@ function SlugStatus({ state }: { state: SlugState }) {
       {state.kind === "taken" && (
         <>
           <X size={10} className="text-[var(--status-error)]" />
-          <span className="text-[var(--status-error)]">taken in this Organisation</span>
+          <span className="text-[var(--status-error)]">
+            taken in this Organisation
+          </span>
         </>
       )}
       {state.kind === "unknown" && (
@@ -880,7 +968,9 @@ function ConnectTab({
   onCancel: () => void;
 }) {
   const [orgId, setOrgId] = useState<string>(cloudOrgs[0]?.remoteId ?? "");
-  const [options, setOptions] = useState<ConnectOptions | null | undefined>(undefined);
+  const [options, setOptions] = useState<ConnectOptions | null | undefined>(
+    undefined,
+  );
   const [selected, setSelected] = useState<string | null>(null);
   const seq = useRef(0);
 
@@ -919,7 +1009,9 @@ function ConnectTab({
     <div className="space-y-2">
       {cloudOrgs.length > 1 && (
         <label className="flex items-center gap-2">
-          <span className="shrink-0 text-[11px] text-[var(--text-tertiary)]">Organisation</span>
+          <span className="shrink-0 text-[11px] text-[var(--text-tertiary)]">
+            Organisation
+          </span>
           <select
             value={orgId}
             onChange={(e) => setOrgId(e.target.value)}
@@ -945,7 +1037,8 @@ function ConnectTab({
         </p>
       ) : options.workspaces.length === 0 ? (
         <p className="rounded bg-[var(--bg-raised)] px-2 py-2 text-[11px] text-[var(--text-tertiary)]">
-          This Organisation has no Workspaces yet. Create one from the Create tab instead.
+          This Organisation has no Workspaces yet. Create one from the Create
+          tab instead.
         </p>
       ) : (
         <>
@@ -968,7 +1061,9 @@ function ConnectTab({
                 onClick={() => setSelected(remote.id)}
                 className={cn(
                   "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors duration-150 focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] active:bg-[var(--bg-active)]",
-                  selected === remote.id ? "bg-[var(--bg-selected)]" : "hover:bg-[var(--bg-hover)]",
+                  selected === remote.id
+                    ? "bg-[var(--bg-selected)]"
+                    : "hover:bg-[var(--bg-hover)]",
                 )}
               >
                 <span className="shrink-0">
@@ -1043,14 +1138,19 @@ function PromoteForm({
     if (!orgId && cloudOrgs[0]) setOrgId(cloudOrgs[0].remoteId);
   }, [orgId, cloudOrgs]);
   const ready =
-    !!orgId && slug.trim().length > 0 && slugState.kind !== "taken" && slugState.kind !== "checking";
+    !!orgId &&
+    slug.trim().length > 0 &&
+    slugState.kind !== "taken" &&
+    slugState.kind !== "checking";
 
   return (
     <div className="space-y-2">
-      <p className="text-[12px] font-medium text-[var(--text-primary)]">Promote to Cloud</p>
+      <p className="text-[12px] font-medium text-[var(--text-primary)]">
+        Promote to Cloud
+      </p>
       <p className="text-[11px] text-[var(--text-tertiary)]">
-        Everything captured here joins your Organisation's timeline. You'll see exactly what
-        before anything is sent.
+        Everything captured here joins your Organisation's timeline. You'll see
+        exactly what before anything is sent.
       </p>
       <CloudFields
         cloudOrgs={cloudOrgs}
@@ -1165,7 +1265,9 @@ function ModeOption({
       </span>
       <span className="min-w-0">
         <span className="block text-[var(--text-primary)]">{label}</span>
-        <span className="block text-[11px] text-[var(--text-tertiary)]">{hint}</span>
+        <span className="block text-[11px] text-[var(--text-tertiary)]">
+          {hint}
+        </span>
       </span>
     </button>
   );
@@ -1189,7 +1291,10 @@ function Detected({
 
   return (
     <dl className="space-y-0.5 rounded bg-[var(--bg-raised)] px-2 py-1.5 text-[11px]">
-      <Row label="Folder" value={detection.root.split("/").pop() ?? detection.root} />
+      <Row
+        label="Folder"
+        value={detection.root.split("/").pop() ?? detection.root}
+      />
       {detection.gitUrl && <Row label="Origin" value={detection.gitUrl} />}
       {detection.rootCommitSha && (
         <Row
@@ -1197,7 +1302,9 @@ function Detected({
           value={`${detection.rootCommitSha.slice(0, 7)}${detection.isShallow ? " (shallow)" : ""}`}
         />
       )}
-      {!detection.isGitRepository && <Row label="Git" value="not a repository" />}
+      {!detection.isGitRepository && (
+        <Row label="Git" value="not a repository" />
+      )}
       {detection.isGitRepository && !detection.hasCommits && (
         <Row label="Git" value="no commits yet" />
       )}
@@ -1227,14 +1334,23 @@ function Row({ label, value }: { label: string; value: string }) {
  * one. Sessions are captured in any directory; git is what lets a commit be
  * traced back to the Session that produced it.
  */
-function GitInitOffer({ busy, onGitInit }: { busy: boolean; onGitInit: () => void }) {
+function GitInitOffer({
+  busy,
+  onGitInit,
+}: {
+  busy: boolean;
+  onGitInit: () => void;
+}) {
   return (
     <div className="flex items-start gap-2 rounded border border-dashed border-[var(--border-default)] px-2 py-1.5">
-      <GitBranch size={12} className="mt-0.5 shrink-0 text-[var(--text-tertiary)]" />
+      <GitBranch
+        size={12}
+        className="mt-0.5 shrink-0 text-[var(--text-tertiary)]"
+      />
       <div className="min-w-0">
         <p className="text-[11px] text-[var(--text-secondary)]">
-          Sessions are recorded here already. Initialise git to also link them to the commits
-          they produce.
+          Sessions are recorded here already. Initialise git to also link them
+          to the commits they produce.
         </p>
         <button
           type="button"
@@ -1251,9 +1367,16 @@ function GitInitOffer({ busy, onGitInit }: { busy: boolean; onGitInit: () => voi
 
 // ── Formatting ──────────────────────────────────────────────────────────────
 
-function dateRange(earliest: string | null, latest: string | null): string | null {
+function dateRange(
+  earliest: string | null,
+  latest: string | null,
+): string | null {
   if (!earliest || !latest) return null;
-  const options: Intl.DateTimeFormatOptions = { day: "numeric", month: "short", year: "numeric" };
+  const options: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  };
   const from = new Date(earliest).toLocaleDateString(undefined, options);
   const to = new Date(latest).toLocaleDateString(undefined, options);
   return from === to ? from : `${from} – ${to}`;
@@ -1262,6 +1385,7 @@ function dateRange(earliest: string | null, latest: string | null): string | nul
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }

--- a/src/features/capture/components/capture-status.tsx
+++ b/src/features/capture/components/capture-status.tsx
@@ -35,12 +35,16 @@ export function StatusDot({
  * continues. The degraded label is `health.summary` because the backend already
  * formats the count and reason better than a recomputation here would.
  */
-export function statusLabel(binding: Binding | null, health: CaptureHealth | null): string {
+export function statusLabel(
+  binding: Binding | null,
+  health: CaptureHealth | null,
+): string {
   if (health?.state === "stopped") return "Capture stopped";
   if (health?.state === "degraded") return health.summary || "Needs review";
   if (!binding) return "Off";
   if (!binding.enabled) return "Paused";
-  if (binding.mode === "cloud" && !binding.importApproved) return "Cloud · import waiting";
+  if (binding.mode === "cloud" && !binding.importApproved)
+    return "Cloud · import waiting";
   const mode = binding.mode === "cloud" ? "Cloud" : "Local";
   const pending = health?.pendingRows ?? 0;
   if (pending > 0) return `${mode} · ${pending} pending`;

--- a/src/features/chat/components/bash-history-panel.tsx
+++ b/src/features/chat/components/bash-history-panel.tsx
@@ -21,7 +21,11 @@ interface BashHistoryPanelProps {
   onClose: () => void;
 }
 
-export function BashHistoryPanel({ messages, onJump, onClose }: BashHistoryPanelProps) {
+export function BashHistoryPanel({
+  messages,
+  onJump,
+  onClose,
+}: BashHistoryPanelProps) {
   const bashPanel = useLayoutStore.use.bashPanel();
   const { setBashPanelWidth } = useLayoutStore.use.actions();
 
@@ -80,7 +84,7 @@ export function BashHistoryPanel({ messages, onJump, onClose }: BashHistoryPanel
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
-    [bashPanel.width, setBashPanelWidth]
+    [bashPanel.width, setBashPanelWidth],
   );
 
   // Virtualized list
@@ -106,92 +110,94 @@ export function BashHistoryPanel({ messages, onJump, onClose }: BashHistoryPanel
         style={{ width: bashPanel.width }}
         className="absolute right-0 top-0 bottom-0 z-30 flex flex-col border-l border-[var(--border-default)] bg-[var(--bg-sidebar)] shadow-[var(--shadow-overlay)] animate-slide-in-right"
       >
-      {/* Left-edge resize handle */}
-      <div
-        onMouseDown={onResizeStart}
-        className="absolute top-0 -left-px w-px h-full bg-border-default hover:bg-accent transition-colors cursor-col-resize z-10"
-        title="Drag to resize"
-      />
+        {/* Left-edge resize handle */}
+        <div
+          onMouseDown={onResizeStart}
+          className="absolute top-0 -left-px w-px h-full bg-border-default hover:bg-accent transition-colors cursor-col-resize z-10"
+          title="Drag to resize"
+        />
 
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 h-[32px] border-b border-[var(--border-default)] shrink-0">
-        <div className="flex items-center gap-1.5">
-          <TerminalSquare size={11} className="text-[var(--text-tertiary)]" />
-          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-            Bash calls
-          </span>
-          <span className="text-[10px] text-[var(--text-tertiary)]">· {entries.length}</span>
-        </div>
-        <button
-          onClick={onClose}
-          className="p-1 rounded hover:bg-[var(--bg-hover)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] cursor-pointer transition-colors"
-          title="Hide bash history"
-        >
-          <ChevronRight size={12} />
-        </button>
-      </div>
-
-      {/* Virtualized list */}
-      <div ref={parentRef} className="flex-1 overflow-y-auto hide-scrollbar">
-        {entries.length === 0 ? (
-          <div className="px-3 py-3 text-[11px] text-[var(--text-tertiary)] leading-relaxed">
-            No bash commands in this chat yet.
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 h-[32px] border-b border-[var(--border-default)] shrink-0">
+          <div className="flex items-center gap-1.5">
+            <TerminalSquare size={11} className="text-[var(--text-tertiary)]" />
+            <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+              Bash calls
+            </span>
+            <span className="text-[10px] text-[var(--text-tertiary)]">
+              · {entries.length}
+            </span>
           </div>
-        ) : (
-          <div
-            style={{
-              height: virtualizer.getTotalSize(),
-              width: "100%",
-              position: "relative",
-            }}
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:bg-[var(--bg-hover)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] cursor-pointer transition-colors"
+            title="Hide bash history"
           >
-            {virtualizer.getVirtualItems().map((vItem) => {
-              const e = entries[vItem.index];
-              const isLast = vItem.index === entries.length - 1;
-              return (
-                <div
-                  key={e.toolCallId}
-                  ref={virtualizer.measureElement}
-                  data-index={vItem.index}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${vItem.start}px)`,
-                  }}
-                >
-                  <button
-                    onClick={() => onJump(e.messageIndex)}
-                    className={cn(
-                      "group w-full text-left px-3 py-2 transition-colors flex flex-col gap-1 cursor-pointer",
-                      "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] opacity-80 hover:opacity-100",
-                      !isLast && "border-b border-[var(--border-subtle)]"
-                    )}
-                    title={e.command}
+            <ChevronRight size={12} />
+          </button>
+        </div>
+
+        {/* Virtualized list */}
+        <div ref={parentRef} className="flex-1 overflow-y-auto hide-scrollbar">
+          {entries.length === 0 ? (
+            <div className="px-3 py-3 text-[11px] text-[var(--text-tertiary)] leading-relaxed">
+              No bash commands in this chat yet.
+            </div>
+          ) : (
+            <div
+              style={{
+                height: virtualizer.getTotalSize(),
+                width: "100%",
+                position: "relative",
+              }}
+            >
+              {virtualizer.getVirtualItems().map((vItem) => {
+                const e = entries[vItem.index];
+                const isLast = vItem.index === entries.length - 1;
+                return (
+                  <div
+                    key={e.toolCallId}
+                    ref={virtualizer.measureElement}
+                    data-index={vItem.index}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${vItem.start}px)`,
+                    }}
                   >
-                    <div className="text-[11px] font-mono break-all line-clamp-2 whitespace-pre-wrap">
-                      {e.command}
-                    </div>
-                    <div className="flex items-center justify-between gap-2">
-                      {e.description ? (
-                        <span className="text-[9px] text-[var(--text-tertiary)] truncate flex-1">
-                          {e.description}
-                        </span>
-                      ) : (
-                        <span className="flex-1" />
+                    <button
+                      onClick={() => onJump(e.messageIndex)}
+                      className={cn(
+                        "group w-full text-left px-3 py-2 transition-colors flex flex-col gap-1 cursor-pointer",
+                        "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] opacity-80 hover:opacity-100",
+                        !isLast && "border-b border-[var(--border-subtle)]",
                       )}
-                      <span className="text-[9px] text-[var(--text-tertiary)] shrink-0">
-                        {timeAgo(e.timestamp)}
-                      </span>
-                    </div>
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
+                      title={e.command}
+                    >
+                      <div className="text-[11px] font-mono break-all line-clamp-2 whitespace-pre-wrap">
+                        {e.command}
+                      </div>
+                      <div className="flex items-center justify-between gap-2">
+                        {e.description ? (
+                          <span className="text-[9px] text-[var(--text-tertiary)] truncate flex-1">
+                            {e.description}
+                          </span>
+                        ) : (
+                          <span className="flex-1" />
+                        )}
+                        <span className="text-[9px] text-[var(--text-tertiary)] shrink-0">
+                          {timeAgo(e.timestamp)}
+                        </span>
+                      </div>
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </>
   );

--- a/src/features/chat/components/chat-input.tsx
+++ b/src/features/chat/components/chat-input.tsx
@@ -131,7 +131,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       minHeight = 44,
       maxHeight = 200,
     },
-    ref
+    ref,
   ) {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
@@ -217,9 +217,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               background: "var(--selection-bg) !important",
             },
           },
-          { dark: true }
+          { dark: true },
         ),
-      [minHeight, maxHeight]
+      [minHeight, maxHeight],
     );
 
     const extensionsKey = extraExtensions ?? null;
@@ -319,7 +319,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                 // when the agent supports image prompts. Unconsumed images
                 // fall through to the path-paste below.
                 const imageFiles = dt?.files
-                  ? Array.from(dt.files).filter((f) => f.type.startsWith("image/"))
+                  ? Array.from(dt.files).filter((f) =>
+                      f.type.startsWith("image/"),
+                    )
                   : [];
                 if (
                   imageFiles.length > 0 &&
@@ -337,7 +339,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                 event.preventDefault();
                 void (async () => {
                   try {
-                    const paths = await invoke<string[]>("clipboard_file_paths");
+                    const paths = await invoke<string[]>(
+                      "clipboard_file_paths",
+                    );
                     if (!paths || paths.length === 0) return;
                     const text = paths.map(quotePath).join(" ") + " ";
                     const head = view.state.selection.main.head;
@@ -371,9 +375,10 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               keymap.of(
                 mentionKeymap(
                   () =>
-                    (keyInterceptorRef.current as MentionKeyInterceptor | null) ?? null,
-                )
-              )
+                    (keyInterceptorRef.current as MentionKeyInterceptor | null) ??
+                    null,
+                ),
+              ),
             ),
             ...(extensionsKey ?? []),
           ],
@@ -421,11 +426,11 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         },
         view: () => viewRef.current,
       }),
-      []
+      [],
     );
 
     return <div ref={containerRef} className="atlas-chat-cm-host" />;
-  }
+  },
 );
 
 /** Whether the current selection's main caret sits on a markdown bullet or

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -1,11 +1,30 @@
-import { lazy, Suspense, memo, useCallback, useEffect, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useChatStore } from "../stores/chat-store";
 import { appendNextStepsDirective } from "../lib/next-steps";
-import { agents, ensureAgent, CODEX_PLUGIN_ID, CERSEI_PLUGIN_ID, DEFAULT_PLUGIN_ID, codexStatus } from "../lib/agents-api";
+import {
+  agents,
+  ensureAgent,
+  CODEX_PLUGIN_ID,
+  CERSEI_PLUGIN_ID,
+  DEFAULT_PLUGIN_ID,
+  codexStatus,
+} from "../lib/agents-api";
 import { loadCachedAcpModes } from "../lib/acp-modes-cache";
 import { warmAcpModels, otherAcpAgent } from "../lib/warm-acp-models";
 import type { ImageAttachment, SessionKey } from "@/types/agents";
-import { hasInFlightToolCalls, isBusyAgentStatus, agentTypeFromPluginId } from "@/types/agent";
+import {
+  hasInFlightToolCalls,
+  isBusyAgentStatus,
+  agentTypeFromPluginId,
+} from "@/types/agent";
 import {
   composePrompt,
   type MentionData,
@@ -246,7 +265,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
                   tabId,
                   snap.current_mode,
                   modes,
-                  agentTypeFromPluginId(snap.plugin_id)
+                  agentTypeFromPluginId(snap.plugin_id),
                 );
             }
             // Seed the ACP model picker (Claude Code / Codex) from the snapshot's
@@ -261,13 +280,15 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
           }
         } catch (err) {
           console.warn("snapshot for modes failed:", err);
-          if (!cancelled) useChatStore.getState().actions.setAcpModesPending(tabId, false);
+          if (!cancelled)
+            useChatStore.getState().actions.setAcpModesPending(tabId, false);
         }
       } catch (err) {
         console.warn("Agent session creation failed:", err);
         // Bind failed (agent not installed / spawn error) — clear the spinner so
         // the picker doesn't hang in a loading state forever.
-        if (!cancelled) useChatStore.getState().actions.setAcpModesPending(tabId, false);
+        if (!cancelled)
+          useChatStore.getState().actions.setAcpModesPending(tabId, false);
       } finally {
         pending = false;
       }
@@ -317,7 +338,10 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     let cancelled = false;
     void (async () => {
       try {
-        const snap = await agents.snapshot({ agent_id: agentId, session_id: acpSessionId });
+        const snap = await agents.snapshot({
+          agent_id: agentId,
+          session_id: acpSessionId,
+        });
         if (cancelled) return;
         const models = snap.available_models ?? [];
         console.debug("[acp-models] backfill", {
@@ -325,7 +349,9 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
           models: models.length,
         });
         if (models.length > 0) {
-          useChatStore.getState().actions.setAcpModels(tabId, snap.current_model, models);
+          useChatStore
+            .getState()
+            .actions.setAcpModels(tabId, snap.current_model, models);
         } else {
           // ACP `session/load` doesn't re-advertise models, so resumed
           // sessions get an empty snapshot. Fall back to the per-agent cache —
@@ -340,7 +366,11 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
           if (cached && cached.availableModels.length > 0) {
             useChatStore
               .getState()
-              .actions.setAcpModels(tabId, cached.currentModel, cached.availableModels);
+              .actions.setAcpModels(
+                tabId,
+                cached.currentModel,
+                cached.availableModels,
+              );
           }
         }
       } catch {
@@ -444,7 +474,8 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
   // the latest logic while keeping a constant identity. This is the H1 fix:
   // ChatPanel still re-renders per chunk, but its heavy composer subtree bails.
   const onSendStable = useCallback(
-    (content: string, mentions: MentionData[]) => handleSendRef.current?.(content, mentions),
+    (content: string, mentions: MentionData[]) =>
+      handleSendRef.current?.(content, mentions),
     [],
   );
   const onStopStable = useCallback(() => handleStopRef.current?.(), []);
@@ -488,7 +519,8 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
   // the prior behaviour.
   useEffect(() => {
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ text?: string; tabId?: string }>).detail;
+      const detail = (e as CustomEvent<{ text?: string; tabId?: string }>)
+        .detail;
       if (detail?.tabId != null && detail.tabId !== tabId) return;
       if (detail?.text && handleSendRef.current) {
         handleSendRef.current(detail.text, []);
@@ -802,7 +834,9 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
             tabId={tabId}
             onSend={onSendStable}
             onStop={onStopStable}
-            running={isBusyAgentStatus(session.status) || hasInFlightToolCalls(session)}
+            running={
+              isBusyAgentStatus(session.status) || hasInFlightToolCalls(session)
+            }
             stopping={!!session.stopping}
             showJumpToBottom={showJumpToBottom}
             jumpCount={jumpCount}
@@ -939,7 +973,9 @@ const ChatComposer = memo(function ChatComposer({
   useEffect(() => {
     if (isClaude) return;
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ sessionId?: string; agentType?: string }>).detail;
+      const detail = (
+        e as CustomEvent<{ sessionId?: string; agentType?: string }>
+      ).detail;
       if (detail?.agentType !== "codex") return;
       const sess = useChatStore.getState().sessions[tabId];
       if (!sess?.acpSessionId || sess.acpSessionId !== detail.sessionId) return;

--- a/src/features/chat/components/chat-search-palette.tsx
+++ b/src/features/chat/components/chat-search-palette.tsx
@@ -25,10 +25,8 @@ export function ChatSearchPalette({
   // Only user messages, with their original indices.
   const userMessages = useMemo(
     () =>
-      messages
-        .map((m, i) => ({ m, i }))
-        .filter(({ m }) => m.role === "user"),
-    [messages]
+      messages.map((m, i) => ({ m, i })).filter(({ m }) => m.role === "user"),
+    [messages],
   );
 
   const filtered = useMemo(() => {
@@ -75,7 +73,7 @@ export function ChatSearchPalette({
             "w-[560px] max-h-[440px] rounded-xl overflow-hidden",
             "bg-[var(--bg-secondary)] border border-[var(--border-default)]",
             "shadow-[var(--shadow-overlay)]",
-            "flex flex-col"
+            "flex flex-col",
           )}
           onOpenAutoFocus={(e) => {
             e.preventDefault();
@@ -84,7 +82,10 @@ export function ChatSearchPalette({
         >
           <Dialog.Title className="sr-only">Find user message</Dialog.Title>
           <div className="flex items-center gap-2 px-4 h-[44px] border-b border-[var(--border-default)] shrink-0">
-            <Search size={14} className="text-[var(--text-tertiary)] shrink-0" />
+            <Search
+              size={14}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
             <input
               ref={inputRef}
               value={query}
@@ -124,15 +125,18 @@ export function ChatSearchPalette({
                       "w-full flex items-start gap-3 px-4 py-2 text-left cursor-pointer",
                       active
                         ? "bg-[var(--bg-selected)]"
-                        : "hover:bg-[var(--bg-hover)]"
+                        : "hover:bg-[var(--bg-hover)]",
                     )}
                   >
                     <span
                       className={cn(
-                        "mt-0.5 w-5 h-5 rounded-full flex items-center justify-center shrink-0 bg-[var(--accent-primary-muted)]"
+                        "mt-0.5 w-5 h-5 rounded-full flex items-center justify-center shrink-0 bg-[var(--accent-primary-muted)]",
                       )}
                     >
-                      <User size={10} className="text-[var(--accent-primary)]" />
+                      <User
+                        size={10}
+                        className="text-[var(--accent-primary)]"
+                      />
                     </span>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">

--- a/src/features/chat/components/codex-login-dialog.tsx
+++ b/src/features/chat/components/codex-login-dialog.tsx
@@ -77,11 +77,23 @@ export function CodexLoginDialog({
         await agents.authenticate(agentId, method.id);
       }
       setPhase({ kind: "done" });
-      logEvent({ source: "atlas", kind: "codex-auth", summary: `Codex auth via ${method.id}`, status: "success", payload: { method: method.id } });
+      logEvent({
+        source: "atlas",
+        kind: "codex-auth",
+        summary: `Codex auth via ${method.id}`,
+        status: "success",
+        payload: { method: method.id },
+      });
       setTimeout(() => onOpenChange(false), 700);
     } catch (err) {
       setPhase({ kind: "error", message: String(err) });
-      logEvent({ source: "atlas", kind: "codex-auth", summary: `Codex auth failed (${method.id})`, status: "failure", payload: { method: method.id, error: String(err) } });
+      logEvent({
+        source: "atlas",
+        kind: "codex-auth",
+        summary: `Codex auth failed (${method.id})`,
+        status: "failure",
+        payload: { method: method.id, error: String(err) },
+      });
     }
   };
 
@@ -99,7 +111,9 @@ export function CodexLoginDialog({
           <div className="flex items-start gap-2.5 border-b border-border-default px-4 py-3">
             <Info className="mt-0.5 size-4 text-text-tertiary" />
             <div>
-              <Dialog.Title className="text-sm font-medium">Authenticate to Codex CLI</Dialog.Title>
+              <Dialog.Title className="text-sm font-medium">
+                Authenticate to Codex CLI
+              </Dialog.Title>
               <Dialog.Description className="mt-0.5 text-xs text-text-secondary">
                 Choose one of the following authentication options.
               </Dialog.Description>
@@ -120,12 +134,16 @@ export function CodexLoginDialog({
             )}
 
             {phase.kind === "done" && (
-              <div className="px-2 py-6 text-xs text-[var(--status-success)]">Signed in to Codex.</div>
+              <div className="px-2 py-6 text-xs text-[var(--status-success)]">
+                Signed in to Codex.
+              </div>
             )}
 
             {phase.kind === "error" && (
               <div className="space-y-3">
-                <p className="px-2 text-xs text-[var(--status-error)] break-words">{phase.message}</p>
+                <p className="px-2 text-xs text-[var(--status-error)] break-words">
+                  {phase.message}
+                </p>
                 <button
                   onClick={() => setPhase({ kind: "loading" })}
                   className="ml-2 rounded-sm border border-border-default px-2.5 py-1 text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary"
@@ -149,9 +167,13 @@ export function CodexLoginDialog({
                     className="group flex items-center gap-3 rounded-sm border border-border-default bg-bg-base px-3 py-2.5 text-left transition-colors hover:bg-bg-hover"
                   >
                     <span className="flex-1 min-w-0">
-                      <span className="block text-xs font-medium text-text-primary">{m.name}</span>
+                      <span className="block text-xs font-medium text-text-primary">
+                        {m.name}
+                      </span>
                       {m.description && (
-                        <span className="mt-0.5 block text-[11px] text-text-secondary">{m.description}</span>
+                        <span className="mt-0.5 block text-[11px] text-text-secondary">
+                          {m.description}
+                        </span>
                       )}
                     </span>
                     <ChevronRight className="size-3.5 shrink-0 text-text-tertiary group-hover:text-text-primary transition-colors" />

--- a/src/features/chat/components/commit-flow.tsx
+++ b/src/features/chat/components/commit-flow.tsx
@@ -123,7 +123,12 @@ export function CommitFlow({
                 className="absolute left-0 w-full"
                 style={{ transform: `translateY(${i * ROW_HEIGHT}px)` }}
               >
-                <CommitRowView row={row} selected={i === 0} compact onSelect={() => {}} />
+                <CommitRowView
+                  row={row}
+                  selected={i === 0}
+                  compact
+                  onSelect={() => {}}
+                />
               </div>
             ))}
           </div>

--- a/src/features/chat/components/composer-add-menu.tsx
+++ b/src/features/chat/components/composer-add-menu.tsx
@@ -32,7 +32,11 @@ import {
 import { cn } from "@/lib/utils";
 import { AgentIcons } from "@/components/agent-icons";
 import { AtlasIcon } from "@/components/atlas-icon";
-import { SWITCHABLE_AGENTS, AGENT_LABEL, type SwitchableAgent } from "@/types/agent";
+import {
+  SWITCHABLE_AGENTS,
+  AGENT_LABEL,
+  type SwitchableAgent,
+} from "@/types/agent";
 import type { GithubRepo, ClonedRepo } from "@/features/github/types";
 import {
   searchMentions,
@@ -177,7 +181,10 @@ export function ComposerAddMenu({
           className={cn(CONTENT_CLASS, "min-w-[210px]")}
           style={{ zIndex: 9999 }}
         >
-          <DropdownMenu.Item className={ITEM_CLASS} onSelect={onAddFilesOrPhotos}>
+          <DropdownMenu.Item
+            className={ITEM_CLASS}
+            onSelect={onAddFilesOrPhotos}
+          >
             <Paperclip size={11} />
             <span>{imageSupported ? "Add files or photos" : "Add files"}</span>
           </DropdownMenu.Item>
@@ -189,7 +196,10 @@ export function ComposerAddMenu({
             <DropdownMenu.SubTrigger className={ITEM_CLASS}>
               <Camera size={11} />
               <span>Take a screenshot</span>
-              <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
+              <ChevronRight
+                size={11}
+                className="ml-auto text-[var(--text-tertiary)]"
+              />
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
@@ -197,11 +207,17 @@ export function ComposerAddMenu({
                 className={cn(CONTENT_CLASS, "min-w-[190px]")}
                 style={{ zIndex: 9999 }}
               >
-                <DropdownMenu.Item className={ITEM_CLASS} onSelect={() => onTakeScreenshot("region")}>
+                <DropdownMenu.Item
+                  className={ITEM_CLASS}
+                  onSelect={() => onTakeScreenshot("region")}
+                >
                   <Crop size={11} />
                   <span>Selected region</span>
                 </DropdownMenu.Item>
-                <DropdownMenu.Item className={ITEM_CLASS} onSelect={() => onTakeScreenshot("full")}>
+                <DropdownMenu.Item
+                  className={ITEM_CLASS}
+                  onSelect={() => onTakeScreenshot("full")}
+                >
                   <Monitor size={11} />
                   <span>Whole desktop</span>
                 </DropdownMenu.Item>
@@ -217,12 +233,18 @@ export function ComposerAddMenu({
             <DropdownMenu.SubTrigger className={ITEM_CLASS}>
               <SquareSlash size={11} />
               <span>Skills</span>
-              <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
+              <ChevronRight
+                size={11}
+                className="ml-auto text-[var(--text-tertiary)]"
+              />
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
                 sideOffset={6}
-                className={cn(CONTENT_CLASS, "min-w-[220px] max-w-[280px] max-h-[320px] overflow-y-auto")}
+                className={cn(
+                  CONTENT_CLASS,
+                  "min-w-[220px] max-w-[280px] max-h-[320px] overflow-y-auto",
+                )}
                 style={{ zIndex: 9999 }}
               >
                 {skills === null ? (
@@ -232,7 +254,9 @@ export function ComposerAddMenu({
                   </div>
                 ) : skills.length === 0 ? (
                   <div className="px-3 py-1.5 text-[11px] text-[var(--text-tertiary)]">
-                    {skillsError ? "Couldn't load skills." : "No skills installed"}
+                    {skillsError
+                      ? "Couldn't load skills."
+                      : "No skills installed"}
                   </div>
                 ) : (
                   skills.map((skill) => (
@@ -265,7 +289,11 @@ export function ComposerAddMenu({
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
 
-          <SessionsSubmenu projectPath={projectPath} agentId={agentId} onPickSession={onPickSession} />
+          <SessionsSubmenu
+            projectPath={projectPath}
+            agentId={agentId}
+            onPickSession={onPickSession}
+          />
 
           <WorkspaceSubmenu
             projectPath={projectPath}
@@ -309,7 +337,10 @@ export function ComposerAddMenu({
                 );
               })}
             </div>
-            <span className="flex items-center gap-1 text-[10px] text-[var(--text-tertiary)]" title="Cycle coding agent">
+            <span
+              className="flex items-center gap-1 text-[10px] text-[var(--text-tertiary)]"
+              title="Cycle coding agent"
+            >
               <kbd className="rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] px-1 leading-[15px] font-sans">
                 ⌥
               </kbd>
@@ -354,8 +385,12 @@ function GithubSubmenu({
 
   // A searched repo is "already downloaded" when its on-disk dir (`owner-repo`)
   // is present in the cloned list — the same name we pass to `clone_github_repo`.
-  const clonedDirs = useMemo(() => new Set(cloned.map((c) => c.name)), [cloned]);
-  const isCloned = (repo: GithubRepo) => clonedDirs.has(repo.full_name.replace(/\//g, "-"));
+  const clonedDirs = useMemo(
+    () => new Set(cloned.map((c) => c.name)),
+    [cloned],
+  );
+  const isCloned = (repo: GithubRepo) =>
+    clonedDirs.has(repo.full_name.replace(/\//g, "-"));
 
   const runSearch = () => {
     const q = query.trim();
@@ -372,7 +407,10 @@ function GithubSubmenu({
       <DropdownMenu.SubTrigger className={ITEM_CLASS}>
         <Github size={11} />
         <span>Add from GitHub</span>
-        <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
+        <ChevronRight
+          size={11}
+          className="ml-auto text-[var(--text-tertiary)]"
+        />
       </DropdownMenu.SubTrigger>
       <DropdownMenu.Portal>
         <DropdownMenu.SubContent
@@ -403,12 +441,21 @@ function GithubSubmenu({
                       <DropdownMenu.Item
                         key={c.name}
                         disabled
-                        className={cn(ITEM_CLASS, "opacity-60 data-[disabled]:opacity-60")}
+                        className={cn(
+                          ITEM_CLASS,
+                          "opacity-60 data-[disabled]:opacity-60",
+                        )}
                         title={`Already downloaded · ${c.path}`}
                       >
-                        <FolderGit2 size={11} className="shrink-0 text-[var(--text-tertiary)]" />
+                        <FolderGit2
+                          size={11}
+                          className="shrink-0 text-[var(--text-tertiary)]"
+                        />
                         <span className="truncate">{c.display_name}</span>
-                        <Check size={11} className="ml-auto shrink-0 text-[var(--status-success)]" />
+                        <Check
+                          size={11}
+                          className="ml-auto shrink-0 text-[var(--status-success)]"
+                        />
                       </DropdownMenu.Item>
                     ))}
                     <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
@@ -445,13 +492,21 @@ function GithubSubmenu({
                         title={repo.description || repo.full_name}
                       >
                         {already ? (
-                          <Check size={11} className="mt-0.5 shrink-0 text-[var(--status-success)]" />
+                          <Check
+                            size={11}
+                            className="mt-0.5 shrink-0 text-[var(--status-success)]"
+                          />
                         ) : (
-                          <Download size={11} className="mt-0.5 shrink-0 text-[var(--text-tertiary)]" />
+                          <Download
+                            size={11}
+                            className="mt-0.5 shrink-0 text-[var(--text-tertiary)]"
+                          />
                         )}
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-1.5">
-                            <span className="truncate text-[var(--text-primary)]">{repo.full_name}</span>
+                            <span className="truncate text-[var(--text-primary)]">
+                              {repo.full_name}
+                            </span>
                             {already ? (
                               <span className="ml-auto shrink-0 text-[9px] text-[var(--text-tertiary)]">
                                 downloaded
@@ -512,7 +567,10 @@ function SessionsSubmenu({
       <DropdownMenu.SubTrigger className={ITEM_CLASS}>
         <MessageSquareText size={11} />
         <span>Attach a session</span>
-        <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
+        <ChevronRight
+          size={11}
+          className="ml-auto text-[var(--text-tertiary)]"
+        />
       </DropdownMenu.SubTrigger>
       <DropdownMenu.Portal>
         <DropdownMenu.SubContent
@@ -526,7 +584,11 @@ function SessionsSubmenu({
             </div>
           ) : (
             <>
-              <SearchBox value={query} onChange={setQuery} placeholder="Search sessions…" />
+              <SearchBox
+                value={query}
+                onChange={setQuery}
+                placeholder="Search sessions…"
+              />
               <div className="max-h-[300px] overflow-y-auto">
                 {sessions === null ? (
                   <div className="flex items-center gap-2 px-3 h-[26px] text-[11px] text-[var(--text-tertiary)]">
@@ -535,7 +597,9 @@ function SessionsSubmenu({
                   </div>
                 ) : filtered.length === 0 ? (
                   <div className="px-3 py-1.5 text-[11px] text-[var(--text-tertiary)]">
-                    {sessions.length === 0 ? "No past sessions in this project." : "No matches."}
+                    {sessions.length === 0
+                      ? "No past sessions in this project."
+                      : "No matches."}
                   </div>
                 ) : (
                   filtered.map((s) => (
@@ -545,11 +609,17 @@ function SessionsSubmenu({
                       onSelect={() => onPickSession(s)}
                       title={s.title}
                     >
-                      <MessageSquareText size={11} className="mt-0.5 shrink-0 text-[var(--text-tertiary)]" />
+                      <MessageSquareText
+                        size={11}
+                        className="mt-0.5 shrink-0 text-[var(--text-tertiary)]"
+                      />
                       <div className="min-w-0 flex-1">
-                        <div className="truncate text-[var(--text-primary)]">{s.title}</div>
+                        <div className="truncate text-[var(--text-primary)]">
+                          {s.title}
+                        </div>
                         <div className="text-[10px] text-[var(--text-tertiary)]">
-                          {s.messageCount} message{s.messageCount === 1 ? "" : "s"}
+                          {s.messageCount} message
+                          {s.messageCount === 1 ? "" : "s"}
                         </div>
                       </div>
                     </DropdownMenu.Item>
@@ -589,7 +659,9 @@ function WorkspaceSubmenu({
     void searchMentions(query, "workspace", { projectPath, agentId })
       .then((rows) => {
         if (cancelled) return;
-        setWorkspaces(rows.filter((m): m is MentionWorkspace => m.kind === "workspace"));
+        setWorkspaces(
+          rows.filter((m): m is MentionWorkspace => m.kind === "workspace"),
+        );
       })
       .catch(() => {
         if (!cancelled) setWorkspaces([]);
@@ -604,7 +676,10 @@ function WorkspaceSubmenu({
       <DropdownMenu.SubTrigger className={ITEM_CLASS}>
         <Boxes size={11} />
         <span>Reference workspace</span>
-        <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
+        <ChevronRight
+          size={11}
+          className="ml-auto text-[var(--text-tertiary)]"
+        />
       </DropdownMenu.SubTrigger>
       <DropdownMenu.Portal>
         <DropdownMenu.SubContent
@@ -612,7 +687,11 @@ function WorkspaceSubmenu({
           className={cn(CONTENT_CLASS, "w-[300px]")}
           style={{ zIndex: 9999 }}
         >
-          <SearchBox value={query} onChange={setQuery} placeholder="Search workspaces…" />
+          <SearchBox
+            value={query}
+            onChange={setQuery}
+            placeholder="Search workspaces…"
+          />
           <div className="max-h-[300px] overflow-y-auto">
             {workspaces === null ? (
               <div className="flex items-center gap-2 px-3 h-[26px] text-[11px] text-[var(--text-tertiary)]">
@@ -621,7 +700,9 @@ function WorkspaceSubmenu({
               </div>
             ) : workspaces.length === 0 ? (
               <div className="px-3 py-1.5 text-[11px] text-[var(--text-tertiary)]">
-                {query ? "No matches." : "No other projects in this organisation."}
+                {query
+                  ? "No matches."
+                  : "No other projects in this organisation."}
               </div>
             ) : (
               workspaces.map((w) => (
@@ -631,9 +712,14 @@ function WorkspaceSubmenu({
                   onSelect={() => onPickWorkspace(w)}
                   title={w.absPath}
                 >
-                  <Boxes size={11} className="mt-0.5 shrink-0 text-[var(--text-tertiary)]" />
+                  <Boxes
+                    size={11}
+                    className="mt-0.5 shrink-0 text-[var(--text-tertiary)]"
+                  />
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-[var(--text-primary)]">{w.displayName}</div>
+                    <div className="truncate text-[var(--text-primary)]">
+                      {w.displayName}
+                    </div>
                     <div className="truncate text-[10px] text-[var(--text-tertiary)]">
                       {w.absPath}
                     </div>

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -16,7 +16,12 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "../stores/chat-store";
 import { agents } from "../lib/agents-api";
-import { CLAUDE_PERMISSION_MODE_LABEL, AGENT_LABEL, agentTypeFromPluginId, type SwitchableAgent } from "@/types/agent";
+import {
+  CLAUDE_PERMISSION_MODE_LABEL,
+  AGENT_LABEL,
+  agentTypeFromPluginId,
+  type SwitchableAgent,
+} from "@/types/agent";
 import { AgentMark } from "@/components/agent-mark";
 import { ProviderModelPills } from "./provider-model-pills";
 import { loadCerseiEffort, loadCerseiCompress } from "../lib/cersei-model-pref";
@@ -32,7 +37,10 @@ import { loadCachedAcpModels } from "../lib/acp-models-cache";
 // `MentionPicker` only mounts when the user types `@`, so we let its chunk
 // load purely on demand — no eager preload (that would add a wasted Vite
 // roundtrip in dev for every MessageInput mount).
-import type { ChatInput as ChatInputComponent, ChatInputHandle } from "./chat-input";
+import type {
+  ChatInput as ChatInputComponent,
+  ChatInputHandle,
+} from "./chat-input";
 import type {
   MentionPicker as MentionPickerComponent,
   MentionPickerHandle,
@@ -76,8 +84,9 @@ const chatInputPromise: Promise<typeof import("./chat-input")> =
 const mentionPickerPromise: Promise<
   typeof import("@/features/mentions/components/mention-picker")
 > = import("@/features/mentions/components/mention-picker");
-const slashCommandPickerPromise: Promise<typeof import("./slash-command-picker")> =
-  import("./slash-command-picker");
+const slashCommandPickerPromise: Promise<
+  typeof import("./slash-command-picker")
+> = import("./slash-command-picker");
 
 // Module-level frozen empty array so selectors that return a "default empty
 // queue" hand back a stable reference instead of allocating per render.
@@ -86,7 +95,9 @@ const EMPTY_QUEUE: readonly string[] = Object.freeze([]);
 /** Read an image `File` (clipboard paste) into a base64 attachment. Returns
  *  null for non-images. The `data:` URI prefix is stripped — the wire shape
  *  carries raw base64 + mime separately. */
-async function fileToImageAttachment(file: File): Promise<ImageAttachment | null> {
+async function fileToImageAttachment(
+  file: File,
+): Promise<ImageAttachment | null> {
   if (!file.type.startsWith("image/")) return null;
   const dataUrl = await new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
@@ -134,9 +145,12 @@ interface MessageInputProps {
  */
 function acpModeColor(modeId: string | undefined): string {
   const id = (modeId ?? "").toLowerCase();
-  if (/full|bypass|\ball\b|danger|yolo|unrestricted/.test(id)) return "var(--status-error)";
-  if (/read.?only|\bplan\b|ask|suggest/.test(id)) return "var(--accent-primary)";
-  if (/auto|default|edit|accept|agent|workspace/.test(id)) return "var(--status-success)";
+  if (/full|bypass|\ball\b|danger|yolo|unrestricted/.test(id))
+    return "var(--status-error)";
+  if (/read.?only|\bplan\b|ask|suggest/.test(id))
+    return "var(--accent-primary)";
+  if (/auto|default|edit|accept|agent|workspace/.test(id))
+    return "var(--status-success)";
   return "var(--text-tertiary)";
 }
 
@@ -207,9 +221,19 @@ function CerseiMemoryPill() {
       className="flex items-center gap-1.5 px-2 h-6.5 rounded-full border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[10px] leading-none font-medium text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer tabular-nums disabled:cursor-default"
     >
       {indexing ? (
-        <Loader2 size={11} className="animate-spin text-[var(--accent-primary)]" />
+        <Loader2
+          size={11}
+          className="animate-spin text-[var(--accent-primary)]"
+        />
       ) : (
-        <Database size={11} className={status?.indexed ? "text-[var(--accent-primary)]" : "text-[var(--text-tertiary)]"} />
+        <Database
+          size={11}
+          className={
+            status?.indexed
+              ? "text-[var(--accent-primary)]"
+              : "text-[var(--text-tertiary)]"
+          }
+        />
       )}
       {label}
     </button>
@@ -239,7 +263,11 @@ function EffortPill({ tabId }: { tabId: string }) {
     >
       <Brain
         size={11}
-        className={active ? "text-[var(--accent-primary)]" : "text-[var(--text-tertiary)]"}
+        className={
+          active
+            ? "text-[var(--accent-primary)]"
+            : "text-[var(--text-tertiary)]"
+        }
       />
       {active ? `Think: ${effort}` : "Think"}
     </button>
@@ -252,7 +280,9 @@ function EffortPill({ tabId }: { tabId: string }) {
  *  own session's usage/compaction changes. */
 function CerseiUsagePill({ tabId }: { tabId: string }) {
   const usage = useChatStore((s) => s.sessions[tabId]?.usage);
-  const compacting = useChatStore((s) => s.sessions[tabId]?.compacting ?? false);
+  const compacting = useChatStore(
+    (s) => s.sessions[tabId]?.compacting ?? false,
+  );
   if (compacting) {
     return (
       <span
@@ -268,7 +298,10 @@ function CerseiUsagePill({ tabId }: { tabId: string }) {
   const total = (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
   if (total === 0) return null;
   const tokens = total >= 1000 ? `${(total / 1000).toFixed(1)}K` : `${total}`;
-  const cost = usage.cost && usage.cost > 0 ? ` · $${usage.cost.toFixed(usage.cost < 1 ? 3 : 2)}` : "";
+  const cost =
+    usage.cost && usage.cost > 0
+      ? ` · $${usage.cost.toFixed(usage.cost < 1 ? 3 : 2)}`
+      : "";
   return (
     <span
       className="flex items-center gap-1.5 px-2 h-6.5 rounded-full border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[10px] leading-none font-medium text-[var(--text-tertiary)] select-none tabular-nums"
@@ -288,8 +321,12 @@ function CerseiUsagePill({ tabId }: { tabId: string }) {
  */
 function AcpModePicker({ tabId }: { tabId: string }) {
   const currentMode = useChatStore((s) => s.sessions[tabId]?.acpCurrentMode);
-  const availableModes = useChatStore((s) => s.sessions[tabId]?.acpAvailableModes);
-  const pending = useChatStore((s) => s.sessions[tabId]?.acpModesPending ?? false);
+  const availableModes = useChatStore(
+    (s) => s.sessions[tabId]?.acpAvailableModes,
+  );
+  const pending = useChatStore(
+    (s) => s.sessions[tabId]?.acpModesPending ?? false,
+  );
   const { setAcpMode } = useChatStore.use.actions();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -297,7 +334,8 @@ function AcpModePicker({ tabId }: { tabId: string }) {
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     window.addEventListener("mousedown", onDown);
     return () => window.removeEventListener("mousedown", onDown);
@@ -353,7 +391,7 @@ function AcpModePicker({ tabId }: { tabId: string }) {
                   "flex w-full items-start gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors",
                   active
                     ? "bg-[var(--bg-selected)]"
-                    : "hover:bg-[var(--bg-hover)]"
+                    : "hover:bg-[var(--bg-hover)]",
                 )}
               >
                 <span
@@ -364,7 +402,10 @@ function AcpModePicker({ tabId }: { tabId: string }) {
                   <span className="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-primary)]">
                     {m.name}
                     {active && (
-                      <Check size={11} className="text-[var(--accent-primary)]" />
+                      <Check
+                        size={11}
+                        className="text-[var(--accent-primary)]"
+                      />
                     )}
                   </span>
                   {m.description && (
@@ -391,14 +432,19 @@ function AcpModePicker({ tabId }: { tabId: string }) {
  */
 /** Claude Code advertises its default model as "Recommended"; show "Default". */
 function modelLabel(m: { id: string; name: string }): string {
-  if (m.name.trim().toLowerCase() === "recommended" || m.id === "default") return "Default";
+  if (m.name.trim().toLowerCase() === "recommended" || m.id === "default")
+    return "Default";
   return m.name;
 }
 
 function AcpModelPicker({ tabId }: { tabId: string }) {
   const currentModel = useChatStore((s) => s.sessions[tabId]?.acpCurrentModel);
-  const availableModels = useChatStore((s) => s.sessions[tabId]?.acpAvailableModels);
-  const agentType = useChatStore((s) => s.sessions[tabId]?.agentType ?? "claude-code");
+  const availableModels = useChatStore(
+    (s) => s.sessions[tabId]?.acpAvailableModels,
+  );
+  const agentType = useChatStore(
+    (s) => s.sessions[tabId]?.agentType ?? "claude-code",
+  );
   const { setAcpModel } = useChatStore.use.actions();
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
@@ -407,7 +453,8 @@ function AcpModelPicker({ tabId }: { tabId: string }) {
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     window.addEventListener("mousedown", onDown);
     return () => window.removeEventListener("mousedown", onDown);
@@ -448,14 +495,22 @@ function AcpModelPicker({ tabId }: { tabId: string }) {
         title="Model"
       >
         <Cpu size={11} className="shrink-0 text-[var(--text-tertiary)]" />
-        <span className="max-w-[120px] truncate">{current ? modelLabel(current) : (currentModel ?? "Model")}</span>
-        <ChevronDown size={10} className="shrink-0 text-[var(--text-tertiary)]" />
+        <span className="max-w-[120px] truncate">
+          {current ? modelLabel(current) : (currentModel ?? "Model")}
+        </span>
+        <ChevronDown
+          size={10}
+          className="shrink-0 text-[var(--text-tertiary)]"
+        />
       </button>
       {open && (
         <div className="absolute bottom-full left-0 mb-1.5 z-50 w-[260px] overflow-hidden rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] shadow-lg">
           {/* Search combobox */}
           <div className="flex items-center gap-1.5 h-8 border-b border-[var(--border-subtle)] px-2.5">
-            <Search size={12} className="shrink-0 text-[var(--text-tertiary)]" />
+            <Search
+              size={12}
+              className="shrink-0 text-[var(--text-tertiary)]"
+            />
             <input
               autoFocus
               value={q}
@@ -467,7 +522,9 @@ function AcpModelPicker({ tabId }: { tabId: string }) {
           </div>
           <div className="max-h-[280px] overflow-y-auto hide-scrollbar p-1">
             {filtered.length === 0 ? (
-              <div className="px-2.5 py-2 text-[11px] text-[var(--text-tertiary)]">No models</div>
+              <div className="px-2.5 py-2 text-[11px] text-[var(--text-tertiary)]">
+                No models
+              </div>
             ) : (
               filtered.map((m) => {
                 const active = m.id === currentModel;
@@ -480,21 +537,28 @@ function AcpModelPicker({ tabId }: { tabId: string }) {
                     }}
                     className={cn(
                       "flex w-full items-start gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors cursor-pointer",
-                      active ? "bg-[var(--bg-selected)]" : "hover:bg-[var(--bg-hover)]",
+                      active
+                        ? "bg-[var(--bg-selected)]"
+                        : "hover:bg-[var(--bg-hover)]",
                     )}
                   >
                     <span className="flex-1 min-w-0">
                       <span className="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-primary)]">
                         <span className="truncate">{modelLabel(m)}</span>
                         {active && (
-                          <Check size={11} className="shrink-0 text-[var(--accent-primary)]" />
+                          <Check
+                            size={11}
+                            className="shrink-0 text-[var(--accent-primary)]"
+                          />
                         )}
                       </span>
-                      {m.description && m.description.trim().toLowerCase() !== "recommended" && (
-                        <span className="mt-0.5 block text-[9px] leading-snug text-[var(--text-tertiary)] line-clamp-2">
-                          {m.description}
-                        </span>
-                      )}
+                      {m.description &&
+                        m.description.trim().toLowerCase() !==
+                          "recommended" && (
+                          <span className="mt-0.5 block text-[9px] leading-snug text-[var(--text-tertiary)] line-clamp-2">
+                            {m.description}
+                          </span>
+                        )}
                     </span>
                   </button>
                 );
@@ -530,13 +594,13 @@ export function MessageInput({
   // Codex/other ACP agents advertise their own permission modes; show the
   // picker only when this session actually has modes (Claude uses its own pill).
   const hasAcpModes = useChatStore(
-    (s) => (s.sessions[tabId]?.acpAvailableModes?.length ?? 0) > 0
+    (s) => (s.sessions[tabId]?.acpAvailableModes?.length ?? 0) > 0,
   );
   // Show the picker as soon as the agent is non-Claude — even before its modes
   // load — so the composer can render a loading pill instead of nothing during
   // the agent spawn + new_session boot.
   const acpModesPending = useChatStore(
-    (s) => s.sessions[tabId]?.acpModesPending ?? false
+    (s) => s.sessions[tabId]?.acpModesPending ?? false,
   );
   // Self-heal the mode picker. chat-panel seeds the modes when a session is
   // first bound, but that path can be missed (resumed/restored sessions, an
@@ -565,7 +629,7 @@ export function MessageInput({
             tabId,
             snap.current_mode,
             snap.available_modes,
-            agentTypeFromPluginId(snap.plugin_id)
+            agentTypeFromPluginId(snap.plugin_id),
           );
         }
       } catch (err) {
@@ -591,25 +655,33 @@ export function MessageInput({
   // component otherwise would re-render on every streaming chunk because it
   // sits inside the active chat panel.
   const permissionMode = useChatStore(
-    (s) => s.sessions[tabId]?.claudePermissionMode ?? "default"
+    (s) => s.sessions[tabId]?.claudePermissionMode ?? "default",
   );
   const agentType = useChatStore(
-    (s) => s.sessions[tabId]?.agentType ?? "claude-code"
+    (s) => s.sessions[tabId]?.agentType ?? "claude-code",
   );
   // `agentType` widened to a SwitchableAgent (drops "custom") for the composer
   // sub-components (skill/session scope, agent switcher) + the label lookup.
   const switchableAgent: SwitchableAgent =
-    agentType === "codex" ? "codex" : agentType === "cersei" ? "cersei" : "claude-code";
+    agentType === "codex"
+      ? "codex"
+      : agentType === "cersei"
+        ? "cersei"
+        : "claude-code";
   // Native Cersei agent only: BYOK provider + model selection for the composer.
-  const cerseiProvider = useChatStore((s) => s.sessions[tabId]?.cerseiProvider ?? "");
-  const cerseiModel = useChatStore((s) => s.sessions[tabId]?.acpCurrentModel ?? "");
+  const cerseiProvider = useChatStore(
+    (s) => s.sessions[tabId]?.cerseiProvider ?? "",
+  );
+  const cerseiModel = useChatStore(
+    (s) => s.sessions[tabId]?.acpCurrentModel ?? "",
+  );
   const onCerseiProvider = useCallback(
     (id: string) => setCerseiProvider(tabId, id),
-    [tabId, setCerseiProvider]
+    [tabId, setCerseiProvider],
   );
   const onCerseiModel = useCallback(
     (id: string) => setCerseiModel(tabId, id),
-    [tabId, setCerseiModel]
+    [tabId, setCerseiModel],
   );
   // The composer may settle on a provider/model before the session is bound
   // (the `agents_set_model` push no-ops until then). Re-push once the binding
@@ -633,7 +705,9 @@ export function MessageInput({
   const cerseiEffort = useChatStore((s) => s.sessions[tabId]?.cerseiEffort);
   const cerseiBound = useChatStore((s) => {
     const sess = s.sessions[tabId];
-    return sess?.agentType === "cersei" && !!sess.acpAgentId && !!sess.acpSessionId
+    return sess?.agentType === "cersei" &&
+      !!sess.acpAgentId &&
+      !!sess.acpSessionId
       ? `${sess.acpAgentId}::${sess.acpSessionId}`
       : null;
   });
@@ -649,17 +723,24 @@ export function MessageInput({
   useEffect(() => {
     if (agentType !== "cersei") return;
     const on = cerseiCompress ?? loadCerseiCompress();
-    if (cerseiBound || cerseiCompress === undefined) setCerseiCompress(tabId, on);
+    if (cerseiBound || cerseiCompress === undefined)
+      setCerseiCompress(tabId, on);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabId, agentType, cerseiBound]);
   // ACP-reported slash commands for this session (Codex). Claude keeps its
   // curated catalogue (the picker's default).
-  const availableCommands = useChatStore((s) => s.sessions[tabId]?.availableCommands);
+  const availableCommands = useChatStore(
+    (s) => s.sessions[tabId]?.availableCommands,
+  );
   const agentSlashCommands = useMemo<SlashCommand[] | undefined>(() => {
     if (agentType !== "codex") return undefined;
     const fromAgent: SlashCommand[] = (availableCommands ?? [])
       .map((c) => {
-        const o = (c ?? {}) as { name?: string; description?: string; input?: unknown };
+        const o = (c ?? {}) as {
+          name?: string;
+          description?: string;
+          input?: unknown;
+        };
         const name = (o.name ?? "").replace(/^\//, "");
         return {
           name,
@@ -712,12 +793,15 @@ export function MessageInput({
   // fallback — instead the placeholder div below holds the layout slot at
   // the same height so the swap is invisible (no reflow, no mount/unmount
   // of an interactive element mid-typing).
-  const [LazyChatInput, setLazyChatInput] =
-    useState<typeof ChatInputComponent | null>(null);
-  const [LazyMentionPicker, setLazyMentionPicker] =
-    useState<typeof MentionPickerComponent | null>(null);
-  const [LazySlashPicker, setLazySlashPicker] =
-    useState<typeof SlashCommandPickerComponent | null>(null);
+  const [LazyChatInput, setLazyChatInput] = useState<
+    typeof ChatInputComponent | null
+  >(null);
+  const [LazyMentionPicker, setLazyMentionPicker] = useState<
+    typeof MentionPickerComponent | null
+  >(null);
+  const [LazySlashPicker, setLazySlashPicker] = useState<
+    typeof SlashCommandPickerComponent | null
+  >(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -747,7 +831,7 @@ export function MessageInput({
     if (focusedOnceRef.current) return;
     focusedOnceRef.current = true;
     window.dispatchEvent(
-      new CustomEvent("atlas:chat-input-focused", { detail: { tabId } })
+      new CustomEvent("atlas:chat-input-focused", { detail: { tabId } }),
     );
   }, [tabId]);
 
@@ -771,7 +855,9 @@ export function MessageInput({
   // Codex sign-in pill is handled in ChatComposer (it owns that probe state).
   useEffect(() => {
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ sessionId?: string; agentType?: string }>).detail;
+      const detail = (
+        e as CustomEvent<{ sessionId?: string; agentType?: string }>
+      ).detail;
       if (detail?.agentType !== "claude-code") return;
       const sess = useChatStore.getState().sessions[tabId];
       if (!sess?.acpSessionId || sess.acpSessionId !== detail.sessionId) return;
@@ -781,23 +867,22 @@ export function MessageInput({
     return () => window.removeEventListener("atlas:auth-required", handler);
   }, [tabId, openLoginDialog]);
 
-  const handleMentionSelect = useCallback(
-    (mention: MentionData) => {
-      const t = triggerRef.current;
-      if (!t) return;
-      inputRef.current?.insertMention(mention, t.from, t.to);
-      // Trigger naturally closes when the doc no longer has an `@…` before
-      // the caret; the plugin will fire the null transition for us.
-    },
-    []
-  );
+  const handleMentionSelect = useCallback((mention: MentionData) => {
+    const t = triggerRef.current;
+    if (!t) return;
+    inputRef.current?.insertMention(mention, t.from, t.to);
+    // Trigger naturally closes when the doc no longer has an `@…` before
+    // the caret; the plugin will fire the null transition for us.
+  }, []);
 
   // ── Drag-and-drop OS files onto the composer → attach as mention chips ──
   const composerRef = useRef<HTMLDivElement>(null);
   const handleDropFiles = useCallback(
     (paths: string[]) => {
       const root =
-        projectPath && !projectPath.endsWith("/") ? `${projectPath}/` : projectPath;
+        projectPath && !projectPath.endsWith("/")
+          ? `${projectPath}/`
+          : projectPath;
       for (const abs of paths) {
         // Relative-to-project display name when the file lives inside the
         // project; otherwise just the basename (dropped files can be anywhere).
@@ -815,7 +900,7 @@ export function MessageInput({
       }
       requestAnimationFrame(() => inputRef.current?.focus());
     },
-    [projectPath]
+    [projectPath],
   );
   const { isDropTarget } = useComposerFileDrop({
     targetRef: composerRef,
@@ -873,7 +958,10 @@ export function MessageInput({
   const pickFilesOrPhotos = useCallback(async () => {
     try {
       const { open } = await import("@tauri-apps/plugin-dialog");
-      const picked = await open({ multiple: true, title: "Attach files or photos" });
+      const picked = await open({
+        multiple: true,
+        title: "Attach files or photos",
+      });
       if (!picked) return;
       const paths = (Array.isArray(picked) ? picked : [picked]) as string[];
       const images: ImageAttachment[] = [];
@@ -923,8 +1011,20 @@ export function MessageInput({
           {
             name: "Media",
             extensions: [
-              "png", "jpg", "jpeg", "gif", "webp", "heic", "bmp", "svg",
-              "mp4", "mov", "webm", "m4v", "avi", "mkv",
+              "png",
+              "jpg",
+              "jpeg",
+              "gif",
+              "webp",
+              "heic",
+              "bmp",
+              "svg",
+              "mp4",
+              "mov",
+              "webm",
+              "m4v",
+              "avi",
+              "mkv",
             ],
           },
         ],
@@ -958,29 +1058,36 @@ export function MessageInput({
   // `screencapture` CLI (region selection or whole desktop), then attaches the
   // PNG — inline (multimodal) when the agent supports images, else as an @file
   // chip pointing at the saved `.atlas/screenshots/…` path.
-  const handleTakeScreenshot = useCallback(async (mode: "region" | "full") => {
-    try {
-      // Let the "+" menu fully close first so it (and any dropdown) isn't caught
-      // in a whole-desktop capture.
-      await new Promise((r) => setTimeout(r, 250));
-      const proj = useProjectStore.getState().currentProject?.path ?? null;
-      const res = await invoke<{ path: string; mimeType: string; dataBase64: string } | null>(
-        "capture_screenshot",
-        { mode, projectPath: proj },
-      );
-      if (!res) return; // cancelled (Esc during region select)
-      if (imageSupported) {
-        setStagedImages((prev) => [...prev, { mimeType: res.mimeType, dataBase64: res.dataBase64 }]);
-      } else {
-        handleDropFiles([res.path]);
+  const handleTakeScreenshot = useCallback(
+    async (mode: "region" | "full") => {
+      try {
+        // Let the "+" menu fully close first so it (and any dropdown) isn't caught
+        // in a whole-desktop capture.
+        await new Promise((r) => setTimeout(r, 250));
+        const proj = useProjectStore.getState().currentProject?.path ?? null;
+        const res = await invoke<{
+          path: string;
+          mimeType: string;
+          dataBase64: string;
+        } | null>("capture_screenshot", { mode, projectPath: proj });
+        if (!res) return; // cancelled (Esc during region select)
+        if (imageSupported) {
+          setStagedImages((prev) => [
+            ...prev,
+            { mimeType: res.mimeType, dataBase64: res.dataBase64 },
+          ]);
+        } else {
+          handleDropFiles([res.path]);
+        }
+        requestAnimationFrame(() => inputRef.current?.focus());
+      } catch (err) {
+        toast.error(
+          `Screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
-      requestAnimationFrame(() => inputRef.current?.focus());
-    } catch (err) {
-      toast.error(
-        `Screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }, [imageSupported, handleDropFiles]);
+    },
+    [imageSupported, handleDropFiles],
+  );
 
   // "+" menu → "Add from GitHub". Shorthand for the GitHub panel's search+clone:
   // download the repo into `<project>/.atlas/repos`, lock the composer while it
@@ -1000,7 +1107,8 @@ export function MessageInput({
         cloneUrl: repo.clone_url,
         repoName: repo.full_name.replace(/\//g, "-"),
       });
-      const folderName = dest.split("/").pop() || repo.full_name.replace(/\//g, "-");
+      const folderName =
+        dest.split("/").pop() || repo.full_name.replace(/\//g, "-");
       const mention: MentionRepo = {
         kind: "repo",
         id: dest,
@@ -1041,18 +1149,23 @@ export function MessageInput({
   // straight to the picked agent: an empty chat flips in place; a started chat
   // clears + rebinds in the SAME tab (singleton model — the abandoned turn
   // persists to the history sidebar).
-  const handleSwitchAgent = useCallback((next: SwitchableAgent) => {
-    const chat = useChatStore.getState();
-    const sess = chat.sessions[tabId];
-    if ((sess?.agentType ?? "claude-code") === next) return;
-    if ((sess?.messages.length ?? 0) === 0) {
-      chat.actions.switchChatAgent(tabId, next);
-    } else {
-      chat.actions.clearSession(tabId);
-      chat.actions.switchChatAgent(tabId, next);
-    }
-    window.dispatchEvent(new CustomEvent("atlas:chat-focus", { detail: { tabId } }));
-  }, [tabId]);
+  const handleSwitchAgent = useCallback(
+    (next: SwitchableAgent) => {
+      const chat = useChatStore.getState();
+      const sess = chat.sessions[tabId];
+      if ((sess?.agentType ?? "claude-code") === next) return;
+      if ((sess?.messages.length ?? 0) === 0) {
+        chat.actions.switchChatAgent(tabId, next);
+      } else {
+        chat.actions.clearSession(tabId);
+        chat.actions.switchChatAgent(tabId, next);
+      }
+      window.dispatchEvent(
+        new CustomEvent("atlas:chat-focus", { detail: { tabId } }),
+      );
+    },
+    [tabId],
+  );
 
   // Clipboard images (screenshots) → staged attachments. Returning false
   // lets chat-input's default file-paste (native pasteboard → quoted paths)
@@ -1124,7 +1237,7 @@ export function MessageInput({
       setSlashTrigger(null);
       onSend(`/${cmd.name}`, []);
     },
-    [openLoginDialog, onSend, disabled]
+    [openLoginDialog, onSend, disabled],
   );
 
   // Forward Up/Down/Enter/Esc/Backspace from CodeMirror to whichever
@@ -1182,7 +1295,7 @@ export function MessageInput({
           return false;
       }
     },
-    []
+    [],
   );
 
   // Auto-focus the composer whenever this panel mounts (tab switch back into
@@ -1246,7 +1359,8 @@ export function MessageInput({
   // the ACTIVE session reacts, so it doesn't fan out to every mounted chat tab.
   useEffect(() => {
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ text: string; tabId?: string }>).detail;
+      const detail = (e as CustomEvent<{ text: string; tabId?: string }>)
+        .detail;
       if (!detail?.text) return;
       if (detail.tabId) {
         // Tab-targeted insert (KB "send selection to chat"). The sender
@@ -1303,7 +1417,17 @@ export function MessageInput({
     // The value→draft sync effect will collapse the empty value into a
     // `delete s.drafts[tabId]` on the next commit, so no explicit
     // clearDraft call is needed.
-  }, [value, running, onSend, onStop, enqueueMessage, tabId, disabled, stagedImages, githubSyncing]);
+  }, [
+    value,
+    running,
+    onSend,
+    onStop,
+    enqueueMessage,
+    tabId,
+    disabled,
+    stagedImages,
+    githubSyncing,
+  ]);
 
   const trimmed = value.trim();
   // Tri-state button:
@@ -1322,7 +1446,9 @@ export function MessageInput({
   // composer no longer mirrors the setup phase here (the setup pill above the
   // input already communicates install/auth state). Only the queue hint
   // overrides it.
-  const effectivePlaceholder = running ? "Type to queue the next message…" : placeholder;
+  const effectivePlaceholder = running
+    ? "Type to queue the next message…"
+    : placeholder;
 
   return (
     <div className="px-4 pb-4 pt-2 bg-transparent">
@@ -1416,7 +1542,9 @@ export function MessageInput({
                     />
                     <button
                       onClick={() =>
-                        setStagedImages((prev) => prev.filter((_, j) => j !== i))
+                        setStagedImages((prev) =>
+                          prev.filter((_, j) => j !== i),
+                        )
                       }
                       className="absolute -top-1.5 -right-1.5 hidden group-hover:flex items-center justify-center w-4 h-4 rounded-full bg-[var(--bg-elevated)] border border-[var(--border-default)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] cursor-pointer"
                       title="Remove image"
@@ -1469,7 +1597,9 @@ export function MessageInput({
             <div className="flex items-center gap-1">
               <ComposerAddMenu
                 disabled={disabled || githubSyncing !== null}
-                projectPath={useProjectStore.getState().currentProject?.path ?? null}
+                projectPath={
+                  useProjectStore.getState().currentProject?.path ?? null
+                }
                 agentId={switchableAgent}
                 imageSupported={imageSupported}
                 onAddFilesOrPhotos={() => void pickFilesOrPhotos()}
@@ -1488,30 +1618,37 @@ export function MessageInput({
                 className="flex items-center gap-1.5 px-1.5 h-6.5 rounded-full border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[10px] leading-none font-medium text-[var(--text-secondary)] select-none"
                 title="Coding agent (switch with ⌥/ on a new chat)"
               >
-                <AgentMark agentType={agentType} className="!h-4 !w-4 !text-[9px] !rounded" />
+                <AgentMark
+                  agentType={agentType}
+                  className="!h-4 !w-4 !text-[9px] !rounded"
+                />
                 {AGENT_LABEL[switchableAgent]}
               </span>
               {agentType === "claude-code" && (
-              <button
-                onClick={() => cycleClaudePermissionMode(tabId)}
-                className="flex items-center gap-1.5 px-2 h-6.5 rounded-full border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[10px] leading-none font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
-                title="Cycle permission mode (⇧⇥)"
-              >
-                <span
-                  className={cn(
-                    "w-1.5 h-1.5 rounded-full shrink-0",
-                    permissionMode === "default" && "bg-[var(--text-tertiary)]",
-                    permissionMode === "acceptEdits" && "bg-[var(--status-success)]",
-                    permissionMode === "plan" && "bg-[var(--accent-primary)]",
-                    permissionMode === "bypassPermissions" && "bg-[var(--status-error)]"
-                  )}
-                />
-                {CLAUDE_PERMISSION_MODE_LABEL[permissionMode]}
-              </button>
+                <button
+                  onClick={() => cycleClaudePermissionMode(tabId)}
+                  className="flex items-center gap-1.5 px-2 h-6.5 rounded-full border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[10px] leading-none font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
+                  title="Cycle permission mode (⇧⇥)"
+                >
+                  <span
+                    className={cn(
+                      "w-1.5 h-1.5 rounded-full shrink-0",
+                      permissionMode === "default" &&
+                        "bg-[var(--text-tertiary)]",
+                      permissionMode === "acceptEdits" &&
+                        "bg-[var(--status-success)]",
+                      permissionMode === "plan" && "bg-[var(--accent-primary)]",
+                      permissionMode === "bypassPermissions" &&
+                        "bg-[var(--status-error)]",
+                    )}
+                  />
+                  {CLAUDE_PERMISSION_MODE_LABEL[permissionMode]}
+                </button>
               )}
-              {agentType !== "claude-code" && (hasAcpModes || acpModesPending) && (
-                <AcpModePicker tabId={tabId} />
-              )}
+              {agentType !== "claude-code" &&
+                (hasAcpModes || acpModesPending) && (
+                  <AcpModePicker tabId={tabId} />
+                )}
               {/* ACP first-party model picker — Claude Code / Codex advertise
                   their models in `session/new` (the native agent uses the BYOK
                   ProviderModelPills below instead). Renders nothing if empty. */}
@@ -1539,7 +1676,7 @@ export function MessageInput({
                   "flex items-center justify-center w-7 h-7 rounded-full transition-colors",
                   buttonEnabled
                     ? "bg-[var(--text-primary)] text-[var(--bg-primary)] hover:bg-[var(--text-secondary)] cursor-pointer"
-                    : "bg-[var(--bg-elevated)] text-[var(--text-tertiary)] cursor-not-allowed"
+                    : "bg-[var(--bg-elevated)] text-[var(--text-tertiary)] cursor-not-allowed",
                 )}
                 title={
                   mode === "stop"
@@ -1547,8 +1684,8 @@ export function MessageInput({
                       ? "Stopping… (waiting for the agent to wind down)"
                       : "Stop generation"
                     : mode === "queue"
-                    ? "Queue message (sends after current finishes)"
-                    : "Send to agent (⌘↵)"
+                      ? "Queue message (sends after current finishes)"
+                      : "Send to agent (⌘↵)"
                 }
               >
                 {mode === "stop" ? (
@@ -1593,7 +1730,10 @@ export function MessageInput({
           footerLabel={agentType === "codex" ? "Codex commands" : undefined}
         />
       )}
-      <CodexLoginDialog open={codexLoginOpen} onOpenChange={setCodexLoginOpen} />
+      <CodexLoginDialog
+        open={codexLoginOpen}
+        onOpenChange={setCodexLoginOpen}
+      />
     </div>
   );
 }

--- a/src/features/chat/components/message-item.tsx
+++ b/src/features/chat/components/message-item.tsx
@@ -70,7 +70,6 @@ function getAtlasSplit(message: ChatMessage): SplitContext {
   return splitAtlasContext(message.content);
 }
 
-
 function openFileInEditor(filePath: string) {
   useLayoutStore.getState().actions.addTab({
     id: `editor:${filePath}`,
@@ -209,7 +208,11 @@ export const MessageItem = memo(function MessageItem({
             {!compact && (
               <div className="flex items-center gap-2">
                 <span className="text-[11px] font-semibold text-[var(--text-secondary)] uppercase tracking-wide">
-                  {isUser ? "You" : isAssistant ? (agentLabel ?? "Assistant") : message.role}
+                  {isUser
+                    ? "You"
+                    : isAssistant
+                      ? (agentLabel ?? "Assistant")
+                      : message.role}
                 </span>
                 <span className="text-[10px] text-[var(--text-tertiary)] font-mono">
                   {new Date(message.timestamp).toLocaleTimeString([], {
@@ -319,9 +322,10 @@ export const MessageItem = memo(function MessageItem({
             {/* Per-turn usage footer (native agent) — token count + cost at the
                 end of the turn, since with the in-process agent we know the
                 model + have exact usage. */}
-            {message.usage && message.usage.input + message.usage.output > 0 && (
-              <UsageFooter usage={message.usage} model={model ?? null} />
-            )}
+            {message.usage &&
+              message.usage.input + message.usage.output > 0 && (
+                <UsageFooter usage={message.usage} model={model ?? null} />
+              )}
             {/* Adaptive per-turn footer (files touched + next-step chips) —
                 only on the trailing message of a completed turn. */}
             {isLastInGroup &&
@@ -834,9 +838,12 @@ function UsageFooter({
           usage.cost > 0 ? ` · est. $${usage.cost.toFixed(4)}` : ""
         }`}
       >
-        ↑ {fmt(usage.input)} ↓ {fmt(usage.output)} · {fmt(usage.input + usage.output)} tokens{cost}
+        ↑ {fmt(usage.input)} ↓ {fmt(usage.output)} ·{" "}
+        {fmt(usage.input + usage.output)} tokens{cost}
       </span>
-      {model && <span className="text-[var(--text-tertiary)]/70">· {model}</span>}
+      {model && (
+        <span className="text-[var(--text-tertiary)]/70">· {model}</span>
+      )}
       {saved > 0 && (
         <span
           className="flex items-center gap-1 rounded-full border border-[var(--status-success)]/30 px-1.5 py-px text-[var(--status-success)]"
@@ -889,9 +896,11 @@ const MemoryRecallCard = memo(function MemoryRecallCard({
   const [open, setOpen] = useState(false);
   const args = toolCall.arguments as Record<string, unknown>;
   const query = typeof args.query === "string" ? args.query : "";
-  const isRunning = toolCall.status === "running" || toolCall.status === "pending";
+  const isRunning =
+    toolCall.status === "running" || toolCall.status === "pending";
   const failed = toolCall.status === "failed";
-  const docs = !isRunning && toolCall.result ? parseRecalledDocs(toolCall.result) : [];
+  const docs =
+    !isRunning && toolCall.result ? parseRecalledDocs(toolCall.result) : [];
 
   return (
     <div className="rounded-md border border-l-2 border-[var(--border-default)] border-l-[var(--accent-primary)] bg-[var(--bg-secondary)] overflow-hidden">
@@ -900,7 +909,10 @@ const MemoryRecallCard = memo(function MemoryRecallCard({
         className="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
       >
         {isRunning ? (
-          <Loader2 size={12} className="shrink-0 animate-spin text-[var(--accent-primary)]" />
+          <Loader2
+            size={12}
+            className="shrink-0 animate-spin text-[var(--accent-primary)]"
+          />
         ) : (
           <Brain size={12} className="shrink-0 text-[var(--accent-primary)]" />
         )}
@@ -920,7 +932,10 @@ const MemoryRecallCard = memo(function MemoryRecallCard({
         {docs.length > 0 && (
           <ChevronRight
             size={13}
-            className={cn("shrink-0 text-[var(--text-tertiary)] transition-transform", open && "rotate-90")}
+            className={cn(
+              "shrink-0 text-[var(--text-tertiary)] transition-transform",
+              open && "rotate-90",
+            )}
           />
         )}
       </button>
@@ -942,7 +957,7 @@ const MemoryRecallCard = memo(function MemoryRecallCard({
                 <span
                   className={cn(
                     "shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide",
-                    MEMORY_SOURCE_STYLE[d.source] ?? MEMORY_SOURCE_STYLE.shared
+                    MEMORY_SOURCE_STYLE[d.source] ?? MEMORY_SOURCE_STYLE.shared,
                   )}
                 >
                   {d.source}

--- a/src/features/chat/components/messages-list.tsx
+++ b/src/features/chat/components/messages-list.tsx
@@ -130,7 +130,9 @@ function recordHeight(id: string, h: number) {
 }
 
 function averageHeight(): number {
-  return heightCount > 0 ? Math.round(heightSum / heightCount) : DEFAULT_ROW_ESTIMATE;
+  return heightCount > 0
+    ? Math.round(heightSum / heightCount)
+    : DEFAULT_ROW_ESTIMATE;
 }
 // Wider than it looks like it should be: a streaming assistant message
 // grows in chunks of several lines per RAF. If the user is within ~one
@@ -162,10 +164,15 @@ function WorkingIndicator() {
     <div className="group px-6 pb-6 animate-scale-in">
       <div className="flex gap-4 max-w-[760px] mx-auto">
         <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 mt-0.5 bg-[var(--bg-elevated)] border border-[var(--border-default)]">
-          <Sparkles size={14} className="text-[var(--text-secondary)] animate-pulse" />
+          <Sparkles
+            size={14}
+            className="text-[var(--text-secondary)] animate-pulse"
+          />
         </div>
         <div className="flex h-8 items-center gap-1.5">
-          <span className="text-[12px] text-[var(--text-secondary)]">Thinking</span>
+          <span className="text-[12px] text-[var(--text-secondary)]">
+            Thinking
+          </span>
           <span className="flex items-center gap-0.5">
             {[0, 1, 2].map((i) => (
               <span
@@ -194,705 +201,726 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(
     },
     ref,
   ) {
-  // Resolved once per agent change, not once per row. Both values are stable
-  // references (the avatars are module constants, the label a constant string)
-  // so they never invalidate MessageItem's memo.
-  const agent = switchable(agentType);
-  const agentAvatar = AGENT_AVATAR[agent];
-  const agentLabel = AGENT_LABEL[agent];
+    // Resolved once per agent change, not once per row. Both values are stable
+    // references (the avatars are module constants, the label a constant string)
+    // so they never invalidate MessageItem's memo.
+    const agent = switchable(agentType);
+    const agentAvatar = AGENT_AVATAR[agent];
+    const agentLabel = AGENT_LABEL[agent];
 
-  const streamingId =
-    isStreaming && messages.length > 0 && messages[messages.length - 1].role === "assistant"
-      ? messages[messages.length - 1].id
-      : null;
-  const parentRef = useRef<HTMLDivElement>(null);
-  const cacheKey = `${tabId}:${acpSessionId}`;
+    const streamingId =
+      isStreaming &&
+      messages.length > 0 &&
+      messages[messages.length - 1].role === "assistant"
+        ? messages[messages.length - 1].id
+        : null;
+    const parentRef = useRef<HTMLDivElement>(null);
+    const cacheKey = `${tabId}:${acpSessionId}`;
 
-  // The assistant turn badge renders the model stamped onto each message at
-  // creation (`message.model`) — never live session state, which relabels the
-  // whole thread when the session's model or agent changes later. Unstamped
-  // messages (pre-fix history, disk-hydrated transcripts) show no badge
-  // rather than a possibly-wrong one.
+    // The assistant turn badge renders the model stamped onto each message at
+    // creation (`message.model`) — never live session state, which relabels the
+    // whole thread when the session's model or agent changes later. Unstamped
+    // messages (pre-fix history, disk-hydrated transcripts) show no badge
+    // rather than a possibly-wrong one.
 
-  // Apply role filter + map filtered→original indices in one pass. The old
-  // implementation used `messages.findIndex` per filtered message, making
-  // this O(n²) on every streaming chunk (hot path) — at a few thousand
-  // messages it was the single biggest contributor to UI stutter.
-  //
-  // We also drop phantom-empty messages (e.g. claude-agent-acp's empty
-  // `thinking` blocks that arrive with `thinking: ""`). They render
-  // nothing but still pay the MessageItem wrapper's vertical padding,
-  // which used to show up as a mystery gap in the thread.
-  // Stabilize `filtered` array identity when only the trailing message
-  // mutated. During streaming, immer rewrites `session.messages` on
-  // every chunk (new array ref + new tail message), while messages
-  // 0..N-1 keep their object identity via structural sharing. A naive
-  // useMemo would still allocate a fresh `filt` array per chunk and
-  // force the virtualizer's reconciliation pass over every visible
-  // item. The ref-based memo below reuses the prior `filtered` array
-  // when shape + ids are unchanged — only the tail slot is swapped in
-  // when its object identity changed. The virtualizer's id-keyed
-  // measurement cache then keeps non-tail rows from re-measuring, and
-  // memo'd MessageItems skip rendering for unchanged props.
-  const prevFilteredRef = useRef<{
-    filtered: ChatMessage[];
-    indexMap: number[];
-  } | null>(null);
-  const { filtered, indexMap } = useMemo(() => {
-    const filt: ChatMessage[] = [];
-    const idx: number[] = [];
-    const lastIdx = messages.length - 1;
-    for (let i = 0; i < messages.length; i++) {
-      const m = messages[i];
-      if (roleFilter !== "all" && m.role !== roleFilter) continue;
-      // Keep the streaming-tail message even if it's transiently empty
-      // so MessageItem can render its "Thinking…" spinner; otherwise
-      // drop phantom-empty messages so they don't add invisible gaps.
-      const isStreamingTail = isStreaming && i === lastIdx && m.role === "assistant";
-      if (!isStreamingTail && isEmptyMessage(m)) continue;
-      filt.push(m);
-      idx.push(i);
-    }
-    const prev = prevFilteredRef.current;
-    if (prev && prev.filtered.length === filt.length) {
-      // Check id-shape parity. We expect either:
-      //   (a) every element identical (no change) → reuse prev as-is.
-      //   (b) every element identical except the last → swap the tail
-      //       in place into the previous array so the reference is
-      //       stable but content is up to date.
-      let allSameRef = true;
-      let allSameId = true;
-      for (let i = 0; i < filt.length; i++) {
-        if (filt[i] !== prev.filtered[i]) allSameRef = false;
-        if (filt[i].id !== prev.filtered[i].id) {
-          allSameId = false;
-          break;
-        }
+    // Apply role filter + map filtered→original indices in one pass. The old
+    // implementation used `messages.findIndex` per filtered message, making
+    // this O(n²) on every streaming chunk (hot path) — at a few thousand
+    // messages it was the single biggest contributor to UI stutter.
+    //
+    // We also drop phantom-empty messages (e.g. claude-agent-acp's empty
+    // `thinking` blocks that arrive with `thinking: ""`). They render
+    // nothing but still pay the MessageItem wrapper's vertical padding,
+    // which used to show up as a mystery gap in the thread.
+    // Stabilize `filtered` array identity when only the trailing message
+    // mutated. During streaming, immer rewrites `session.messages` on
+    // every chunk (new array ref + new tail message), while messages
+    // 0..N-1 keep their object identity via structural sharing. A naive
+    // useMemo would still allocate a fresh `filt` array per chunk and
+    // force the virtualizer's reconciliation pass over every visible
+    // item. The ref-based memo below reuses the prior `filtered` array
+    // when shape + ids are unchanged — only the tail slot is swapped in
+    // when its object identity changed. The virtualizer's id-keyed
+    // measurement cache then keeps non-tail rows from re-measuring, and
+    // memo'd MessageItems skip rendering for unchanged props.
+    const prevFilteredRef = useRef<{
+      filtered: ChatMessage[];
+      indexMap: number[];
+    } | null>(null);
+    const { filtered, indexMap } = useMemo(() => {
+      const filt: ChatMessage[] = [];
+      const idx: number[] = [];
+      const lastIdx = messages.length - 1;
+      for (let i = 0; i < messages.length; i++) {
+        const m = messages[i];
+        if (roleFilter !== "all" && m.role !== roleFilter) continue;
+        // Keep the streaming-tail message even if it's transiently empty
+        // so MessageItem can render its "Thinking…" spinner; otherwise
+        // drop phantom-empty messages so they don't add invisible gaps.
+        const isStreamingTail =
+          isStreaming && i === lastIdx && m.role === "assistant";
+        if (!isStreamingTail && isEmptyMessage(m)) continue;
+        filt.push(m);
+        idx.push(i);
       }
-      if (allSameId) {
-        if (allSameRef) {
+      const prev = prevFilteredRef.current;
+      if (prev && prev.filtered.length === filt.length) {
+        // Check id-shape parity. We expect either:
+        //   (a) every element identical (no change) → reuse prev as-is.
+        //   (b) every element identical except the last → swap the tail
+        //       in place into the previous array so the reference is
+        //       stable but content is up to date.
+        let allSameRef = true;
+        let allSameId = true;
+        for (let i = 0; i < filt.length; i++) {
+          if (filt[i] !== prev.filtered[i]) allSameRef = false;
+          if (filt[i].id !== prev.filtered[i].id) {
+            allSameId = false;
+            break;
+          }
+        }
+        if (allSameId) {
+          if (allSameRef) {
+            return prev;
+          }
+          // Determine which slots changed identity. Common case during
+          // streaming: only the last slot. Mutate prev in place so the
+          // outer array reference is stable; React keys by message.id so
+          // mutation is safe across the diff.
+          for (let i = 0; i < filt.length; i++) {
+            if (filt[i] !== prev.filtered[i]) prev.filtered[i] = filt[i];
+          }
           return prev;
         }
-        // Determine which slots changed identity. Common case during
-        // streaming: only the last slot. Mutate prev in place so the
-        // outer array reference is stable; React keys by message.id so
-        // mutation is safe across the diff.
-        for (let i = 0; i < filt.length; i++) {
-          if (filt[i] !== prev.filtered[i]) prev.filtered[i] = filt[i];
+      }
+      const next = { filtered: filt, indexMap: idx };
+      prevFilteredRef.current = next;
+      return next;
+    }, [messages, roleFilter, isStreaming]);
+
+    const virtualizer = useVirtualizer({
+      count: filtered.length,
+      getScrollElement: () => parentRef.current,
+      estimateSize: (i) => {
+        // Consult the cross-remount height cache first — when a message
+        // scrolls back into view we want the row to occupy its real
+        // height immediately instead of starting from the default
+        // estimate and snapping after measureElement fires (visible
+        // jump). For rows we haven't measured yet, estimate from the
+        // running average of measured rows rather than a flat constant —
+        // far closer to reality, so the total barely drifts as new rows
+        // measure in and the scroll correction stays imperceptible.
+        const id = filtered[i]?.id;
+        if (id) {
+          const cached = measuredHeights.get(id);
+          if (cached !== undefined) return cached;
         }
-        return prev;
-      }
-    }
-    const next = { filtered: filt, indexMap: idx };
-    prevFilteredRef.current = next;
-    return next;
-  }, [messages, roleFilter, isStreaming]);
-
-  const virtualizer = useVirtualizer({
-    count: filtered.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: (i) => {
-      // Consult the cross-remount height cache first — when a message
-      // scrolls back into view we want the row to occupy its real
-      // height immediately instead of starting from the default
-      // estimate and snapping after measureElement fires (visible
-      // jump). For rows we haven't measured yet, estimate from the
-      // running average of measured rows rather than a flat constant —
-      // far closer to reality, so the total barely drifts as new rows
-      // measure in and the scroll correction stays imperceptible.
-      const id = filtered[i]?.id;
-      if (id) {
-        const cached = measuredHeights.get(id);
-        if (cached !== undefined) return cached;
-      }
-      return averageHeight();
-    },
-    // Higher overscan keeps fast scrolls inside DOM-mounted territory
-    // — items don't unmount/remount as the user flicks through the
-    // thread, which kills both the markdown re-parse cost and the
-    // first-paint estimate jump. Memory cost on a typical thread (a
-    // few hundred messages × ~2 KB DOM) is trivial.
-    overscan: 12,
-    getItemKey: (i) => filtered[i]?.id ?? i,
-    measureElement:
-      typeof window !== "undefined" && !navigator.userAgent.includes("Firefox")
-        ? (el) => {
-            const id = el?.getAttribute("data-message-id") ?? undefined;
-            // While actively scrolling, report the cached height for any
-            // already-measured settled row instead of re-reading the DOM. This
-            // stops a row that reflows mid-scroll (highlight applying, font
-            // swap, image load) from feeding a changed height back and shifting
-            // every offset below it — the lurch. The streaming tail is exempt
-            // (it must follow live growth), and rows with no cached height yet
-            // still measure (there's nothing to reuse). The scroll-idle
-            // reconcile in `onScroll` re-measures everything once movement
-            // stops, so nothing stays stale (the fix the old hack lacked).
-            if (
-              isScrollingRef.current &&
-              id &&
-              id !== streamTailIdRef.current &&
-              measuredHeights.has(id)
-            ) {
-              return measuredHeights.get(id)!;
+        return averageHeight();
+      },
+      // Higher overscan keeps fast scrolls inside DOM-mounted territory
+      // — items don't unmount/remount as the user flicks through the
+      // thread, which kills both the markdown re-parse cost and the
+      // first-paint estimate jump. Memory cost on a typical thread (a
+      // few hundred messages × ~2 KB DOM) is trivial.
+      overscan: 12,
+      getItemKey: (i) => filtered[i]?.id ?? i,
+      measureElement:
+        typeof window !== "undefined" &&
+        !navigator.userAgent.includes("Firefox")
+          ? (el) => {
+              const id = el?.getAttribute("data-message-id") ?? undefined;
+              // While actively scrolling, report the cached height for any
+              // already-measured settled row instead of re-reading the DOM. This
+              // stops a row that reflows mid-scroll (highlight applying, font
+              // swap, image load) from feeding a changed height back and shifting
+              // every offset below it — the lurch. The streaming tail is exempt
+              // (it must follow live growth), and rows with no cached height yet
+              // still measure (there's nothing to reuse). The scroll-idle
+              // reconcile in `onScroll` re-measures everything once movement
+              // stops, so nothing stays stale (the fix the old hack lacked).
+              if (
+                isScrollingRef.current &&
+                id &&
+                id !== streamTailIdRef.current &&
+                measuredHeights.has(id)
+              ) {
+                return measuredHeights.get(id)!;
+              }
+              // A row measured inside a `display:none` subtree reports height 0.
+              // The center panel keeps inactive tabs MOUNTED with `display:none`
+              // (fast tab-switch), so backgrounding this chat — e.g. the turn
+              // card's "Draw diagram" action opens the canvas tab — fires a 0×0
+              // ResizeObserver notification for every mounted row. Recording that
+              // 0 into the module-level height cache (and dragging down the
+              // running average) poisons every row's offset and collapses the
+              // whole thread into overlapping bubbles that survive until app
+              // restart. Treat any non-positive measurement as "not measurable
+              // right now": don't record it, and return the last known-good
+              // height (or the running estimate) so offsets stay stable. The real
+              // height is recorded again when the tab is shown and the row
+              // re-measures.
+              const raw = el?.getBoundingClientRect().height ?? 0;
+              if (raw < 1) {
+                return (
+                  (id ? measuredHeights.get(id) : undefined) ?? averageHeight()
+                );
+              }
+              // Round to an integer so re-measures of unchanged content return the
+              // exact same value and the virtualizer treats them as no-ops (no
+              // offset recompute, no scrollTop nudge).
+              const h = Math.round(raw);
+              if (id) recordHeight(id, h);
+              return h;
             }
-            // A row measured inside a `display:none` subtree reports height 0.
-            // The center panel keeps inactive tabs MOUNTED with `display:none`
-            // (fast tab-switch), so backgrounding this chat — e.g. the turn
-            // card's "Draw diagram" action opens the canvas tab — fires a 0×0
-            // ResizeObserver notification for every mounted row. Recording that
-            // 0 into the module-level height cache (and dragging down the
-            // running average) poisons every row's offset and collapses the
-            // whole thread into overlapping bubbles that survive until app
-            // restart. Treat any non-positive measurement as "not measurable
-            // right now": don't record it, and return the last known-good
-            // height (or the running estimate) so offsets stay stable. The real
-            // height is recorded again when the tab is shown and the row
-            // re-measures.
-            const raw = el?.getBoundingClientRect().height ?? 0;
-            if (raw < 1) {
-              return (id ? measuredHeights.get(id) : undefined) ?? averageHeight();
-            }
-            // Round to an integer so re-measures of unchanged content return the
-            // exact same value and the virtualizer treats them as no-ops (no
-            // offset recompute, no scrollTop nudge).
-            const h = Math.round(raw);
-            if (id) recordHeight(id, h);
-            return h;
-          }
-        : undefined,
-  });
+          : undefined,
+    });
 
-  // Restore cached scroll on mount / session switch. We apply the
-  // distance-from-bottom over several frames because the virtualizer
-  // grows scrollHeight as it measures each item the first time it
-  // renders — a single restore against the initial estimate-based
-  // total lands at the wrong absolute position.
-  useLayoutEffect(() => {
-    const el = parentRef.current;
-    if (!el) return;
-    const cached = scrollPositionCache.get(cacheKey);
-    const apply = () => {
-      const node = parentRef.current;
-      if (!node) return;
-      if (!cached || cached.isAtBottom) {
-        node.scrollTop = node.scrollHeight;
-      } else {
-        node.scrollTop = Math.max(
-          0,
-          node.scrollHeight - node.clientHeight - cached.distanceFromBottom,
-        );
-      }
-    };
-    apply();
-    // Re-apply across the next few frames as MessageItems measure their
-    // real heights (the virtualizer ResizeObserver bumps total size on
-    // each measurement). Six frames is roughly 100 ms — enough for the
-    // typical ~30-message viewport to settle.
-    let rafs = 0;
-    const tick = () => {
-      apply();
-      if (++rafs < 6) requestAnimationFrame(tick);
-    };
-    requestAnimationFrame(tick);
-  }, [cacheKey]);
-
-  // Cold-wake warm-up. When the window becomes active after a long idle, WebKit
-  // has throttled the main thread / rAF / layout; the first scroll otherwise
-  // eats the catch-up (a measurement + re-render storm), which reads as lag.
-  // Front-load it here — re-measure the virtualizer and re-anchor scroll the
-  // moment we regain focus, plus nudge the markdown worker awake — so the user's
-  // first scroll lands on an already-warm pipeline.
-  useEffect(() => {
-    const onActive = () => {
-      warmMarkdownWorker();
-      virtualizer.measure();
+    // Restore cached scroll on mount / session switch. We apply the
+    // distance-from-bottom over several frames because the virtualizer
+    // grows scrollHeight as it measures each item the first time it
+    // renders — a single restore against the initial estimate-based
+    // total lands at the wrong absolute position.
+    useLayoutEffect(() => {
+      const el = parentRef.current;
+      if (!el) return;
       const cached = scrollPositionCache.get(cacheKey);
-      let rafs = 0;
-      const tick = () => {
-        const n = parentRef.current;
-        if (!n) return;
+      const apply = () => {
+        const node = parentRef.current;
+        if (!node) return;
         if (!cached || cached.isAtBottom) {
-          n.scrollTop = n.scrollHeight;
+          node.scrollTop = node.scrollHeight;
         } else {
-          n.scrollTop = Math.max(
+          node.scrollTop = Math.max(
             0,
-            n.scrollHeight - n.clientHeight - cached.distanceFromBottom,
+            node.scrollHeight - node.clientHeight - cached.distanceFromBottom,
           );
         }
-        if (++rafs < 3) requestAnimationFrame(tick);
+      };
+      apply();
+      // Re-apply across the next few frames as MessageItems measure their
+      // real heights (the virtualizer ResizeObserver bumps total size on
+      // each measurement). Six frames is roughly 100 ms — enough for the
+      // typical ~30-message viewport to settle.
+      let rafs = 0;
+      const tick = () => {
+        apply();
+        if (++rafs < 6) requestAnimationFrame(tick);
       };
       requestAnimationFrame(tick);
-    };
-    window.addEventListener("atlas:window-active", onActive);
-    return () => window.removeEventListener("atlas:window-active", onActive);
-  }, [virtualizer, cacheKey]);
+    }, [cacheKey]);
 
-  // Save scroll continuously + on unmount. Publishes the "scrolled up"
-  // bit to the parent via `onShowJumpChange` so the chat composer can
-  // render the scroll-to-bottom pill centered alongside the Claude
-  // setup pill (the parent owns the floating row above the input now).
-  const [showJumpToBottom, setShowJumpToBottom] = useState(false);
-  // Count of messages that arrived while the user was scrolled up, shown
-  // on the scroll-to-bottom pill ("3 new"). `lastSeenLenRef` marks how
-  // many were visible the last time the user was at the bottom.
-  const [newCount, setNewCount] = useState(0);
-  const lastSeenLenRef = useRef(filtered.length);
-  const filteredLenRef = useRef(filtered.length);
-  filteredLenRef.current = filtered.length;
+    // Cold-wake warm-up. When the window becomes active after a long idle, WebKit
+    // has throttled the main thread / rAF / layout; the first scroll otherwise
+    // eats the catch-up (a measurement + re-render storm), which reads as lag.
+    // Front-load it here — re-measure the virtualizer and re-anchor scroll the
+    // moment we regain focus, plus nudge the markdown worker awake — so the user's
+    // first scroll lands on an already-warm pipeline.
+    useEffect(() => {
+      const onActive = () => {
+        warmMarkdownWorker();
+        virtualizer.measure();
+        const cached = scrollPositionCache.get(cacheKey);
+        let rafs = 0;
+        const tick = () => {
+          const n = parentRef.current;
+          if (!n) return;
+          if (!cached || cached.isAtBottom) {
+            n.scrollTop = n.scrollHeight;
+          } else {
+            n.scrollTop = Math.max(
+              0,
+              n.scrollHeight - n.clientHeight - cached.distanceFromBottom,
+            );
+          }
+          if (++rafs < 3) requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      };
+      window.addEventListener("atlas:window-active", onActive);
+      return () => window.removeEventListener("atlas:window-active", onActive);
+    }, [virtualizer, cacheKey]);
 
-  // The nav rail's active tick is derived from the top-of-viewport row. We keep
-  // it as rAF-throttled state sampled from real scroll movement rather than
-  // reading `virtualizer.getVirtualItems()[0]` inline every render — otherwise
-  // the tick tracks the virtualizer's offset in lockstep and jitters whenever a
-  // row re-measures (streaming settle, accordion toggle) recomputes offsets.
-  const [railTopVIndex, setRailTopVIndex] = useState(0);
-  const railRafRef = useRef<number | null>(null);
+    // Save scroll continuously + on unmount. Publishes the "scrolled up"
+    // bit to the parent via `onShowJumpChange` so the chat composer can
+    // render the scroll-to-bottom pill centered alongside the Claude
+    // setup pill (the parent owns the floating row above the input now).
+    const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+    // Count of messages that arrived while the user was scrolled up, shown
+    // on the scroll-to-bottom pill ("3 new"). `lastSeenLenRef` marks how
+    // many were visible the last time the user was at the bottom.
+    const [newCount, setNewCount] = useState(0);
+    const lastSeenLenRef = useRef(filtered.length);
+    const filteredLenRef = useRef(filtered.length);
+    filteredLenRef.current = filtered.length;
 
-  // Scroll-state gate for measurement (see `measureElement`). While the user is
-  // actively scrolling we return cached heights for settled rows instead of
-  // re-measuring, so a row settling/reflowing mid-scroll (highlight applying,
-  // font swap, image load) can't shift the virtualizer's offsets and lurch the
-  // viewport. On scroll-idle we force one `virtualizer.measure()` reconcile so
-  // any height that genuinely changed mid-scroll is corrected — this is what the
-  // previously-removed "skip while scrolling" hack lacked (it went stale and
-  // overlapped). The streaming tail is never skipped (it must follow growth).
-  const isScrollingRef = useRef(false);
-  const scrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const streamTailIdRef = useRef<string | null>(null);
-  streamTailIdRef.current =
-    isStreaming && filtered.length > 0 ? filtered[filtered.length - 1].id : null;
-  useEffect(() => {
-    const el = parentRef.current;
-    if (!el) return;
-    const onScroll = () => {
-      // Enter "scrolling" state and (re)arm the idle timer. `measureElement`
-      // skips re-measuring settled rows while this is true; when scrolling
-      // stops we drop the flag and force one reconcile pass so any mid-scroll
-      // height change is corrected.
-      isScrollingRef.current = true;
-      if (scrollIdleTimerRef.current !== null) {
-        clearTimeout(scrollIdleTimerRef.current);
-      }
-      scrollIdleTimerRef.current = setTimeout(() => {
-        scrollIdleTimerRef.current = null;
-        isScrollingRef.current = false;
-        // Force a real DOM re-read of the mounted rows. A row that changed
-        // height while we were skipping (image load, late highlight) had its
-        // change swallowed — its ResizeObserver already fired with the cached
-        // value and won't fire again. `virtualizer.measure()` alone would only
-        // recompute positions from the (now-stale) size cache, so we re-measure
-        // each mounted element explicitly; with the scroll gate now off these
-        // reads record real heights and reconcile any drift.
-        const node = parentRef.current;
-        if (node) {
-          node
-            .querySelectorAll<HTMLElement>("[data-message-id]")
-            .forEach((row) => virtualizer.measureElement(row));
+    // The nav rail's active tick is derived from the top-of-viewport row. We keep
+    // it as rAF-throttled state sampled from real scroll movement rather than
+    // reading `virtualizer.getVirtualItems()[0]` inline every render — otherwise
+    // the tick tracks the virtualizer's offset in lockstep and jitters whenever a
+    // row re-measures (streaming settle, accordion toggle) recomputes offsets.
+    const [railTopVIndex, setRailTopVIndex] = useState(0);
+    const railRafRef = useRef<number | null>(null);
+
+    // Scroll-state gate for measurement (see `measureElement`). While the user is
+    // actively scrolling we return cached heights for settled rows instead of
+    // re-measuring, so a row settling/reflowing mid-scroll (highlight applying,
+    // font swap, image load) can't shift the virtualizer's offsets and lurch the
+    // viewport. On scroll-idle we force one `virtualizer.measure()` reconcile so
+    // any height that genuinely changed mid-scroll is corrected — this is what the
+    // previously-removed "skip while scrolling" hack lacked (it went stale and
+    // overlapped). The streaming tail is never skipped (it must follow growth).
+    const isScrollingRef = useRef(false);
+    const scrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    );
+    const streamTailIdRef = useRef<string | null>(null);
+    streamTailIdRef.current =
+      isStreaming && filtered.length > 0
+        ? filtered[filtered.length - 1].id
+        : null;
+    useEffect(() => {
+      const el = parentRef.current;
+      if (!el) return;
+      const onScroll = () => {
+        // Enter "scrolling" state and (re)arm the idle timer. `measureElement`
+        // skips re-measuring settled rows while this is true; when scrolling
+        // stops we drop the flag and force one reconcile pass so any mid-scroll
+        // height change is corrected.
+        isScrollingRef.current = true;
+        if (scrollIdleTimerRef.current !== null) {
+          clearTimeout(scrollIdleTimerRef.current);
         }
-      }, 150);
-
-      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      const isAtBottom = distance <= NEAR_BOTTOM_PX;
-      scrollPositionCache.set(cacheKey, {
-        distanceFromBottom: distance,
-        isAtBottom,
-      });
-      setShowJumpToBottom(!isAtBottom);
-      if (isAtBottom) {
-        // Caught up — everything is seen.
-        lastSeenLenRef.current = filteredLenRef.current;
-        setNewCount((c) => (c === 0 ? c : 0));
-      }
-      // Sample the top-of-viewport row for the nav rail, rAF-throttled so a fast
-      // flick coalesces to one update per frame and the tick only moves on real
-      // scroll — not on measurement-driven offset recomputes.
-      if (railRafRef.current === null) {
-        railRafRef.current = requestAnimationFrame(() => {
-          railRafRef.current = null;
+        scrollIdleTimerRef.current = setTimeout(() => {
+          scrollIdleTimerRef.current = null;
+          isScrollingRef.current = false;
+          // Force a real DOM re-read of the mounted rows. A row that changed
+          // height while we were skipping (image load, late highlight) had its
+          // change swallowed — its ResizeObserver already fired with the cached
+          // value and won't fire again. `virtualizer.measure()` alone would only
+          // recompute positions from the (now-stale) size cache, so we re-measure
+          // each mounted element explicitly; with the scroll gate now off these
+          // reads record real heights and reconcile any drift.
           const node = parentRef.current;
-          if (!node) return;
-          const top = virtualizer.getVirtualItemForOffset(node.scrollTop);
-          if (top) setRailTopVIndex((prev) => (prev === top.index ? prev : top.index));
+          if (node) {
+            node
+              .querySelectorAll<HTMLElement>("[data-message-id]")
+              .forEach((row) => virtualizer.measureElement(row));
+          }
+        }, 150);
+
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        const isAtBottom = distance <= NEAR_BOTTOM_PX;
+        scrollPositionCache.set(cacheKey, {
+          distanceFromBottom: distance,
+          isAtBottom,
         });
-      }
-    };
-    el.addEventListener("scroll", onScroll, { passive: true });
-    onScroll();
-    return () => {
-      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      scrollPositionCache.set(cacheKey, {
-        distanceFromBottom: distance,
-        isAtBottom: distance <= NEAR_BOTTOM_PX,
-      });
-      el.removeEventListener("scroll", onScroll);
-      if (railRafRef.current !== null) {
-        cancelAnimationFrame(railRafRef.current);
-        railRafRef.current = null;
-      }
-      if (scrollIdleTimerRef.current !== null) {
-        clearTimeout(scrollIdleTimerRef.current);
-        scrollIdleTimerRef.current = null;
-        isScrollingRef.current = false;
-      }
-    };
-  }, [cacheKey]);
-
-  useEffect(() => {
-    onShowJumpChange?.(showJumpToBottom, showJumpToBottom ? newCount : 0);
-  }, [showJumpToBottom, newCount, onShowJumpChange]);
-
-  // Container resize (panel drag, window resize, sidebar toggle) reflows
-  // every message — their cached heights become wrong for the new width
-  // and `scrollTop` drifts because total height shifts under it. Snapshot
-  // distance-from-bottom on every width change and re-apply across a few
-  // frames as the virtualizer's ResizeObserver re-measures rows. Same
-  // mechanism as the mount/session-switch restore above, just driven by
-  // width changes instead of cache-key changes.
-  useEffect(() => {
-    const el = parentRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    let lastWidth = el.clientWidth;
-    let activeRaf: number | null = null;
-    const ro = new ResizeObserver(() => {
-      const node = parentRef.current;
-      if (!node) return;
-      const newWidth = node.clientWidth;
-      if (newWidth === lastWidth) return;
-      // Capture intent BEFORE the post-resize scroll has a chance to
-      // fire and overwrite our cached distance. Using current scrollTop
-      // here rather than the cached `distanceFromBottom` because the
-      // cache may be stale by one frame.
-      const distanceBefore = node.scrollHeight - node.scrollTop - node.clientHeight;
-      const wasAtBottom = distanceBefore <= NEAR_BOTTOM_PX;
-      lastWidth = newWidth;
-      // NB: do NOT clear the height cache here. A panel drag fires this
-      // observer continuously; wiping all heights every tick collapses
-      // the total to count×average and makes the scroll reapply fight a
-      // wildly wrong scrollHeight (visible as violent jumping). The
-      // visible rows whose width actually changed are re-measured
-      // automatically by the virtualizer's own per-row ResizeObserver;
-      // off-screen rows keep their (stale-width) height until revisited,
-      // which is a cheap one-time correction rather than a per-frame
-      // storm.
-      // Reapply for ~6 frames as item heights re-measure. Each pass
-      // corrects against the latest scrollHeight, so we converge as
-      // measurements settle.
-      if (activeRaf !== null) cancelAnimationFrame(activeRaf);
-      let rafs = 0;
-      const tick = () => {
-        const n = parentRef.current;
-        if (!n) return;
-        if (wasAtBottom) {
-          n.scrollTop = n.scrollHeight;
-        } else {
-          n.scrollTop = Math.max(
-            0,
-            n.scrollHeight - n.clientHeight - distanceBefore,
-          );
+        setShowJumpToBottom(!isAtBottom);
+        if (isAtBottom) {
+          // Caught up — everything is seen.
+          lastSeenLenRef.current = filteredLenRef.current;
+          setNewCount((c) => (c === 0 ? c : 0));
         }
-        rafs += 1;
-        if (rafs < 6) {
-          activeRaf = requestAnimationFrame(tick);
-        } else {
-          activeRaf = null;
+        // Sample the top-of-viewport row for the nav rail, rAF-throttled so a fast
+        // flick coalesces to one update per frame and the tick only moves on real
+        // scroll — not on measurement-driven offset recomputes.
+        if (railRafRef.current === null) {
+          railRafRef.current = requestAnimationFrame(() => {
+            railRafRef.current = null;
+            const node = parentRef.current;
+            if (!node) return;
+            const top = virtualizer.getVirtualItemForOffset(node.scrollTop);
+            if (top)
+              setRailTopVIndex((prev) =>
+                prev === top.index ? prev : top.index,
+              );
+          });
         }
       };
-      activeRaf = requestAnimationFrame(tick);
-    });
-    ro.observe(el);
-    return () => {
-      ro.disconnect();
-      if (activeRaf !== null) cancelAnimationFrame(activeRaf);
-    };
-  }, []);
+      el.addEventListener("scroll", onScroll, { passive: true });
+      onScroll();
+      return () => {
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        scrollPositionCache.set(cacheKey, {
+          distanceFromBottom: distance,
+          isAtBottom: distance <= NEAR_BOTTOM_PX,
+        });
+        el.removeEventListener("scroll", onScroll);
+        if (railRafRef.current !== null) {
+          cancelAnimationFrame(railRafRef.current);
+          railRafRef.current = null;
+        }
+        if (scrollIdleTimerRef.current !== null) {
+          clearTimeout(scrollIdleTimerRef.current);
+          scrollIdleTimerRef.current = null;
+          isScrollingRef.current = false;
+        }
+      };
+    }, [cacheKey]);
 
-  // When this list unmounts (tab close, project change), make sure the
-  // parent's "scrolled up" bit doesn't get stuck at `true`.
-  useEffect(() => {
-    return () => {
-      onShowJumpChange?.(false);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    useEffect(() => {
+      onShowJumpChange?.(showJumpToBottom, showJumpToBottom ? newCount : 0);
+    }, [showJumpToBottom, newCount, onShowJumpChange]);
 
-  // `virtualizer.scrollToIndex(..., {align: "end"})` computes its
-  // target from the items' currently estimated/measured sizes. During
-  // streaming the trailing message keeps growing past that estimate,
-  // so the viewport is left a few hundred px above the true bottom.
-  // Pinning directly to `scrollHeight` on the next frame always lands
-  // at the actual bottom regardless of measurement state.
-  const pinToBottom = useCallback(() => {
-    const el = parentRef.current;
-    if (!el) return;
-    requestAnimationFrame(() => {
-      if (!parentRef.current) return;
-      parentRef.current.scrollTop = parentRef.current.scrollHeight;
-    });
-  }, []);
+    // Container resize (panel drag, window resize, sidebar toggle) reflows
+    // every message — their cached heights become wrong for the new width
+    // and `scrollTop` drifts because total height shifts under it. Snapshot
+    // distance-from-bottom on every width change and re-apply across a few
+    // frames as the virtualizer's ResizeObserver re-measures rows. Same
+    // mechanism as the mount/session-switch restore above, just driven by
+    // width changes instead of cache-key changes.
+    useEffect(() => {
+      const el = parentRef.current;
+      if (!el || typeof ResizeObserver === "undefined") return;
+      let lastWidth = el.clientWidth;
+      let activeRaf: number | null = null;
+      const ro = new ResizeObserver(() => {
+        const node = parentRef.current;
+        if (!node) return;
+        const newWidth = node.clientWidth;
+        if (newWidth === lastWidth) return;
+        // Capture intent BEFORE the post-resize scroll has a chance to
+        // fire and overwrite our cached distance. Using current scrollTop
+        // here rather than the cached `distanceFromBottom` because the
+        // cache may be stale by one frame.
+        const distanceBefore =
+          node.scrollHeight - node.scrollTop - node.clientHeight;
+        const wasAtBottom = distanceBefore <= NEAR_BOTTOM_PX;
+        lastWidth = newWidth;
+        // NB: do NOT clear the height cache here. A panel drag fires this
+        // observer continuously; wiping all heights every tick collapses
+        // the total to count×average and makes the scroll reapply fight a
+        // wildly wrong scrollHeight (visible as violent jumping). The
+        // visible rows whose width actually changed are re-measured
+        // automatically by the virtualizer's own per-row ResizeObserver;
+        // off-screen rows keep their (stale-width) height until revisited,
+        // which is a cheap one-time correction rather than a per-frame
+        // storm.
+        // Reapply for ~6 frames as item heights re-measure. Each pass
+        // corrects against the latest scrollHeight, so we converge as
+        // measurements settle.
+        if (activeRaf !== null) cancelAnimationFrame(activeRaf);
+        let rafs = 0;
+        const tick = () => {
+          const n = parentRef.current;
+          if (!n) return;
+          if (wasAtBottom) {
+            n.scrollTop = n.scrollHeight;
+          } else {
+            n.scrollTop = Math.max(
+              0,
+              n.scrollHeight - n.clientHeight - distanceBefore,
+            );
+          }
+          rafs += 1;
+          if (rafs < 6) {
+            activeRaf = requestAnimationFrame(tick);
+          } else {
+            activeRaf = null;
+          }
+        };
+        activeRaf = requestAnimationFrame(tick);
+      });
+      ro.observe(el);
+      return () => {
+        ro.disconnect();
+        if (activeRaf !== null) cancelAnimationFrame(activeRaf);
+      };
+    }, []);
 
-  // Auto-follow new messages only when already near bottom.
-  const prevLenRef = useRef(filtered.length);
-  useEffect(() => {
-    const el = parentRef.current;
-    if (!el) return;
-    const grew = filtered.length > prevLenRef.current;
-    prevLenRef.current = filtered.length;
-    if (!grew) return;
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distance <= NEAR_BOTTOM_PX) {
+    // When this list unmounts (tab close, project change), make sure the
+    // parent's "scrolled up" bit doesn't get stuck at `true`.
+    useEffect(() => {
+      return () => {
+        onShowJumpChange?.(false);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // `virtualizer.scrollToIndex(..., {align: "end"})` computes its
+    // target from the items' currently estimated/measured sizes. During
+    // streaming the trailing message keeps growing past that estimate,
+    // so the viewport is left a few hundred px above the true bottom.
+    // Pinning directly to `scrollHeight` on the next frame always lands
+    // at the actual bottom regardless of measurement state.
+    const pinToBottom = useCallback(() => {
+      const el = parentRef.current;
+      if (!el) return;
+      requestAnimationFrame(() => {
+        if (!parentRef.current) return;
+        parentRef.current.scrollTop = parentRef.current.scrollHeight;
+      });
+    }, []);
+
+    // Auto-follow new messages only when already near bottom.
+    const prevLenRef = useRef(filtered.length);
+    useEffect(() => {
+      const el = parentRef.current;
+      if (!el) return;
+      const grew = filtered.length > prevLenRef.current;
+      prevLenRef.current = filtered.length;
+      if (!grew) return;
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distance <= NEAR_BOTTOM_PX) {
+        pinToBottom();
+        lastSeenLenRef.current = filtered.length;
+        setNewCount((c) => (c === 0 ? c : 0));
+      } else {
+        // New messages landed while the user is reading above — surface the
+        // unseen count on the scroll-to-bottom pill.
+        setNewCount(Math.max(0, filtered.length - lastSeenLenRef.current));
+      }
+    }, [filtered.length, pinToBottom]);
+
+    // Auto-follow STREAMING content. The effect above only fires when a new
+    // message is appended; during a streaming turn the agent mutates the
+    // trailing message's `content` / `thinking` / `toolCalls` without
+    // changing `filtered.length`, so we'd be left behind. Depend on those
+    // three signals explicitly. Still gated on near-bottom so users who
+    // scrolled up to read aren't yanked back down.
+    const trailing = filtered[filtered.length - 1];
+    const trailingContentLen = trailing?.content.length ?? 0;
+    const trailingThinkingLen = trailing?.thinking?.length ?? 0;
+    const trailingToolCount = trailing?.toolCalls.length ?? 0;
+    useEffect(() => {
+      if (!isStreaming) return;
+      if (filtered.length === 0) return;
+      const el = parentRef.current;
+      if (!el) return;
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distance <= NEAR_BOTTOM_PX) {
+        pinToBottom();
+      }
+    }, [
+      isStreaming,
+      trailingContentLen,
+      trailingThinkingLen,
+      trailingToolCount,
+      filtered.length,
+      pinToBottom,
+    ]);
+
+    // Auto-follow the TURN-END adaptive card. The streaming effect above is gated
+    // on `isStreaming`, so it doesn't fire when the trailing message grows *after*
+    // the turn ends — i.e. when the TurnSummaryCard's files/actions land at
+    // turn_finished, or its suggestion chips resolve from loading→ready. Without
+    // this a near-bottom reader drifts up a few hundred px as the card appears.
+    // Same near-bottom gate, so a user reading above is never yanked.
+    const trailingFooterSig = `${trailing?.turnSummary ? 1 : 0}:${trailing?.suggestions?.status ?? ""}:${trailing?.suggestions?.chips.length ?? 0}`;
+    useEffect(() => {
+      if (filtered.length === 0) return;
+      const el = parentRef.current;
+      if (!el) return;
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distance <= NEAR_BOTTOM_PX) pinToBottom();
+    }, [trailingFooterSig, filtered.length, pinToBottom]);
+
+    const scrollToBottom = useCallback(() => {
+      if (filtered.length === 0) return;
       pinToBottom();
-      lastSeenLenRef.current = filtered.length;
-      setNewCount((c) => (c === 0 ? c : 0));
-    } else {
-      // New messages landed while the user is reading above — surface the
-      // unseen count on the scroll-to-bottom pill.
-      setNewCount(Math.max(0, filtered.length - lastSeenLenRef.current));
+    }, [filtered.length, pinToBottom]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollToBottom,
+      }),
+      [scrollToBottom],
+    );
+
+    const jumpToMessage = useCallback(
+      (originalIndex: number) => {
+        const filteredIdx = indexMap.findIndex((oi) => oi === originalIndex);
+        if (filteredIdx < 0) return;
+        virtualizer.scrollToIndex(filteredIdx, { align: "center" });
+      },
+      [indexMap, virtualizer],
+    );
+
+    // Listen for external jump requests (e.g. clicks in the bash-history panel).
+    useEffect(() => {
+      const handler = (e: Event) => {
+        const detail = (e as CustomEvent<{ index: number }>).detail;
+        if (typeof detail?.index !== "number") return;
+        jumpToMessage(detail.index);
+      };
+      window.addEventListener("atlas:chat-jump", handler);
+      return () => window.removeEventListener("atlas:chat-jump", handler);
+    }, [jumpToMessage]);
+
+    // ChatGPT-style navigation rail: one tick per user message, on the left.
+    const userAnchors = useMemo(
+      () =>
+        messages
+          .map((m, i) => ({
+            id: m.id,
+            index: i,
+            role: m.role,
+            content: m.content,
+          }))
+          .filter((a) => a.role === "user")
+          .map((a) => ({
+            id: a.id,
+            index: a.index,
+            preview: (a.content || "").replace(/\s+/g, " ").trim().slice(0, 80),
+          })),
+      [messages],
+    );
+    // The active tick = the last user message at/above the top of the viewport.
+    // `railTopVIndex` is the rAF-throttled top *filtered* index sampled in
+    // `onScroll`; map it to the original message index here with the live
+    // `indexMap` so it stays correct as the filter/thread changes.
+    const topOriginalIndex = indexMap[railTopVIndex] ?? 0;
+    let activeAnchorIndex = -1;
+    for (const a of userAnchors) {
+      if (a.index <= topOriginalIndex) activeAnchorIndex = a.index;
+      else break;
     }
-  }, [filtered.length, pinToBottom]);
 
-  // Auto-follow STREAMING content. The effect above only fires when a new
-  // message is appended; during a streaming turn the agent mutates the
-  // trailing message's `content` / `thinking` / `toolCalls` without
-  // changing `filtered.length`, so we'd be left behind. Depend on those
-  // three signals explicitly. Still gated on near-bottom so users who
-  // scrolled up to read aren't yanked back down.
-  const trailing = filtered[filtered.length - 1];
-  const trailingContentLen = trailing?.content.length ?? 0;
-  const trailingThinkingLen = trailing?.thinking?.length ?? 0;
-  const trailingToolCount = trailing?.toolCalls.length ?? 0;
-  useEffect(() => {
-    if (!isStreaming) return;
-    if (filtered.length === 0) return;
-    const el = parentRef.current;
-    if (!el) return;
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distance <= NEAR_BOTTOM_PX) {
-      pinToBottom();
-    }
-  }, [
-    isStreaming,
-    trailingContentLen,
-    trailingThinkingLen,
-    trailingToolCount,
-    filtered.length,
-    pinToBottom,
-  ]);
-
-  // Auto-follow the TURN-END adaptive card. The streaming effect above is gated
-  // on `isStreaming`, so it doesn't fire when the trailing message grows *after*
-  // the turn ends — i.e. when the TurnSummaryCard's files/actions land at
-  // turn_finished, or its suggestion chips resolve from loading→ready. Without
-  // this a near-bottom reader drifts up a few hundred px as the card appears.
-  // Same near-bottom gate, so a user reading above is never yanked.
-  const trailingFooterSig = `${trailing?.turnSummary ? 1 : 0}:${trailing?.suggestions?.status ?? ""}:${trailing?.suggestions?.chips.length ?? 0}`;
-  useEffect(() => {
-    if (filtered.length === 0) return;
-    const el = parentRef.current;
-    if (!el) return;
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distance <= NEAR_BOTTOM_PX) pinToBottom();
-  }, [trailingFooterSig, filtered.length, pinToBottom]);
-
-  const scrollToBottom = useCallback(() => {
-    if (filtered.length === 0) return;
-    pinToBottom();
-  }, [filtered.length, pinToBottom]);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      scrollToBottom,
-    }),
-    [scrollToBottom],
-  );
-
-  const jumpToMessage = useCallback(
-    (originalIndex: number) => {
-      const filteredIdx = indexMap.findIndex((oi) => oi === originalIndex);
-      if (filteredIdx < 0) return;
-      virtualizer.scrollToIndex(filteredIdx, { align: "center" });
-    },
-    [indexMap, virtualizer]
-  );
-
-  // Listen for external jump requests (e.g. clicks in the bash-history panel).
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ index: number }>).detail;
-      if (typeof detail?.index !== "number") return;
-      jumpToMessage(detail.index);
-    };
-    window.addEventListener("atlas:chat-jump", handler);
-    return () => window.removeEventListener("atlas:chat-jump", handler);
-  }, [jumpToMessage]);
-
-  // ChatGPT-style navigation rail: one tick per user message, on the left.
-  const userAnchors = useMemo(
-    () =>
-      messages
-        .map((m, i) => ({ id: m.id, index: i, role: m.role, content: m.content }))
-        .filter((a) => a.role === "user")
-        .map((a) => ({
-          id: a.id,
-          index: a.index,
-          preview: (a.content || "").replace(/\s+/g, " ").trim().slice(0, 80),
-        })),
-    [messages],
-  );
-  // The active tick = the last user message at/above the top of the viewport.
-  // `railTopVIndex` is the rAF-throttled top *filtered* index sampled in
-  // `onScroll`; map it to the original message index here with the live
-  // `indexMap` so it stays correct as the filter/thread changes.
-  const topOriginalIndex = indexMap[railTopVIndex] ?? 0;
-  let activeAnchorIndex = -1;
-  for (const a of userAnchors) {
-    if (a.index <= topOriginalIndex) activeAnchorIndex = a.index;
-    else break;
-  }
-
-  return (
-    <div className="relative flex-1 min-h-0">
-      {userAnchors.length > 1 && (
-        <div className="pointer-events-none absolute left-0 top-1/2 z-[3] -translate-y-1/2">
-          {/* Fade so the rail reads cleanly over message borders/content. */}
-          <div className="pointer-events-none absolute inset-y-[-12px] left-0 w-10 bg-gradient-to-r from-[var(--bg-surface)] via-[var(--bg-surface)]/70 to-transparent" />
-          {/* No overflow here: an `overflow` container would clip the
+    return (
+      <div className="relative flex-1 min-h-0">
+        {userAnchors.length > 1 && (
+          <div className="pointer-events-none absolute left-0 top-1/2 z-[3] -translate-y-1/2">
+            {/* Fade so the rail reads cleanly over message borders/content. */}
+            <div className="pointer-events-none absolute inset-y-[-12px] left-0 w-10 bg-gradient-to-r from-[var(--bg-surface)] via-[var(--bg-surface)]/70 to-transparent" />
+            {/* No overflow here: an `overflow` container would clip the
               horizontally-extending hover tooltip. Natural height, centered. */}
-          <div className="relative flex flex-col justify-center gap-1.5 py-2 pl-2 pr-4">
-            {userAnchors.map((a) => {
-              const active = a.index === activeAnchorIndex;
-              return (
-                <button
-                  key={a.id}
-                  type="button"
-                  aria-label={a.preview || "Jump to message"}
-                  onClick={() =>
-                    window.dispatchEvent(
-                      new CustomEvent("atlas:chat-jump", { detail: { index: a.index } }),
-                    )
-                  }
-                  className="group pointer-events-auto relative flex cursor-pointer items-center"
-                >
-                  <span
-                    className={cn(
-                      "h-0.5 rounded-full transition-all duration-200 ease-out",
-                      active
-                        ? "w-4 bg-[var(--accent-primary)]"
-                        : "w-2 bg-[var(--text-tertiary)]/40 group-hover:w-3 group-hover:bg-[var(--text-tertiary)]",
-                    )}
-                  />
-                  {/* Styled tooltip: the target user message preview. High z so
-                      it renders above the thread content. */}
-                  <span
-                    className="pointer-events-none absolute left-5 top-1/2 z-[50] max-w-[260px] -translate-y-1/2 translate-x-[-4px] truncate rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] px-2 py-1 text-[10px] text-[var(--text-secondary)] opacity-0 shadow-[var(--shadow-overlay)] transition-all duration-150 group-hover:translate-x-0 group-hover:opacity-100"
-                    style={{ backdropFilter: "blur(8px)" }}
+            <div className="relative flex flex-col justify-center gap-1.5 py-2 pl-2 pr-4">
+              {userAnchors.map((a) => {
+                const active = a.index === activeAnchorIndex;
+                return (
+                  <button
+                    key={a.id}
+                    type="button"
+                    aria-label={a.preview || "Jump to message"}
+                    onClick={() =>
+                      window.dispatchEvent(
+                        new CustomEvent("atlas:chat-jump", {
+                          detail: { index: a.index },
+                        }),
+                      )
+                    }
+                    className="group pointer-events-auto relative flex cursor-pointer items-center"
                   >
-                    {a.preview || "(message)"}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-      <div
-        ref={parentRef}
-        // `overflow-anchor: none` stops the browser's native scroll
-        // anchoring from competing with the virtualizer's own offset
-        // bookkeeping (a source of small scroll-position fights).
-        className="h-full overflow-y-auto hide-scrollbar [overflow-anchor:none]"
-      >
-        {filtered.length === 0 ? (
-          <div className="h-full flex items-center justify-center text-[11px] text-[var(--text-tertiary)]">
-            No messages match the filter.
-          </div>
-        ) : (
-          <div
-            style={{
-              height: virtualizer.getTotalSize(),
-              width: "100%",
-              position: "relative",
-            }}
-          >
-            {virtualizer.getVirtualItems().map((vItem) => {
-              const message = filtered[vItem.index];
-              const prev = vItem.index > 0 ? filtered[vItem.index - 1] : null;
-              const gapMs = prev
-                ? new Date(message.timestamp).getTime() -
-                  new Date(prev.timestamp).getTime()
-                : 0;
-              const timeGapAbove =
-                prev && gapMs > TURN_GAP_MS ? formatGap(gapMs) : null;
-              return (
-                <div
-                  key={message.id}
-                  ref={virtualizer.measureElement}
-                  data-index={vItem.index}
-                  data-message-id={message.id}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${vItem.start}px)`,
-                  }}
-                >
-                  <MessageItem
-                    message={message}
-                    tabId={tabId}
-                    agentAvatar={agentAvatar}
-                    agentLabel={agentLabel}
-                    streaming={message.id === streamingId}
-                    model={message.model ?? null}
-                    timeGapAbove={timeGapAbove}
-                    dividerAbove={
-                      vItem.index > 0 &&
-                      filtered[vItem.index - 1].role !== message.role
-                    }
-                    // Suppress avatar + role header for consecutive
-                    // assistant messages — the per-block model emits one
-                    // message per tool/text/thought, and we want them
-                    // grouped under a single ASSISTANT turn header like Zed.
-                    compact={
-                      vItem.index > 0 &&
-                      filtered[vItem.index - 1].role === message.role &&
-                      message.role === "assistant"
-                    }
-                    // Last in a same-role run — show the Reply/Save/Copy row
-                    // here instead of on every member of the group.
-                    isLastInGroup={
-                      vItem.index === filtered.length - 1 ||
-                      filtered[vItem.index + 1].role !== message.role
-                    }
-                  />
-                </div>
-              );
-            })}
+                    <span
+                      className={cn(
+                        "h-0.5 rounded-full transition-all duration-200 ease-out",
+                        active
+                          ? "w-4 bg-[var(--accent-primary)]"
+                          : "w-2 bg-[var(--text-tertiary)]/40 group-hover:w-3 group-hover:bg-[var(--text-tertiary)]",
+                      )}
+                    />
+                    {/* Styled tooltip: the target user message preview. High z so
+                      it renders above the thread content. */}
+                    <span
+                      className="pointer-events-none absolute left-5 top-1/2 z-[50] max-w-[260px] -translate-y-1/2 translate-x-[-4px] truncate rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] px-2 py-1 text-[10px] text-[var(--text-secondary)] opacity-0 shadow-[var(--shadow-overlay)] transition-all duration-150 group-hover:translate-x-0 group-hover:opacity-100"
+                      style={{ backdropFilter: "blur(8px)" }}
+                    >
+                      {a.preview || "(message)"}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
-        {/* Working indicator: the turn is running but no assistant token has
+        <div
+          ref={parentRef}
+          // `overflow-anchor: none` stops the browser's native scroll
+          // anchoring from competing with the virtualizer's own offset
+          // bookkeeping (a source of small scroll-position fights).
+          className="h-full overflow-y-auto hide-scrollbar [overflow-anchor:none]"
+        >
+          {filtered.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-[11px] text-[var(--text-tertiary)]">
+              No messages match the filter.
+            </div>
+          ) : (
+            <div
+              style={{
+                height: virtualizer.getTotalSize(),
+                width: "100%",
+                position: "relative",
+              }}
+            >
+              {virtualizer.getVirtualItems().map((vItem) => {
+                const message = filtered[vItem.index];
+                const prev = vItem.index > 0 ? filtered[vItem.index - 1] : null;
+                const gapMs = prev
+                  ? new Date(message.timestamp).getTime() -
+                    new Date(prev.timestamp).getTime()
+                  : 0;
+                const timeGapAbove =
+                  prev && gapMs > TURN_GAP_MS ? formatGap(gapMs) : null;
+                return (
+                  <div
+                    key={message.id}
+                    ref={virtualizer.measureElement}
+                    data-index={vItem.index}
+                    data-message-id={message.id}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${vItem.start}px)`,
+                    }}
+                  >
+                    <MessageItem
+                      message={message}
+                      tabId={tabId}
+                      agentAvatar={agentAvatar}
+                      agentLabel={agentLabel}
+                      streaming={message.id === streamingId}
+                      model={message.model ?? null}
+                      timeGapAbove={timeGapAbove}
+                      dividerAbove={
+                        vItem.index > 0 &&
+                        filtered[vItem.index - 1].role !== message.role
+                      }
+                      // Suppress avatar + role header for consecutive
+                      // assistant messages — the per-block model emits one
+                      // message per tool/text/thought, and we want them
+                      // grouped under a single ASSISTANT turn header like Zed.
+                      compact={
+                        vItem.index > 0 &&
+                        filtered[vItem.index - 1].role === message.role &&
+                        message.role === "assistant"
+                      }
+                      // Last in a same-role run — show the Reply/Save/Copy row
+                      // here instead of on every member of the group.
+                      isLastInGroup={
+                        vItem.index === filtered.length - 1 ||
+                        filtered[vItem.index + 1].role !== message.role
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {/* Working indicator: the turn is running but no assistant token has
             arrived yet (the 5–8s the model spends before its first chunk). The
             streaming spinner only shows once an assistant message exists, so
             without this the thread looks idle after sending. */}
-        {isStreaming && !streamingId && <WorkingIndicator />}
-      </div>
+          {isStreaming && !streamingId && <WorkingIndicator />}
+        </div>
 
-      {/* Bottom fade — visual cue that there's more content below the
+        {/* Bottom fade — visual cue that there's more content below the
           fold. Gated on the same `showJumpToBottom` bit we publish to
           the parent so the fade and the (now parent-owned) scroll
           button crossfade together. */}
-      <div
-        aria-hidden
-        className={cn(
-          "pointer-events-none absolute left-0 right-0 bottom-0 h-16 z-[1] transition-opacity duration-200",
-          showJumpToBottom ? "opacity-100" : "opacity-0"
-        )}
-        style={{
-          background:
-            "linear-gradient(to bottom, transparent, var(--bg-surface))",
-        }}
-      />
-    </div>
-  );
-});
-
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute left-0 right-0 bottom-0 h-16 z-[1] transition-opacity duration-200",
+            showJumpToBottom ? "opacity-100" : "opacity-0",
+          )}
+          style={{
+            background:
+              "linear-gradient(to bottom, transparent, var(--bg-surface))",
+          }}
+        />
+      </div>
+    );
+  },
+);

--- a/src/features/chat/components/permission-modal.tsx
+++ b/src/features/chat/components/permission-modal.tsx
@@ -31,7 +31,8 @@ function isReject(kind: string) {
 // never names the wrong agent. Ordered longest-first to avoid partial matches.
 const AGENT_BRANDS = ["Claude Code", "Codex", "Claude"];
 function relabelAgentBrand(label: string, agentType: AgentType): string {
-  const display = (AGENT_LABEL as Record<string, string>)[agentType] ?? "the agent";
+  const display =
+    (AGENT_LABEL as Record<string, string>)[agentType] ?? "the agent";
   let out = label;
   for (const brand of AGENT_BRANDS) {
     if (brand === display) continue;
@@ -55,7 +56,10 @@ interface PermissionModalProps {
  * Cancelled requests (ESC / click outside) resolve as `cancelled` on the wire
  * so the agent backs off correctly.
  */
-export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) {
+export function PermissionModal({
+  tabId,
+  onSendMessage,
+}: PermissionModalProps) {
   // Narrow subscription: only this tab's acpSessionId and the head of its
   // permission queue, so the card stays idle until a request actually arrives.
   const acpSessionId = useChatStore((s) => s.sessions[tabId]?.acpSessionId);
@@ -65,7 +69,9 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
   const queueLength = useChatStore((s) =>
     acpSessionId ? (s.pendingPermissions[acpSessionId]?.length ?? 0) : 0,
   );
-  const agentType = useChatStore((s) => s.sessions[tabId]?.agentType ?? "claude-code");
+  const agentType = useChatStore(
+    (s) => s.sessions[tabId]?.agentType ?? "claude-code",
+  );
   const popPermission = useChatStore.use.actions().popPermission;
 
   const [draft, setDraft] = useState("");
@@ -85,7 +91,12 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
     if (!current) return;
     const send = (decision: Parameters<typeof agents.respondPermission>[3]) => {
       agents
-        .respondPermission(current.agentId, current.acpSessionId, current.requestId, decision)
+        .respondPermission(
+          current.agentId,
+          current.acpSessionId,
+          current.requestId,
+          decision,
+        )
         .catch((e) => toast.error(`Permission send failed: ${e}`))
         .finally(() => popPermission(current.acpSessionId, current.requestId));
     };
@@ -122,19 +133,29 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
 
   const resolve = (optId: string) => {
     agents
-      .respondPermission(current.agentId, current.acpSessionId, current.requestId, {
-        kind: "selected",
-        option_id: optId,
-      })
+      .respondPermission(
+        current.agentId,
+        current.acpSessionId,
+        current.requestId,
+        {
+          kind: "selected",
+          option_id: optId,
+        },
+      )
       .catch((e) => toast.error(`Permission send failed: ${e}`))
       .finally(() => popPermission(current.acpSessionId, current.requestId));
   };
 
   const cancel = () => {
     agents
-      .respondPermission(current.agentId, current.acpSessionId, current.requestId, {
-        kind: "cancelled",
-      })
+      .respondPermission(
+        current.agentId,
+        current.acpSessionId,
+        current.requestId,
+        {
+          kind: "cancelled",
+        },
+      )
       .catch((e) => toast.error(`Permission cancel failed: ${e}`))
       .finally(() => popPermission(current.acpSessionId, current.requestId));
   };
@@ -151,7 +172,8 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
   const title = current.toolCall.title ?? current.toolCall.kind ?? "Tool call";
   const planMarkdown = extractPlanMarkdown(current.toolCall);
   const questions = extractQuestions(current.toolCall);
-  const queueNote = queueLength > 1 ? `${queueLength - 1} more pending after this` : null;
+  const queueNote =
+    queueLength > 1 ? `${queueLength - 1} more pending after this` : null;
 
   // Numbered option list — shared by both layouts.
   const optionList = (
@@ -190,9 +212,12 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
             <div className="flex items-start gap-3 border-b border-border-default px-4 py-3">
               <ClipboardList className="mt-0.5 size-4 text-accent" />
               <div className="flex-1">
-                <Dialog.Title className="text-sm font-medium">Review plan</Dialog.Title>
+                <Dialog.Title className="text-sm font-medium">
+                  Review plan
+                </Dialog.Title>
                 <Dialog.Description className="mt-0.5 text-xs text-text-secondary">
-                  The agent proposed a plan before continuing. Review it, then approve or reject.
+                  The agent proposed a plan before continuing. Review it, then
+                  approve or reject.
                 </Dialog.Description>
               </div>
               {queueNote && (
@@ -208,7 +233,9 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
                 </div>
               </section>
               <aside className="flex w-[320px] shrink-0 flex-col border-l border-border-default">
-                <div className="min-h-0 min-w-0 flex-1 overflow-auto px-4 py-3">{optionList}</div>
+                <div className="min-h-0 min-w-0 flex-1 overflow-auto px-4 py-3">
+                  {optionList}
+                </div>
                 <div className="flex items-center justify-end gap-2 border-t border-border-default px-4 py-2.5">
                   <button
                     type="button"
@@ -246,7 +273,9 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
     // ACP options with no corresponding answer choice (e.g. an explicit
     // reject/cancel) — surfaced below so the user can still decline.
     const specLabels = new Set(
-      questions.flatMap((q) => q.options.map((o) => o.label.trim().toLowerCase())),
+      questions.flatMap((q) =>
+        q.options.map((o) => o.label.trim().toLowerCase()),
+      ),
     );
     const extraOptions = current.options.filter(
       (o) => !specLabels.has(o.name.trim().toLowerCase()),
@@ -273,7 +302,9 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
                 </div>
               )}
               {queueNote && (
-                <div className="mt-0.5 text-[11px] text-text-secondary">{queueNote}</div>
+                <div className="mt-0.5 text-[11px] text-text-secondary">
+                  {queueNote}
+                </div>
               )}
             </div>
           </div>
@@ -283,7 +314,9 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
             <div className="mx-3 mt-2 space-y-1 rounded-md border border-border-default bg-bg-base px-3 py-2">
               {questions.slice(1).map((q, i) => (
                 <div key={i} className="text-[11px] text-text-secondary">
-                  {q.header && <span className="text-text-tertiary">{q.header}: </span>}
+                  {q.header && (
+                    <span className="text-text-tertiary">{q.header}: </span>
+                  )}
                   {q.question}
                 </div>
               ))}
@@ -343,7 +376,9 @@ export function PermissionModal({ tabId, onSendMessage }: PermissionModalProps) 
               <span className="font-mono text-text-primary">{title}</span>?
             </div>
             {queueNote && (
-              <div className="mt-0.5 text-[11px] text-text-secondary">{queueNote}</div>
+              <div className="mt-0.5 text-[11px] text-text-secondary">
+                {queueNote}
+              </div>
             )}
           </div>
         </div>
@@ -410,7 +445,9 @@ function PermissionOption({
         <span
           className={cn(
             "flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-semibold",
-            isPrimary ? "bg-[var(--bg-base)]/15 text-[var(--bg-base)]" : "bg-bg-elevated text-text-secondary",
+            isPrimary
+              ? "bg-[var(--bg-base)]/15 text-[var(--bg-base)]"
+              : "bg-bg-elevated text-text-secondary",
           )}
         >
           {index}
@@ -419,7 +456,9 @@ function PermissionOption({
       <Icon className="size-3.5 shrink-0" />
       <span className="min-w-0 flex-1 font-medium break-words">{label}</span>
       {isPrimary && (
-        <Kbd className="border-[var(--bg-base)]/20 bg-[var(--bg-base)]/10 text-[var(--bg-base)]">↵</Kbd>
+        <Kbd className="border-[var(--bg-base)]/20 bg-[var(--bg-base)]/10 text-[var(--bg-base)]">
+          ↵
+        </Kbd>
       )}
     </button>
   );
@@ -453,7 +492,9 @@ function QuestionOption({
         {index}
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block font-medium break-words text-text-primary">{label}</span>
+        <span className="block font-medium break-words text-text-primary">
+          {label}
+        </span>
         {description && (
           <span className="mt-0.5 block text-[11px] font-normal leading-snug text-text-secondary break-words">
             {description}
@@ -466,8 +507,10 @@ function QuestionOption({
 
 function ToolCallPreview({ tc }: { tc: PendingPermission["toolCall"] }) {
   const inputValue =
-    (tc as Record<string, unknown>).rawInput ?? (tc as Record<string, unknown>).input;
-  const formatted = inputValue !== undefined ? safeStringify(inputValue, 2) : null;
+    (tc as Record<string, unknown>).rawInput ??
+    (tc as Record<string, unknown>).input;
+  const formatted =
+    inputValue !== undefined ? safeStringify(inputValue, 2) : null;
   if (!formatted) return null;
   return (
     <div className="mx-3 mt-2 rounded-md border border-border-default bg-bg-base px-3 py-2">

--- a/src/features/chat/components/plan-dock.tsx
+++ b/src/features/chat/components/plan-dock.tsx
@@ -28,7 +28,10 @@ function StepIcon({ status }: { status: PlanStep["status"] }) {
     return <CheckCircle2 size={12} className="text-[var(--status-success)]" />;
   if (status === "in_progress")
     return (
-      <Loader2 size={12} className="animate-spin text-[var(--accent-primary)]" />
+      <Loader2
+        size={12}
+        className="animate-spin text-[var(--accent-primary)]"
+      />
     );
   return (
     <div className="h-3 w-3 rounded-full border border-[var(--border-strong)]" />

--- a/src/features/chat/components/plans-panel.tsx
+++ b/src/features/chat/components/plans-panel.tsx
@@ -86,7 +86,7 @@ export function PlansPanel({ onClose }: PlansPanelProps) {
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
-    [plansPanel.width, setPlansPanelWidth]
+    [plansPanel.width, setPlansPanelWidth],
   );
 
   return (
@@ -144,7 +144,7 @@ export function PlansPanel({ onClose }: PlansPanelProps) {
                   key={p.id}
                   className={cn(
                     "px-3 py-2.5",
-                    !isLast && "border-b border-[var(--border-subtle)]"
+                    !isLast && "border-b border-[var(--border-subtle)]",
                   )}
                 >
                   {/* Header row: user message + expand toggle */}
@@ -167,7 +167,7 @@ export function PlansPanel({ onClose }: PlansPanelProps) {
                     <span
                       className={cn(
                         "text-[12px] leading-snug text-[var(--text-secondary)] group-hover:text-[var(--text-primary)] transition-colors",
-                        !isOpen && "line-clamp-2"
+                        !isOpen && "line-clamp-2",
                       )}
                     >
                       {p.userMessage || "(no message)"}
@@ -176,7 +176,9 @@ export function PlansPanel({ onClose }: PlansPanelProps) {
 
                   {/* Meta: human timestamp + relative age + session */}
                   <div className="flex items-center gap-2 pl-[18px] mt-1 text-[10px] text-[var(--text-tertiary)]">
-                    <span title={p.timestamp}>{formatPlanTimestamp(p.timestamp)}</span>
+                    <span title={p.timestamp}>
+                      {formatPlanTimestamp(p.timestamp)}
+                    </span>
                     <span>·</span>
                     <span>{planTimeAgo(p.timestamp)}</span>
                     {p.sessionTitle && (

--- a/src/features/chat/components/provider-model-pills.tsx
+++ b/src/features/chat/components/provider-model-pills.tsx
@@ -10,14 +10,24 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Popover from "@radix-ui/react-popover";
-import { Check, ChevronDown, Loader2, RefreshCw, Search, Star } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Loader2,
+  RefreshCw,
+  Search,
+  Star,
+} from "lucide-react";
 import { ProviderLogo } from "@/components/provider-logo";
 import {
   useModelPricingStore,
   priceFor,
   formatPrice,
 } from "@/features/settings/stores/model-pricing-store";
-import { CHAT_PROVIDERS, providerById } from "@/features/settings/lib/providers";
+import {
+  CHAT_PROVIDERS,
+  providerById,
+} from "@/features/settings/lib/providers";
 import { useByokStore } from "@/features/settings/stores/byok-store";
 import { modelchat } from "@/features/model-chat/lib/model-chat-api";
 import {
@@ -43,7 +53,10 @@ function loadModelIds(provider: string): Promise<string[]> {
   const p = modelchat
     .models(provider)
     .then((rows) => {
-      const curated = curateModels(provider, rows.map((r) => r.id));
+      const curated = curateModels(
+        provider,
+        rows.map((r) => r.id),
+      );
       modelListCache.set(provider, curated);
       modelListInFlight.delete(provider);
       return curated;
@@ -100,7 +113,9 @@ export function ProviderModelPills({
     if (provider || configuredIds.length === 0) return;
     const pref = prefRef.current;
     const next =
-      pref && configuredIds.includes(pref.provider) ? pref.provider : configuredIds[0];
+      pref && configuredIds.includes(pref.provider)
+        ? pref.provider
+        : configuredIds[0];
     onProvider(next);
   }, [provider, configuredIds, onProvider]);
 
@@ -108,7 +123,9 @@ export function ProviderModelPills({
   // can point at an unconfigured provider (to show the "Set up key" prompt).
   const [viewProvider, setViewProvider] = useState(provider);
   useEffect(() => {
-    setViewProvider(provider || configuredIds[0] || CHAT_PROVIDERS[0]?.id || "");
+    setViewProvider(
+      provider || configuredIds[0] || CHAT_PROVIDERS[0]?.id || "",
+    );
   }, [provider, configuredIds]);
 
   const [models, setModels] = useState<string[]>([]);
@@ -130,7 +147,9 @@ export function ProviderModelPills({
       if (viewProvider !== provider || model || ids.length === 0) return;
       const pref = prefRef.current;
       const remembered =
-        pref && pref.provider === provider && ids.includes(pref.model) ? pref.model : null;
+        pref && pref.provider === provider && ids.includes(pref.model)
+          ? pref.model
+          : null;
       onModel(remembered ?? defaultModelFor(provider, ids) ?? ids[0]);
     };
     const cached = modelListCache.get(viewProvider);
@@ -167,23 +186,26 @@ export function ProviderModelPills({
   );
 
   const openApiKeys = useCallback(() => {
-    void import("@/features/layout/stores/layout-store").then(({ useLayoutStore }) => {
-      useLayoutStore.getState().actions.addTab({
-        id: "settings",
-        type: "settings",
-        title: "Settings",
-        closable: true,
-        dirty: false,
-        data: { section: "providers" },
-      });
-    });
+    void import("@/features/layout/stores/layout-store").then(
+      ({ useLayoutStore }) => {
+        useLayoutStore.getState().actions.addTab({
+          id: "settings",
+          type: "settings",
+          title: "Settings",
+          closable: true,
+          dirty: false,
+          data: { section: "providers" },
+        });
+      },
+    );
     setOpen(false);
   }, []);
 
   // Model pricing (models.dev, cached by Rust) — shows $/1M per model.
   const prices = useModelPricingStore.use.prices();
   const pricingLoading = useModelPricingStore.use.loading();
-  const { load: loadPricing, refresh: refreshPricing } = useModelPricingStore.use.actions();
+  const { load: loadPricing, refresh: refreshPricing } =
+    useModelPricingStore.use.actions();
   useEffect(() => {
     void loadPricing();
   }, [loadPricing]);
@@ -192,7 +214,9 @@ export function ProviderModelPills({
     const s = q.trim().toLowerCase();
     const match = (m: string) => (s ? m.toLowerCase().includes(s) : true);
     const order = preferredModels(viewProvider);
-    const pinnedSet = new Set(models.filter((m) => isPreferredModel(viewProvider, m)));
+    const pinnedSet = new Set(
+      models.filter((m) => isPreferredModel(viewProvider, m)),
+    );
     return {
       pinned: order.filter((m) => pinnedSet.has(m) && match(m)),
       rest: models.filter((m) => !pinnedSet.has(m) && match(m)),
@@ -200,7 +224,10 @@ export function ProviderModelPills({
   }, [viewProvider, models, q]);
 
   const renderModel = (id: string, starred: boolean) => {
-    const price = formatPrice(priceFor(prices, viewProvider, id), pricingLoading);
+    const price = formatPrice(
+      priceFor(prices, viewProvider, id),
+      pricingLoading,
+    );
     return (
       <button
         key={id}
@@ -208,7 +235,10 @@ export function ProviderModelPills({
         className="flex w-full items-center gap-2 px-2.5 h-[26px] text-left text-[11px] font-mono text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer outline-none"
       >
         {starred && (
-          <Star size={10} className="shrink-0 fill-[var(--accent-primary)] text-[var(--accent-primary)]" />
+          <Star
+            size={10}
+            className="shrink-0 fill-[var(--accent-primary)] text-[var(--accent-primary)]"
+          />
         )}
         <span className="min-w-0 flex-1 truncate">{id}</span>
         <span
@@ -233,9 +263,17 @@ export function ProviderModelPills({
       }}
     >
       <Popover.Trigger asChild>
-        <button className={PILL_CLASS} title="Model — click to choose provider + model">
+        <button
+          className={PILL_CLASS}
+          title="Model — click to choose provider + model"
+        >
           <ProviderLogo id={provider || viewProvider} size={13} />
-          {loadingModels && <Loader2 size={10} className="animate-spin text-[var(--text-tertiary)]" />}
+          {loadingModels && (
+            <Loader2
+              size={10}
+              className="animate-spin text-[var(--text-tertiary)]"
+            />
+          )}
           <span className="max-w-[150px] truncate font-mono">
             {model || (loadingModels ? "Loading…" : "Select model")}
           </span>
@@ -280,7 +318,10 @@ export function ProviderModelPills({
                 <>
                   {/* Search + pricing refresh */}
                   <div className="flex items-center gap-1.5 h-8 border-b border-[var(--border-subtle)] px-2.5">
-                    <Search size={12} className="shrink-0 text-[var(--text-tertiary)]" />
+                    <Search
+                      size={12}
+                      className="shrink-0 text-[var(--text-tertiary)]"
+                    />
                     <input
                       autoFocus
                       value={q}
@@ -295,7 +336,10 @@ export function ProviderModelPills({
                       title="Refresh model pricing (models.dev)"
                       className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] cursor-pointer disabled:cursor-default"
                     >
-                      <RefreshCw size={11} className={cn(pricingLoading && "animate-spin")} />
+                      <RefreshCw
+                        size={11}
+                        className={cn(pricingLoading && "animate-spin")}
+                      />
                     </button>
                   </div>
 
@@ -314,7 +358,9 @@ export function ProviderModelPills({
                               Recommended for coding
                             </div>
                             {pinned.map((id) => renderModel(id, true))}
-                            {rest.length > 0 && <div className="my-1 h-px bg-[var(--border-subtle)]" />}
+                            {rest.length > 0 && (
+                              <div className="my-1 h-px bg-[var(--border-subtle)]" />
+                            )}
                           </>
                         )}
                         {rest.map((id) => renderModel(id, false))}
@@ -345,21 +391,23 @@ export function ProviderModelPills({
 
           {/* RTK compression toggle (Cursor "MAX Mode"-style footer). */}
           {showCompress && (
-          <button
-            onClick={() => onCompress?.(!compress)}
-            className="flex w-full items-center gap-2 border-t border-[var(--border-subtle)] px-2.5 py-2 text-left text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] cursor-pointer outline-none"
-            title="Tool-output compression — shrinks tool results to save tokens"
-          >
-            <span className="flex-1">Compress Tokens</span>
-            <span
-              className={cn(
-                "flex h-3.5 w-6 items-center rounded-full px-0.5 transition-colors",
-                compress ? "bg-[var(--accent-primary)] justify-end" : "bg-[var(--bg-base)] justify-start",
-              )}
+            <button
+              onClick={() => onCompress?.(!compress)}
+              className="flex w-full items-center gap-2 border-t border-[var(--border-subtle)] px-2.5 py-2 text-left text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] cursor-pointer outline-none"
+              title="Tool-output compression — shrinks tool results to save tokens"
             >
-              <span className="h-2.5 w-2.5 rounded-full bg-[var(--bg-elevated)]" />
-            </span>
-          </button>
+              <span className="flex-1">Compress Tokens</span>
+              <span
+                className={cn(
+                  "flex h-3.5 w-6 items-center rounded-full px-0.5 transition-colors",
+                  compress
+                    ? "bg-[var(--accent-primary)] justify-end"
+                    : "bg-[var(--bg-base)] justify-start",
+                )}
+              >
+                <span className="h-2.5 w-2.5 rounded-full bg-[var(--bg-elevated)]" />
+              </span>
+            </button>
           )}
         </Popover.Content>
       </Popover.Portal>

--- a/src/features/chat/components/retry-pill.tsx
+++ b/src/features/chat/components/retry-pill.tsx
@@ -31,7 +31,10 @@ export function RetryPill({ tabId }: { tabId: string }) {
       className="mb-2 flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[11px] text-[var(--text-secondary)]"
       title={retry.lastError}
     >
-      <RotateCw size={12} className="animate-spin text-[var(--text-tertiary)]" />
+      <RotateCw
+        size={12}
+        className="animate-spin text-[var(--text-tertiary)]"
+      />
       <span className="font-medium text-[var(--text-primary)]">
         Retrying {retry.attempt}/{retry.maxAttempts}
         {secs > 0 ? ` in ${secs}s` : "…"}

--- a/src/features/chat/components/session-sidebar.tsx
+++ b/src/features/chat/components/session-sidebar.tsx
@@ -1,12 +1,10 @@
-import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import {
-  X,
-  MessageSquare,
-  Search,
-  PanelLeftClose,
-  Plus,
-} from "lucide-react";
+  useQuery,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { X, MessageSquare, Search, PanelLeftClose, Plus } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
@@ -199,12 +197,8 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
   } = useChatStore.use.actions();
 
   const chatSidebar = useLayoutStore.use.chatSidebar();
-  const {
-    toggleChatSidebar,
-    setChatSidebarWidth,
-    addTab,
-    setActiveTab,
-  } = useLayoutStore.use.actions();
+  const { toggleChatSidebar, setChatSidebarWidth, addTab, setActiveTab } =
+    useLayoutStore.use.actions();
 
   const [search, setSearch] = useState("");
 
@@ -311,7 +305,7 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
       (e) => {
         if (e.payload.cwd !== cwd) return;
         invalidate();
-      }
+      },
     );
     window.addEventListener("focus", invalidate);
     return () => {
@@ -352,7 +346,7 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
       liveAgents.map((s) => {
         const id = s.acpSessionId ?? `live-${s.id}`;
         return [id, s] as const;
-      })
+      }),
     );
     // Merge both agents' disk listings into one map, tagging each row with the
     // agent that produced it so the row icon + resume routing are correct even
@@ -364,7 +358,8 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
     >();
     for (const d of agentList) diskById.set(d.id, { meta: d, agent: "claude" });
     for (const d of codexList) diskById.set(d.id, { meta: d, agent: "codex" });
-    for (const d of cerseiList) diskById.set(d.id, { meta: d, agent: "cersei" });
+    for (const d of cerseiList)
+      diskById.set(d.id, { meta: d, agent: "cersei" });
 
     // An unbound live row (`live-<tabId>` key — after an agent switch or
     // clearSession dropped the binding but kept messages, or during the
@@ -372,7 +367,8 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
     // conversation as a disk row listed under its real session id. Rendering
     // both shows the session twice, so suppress the live twin whenever a
     // disk row already covers the same first-user text.
-    const normFirstUser = (t: string) => stripInjectedContext(t).trim().slice(0, 60);
+    const normFirstUser = (t: string) =>
+      stripInjectedContext(t).trim().slice(0, 60);
     // Keyed by "<agent>|<text>", paired with the disk row's last-modified
     // time. A live twin is only suppressed when the disk row belongs to the
     // SAME agent and their activity times are close (a true twin's live
@@ -414,10 +410,7 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
       }
     }
 
-    const allIds = new Set<string>([
-      ...liveById.keys(),
-      ...diskById.keys(),
-    ]);
+    const allIds = new Set<string>([...liveById.keys(), ...diskById.keys()]);
 
     const agents: SidebarItem[] = Array.from(allIds, (id) => {
       const live = liveById.get(id);
@@ -763,12 +756,16 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
         targetTabId,
         snapshot.current_mode,
         snapshot.available_modes,
-        agentTypeFromPluginId(snapshot.plugin_id)
+        agentTypeFromPluginId(snapshot.plugin_id),
       );
       // Seed the ACP model picker too (Claude Code / Codex). On resume the agent
       // may not re-advertise models, so setAcpModels falls back to the cache.
       if (snapshot.available_models.length > 0) {
-        setAcpModels(targetTabId, snapshot.current_model, snapshot.available_models);
+        setAcpModels(
+          targetTabId,
+          snapshot.current_model,
+          snapshot.available_models,
+        );
       }
       setTranscriptLoading(targetTabId, false);
     })();
@@ -838,7 +835,7 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
-    [chatSidebar.width, setChatSidebarWidth]
+    [chatSidebar.width, setChatSidebarWidth],
   );
 
   if (!chatSidebar.visible) {
@@ -880,7 +877,9 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
       {/* List */}
       <div className="flex-1 overflow-y-auto hide-scrollbar">
         {isLoading && (
-          <div className="text-[11px] text-[var(--text-tertiary)] px-3 py-2">Loading…</div>
+          <div className="text-[11px] text-[var(--text-tertiary)] px-3 py-2">
+            Loading…
+          </div>
         )}
         {showEmpty && (
           <div className="text-[11px] text-[var(--text-tertiary)] px-3 py-3 leading-relaxed">
@@ -904,7 +903,7 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
                 active
                   ? "bg-[var(--bg-selected)] text-[var(--text-primary)] opacity-100"
                   : "text-[var(--text-secondary)] opacity-80 hover:opacity-100 hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]",
-                !isLast && "border-b border-[var(--border-default)]"
+                !isLast && "border-b border-[var(--border-default)]",
               )}
             >
               <div className="flex items-start gap-2 min-w-0 pr-5">
@@ -921,7 +920,10 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
                   }
                 >
                   {isRunning ? (
-                    <AtlasLoader size={8} className="text-[var(--accent-primary)]" />
+                    <AtlasLoader
+                      size={8}
+                      className="text-[var(--accent-primary)]"
+                    />
                   ) : item.kind === "agent" ? (
                     item.agent === "codex" ? (
                       <CodexIcon className="size-3" />
@@ -931,7 +933,10 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
                       <ClaudeIcon className="size-3" />
                     )
                   ) : (
-                    <MessageSquare size={11} className="text-[var(--accent-primary)]" />
+                    <MessageSquare
+                      size={11}
+                      className="text-[var(--accent-primary)]"
+                    />
                   )}
                 </span>
                 <span className="text-[11px] leading-snug line-clamp-2 flex-1">
@@ -959,15 +964,15 @@ export function SessionSidebar({ tabId }: SessionSidebarProps) {
                 (item.agent === "cersei" ||
                   item.agent === "codex" ||
                   (item.agent === "claude" && !!item.filePath)) && (
-                <button
-                  onClick={(e) => handleDeleteAgent(e, item)}
-                  aria-label="Delete session"
-                  className="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 flex items-center justify-center w-4 h-4 rounded text-[var(--text-tertiary)] hover:text-[var(--status-error)] hover:bg-[var(--bg-elevated)] transition-opacity"
-                  title="Delete session"
-                >
-                  <X size={10} />
-                </button>
-              )}
+                  <button
+                    onClick={(e) => handleDeleteAgent(e, item)}
+                    aria-label="Delete session"
+                    className="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 flex items-center justify-center w-4 h-4 rounded text-[var(--text-tertiary)] hover:text-[var(--status-error)] hover:bg-[var(--bg-elevated)] transition-opacity"
+                    title="Delete session"
+                  >
+                    <X size={10} />
+                  </button>
+                )}
             </div>
           );
         })}

--- a/src/features/chat/components/slash-command-picker.tsx
+++ b/src/features/chat/components/slash-command-picker.tsx
@@ -78,32 +78,162 @@ export interface SlashCommandPickerProps {
 // the actual command logic and emits the response into the chat thread.
 
 export const SLASH_COMMANDS: SlashCommand[] = [
-  { name: "login",            signature: "/login",            description: "Sign in to your Anthropic account.",                                    handler: "atlas-login" },
-  { name: "logout",           signature: "/logout",           description: "Sign out from your Anthropic account.",                                  handler: "passthrough" },
-  { name: "agents",           signature: "/agents",           description: "Manage agent configurations.",                                            handler: "passthrough" },
-  { name: "add-dir",          signature: "/add-dir <path>",   description: "Add a working directory for file access in this session.",                handler: "passthrough" },
-  { name: "clear",            signature: "/clear [name]",     description: "Start a new conversation with empty context.",                            handler: "passthrough" },
-  { name: "compact",          signature: "/compact",          description: "Summarize the conversation to free up context.",                          handler: "passthrough" },
-  { name: "model",            signature: "/model [model]",    description: "Set the AI model for the current session.",                               handler: "passthrough" },
-  { name: "effort",           signature: "/effort [level]",   description: "Set the model effort level (low/medium/high/xhigh/max).",                 handler: "passthrough" },
-  { name: "context",          signature: "/context",          description: "Visualize current context usage.",                                        handler: "passthrough" },
-  { name: "memory",           signature: "/memory",           description: "Edit CLAUDE.md memory files and auto-memory entries.",                    handler: "passthrough" },
-  { name: "resume",           signature: "/resume [session]", description: "Resume a previous conversation.",                                         handler: "passthrough" },
-  { name: "rewind",           signature: "/rewind",           description: "Rewind the conversation or code to a previous point.",                    handler: "passthrough" },
-  { name: "diff",             signature: "/diff",             description: "Open an interactive diff viewer for uncommitted changes.",                handler: "passthrough" },
-  { name: "permissions",      signature: "/permissions",      description: "Manage allow / ask / deny rules for tool permissions.",                   handler: "passthrough" },
-  { name: "config",           signature: "/config",           description: "Open the Settings interface.",                                            handler: "passthrough" },
-  { name: "status",           signature: "/status",           description: "Show version, model, account, and connectivity.",                         handler: "passthrough" },
-  { name: "usage",            signature: "/usage",            description: "Show session cost, plan usage limits, and activity stats.",               handler: "passthrough" },
-  { name: "doctor",           signature: "/doctor",           description: "Diagnose and verify your Claude Code installation.",                      handler: "passthrough" },
-  { name: "mcp",              signature: "/mcp",              description: "Manage MCP server connections and OAuth.",                                handler: "passthrough" },
-  { name: "hooks",            signature: "/hooks",            description: "View hook configurations for tool events.",                               handler: "passthrough" },
-  { name: "ide",              signature: "/ide",              description: "Manage IDE integrations and show status.",                                handler: "passthrough" },
-  { name: "init",             signature: "/init",             description: "Initialize project with a CLAUDE.md guide.",                              handler: "passthrough" },
-  { name: "review",           signature: "/review [PR]",      description: "Review a pull request locally in the current session.",                   handler: "passthrough" },
-  { name: "security-review",  signature: "/security-review",  description: "Analyze pending changes for security vulnerabilities.",                   handler: "passthrough" },
-  { name: "feedback",         signature: "/feedback",         description: "Submit feedback, report a bug, or share the conversation.",               handler: "passthrough" },
-  { name: "help",             signature: "/help",             description: "Show help and available commands.",                                       handler: "passthrough" },
+  {
+    name: "login",
+    signature: "/login",
+    description: "Sign in to your Anthropic account.",
+    handler: "atlas-login",
+  },
+  {
+    name: "logout",
+    signature: "/logout",
+    description: "Sign out from your Anthropic account.",
+    handler: "passthrough",
+  },
+  {
+    name: "agents",
+    signature: "/agents",
+    description: "Manage agent configurations.",
+    handler: "passthrough",
+  },
+  {
+    name: "add-dir",
+    signature: "/add-dir <path>",
+    description: "Add a working directory for file access in this session.",
+    handler: "passthrough",
+  },
+  {
+    name: "clear",
+    signature: "/clear [name]",
+    description: "Start a new conversation with empty context.",
+    handler: "passthrough",
+  },
+  {
+    name: "compact",
+    signature: "/compact",
+    description: "Summarize the conversation to free up context.",
+    handler: "passthrough",
+  },
+  {
+    name: "model",
+    signature: "/model [model]",
+    description: "Set the AI model for the current session.",
+    handler: "passthrough",
+  },
+  {
+    name: "effort",
+    signature: "/effort [level]",
+    description: "Set the model effort level (low/medium/high/xhigh/max).",
+    handler: "passthrough",
+  },
+  {
+    name: "context",
+    signature: "/context",
+    description: "Visualize current context usage.",
+    handler: "passthrough",
+  },
+  {
+    name: "memory",
+    signature: "/memory",
+    description: "Edit CLAUDE.md memory files and auto-memory entries.",
+    handler: "passthrough",
+  },
+  {
+    name: "resume",
+    signature: "/resume [session]",
+    description: "Resume a previous conversation.",
+    handler: "passthrough",
+  },
+  {
+    name: "rewind",
+    signature: "/rewind",
+    description: "Rewind the conversation or code to a previous point.",
+    handler: "passthrough",
+  },
+  {
+    name: "diff",
+    signature: "/diff",
+    description: "Open an interactive diff viewer for uncommitted changes.",
+    handler: "passthrough",
+  },
+  {
+    name: "permissions",
+    signature: "/permissions",
+    description: "Manage allow / ask / deny rules for tool permissions.",
+    handler: "passthrough",
+  },
+  {
+    name: "config",
+    signature: "/config",
+    description: "Open the Settings interface.",
+    handler: "passthrough",
+  },
+  {
+    name: "status",
+    signature: "/status",
+    description: "Show version, model, account, and connectivity.",
+    handler: "passthrough",
+  },
+  {
+    name: "usage",
+    signature: "/usage",
+    description: "Show session cost, plan usage limits, and activity stats.",
+    handler: "passthrough",
+  },
+  {
+    name: "doctor",
+    signature: "/doctor",
+    description: "Diagnose and verify your Claude Code installation.",
+    handler: "passthrough",
+  },
+  {
+    name: "mcp",
+    signature: "/mcp",
+    description: "Manage MCP server connections and OAuth.",
+    handler: "passthrough",
+  },
+  {
+    name: "hooks",
+    signature: "/hooks",
+    description: "View hook configurations for tool events.",
+    handler: "passthrough",
+  },
+  {
+    name: "ide",
+    signature: "/ide",
+    description: "Manage IDE integrations and show status.",
+    handler: "passthrough",
+  },
+  {
+    name: "init",
+    signature: "/init",
+    description: "Initialize project with a CLAUDE.md guide.",
+    handler: "passthrough",
+  },
+  {
+    name: "review",
+    signature: "/review [PR]",
+    description: "Review a pull request locally in the current session.",
+    handler: "passthrough",
+  },
+  {
+    name: "security-review",
+    signature: "/security-review",
+    description: "Analyze pending changes for security vulnerabilities.",
+    handler: "passthrough",
+  },
+  {
+    name: "feedback",
+    signature: "/feedback",
+    description: "Submit feedback, report a bug, or share the conversation.",
+    handler: "passthrough",
+  },
+  {
+    name: "help",
+    signature: "/help",
+    description: "Show help and available commands.",
+    handler: "passthrough",
+  },
 ];
 
 // ── Component ───────────────────────────────────────────────────────────────
@@ -114,7 +244,10 @@ const GAP = 6;
 export const SlashCommandPicker = forwardRef<
   SlashCommandPickerHandle,
   SlashCommandPickerProps
->(function SlashCommandPicker({ open, query, anchor, onSelect, onClose, commands, footerLabel }, ref) {
+>(function SlashCommandPicker(
+  { open, query, anchor, onSelect, onClose, commands, footerLabel },
+  ref,
+) {
   const [active, setActive] = useState(0);
 
   useEffect(() => {

--- a/src/features/chat/components/streaming-markdown.tsx
+++ b/src/features/chat/components/streaming-markdown.tsx
@@ -47,13 +47,20 @@ const MarkdownBlock = memo(function MarkdownBlock({
     );
   }
   return (
-    <CachedMarkdown source={source} className={cn("[display:contents]", className)} />
+    <CachedMarkdown
+      source={source}
+      className={cn("[display:contents]", className)}
+    />
   );
 });
 
 /** rAF-coalesced block split: at most one split per frame while streaming; a
  *  synchronous, memoized split when settled. */
-function useBlocks(source: string, streaming: boolean, whole: boolean): string[] {
+function useBlocks(
+  source: string,
+  streaming: boolean,
+  whole: boolean,
+): string[] {
   const [blocks, setBlocks] = useState<string[]>(() =>
     whole ? [source] : splitTopLevelBlocks(source),
   );

--- a/src/features/chat/components/turn-summary-card.tsx
+++ b/src/features/chat/components/turn-summary-card.tsx
@@ -18,7 +18,10 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { openFile } from "@/lib/open-file";
 import { openGitDiff } from "@/features/git/lib/git-diff-api";
-import { useGitStore, type GitFileStatus } from "@/features/git/stores/git-store";
+import {
+  useGitStore,
+  type GitFileStatus,
+} from "@/features/git/stores/git-store";
 import type { ChatMessage, TurnFile } from "@/types/agent";
 
 /** Compact token count: 1.2k / 42.1k / 1.0M. */
@@ -175,8 +178,7 @@ export const TurnSummaryCard = memo(function TurnSummaryCard({
       toast.error("Pick a BYOK model in the composer first to draw diagrams");
       return;
     }
-    const projectPath =
-      useProjectStore.getState().currentProject?.path ?? "/";
+    const projectPath = useProjectStore.getState().currentProject?.path ?? "/";
     const editedPaths = edits.map((f) => f.path);
     const prompt = [
       "Draw a clear architecture/flow diagram of the changes just made" +
@@ -194,16 +196,14 @@ export const TurnSummaryCard = memo(function TurnSummaryCard({
     // the loading state and can keep chatting with the diagram afterward.
     const groupId = canvas.createAiGroup(anchor, byok.provider, byok.model);
     canvas.requestOpenAiThread(groupId);
-    void useCanvasAiStore
-      .getState()
-      .actions.generate({
-        groupId,
-        anchor,
-        prompt,
-        provider: byok.provider,
-        model: byok.model,
-        projectPath,
-      });
+    void useCanvasAiStore.getState().actions.generate({
+      groupId,
+      anchor,
+      prompt,
+      provider: byok.provider,
+      model: byok.model,
+      projectPath,
+    });
     // Reveal the Spaces tab so the user watches it draw.
     const layout = useLayoutStore.getState().actions;
     layout.addTab({
@@ -277,29 +277,31 @@ export const TurnSummaryCard = memo(function TurnSummaryCard({
           </div>
           <div className="flex flex-wrap gap-1.5">
             {chips.map((chip, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() =>
-                window.dispatchEvent(
-                  // Stamp the ORIGIN tab id so only this chat session sends it —
-                  // the listener is a global window event and every mounted
-                  // ChatPanel hears it, so without this every session would fire.
-                  new CustomEvent("atlas:chat-send", { detail: { text: chip, tabId } }),
-                )
-              }
-              className={cn(
-                "group flex items-center gap-1.5 rounded-full border border-[var(--border-default)]",
-                "bg-[var(--bg-secondary)] px-3 py-1 text-[11px] text-[var(--text-secondary)]",
-                "transition-colors hover:border-[var(--border-focus)] hover:text-[var(--text-primary)]",
-              )}
-            >
-              <span className="max-w-[280px] truncate">{chip}</span>
-              <ArrowRight
-                size={11}
-                className="shrink-0 text-[var(--text-tertiary)] group-hover:text-[var(--accent-primary)]"
-              />
-            </button>
+              <button
+                key={i}
+                type="button"
+                onClick={() =>
+                  window.dispatchEvent(
+                    // Stamp the ORIGIN tab id so only this chat session sends it —
+                    // the listener is a global window event and every mounted
+                    // ChatPanel hears it, so without this every session would fire.
+                    new CustomEvent("atlas:chat-send", {
+                      detail: { text: chip, tabId },
+                    }),
+                  )
+                }
+                className={cn(
+                  "group flex items-center gap-1.5 rounded-full border border-[var(--border-default)]",
+                  "bg-[var(--bg-secondary)] px-3 py-1 text-[11px] text-[var(--text-secondary)]",
+                  "transition-colors hover:border-[var(--border-focus)] hover:text-[var(--text-primary)]",
+                )}
+              >
+                <span className="max-w-[280px] truncate">{chip}</span>
+                <ArrowRight
+                  size={11}
+                  className="shrink-0 text-[var(--text-tertiary)] group-hover:text-[var(--accent-primary)]"
+                />
+              </button>
             ))}
           </div>
         </div>
@@ -332,9 +334,7 @@ export const TurnSummaryCard = memo(function TurnSummaryCard({
           )
         )}
         <ActionButton
-          icon={
-            <span className="inline-block h-2 w-2 rounded-full bg-white" />
-          }
+          icon={<span className="inline-block h-2 w-2 rounded-full bg-white" />}
           label="Save to KB"
           onClick={saveToKb}
         />
@@ -364,7 +364,12 @@ function TurnFileList({ files }: { files: TurnFile[] }) {
   return (
     <>
       {files.map((f) => (
-        <FileRow key={`${f.kind}:${f.path}`} file={f} repoPath={repoPath} gitFiles={gitFiles} />
+        <FileRow
+          key={`${f.kind}:${f.path}`}
+          file={f}
+          repoPath={repoPath}
+          gitFiles={gitFiles}
+        />
       ))}
     </>
   );
@@ -407,7 +412,8 @@ const FileRow = memo(function FileRow({
     }
   };
   const openInDiff = () => {
-    if (repoPath && rel) openGitDiff(repoPath, rel, scEntry?.staged ?? false, null);
+    if (repoPath && rel)
+      openGitDiff(repoPath, rel, scEntry?.staged ?? false, null);
   };
 
   // Clicking the path itself runs the primary action (diff when tracked, else
@@ -419,7 +425,10 @@ const FileRow = memo(function FileRow({
       <FileStatusBadge file={file} />
       <button
         type="button"
-        onClick={(e) => { e.stopPropagation(); openPrimary(); }}
+        onClick={(e) => {
+          e.stopPropagation();
+          openPrimary();
+        }}
         className="min-w-0 truncate text-left text-[var(--text-secondary)] underline-offset-2 transition-colors hover:text-[var(--text-primary)] hover:underline"
       >
         {file.path}
@@ -428,10 +437,22 @@ const FileRow = memo(function FileRow({
       {/* Actions — icons, revealed on row hover. */}
       <span className="ml-auto flex shrink-0 items-center gap-2 pl-2 opacity-0 transition-opacity group-hover:opacity-100">
         {inSourceControl && (
-          <FileAction icon={<GitCompare size={12} />} title="Open diff" onClick={openInDiff} />
+          <FileAction
+            icon={<GitCompare size={12} />}
+            title="Open diff"
+            onClick={openInDiff}
+          />
         )}
-        <FileAction icon={<Code size={12} />} title="Open in editor" onClick={openInEditor} />
-        <FileAction icon={<FolderOpen size={12} />} title="Reveal in Finder" onClick={openInFinder} />
+        <FileAction
+          icon={<Code size={12} />}
+          title="Open in editor"
+          onClick={openInEditor}
+        />
+        <FileAction
+          icon={<FolderOpen size={12} />}
+          title="Reveal in Finder"
+          onClick={openInFinder}
+        />
       </span>
 
       {isEdit && (file.added > 0 || file.removed > 0) && (
@@ -440,7 +461,9 @@ const FileRow = memo(function FileRow({
             <span className="text-[var(--status-success)]">+{file.added}</span>
           )}
           {file.removed > 0 && (
-            <span className="ml-1 text-[var(--status-error)]">−{file.removed}</span>
+            <span className="ml-1 text-[var(--status-error)]">
+              −{file.removed}
+            </span>
           )}
         </span>
       )}
@@ -450,7 +473,15 @@ const FileRow = memo(function FileRow({
 
 /** A tiny icon button for a per-file open action (Diff / Editor / Finder).
  *  `title` provides the tooltip that the removed text label used to convey. */
-function FileAction({ icon, title, onClick }: { icon: React.ReactNode; title: string; onClick: () => void }) {
+function FileAction({
+  icon,
+  title,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  onClick: () => void;
+}) {
   return (
     <button
       type="button"

--- a/src/features/chat/lib/acp-models-cache.ts
+++ b/src/features/chat/lib/acp-models-cache.ts
@@ -28,7 +28,8 @@ export function loadCachedAcpModels(agentType: string): CachedAcpModels | null {
     const raw = localStorage.getItem(key(agentType));
     if (!raw) return null;
     const v = JSON.parse(raw) as CachedAcpModels;
-    if (Array.isArray(v?.availableModels) && v.availableModels.length > 0) return v;
+    if (Array.isArray(v?.availableModels) && v.availableModels.length > 0)
+      return v;
   } catch {
     // corrupt / unavailable storage — treat as a cache miss
   }
@@ -38,7 +39,10 @@ export function loadCachedAcpModels(agentType: string): CachedAcpModels | null {
 /** True when we have a cached list newer than `ttlMs`. A pre-TTL entry (no
  *  `fetchedAt`) counts as fresh — treat existing caches as good rather than
  *  forcing one more warm. */
-export function isCachedAcpModelsFresh(agentType: string, ttlMs: number): boolean {
+export function isCachedAcpModelsFresh(
+  agentType: string,
+  ttlMs: number,
+): boolean {
   const cached = loadCachedAcpModels(agentType);
   if (!cached) return false;
   if (cached.fetchedAt == null) return true;
@@ -46,7 +50,10 @@ export function isCachedAcpModelsFresh(agentType: string, ttlMs: number): boolea
 }
 
 /** Persist the models confirmed by a live session (no-op for empty sets). */
-export function saveCachedAcpModels(agentType: string, models: CachedAcpModels): void {
+export function saveCachedAcpModels(
+  agentType: string,
+  models: CachedAcpModels,
+): void {
   try {
     if (models.availableModels.length > 0) {
       localStorage.setItem(

--- a/src/features/chat/lib/acp-modes-cache.ts
+++ b/src/features/chat/lib/acp-modes-cache.ts
@@ -31,11 +31,15 @@ export function loadCachedAcpModes(agentType: string): CachedAcpModes | null {
     const raw = localStorage.getItem(key(agentType));
     if (!raw) return null;
     const v = JSON.parse(raw) as CachedAcpModes;
-    if (!Array.isArray(v?.availableModes) || v.availableModes.length === 0) return null;
+    if (!Array.isArray(v?.availableModes) || v.availableModes.length === 0)
+      return null;
     // A current mode that isn't one of the available ones is not usable: the
     // picker would render its "Mode" fallback and the first pick would push an
     // id the agent rejects. Keep the list, drop the orphan.
-    if (v.currentMode && !v.availableModes.some((m) => m.id === v.currentMode)) {
+    if (
+      v.currentMode &&
+      !v.availableModes.some((m) => m.id === v.currentMode)
+    ) {
       return { ...v, currentMode: null };
     }
     return v;
@@ -46,7 +50,10 @@ export function loadCachedAcpModes(agentType: string): CachedAcpModes | null {
 }
 
 /** Persist the modes confirmed by a live session (no-op for empty sets). */
-export function saveCachedAcpModes(agentType: string, modes: CachedAcpModes): void {
+export function saveCachedAcpModes(
+  agentType: string,
+  modes: CachedAcpModes,
+): void {
   try {
     if (modes.availableModes.length > 0) {
       localStorage.setItem(key(agentType), JSON.stringify(modes));

--- a/src/features/chat/lib/agents-api.ts
+++ b/src/features/chat/lib/agents-api.ts
@@ -43,8 +43,7 @@ export interface AuthRunDone {
 export const agents = {
   listPlugins: () => invoke<PluginSpec[]>("agents_list_plugins"),
   listRunning: () => invoke<AgentInfo[]>("agents_list_running"),
-  spawn: (pluginId: string) =>
-    invoke<AgentInfo>("agents_spawn", { pluginId }),
+  spawn: (pluginId: string) => invoke<AgentInfo>("agents_spawn", { pluginId }),
   kill: (agentId: AgentId) => invoke<void>("agents_kill", { agentId }),
 
   newSession: (agentId: AgentId, cwd: string) =>
@@ -91,7 +90,7 @@ export const agents = {
     agentId: AgentId,
     sessionId: AcpSessionId,
     requestId: string,
-    decision: PermissionDecision
+    decision: PermissionDecision,
   ) =>
     invoke<void>("agents_respond_permission", {
       agentId,
@@ -111,7 +110,8 @@ export const agents = {
 };
 
 /** Whether Codex has stored credentials (`~/.codex/auth.json`). */
-export const codexStatus = (): Promise<boolean> => invoke<boolean>("codex_status");
+export const codexStatus = (): Promise<boolean> =>
+  invoke<boolean>("codex_status");
 
 export const listenAuthRunDone = (
   handler: (p: AuthRunDone) => void,
@@ -123,7 +123,7 @@ export const listenAuthRunDone = (
  * `agent_id` + `session_id` so the consumer can route to the right tab.
  */
 export const listenAgents = (
-  handler: (env: AgentDelta) => void
+  handler: (env: AgentDelta) => void,
 ): Promise<UnlistenFn> =>
   listen<AgentDelta>("atlas:agents", (e) => handler(e.payload));
 
@@ -195,6 +195,8 @@ export function resetAgent(pluginId?: string): void {
 }
 
 // Back-compat thin wrappers (default = Claude) for existing callers.
-export const ensureDefaultAgent = (): Promise<AgentInfo> => ensureAgent(DEFAULT_PLUGIN_ID);
-export const getDefaultAgentSync = (): AgentInfo | null => getAgentSync(DEFAULT_PLUGIN_ID);
+export const ensureDefaultAgent = (): Promise<AgentInfo> =>
+  ensureAgent(DEFAULT_PLUGIN_ID);
+export const getDefaultAgentSync = (): AgentInfo | null =>
+  getAgentSync(DEFAULT_PLUGIN_ID);
 export const resetDefaultAgent = (): void => resetAgent(DEFAULT_PLUGIN_ID);

--- a/src/features/chat/lib/atlas-context.ts
+++ b/src/features/chat/lib/atlas-context.ts
@@ -56,10 +56,16 @@ export function stripInjectedContext(text: string): string {
 export function splitAtlasContext(content: string): SplitContext {
   const idx = content.indexOf(ATLAS_CONTEXT_MARKER);
   if (idx === -1) {
-    return { prose: stripInjectedContext(content), context: null, blockCount: 0 };
+    return {
+      prose: stripInjectedContext(content),
+      context: null,
+      blockCount: 0,
+    };
   }
   const prose = stripInjectedContext(content.slice(0, idx));
-  const context = content.slice(idx + ATLAS_CONTEXT_MARKER.length).replace(/\n+$/, "");
+  const context = content
+    .slice(idx + ATLAS_CONTEXT_MARKER.length)
+    .replace(/\n+$/, "");
   if (context.length === 0) return { prose, context: null, blockCount: 0 };
   const matches = context.match(/^## /gm);
   return {

--- a/src/features/chat/lib/cersei-model-pref.ts
+++ b/src/features/chat/lib/cersei-model-pref.ts
@@ -19,7 +19,13 @@ export function loadCerseiModelPref(): CerseiModelPref | null {
     const raw = localStorage.getItem(KEY);
     if (!raw) return null;
     const v = JSON.parse(raw) as CerseiModelPref;
-    if (v && typeof v.provider === "string" && typeof v.model === "string" && v.provider && v.model) {
+    if (
+      v &&
+      typeof v.provider === "string" &&
+      typeof v.model === "string" &&
+      v.provider &&
+      v.model
+    ) {
       return v;
     }
   } catch {

--- a/src/features/chat/lib/claude-api.ts
+++ b/src/features/chat/lib/claude-api.ts
@@ -53,10 +53,14 @@ export function listCodexSessions(cwd: string): Promise<ClaudeSessionMeta[]> {
  * persisted JSON transcript under the app config dir.
  */
 export function listCerseiSessions(cwd: string): Promise<ClaudeSessionMeta[]> {
-  return invoke<ClaudeSessionMeta[]>("cersei_list_sessions", { projectPath: cwd });
+  return invoke<ClaudeSessionMeta[]>("cersei_list_sessions", {
+    projectPath: cwd,
+  });
 }
 
-export function readClaudeSession(filePath: string): Promise<ChatMessageDump[]> {
+export function readClaudeSession(
+  filePath: string,
+): Promise<ChatMessageDump[]> {
   return invoke<ChatMessageDump[]>("read_claude_session", { filePath });
 }
 
@@ -69,7 +73,10 @@ export function deleteClaudeSession(filePath: string): Promise<void> {
  * the app config dir (not `~/.claude/projects`), so they need their own command
  * — `delete_claude_session` rejects any path outside the Claude projects dir.
  */
-export function cerseiDeleteSession(cwd: string, sessionId: string): Promise<void> {
+export function cerseiDeleteSession(
+  cwd: string,
+  sessionId: string,
+): Promise<void> {
   return invoke<void>("cersei_delete_session", { projectPath: cwd, sessionId });
 }
 
@@ -95,7 +102,7 @@ export interface ClaudeSessionStats {
 
 export function getClaudeSessionStats(
   cwd: string,
-  sessionId: string
+  sessionId: string,
 ): Promise<ClaudeSessionStats> {
   return invoke<ClaudeSessionStats>("claude_session_stats", { cwd, sessionId });
 }

--- a/src/features/chat/lib/cm-mention-extension.ts
+++ b/src/features/chat/lib/cm-mention-extension.ts
@@ -19,12 +19,7 @@
 // state mutation so other extensions (e.g. an `update` listener that wants
 // to surface mention changes to React) can observe them.
 
-import {
-  Range,
-  RangeSet,
-  StateEffect,
-  StateField,
-} from "@codemirror/state";
+import { Range, RangeSet, StateEffect, StateField } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
@@ -40,7 +35,18 @@ import type { MentionData, MentionKind } from "./mentions";
 import { toShortForm } from "./mentions";
 
 // ── Media hover preview (image/video `@file` chips) ──────────────────────────
-const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "avif", "bmp", "svg", "heic", "heif"]);
+const IMAGE_EXTS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+  "bmp",
+  "svg",
+  "heic",
+  "heif",
+]);
 const VIDEO_EXTS = new Set(["mp4", "mov", "webm", "m4v", "avi", "mkv", "ogv"]);
 
 function mediaKindOf(path: string): "image" | "video" | null {
@@ -57,14 +63,24 @@ function parentDirOf(path: string): string {
 
 function imageMime(path: string): string {
   switch (path.split(".").pop()?.toLowerCase() ?? "") {
-    case "jpg": case "jpeg": return "image/jpeg";
-    case "gif": return "image/gif";
-    case "webp": return "image/webp";
-    case "svg": return "image/svg+xml";
-    case "bmp": return "image/bmp";
-    case "avif": return "image/avif";
-    case "heic": case "heif": return "image/heic";
-    default: return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "svg":
+      return "image/svg+xml";
+    case "bmp":
+      return "image/bmp";
+    case "avif":
+      return "image/avif";
+    case "heic":
+    case "heif":
+      return "image/heic";
+    default:
+      return "image/png";
   }
 }
 
@@ -198,7 +214,7 @@ export function mentionTriggerPlugin(
   onChange: (trigger: MentionTrigger | null) => void,
   // Returns whether the `#` skill picker is enabled. Read live so the active
   // agent (e.g. Cersei, which has no skills) can toggle it without remounting.
-  allowSkill: () => boolean = () => true
+  allowSkill: () => boolean = () => true,
 ): ViewPlugin<{ last: MentionTrigger | null; pending: number }> {
   return ViewPlugin.define((view) => {
     const state = {
@@ -219,7 +235,7 @@ function schedule(
   view: EditorView,
   state: { last: MentionTrigger | null; pending: number },
   onChange: (t: MentionTrigger | null) => void,
-  allowSkill: () => boolean
+  allowSkill: () => boolean,
 ): void {
   const ticket = ++state.pending;
   queueMicrotask(() => {
@@ -233,7 +249,7 @@ function recompute(
   view: EditorView,
   state: { last: MentionTrigger | null; pending: number },
   onChange: (t: MentionTrigger | null) => void,
-  allowSkill: () => boolean
+  allowSkill: () => boolean,
 ): void {
   // The view may have been destroyed between the queueMicrotask schedule
   // and its callback firing (e.g. component unmount inside the same tick).
@@ -244,7 +260,10 @@ function recompute(
   onChange(trig);
 }
 
-function sameTrigger(a: MentionTrigger | null, b: MentionTrigger | null): boolean {
+function sameTrigger(
+  a: MentionTrigger | null,
+  b: MentionTrigger | null,
+): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   return (
@@ -259,7 +278,7 @@ function sameTrigger(a: MentionTrigger | null, b: MentionTrigger | null): boolea
 
 function detectTrigger(
   view: EditorView,
-  allowSkill: () => boolean
+  allowSkill: () => boolean,
 ): MentionTrigger | null {
   const sel = view.state.selection.main;
   if (!sel.empty) return null;
@@ -315,14 +334,12 @@ export type MentionKey = "Up" | "Down" | "Enter" | "Escape" | "Backspace";
 export type MentionKeyInterceptor = (key: MentionKey) => boolean;
 
 export const mentionKeymap = (
-  getInterceptor: () => MentionKeyInterceptor | null
+  getInterceptor: () => MentionKeyInterceptor | null,
 ) => {
-  const tryIntercept =
-    (key: MentionKey) =>
-    () => {
-      const fn = getInterceptor();
-      return fn ? fn(key) : false;
-    };
+  const tryIntercept = (key: MentionKey) => () => {
+    const fn = getInterceptor();
+    return fn ? fn(key) : false;
+  };
   return [
     { key: "ArrowDown", run: tryIntercept("Down") },
     { key: "ArrowUp", run: tryIntercept("Up") },
@@ -401,10 +418,15 @@ class ChipWidget extends WidgetType {
 
     // A media `@file` chip shows a hover preview CARD (image/video) instead of
     // the plain path tooltip.
-    const media = this.mention.kind === "file" ? mediaKindOf(this.mention.absPath) : null;
+    const media =
+      this.mention.kind === "file" ? mediaKindOf(this.mention.absPath) : null;
     if (this.mention.kind === "file" && media) {
       el.setAttribute("data-mention-media", media);
-      el._atlasPreviewCleanup = attachMediaHoverPreview(el, this.mention.absPath, media);
+      el._atlasPreviewCleanup = attachMediaHoverPreview(
+        el,
+        this.mention.absPath,
+        media,
+      );
     } else {
       el.title = chipTitle(this.mention);
     }
@@ -492,35 +514,59 @@ const ICON_ZAP = lucideSvg(
 
 function kindGlyph(kind: MentionKind): string {
   switch (kind) {
-    case "file":         return ICON_FILE;
-    case "folder":       return ICON_FOLDER;
-    case "symbol":       return ICON_HASH;
-    case "knowledge":    return ICON_BOOK_OPEN;
-    case "skill":        return ICON_ZAP;
-    case "component":    return ICON_ZAP;
-    case "repo":         return ICON_FOLDER_GIT;
-    case "workspace":    return ICON_FOLDER_GIT;
-    case "paper":        return ICON_NEWSPAPER;
-    case "branch":       return ICON_GIT_BRANCH;
-    case "past_message": return ICON_MESSAGE_SQUARE;
-    case "past_session": return ICON_MESSAGE_SQUARE;
+    case "file":
+      return ICON_FILE;
+    case "folder":
+      return ICON_FOLDER;
+    case "symbol":
+      return ICON_HASH;
+    case "knowledge":
+      return ICON_BOOK_OPEN;
+    case "skill":
+      return ICON_ZAP;
+    case "component":
+      return ICON_ZAP;
+    case "repo":
+      return ICON_FOLDER_GIT;
+    case "workspace":
+      return ICON_FOLDER_GIT;
+    case "paper":
+      return ICON_NEWSPAPER;
+    case "branch":
+      return ICON_GIT_BRANCH;
+    case "past_message":
+      return ICON_MESSAGE_SQUARE;
+    case "past_session":
+      return ICON_MESSAGE_SQUARE;
   }
 }
 
 function chipTitle(m: MentionData): string {
   switch (m.kind) {
-    case "file":         return m.absPath;
-    case "folder":       return m.absPath;
-    case "symbol":       return `${m.symbolKind} · ${m.filePath}:${m.line}`;
-    case "knowledge":    return `${m.source} · ${m.filePath}`;
-    case "skill":        return m.description || m.displayName;
-    case "component":    return m.description || m.displayName;
-    case "repo":         return m.absPath;
-    case "workspace":    return m.absPath;
-    case "paper":        return m.authors.length ? m.authors.join(", ") : "paper";
-    case "branch":       return `${m.refKind} · ${m.sha.slice(0, 7)}`;
-    case "past_message": return m.sessionTitle;
-    case "past_session": return `session · ${m.sessionTitle}`;
+    case "file":
+      return m.absPath;
+    case "folder":
+      return m.absPath;
+    case "symbol":
+      return `${m.symbolKind} · ${m.filePath}:${m.line}`;
+    case "knowledge":
+      return `${m.source} · ${m.filePath}`;
+    case "skill":
+      return m.description || m.displayName;
+    case "component":
+      return m.description || m.displayName;
+    case "repo":
+      return m.absPath;
+    case "workspace":
+      return m.absPath;
+    case "paper":
+      return m.authors.length ? m.authors.join(", ") : "paper";
+    case "branch":
+      return `${m.refKind} · ${m.sha.slice(0, 7)}`;
+    case "past_message":
+      return m.sessionTitle;
+    case "past_session":
+      return `session · ${m.sessionTitle}`;
   }
 }
 
@@ -531,7 +577,7 @@ function buildDecorations(ranges: readonly MentionRange[]): DecorationSet {
     Decoration.replace({
       widget: new ChipWidget(r.mention),
       inclusive: false,
-    }).range(r.from, r.to)
+    }).range(r.from, r.to),
   );
   return Decoration.set(decos, /* sort */ true);
 }
@@ -544,7 +590,7 @@ function mentionAtomicRanges(view: EditorView): RangeSet<Decoration> {
   if (ranges.length === 0) return RangeSet.empty;
   return RangeSet.of(
     ranges.map((r) => Decoration.mark({}).range(r.from, r.to)),
-    true
+    true,
   );
 }
 
@@ -565,7 +611,7 @@ export function insertMention(
   view: EditorView,
   mention: MentionData,
   from: number,
-  to: number
+  to: number,
 ): void {
   const shortform = toShortForm(mention);
   const insertText = shortform + " ";

--- a/src/features/chat/lib/mentions.ts
+++ b/src/features/chat/lib/mentions.ts
@@ -12,7 +12,11 @@ import { invoke } from "@tauri-apps/api/core";
 
 import { useKnowledgeStore } from "@/features/knowledge/stores/knowledge-store";
 import { useKnowledgeMetaStore } from "@/features/knowledge/stores/knowledge-meta-store";
-import { listClaudeSessions, readClaudeSession, type ChatMessageDump } from "./claude-api";
+import {
+  listClaudeSessions,
+  readClaudeSession,
+  type ChatMessageDump,
+} from "./claude-api";
 import { ensureFileIndex } from "@/features/file-picker/lib/file-picker-api";
 import { activeWorkspaceId } from "@/features/workspaces/lib/active-workspace";
 import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store";
@@ -38,22 +42,22 @@ export type MentionKind =
 
 export interface MentionFile {
   kind: "file";
-  id: string;            // absolute path; also the de-dupe key
-  displayName: string;   // relative path
+  id: string; // absolute path; also the de-dupe key
+  displayName: string; // relative path
   absPath: string;
 }
 
 export interface MentionFolder {
   kind: "folder";
-  id: string;            // absolute path
-  displayName: string;   // relative path (e.g. "src/features/chat")
+  id: string; // absolute path
+  displayName: string; // relative path (e.g. "src/features/chat")
   absPath: string;
 }
 
 export interface MentionSymbol {
   kind: "symbol";
-  id: string;            // `${name}@${file_path}:${line}`
-  displayName: string;   // name
+  id: string; // `${name}@${file_path}:${line}`
+  displayName: string; // name
   signature: string;
   filePath: string;
   line: number;
@@ -62,13 +66,13 @@ export interface MentionSymbol {
 
 export interface MentionKnowledge {
   kind: "knowledge";
-  id: string;            // entry id — path under `.atlas/knowledge/`, may include "/"
-  displayName: string;   // title
+  id: string; // entry id — path under `.atlas/knowledge/`, may include "/"
+  displayName: string; // title
   /** Per-note emoji/glyph from `_meta.json` (same source the knowledge
    *  tree uses). Null when the note has no custom icon. */
   icon: string | null;
   filePath: string;
-  source: string;        // "note" | "paper" | "chat" | ...
+  source: string; // "note" | "paper" | "chat" | ...
   /** Parent folder portion of `id` (e.g. "Adib" for "Adib/weekly-notes").
    *  Surfaces the user's "spaces" — nested subfolders under
    *  `.atlas/knowledge/`. Null for top-level entries. */
@@ -79,7 +83,7 @@ export interface MentionSkill {
   kind: "skill";
   /** `${scope}:${name}` — dedupe key across scopes. */
   id: string;
-  displayName: string;   // skill name (the `#skill:<name>` token)
+  displayName: string; // skill name (the `#skill:<name>` token)
   description: string;
   scope: "global" | "project";
   /** Sanitized on-disk name, passed to `skills_read` at compose time. */
@@ -94,7 +98,7 @@ export interface MentionComponent {
   kind: "component";
   /** `${scope}:${componentKind}:${pack}:${name}` — dedupe key. */
   id: string;
-  displayName: string;   // component name (the `#<kind>:<name>` token)
+  displayName: string; // component name (the `#<kind>:<name>` token)
   description: string;
   /** "command" | "agent" | "rule". */
   componentKind: PackComponentKind;
@@ -108,17 +112,17 @@ export interface MentionComponent {
 
 export interface MentionRepo {
   kind: "repo";
-  id: string;            // absolute path to the cloned repo
-  displayName: string;   // repo folder name
+  id: string; // absolute path to the cloned repo
+  displayName: string; // repo folder name
   absPath: string;
   hasReadme: boolean;
 }
 
 export interface MentionWorkspace {
   kind: "workspace";
-  id: string;            // workspace id — dedupe key
-  displayName: string;   // workspace name
-  absPath: string;       // the project path, expanded into the prompt at send
+  id: string; // workspace id — dedupe key
+  displayName: string; // workspace name
+  absPath: string; // the project path, expanded into the prompt at send
   /** Owning org name, shown as the secondary label to disambiguate. */
   orgName: string | null;
 }
@@ -126,15 +130,15 @@ export interface MentionWorkspace {
 export interface MentionPaper {
   kind: "paper";
   id: string;
-  displayName: string;   // title
+  displayName: string; // title
   authors: string[];
   metadataPath: string;
 }
 
 export interface MentionBranch {
   kind: "branch";
-  id: string;            // ref name
-  displayName: string;   // short name
+  id: string; // ref name
+  displayName: string; // short name
   sha: string;
   refKind: "branch" | "remote" | "tag";
   isCurrent: boolean;
@@ -142,21 +146,21 @@ export interface MentionBranch {
 
 export interface MentionPastMessage {
   kind: "past_message";
-  id: string;            // `${sessionId}#${msgIdx}`
-  displayName: string;   // truncated content
+  id: string; // `${sessionId}#${msgIdx}`
+  displayName: string; // truncated content
   sessionId: string;
   sessionTitle: string;
   timestamp: string | null;
-  content: string;       // the message body — small, fine to keep inline
+  content: string; // the message body — small, fine to keep inline
 }
 
 export interface MentionPastSession {
   kind: "past_session";
-  id: string;            // the session id (JSONL stem = acpSessionId)
-  displayName: string;   // session title/preview
+  id: string; // the session id (JSONL stem = acpSessionId)
+  displayName: string; // session title/preview
   sessionId: string;
   sessionTitle: string;
-  filePath: string;      // JSONL transcript path — read + formatted at send time
+  filePath: string; // JSONL transcript path — read + formatted at send time
 }
 
 export type MentionData =
@@ -185,18 +189,58 @@ export interface MentionCategory {
 }
 
 export const MENTION_CATEGORIES: readonly MentionCategory[] = [
-  { kind: "file",         label: "Files",           aliases: ["file", "f/"],              weight: 1.0  },
-  { kind: "folder",       label: "Folders",         aliases: ["folder", "dir", "d/"],     weight: 0.95 },
-  { kind: "symbol",       label: "Symbols",         aliases: ["symbol", "sym", "s/"],     weight: 0.85 },
-  { kind: "knowledge",    label: "Knowledge",       aliases: ["note", "knowledge", "k/"], weight: 0.85 },
-  { kind: "skill",        label: "Skills",          aliases: ["skill", "sk/"],            weight: 0.9  },
-  { kind: "component",    label: "Pack Components", aliases: ["command", "agent", "rule", "cmd", "c/"], weight: 0.88 },
-  { kind: "repo",         label: "Cloned Repos",    aliases: ["repo", "github", "gh/"],   weight: 0.8  },
-  { kind: "workspace",    label: "Workspaces",      aliases: ["workspace", "project", "ws", "w/"], weight: 0.82 },
-  { kind: "paper",        label: "Papers",          aliases: ["paper", "p/"],             weight: 0.7  },
-  { kind: "branch",       label: "Branches",        aliases: ["branch", "b/"],            weight: 0.6  },
-  { kind: "past_message", label: "Past Messages",   aliases: ["msg", "message", "m/"],    weight: 0.55 },
-  { kind: "past_session", label: "Past Sessions",   aliases: ["session", "sess/"],        weight: 0.5  },
+  { kind: "file", label: "Files", aliases: ["file", "f/"], weight: 1.0 },
+  {
+    kind: "folder",
+    label: "Folders",
+    aliases: ["folder", "dir", "d/"],
+    weight: 0.95,
+  },
+  {
+    kind: "symbol",
+    label: "Symbols",
+    aliases: ["symbol", "sym", "s/"],
+    weight: 0.85,
+  },
+  {
+    kind: "knowledge",
+    label: "Knowledge",
+    aliases: ["note", "knowledge", "k/"],
+    weight: 0.85,
+  },
+  { kind: "skill", label: "Skills", aliases: ["skill", "sk/"], weight: 0.9 },
+  {
+    kind: "component",
+    label: "Pack Components",
+    aliases: ["command", "agent", "rule", "cmd", "c/"],
+    weight: 0.88,
+  },
+  {
+    kind: "repo",
+    label: "Cloned Repos",
+    aliases: ["repo", "github", "gh/"],
+    weight: 0.8,
+  },
+  {
+    kind: "workspace",
+    label: "Workspaces",
+    aliases: ["workspace", "project", "ws", "w/"],
+    weight: 0.82,
+  },
+  { kind: "paper", label: "Papers", aliases: ["paper", "p/"], weight: 0.7 },
+  { kind: "branch", label: "Branches", aliases: ["branch", "b/"], weight: 0.6 },
+  {
+    kind: "past_message",
+    label: "Past Messages",
+    aliases: ["msg", "message", "m/"],
+    weight: 0.55,
+  },
+  {
+    kind: "past_session",
+    label: "Past Sessions",
+    aliases: ["session", "sess/"],
+    weight: 0.5,
+  },
 ];
 
 export function categoryForKind(kind: MentionKind): MentionCategory {
@@ -245,16 +289,17 @@ export interface PastSessionRef {
 }
 
 export async function listPastSessions(
-  ctx: MentionContext
+  ctx: MentionContext,
 ): Promise<PastSessionRef[]> {
   if (!ctx.projectPath) return [];
   try {
     const sessions = await listClaudeSessions(ctx.projectPath);
     return sessions.map((s) => ({
       id: s.id,
-      title: s.preview && s.preview !== "(no user message)"
-        ? s.preview
-        : "Untitled session",
+      title:
+        s.preview && s.preview !== "(no user message)"
+          ? s.preview
+          : "Untitled session",
       filePath: s.file_path,
       lastModified: s.last_modified,
       messageCount: s.message_count,
@@ -267,7 +312,7 @@ export async function listPastSessions(
 export async function listMessagesInPastSession(
   session: PastSessionRef,
   query: string,
-  signal: AbortSignal
+  signal: AbortSignal,
 ): Promise<MentionPastMessage[]> {
   let dump;
   try {
@@ -418,7 +463,10 @@ export async function searchMentions(
     // Blend JS-owned workspaces into the unscoped `@` results (Rust doesn't
     // know about them). A few entries, so a simple prepend is fine.
     if (scope === null) {
-      return [...searchWorkspaces(stripCategoryAlias(query, "file"), ctx), ...results];
+      return [
+        ...searchWorkspaces(stripCategoryAlias(query, "file"), ctx),
+        ...results,
+      ];
     }
     return results;
   } catch (e) {
@@ -431,7 +479,10 @@ export async function searchMentions(
  *  the workspaces from the JS store — EXCLUDING the current one (you never need
  *  to hand an agent its own path) — substring-filtered by name or path. Scoped
  *  to the active org, with the org name attached for disambiguation. */
-function searchWorkspaces(query: string, ctx: MentionContext): MentionWorkspace[] {
+function searchWorkspaces(
+  query: string,
+  ctx: MentionContext,
+): MentionWorkspace[] {
   const q = query.trim().toLowerCase();
   const { workspaces } = useWorkspaceStore.getState();
   const { organisations, activeOrganisationId } = useOrgStore.getState();
@@ -466,9 +517,8 @@ async function searchSkills(
   ctx: MentionContext,
 ): Promise<MentionSkill[]> {
   const q = query.trim().toLowerCase();
-  const sources: { scope: "global" | "project"; projectPath: string | null }[] = [
-    { scope: "global", projectPath: null },
-  ];
+  const sources: { scope: "global" | "project"; projectPath: string | null }[] =
+    [{ scope: "global", projectPath: null }];
   if (ctx.projectPath) {
     sources.push({ scope: "project", projectPath: ctx.projectPath });
   }
@@ -532,9 +582,8 @@ async function searchPackComponents(
   ctx: MentionContext,
 ): Promise<MentionComponent[]> {
   const q = query.trim().toLowerCase();
-  const sources: { scope: "global" | "project"; projectPath: string | null }[] = [
-    { scope: "global", projectPath: null },
-  ];
+  const sources: { scope: "global" | "project"; projectPath: string | null }[] =
+    [{ scope: "global", projectPath: null }];
   if (ctx.projectPath) {
     sources.push({ scope: "project", projectPath: ctx.projectPath });
   }
@@ -627,7 +676,9 @@ let knowledgeEnsuring: Promise<void> | null = null;
  *  the user opened the KB. This loads the entries (if the panel never mounted)
  *  and (re)publishes them to this window's cache, coalesced + cached per
  *  project so it's a no-op cost after the first picker open. */
-export async function ensureKnowledgeMentionCache(projectPath: string): Promise<void> {
+export async function ensureKnowledgeMentionCache(
+  projectPath: string,
+): Promise<void> {
   if (knowledgeEnsuredFor === projectPath) return;
   if (!knowledgeEnsuring) {
     knowledgeEnsuring = (async () => {
@@ -677,7 +728,7 @@ function formatSessionTranscript(dump: ChatMessageDump[]): string {
 
 export async function composePrompt(
   prosePlainText: string,
-  mentions: MentionData[]
+  mentions: MentionData[],
 ): Promise<string> {
   if (mentions.length === 0) return prosePlainText;
   const wireMentions = await Promise.all(
@@ -686,7 +737,8 @@ export async function composePrompt(
         return {
           ...m,
           inlineBody:
-            useKnowledgeStore.getState().entries.find((e) => e.id === m.id)?.content ?? null,
+            useKnowledgeStore.getState().entries.find((e) => e.id === m.id)
+              ?.content ?? null,
         };
       }
       // Skills have no in-memory store, so read the frontmatter-stripped body
@@ -695,7 +747,8 @@ export async function composePrompt(
       if (m.kind === "skill") {
         let inlineBody: string | null = null;
         try {
-          inlineBody = (await skills.read(m.scope, m.skillName, m.projectPath)).body;
+          inlineBody = (await skills.read(m.scope, m.skillName, m.projectPath))
+            .body;
         } catch (e) {
           console.warn("skills.read for compose failed:", e);
         }
@@ -716,7 +769,7 @@ export async function composePrompt(
         return { ...m, inlineBody };
       }
       return m;
-    })
+    }),
   );
   try {
     return await invoke<string>("compose_prompt", {

--- a/src/features/chat/lib/next-steps.ts
+++ b/src/features/chat/lib/next-steps.ts
@@ -32,7 +32,12 @@ export function extractNextSteps(content: string): string[] {
   if (!m) return [];
   return m[1]
     .split("\n")
-    .map((l) => l.trim().replace(/^[-*+\d.)\s]+/, "").trim())
+    .map((l) =>
+      l
+        .trim()
+        .replace(/^[-*+\d.)\s]+/, "")
+        .trim(),
+    )
     .filter(Boolean)
     .map((l) => (l.length > 120 ? l.slice(0, 117) + "…" : l))
     .slice(0, 3);

--- a/src/features/chat/lib/open-agent-session.ts
+++ b/src/features/chat/lib/open-agent-session.ts
@@ -58,7 +58,11 @@ function freshTabId(): string {
  * load flow (focus-if-open, reuse-idle-tab-else-new) so it can be invoked from
  * anywhere (e.g. the workspace switcher's Chats section).
  */
-export async function openAgentSession({ acpSessionId, title, cwd }: OpenOpts): Promise<void> {
+export async function openAgentSession({
+  acpSessionId,
+  title,
+  cwd,
+}: OpenOpts): Promise<void> {
   const chat = useChatStore.getState();
   const layout = useLayoutStore.getState();
   const { addTab, setActiveTab } = layout.actions;
@@ -92,10 +96,13 @@ export async function openAgentSession({ acpSessionId, title, cwd }: OpenOpts): 
   //    idle (load in place — the "open in the agent chat tab" behaviour);
   //    otherwise open a FRESH tab so we never overwrite a running/other session.
   const activeId = layout.activeTabId;
-  const activeTab = activeId ? layout.tabs.find((t) => t.id === activeId) : undefined;
+  const activeTab = activeId
+    ? layout.tabs.find((t) => t.id === activeId)
+    : undefined;
   const activeSession = activeId ? chat.sessions[activeId] : undefined;
   const reuse =
-    activeTab?.type === "chat" && (!activeSession || activeSession.status === "idle");
+    activeTab?.type === "chat" &&
+    (!activeSession || activeSession.status === "idle");
   const targetTabId = reuse && activeId ? activeId : freshTabId();
 
   if (targetTabId !== activeId) {
@@ -187,7 +194,9 @@ export function openNewAgentChat(): void {
   const { clearSession, createSession } = chat.actions;
 
   const focus = (id: string) =>
-    window.dispatchEvent(new CustomEvent("atlas:chat-focus", { detail: { tabId: id } }));
+    window.dispatchEvent(
+      new CustomEvent("atlas:chat-focus", { detail: { tabId: id } }),
+    );
 
   // Prefer the ACTIVE chat tab; fall back to the first chat tab. Multiple chat
   // tabs can coexist (handleOpenAgent spawns a new one when the current chat is
@@ -203,7 +212,9 @@ export function openNewAgentChat(): void {
     // Stop an in-flight turn before resetting so it doesn't keep streaming into
     // an orphaned (hidden) session. Its transcript still persists → history.
     if (s?.status === "running" && s.acpAgentId && s.acpSessionId) {
-      agents.cancel({ agent_id: s.acpAgentId, session_id: s.acpSessionId }).catch(() => {});
+      agents
+        .cancel({ agent_id: s.acpAgentId, session_id: s.acpSessionId })
+        .catch(() => {});
     }
     // Cancel any in-flight history load targeting this tab BEFORE clearing, so a
     // resolving `loadSession → replaceMessages` chain can't repaint the freshly
@@ -220,7 +231,14 @@ export function openNewAgentChat(): void {
 
   // No chat tab open yet → create the one and only one.
   const id = `chat-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-  addTab({ id, type: "chat", title: "Agents", closable: true, dirty: false, data: {} });
+  addTab({
+    id,
+    type: "chat",
+    title: "Agents",
+    closable: true,
+    dirty: false,
+    data: {},
+  });
   createSession(id);
   setActiveTab(id);
 }

--- a/src/features/chat/lib/resume-session.ts
+++ b/src/features/chat/lib/resume-session.ts
@@ -1,7 +1,11 @@
 import { agents } from "./agents-api";
 import { snapshotMessageToWire } from "./snapshot-message";
 import type { AgentInfo } from "@/types/acp";
-import type { SessionKey, SessionMessage, SessionSnapshot } from "@/types/agents";
+import type {
+  SessionKey,
+  SessionMessage,
+  SessionSnapshot,
+} from "@/types/agents";
 
 type WireMessage = ReturnType<typeof snapshotMessageToWire>;
 

--- a/src/features/chat/lib/tool-calls.ts
+++ b/src/features/chat/lib/tool-calls.ts
@@ -20,7 +20,9 @@ const BASH_TOOL_NAMES = new Set([
   "run-command",
 ]);
 
-export function isBashToolCall(tc: Pick<ToolCallDisplay, "kind" | "toolName">): boolean {
+export function isBashToolCall(
+  tc: Pick<ToolCallDisplay, "kind" | "toolName">,
+): boolean {
   if (tc.kind === "execute") return true;
   return BASH_TOOL_NAMES.has(tc.toolName.toLowerCase());
 }

--- a/src/features/chat/lib/tool-files.ts
+++ b/src/features/chat/lib/tool-files.ts
@@ -33,8 +33,7 @@ export interface EditPart {
   neu: string;
 }
 
-const asStr = (v: unknown): string | null =>
-  typeof v === "string" ? v : null;
+const asStr = (v: unknown): string | null => (typeof v === "string" ? v : null);
 
 /** Before/after text pairs for an edit tool call, straight from its args. */
 export function getEditParts(
@@ -86,7 +85,10 @@ export function classifyToolFileKind(
 }
 
 /** Trim common prefix/suffix and count changed lines (matches `EditDiffView`). */
-function countPart(oldStr: string, neu: string): { added: number; removed: number } {
+function countPart(
+  oldStr: string,
+  neu: string,
+): { added: number; removed: number } {
   const o = oldStr.split("\n");
   const n = neu.split("\n");
   let start = 0;

--- a/src/features/chat/lib/warm-acp-models.ts
+++ b/src/features/chat/lib/warm-acp-models.ts
@@ -14,7 +14,12 @@
 // it), so it's invisible to the UI and never persisted (no turn runs). Agents are
 // pooled per plugin, so this is one cheap extra ACP session per agent per launch.
 
-import { agents, ensureAgent, CODEX_PLUGIN_ID, DEFAULT_PLUGIN_ID } from "./agents-api";
+import {
+  agents,
+  ensureAgent,
+  CODEX_PLUGIN_ID,
+  DEFAULT_PLUGIN_ID,
+} from "./agents-api";
 import {
   loadCachedAcpModels,
   saveCachedAcpModels,
@@ -50,8 +55,14 @@ const warmed = new Set<string>();
  * persist them to the cache. No-op for non-ACP agents or if already warmed this
  * session. Best-effort + silent — never throws into the caller.
  */
-export async function warmAcpModels(agentType: string, cwd: string): Promise<void> {
-  const at = agentType === "claude-code" || agentType === "codex" ? (agentType as AcpAgentType) : null;
+export async function warmAcpModels(
+  agentType: string,
+  cwd: string,
+): Promise<void> {
+  const at =
+    agentType === "claude-code" || agentType === "codex"
+      ? (agentType as AcpAgentType)
+      : null;
   if (!at) return;
   if (warmed.has(at)) return;
   // TTL gate: if we already have a fresh cached list, DON'T spawn a throwaway

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -21,12 +21,19 @@ import type {
 } from "@/types/agents";
 import { splitAtlasContext } from "../lib/atlas-context";
 import { loadCachedAcpModes, saveCachedAcpModes } from "../lib/acp-modes-cache";
-import { loadCachedAcpModels, saveCachedAcpModels } from "../lib/acp-models-cache";
+import {
+  loadCachedAcpModels,
+  saveCachedAcpModels,
+} from "../lib/acp-models-cache";
 import {
   loadCachedContextUsage,
   saveCachedContextUsage,
 } from "../lib/context-usage-cache";
-import { saveCerseiModelPref, saveCerseiEffort, saveCerseiCompress } from "../lib/cersei-model-pref";
+import {
+  saveCerseiModelPref,
+  saveCerseiEffort,
+  saveCerseiCompress,
+} from "../lib/cersei-model-pref";
 import { invoke } from "@tauri-apps/api/core";
 import { extractPlanMarkdown, type PlanRecord } from "../lib/plans";
 import { extractNextSteps } from "../lib/next-steps";
@@ -140,12 +147,14 @@ function pushPermissionModeToAgent(state: ChatState, sessionId: string): void {
  *  No-op until the session is bound. */
 function pushAcpModeToAgent(state: ChatState, sessionId: string): void {
   const session = state.sessions[sessionId];
-  if (!session?.acpAgentId || !session.acpSessionId || !session.acpCurrentMode) return;
+  if (!session?.acpAgentId || !session.acpSessionId || !session.acpCurrentMode)
+    return;
   // Only push ids this session's agent actually advertised. A mode carried over
   // from another agent is rejected (`invalidParams`), and the actor rolls its
   // optimistic flip back — which reads as a picker that silently does nothing.
   const modes = session.acpAvailableModes ?? [];
-  if (modes.length > 0 && !modes.some((m) => m.id === session.acpCurrentMode)) return;
+  if (modes.length > 0 && !modes.some((m) => m.id === session.acpCurrentMode))
+    return;
   void invoke("agents_set_mode", {
     key: { agent_id: session.acpAgentId, session_id: session.acpSessionId },
     modeId: session.acpCurrentMode,
@@ -157,7 +166,8 @@ function pushAcpModeToAgent(state: ChatState, sessionId: string): void {
  *  `provider/` prefix — that's the native Cersei form). No-op until bound. */
 function pushAcpModelToAgent(state: ChatState, sessionId: string): void {
   const session = state.sessions[sessionId];
-  if (!session?.acpAgentId || !session.acpSessionId || !session.acpCurrentModel) return;
+  if (!session?.acpAgentId || !session.acpSessionId || !session.acpCurrentModel)
+    return;
   void invoke("agents_set_model", {
     key: { agent_id: session.acpAgentId, session_id: session.acpSessionId },
     modelId: session.acpCurrentModel,
@@ -266,12 +276,12 @@ interface ChatActions {
       sessionId: string,
       role: MessageRole,
       content: string,
-      attachments?: ImageAttachment[]
+      attachments?: ImageAttachment[],
     ) => void;
     appendToolCall: (
       sessionId: string,
       toolName: string,
-      input: Record<string, unknown>
+      input: Record<string, unknown>,
     ) => void;
     updateLastAssistantMessage: (sessionId: string, content: string) => void;
     updateSessionStatus: (sessionId: string, status: AgentStatus) => void;
@@ -296,7 +306,7 @@ interface ChatActions {
     cycleClaudePermissionMode: (sessionId: string) => void;
     setClaudePermissionMode: (
       sessionId: string,
-      mode: ClaudePermissionMode
+      mode: ClaudePermissionMode,
     ) => void;
     /** Seed the generic ACP mode state (current + available list) from a
      *  session snapshot. Used for non-Claude agents (e.g. Codex). */
@@ -307,7 +317,7 @@ interface ChatActions {
       /** Agent the snapshot came from (`agentTypeFromPluginId(snap.plugin_id)`).
        *  When it disagrees with the tab's current agent the seed is stale and is
        *  dropped — see the action for the cross-agent bug that motivated it. */
-      sourceAgentType?: AgentType
+      sourceAgentType?: AgentType,
     ) => void;
     /** Pick a generic ACP session mode and push it to the bound agent.
      *  The Codex equivalent of `setClaudePermissionMode`. */
@@ -321,7 +331,7 @@ interface ChatActions {
     setAcpModels: (
       sessionId: string,
       currentModel: string | null,
-      availableModels: SessionModeInfo[]
+      availableModels: SessionModeInfo[],
     ) => void;
     /** Pick an ACP model and push it to the bound agent (`session/set_model`). */
     setAcpModel: (sessionId: string, modelId: string) => void;
@@ -350,7 +360,7 @@ interface ChatActions {
           arguments: Record<string, unknown>;
           result?: string | null;
         }>;
-      }>
+      }>,
     ) => void;
     /** Restore live (non-transcript) session state from a `session/load`
      *  snapshot: the backend's current status and the current turn's live plan.
@@ -389,7 +399,7 @@ interface ChatActions {
       agentId: string,
       acpSessionId: string,
       /** Project root the session was created with — stamps `workingDirectory`. */
-      cwd?: string
+      cwd?: string,
     ) => void;
     /**
      * Apply one `atlas:acp` event to whichever chat tab owns its acpSessionId.
@@ -446,7 +456,7 @@ interface ChatActions {
 
 function findTabByAcpSession(
   sessions: Record<string, ChatSession>,
-  acpSessionId: string
+  acpSessionId: string,
 ): string | null {
   for (const [tid, s] of Object.entries(sessions)) {
     if (s.acpSessionId === acpSessionId) return tid;
@@ -462,7 +472,7 @@ function findTabByAcpSession(
  */
 async function capturePlanIfPresent(
   req: PendingPermission,
-  sessions: Record<string, ChatSession>
+  sessions: Record<string, ChatSession>,
 ): Promise<void> {
   const plan = extractPlanMarkdown(req.toolCall);
   if (!plan) return;
@@ -483,9 +493,8 @@ async function capturePlanIfPresent(
     }
   }
 
-  const { useProjectStore } = await import(
-    "@/features/project/stores/project-store"
-  );
+  const { useProjectStore } =
+    await import("@/features/project/stores/project-store");
   const projectPath = useProjectStore.getState().currentProject?.path;
   if (!projectPath) return;
 
@@ -540,7 +549,9 @@ function makeAssistantThinkingMessage(thinking: string): ChatMessage {
   };
 }
 
-function makeAssistantToolMessage(toolCall: ChatMessage["toolCalls"][number]): ChatMessage {
+function makeAssistantToolMessage(
+  toolCall: ChatMessage["toolCalls"][number],
+): ChatMessage {
   return {
     id: nextMessageId(),
     role: "assistant",
@@ -556,7 +567,7 @@ function makeAssistantToolMessage(toolCall: ChatMessage["toolCalls"][number]): C
 /** Find the message + tool call entry across all messages by toolCallId. */
 function findToolCall(
   session: ChatSession,
-  toolCallId: string
+  toolCallId: string,
 ): { msg: ChatMessage; tc: ChatMessage["toolCalls"][number] } | null {
   for (let i = session.messages.length - 1; i >= 0; i--) {
     const m = session.messages[i];
@@ -591,7 +602,8 @@ export const useChatStore = createSelectors(
               updatedAt: new Date().toISOString(),
               // Permission mode is a Claude Code feature; Codex drives its
               // modes generically via ACP (acpCurrentMode).
-              claudePermissionMode: agentType === "claude-code" ? "default" : undefined,
+              claudePermissionMode:
+                agentType === "claude-code" ? "default" : undefined,
               // Optimistically pre-fill a non-Claude agent's mode picker from the
               // persisted cache so switching feels instant; mark pending until the
               // real session confirms (the picker shows a loading state).
@@ -610,7 +622,10 @@ export const useChatStore = createSelectors(
               ...(() => {
                 const m = loadCachedAcpModels(agentType);
                 return m
-                  ? { acpAvailableModels: m.availableModels, acpCurrentModel: m.currentModel ?? undefined }
+                  ? {
+                      acpAvailableModels: m.availableModels,
+                      acpCurrentModel: m.currentModel ?? undefined,
+                    }
                   : {};
               })(),
             };
@@ -624,7 +639,8 @@ export const useChatStore = createSelectors(
             // stale request from the previous agent can't render under the new
             // one (agents are pooled per plugin, so the process keeps running —
             // we only clear THIS session's queue, not the agent).
-            if (sess.acpSessionId) delete s.pendingPermissions[sess.acpSessionId];
+            if (sess.acpSessionId)
+              delete s.pendingPermissions[sess.acpSessionId];
             sess.agentType = agentType;
             sess.claudePermissionMode =
               agentType === "claude-code" ? "default" : undefined;
@@ -835,7 +851,12 @@ export const useChatStore = createSelectors(
           });
           pushPermissionModeToAgent(get(), sessionId);
         },
-        setAcpModes: (sessionId, currentMode, availableModes, sourceAgentType) => {
+        setAcpModes: (
+          sessionId,
+          currentMode,
+          availableModes,
+          sourceAgentType,
+        ) => {
           const at = get().sessions[sessionId]?.agentType;
           // Modes are per-agent, and a snapshot can outlive the binding it came
           // from: `setSessionAgentType` relabels a tab WITHOUT clearing its ACP
@@ -871,7 +892,10 @@ export const useChatStore = createSelectors(
           // Persist the confirmed modes so the next switch to this agent is
           // instant. Done outside the immer pass (side effect, not state).
           if (availableModes.length > 0 && at && at !== "claude-code") {
-            saveCachedAcpModes(at, { currentMode: currentMode ?? null, availableModes });
+            saveCachedAcpModes(at, {
+              currentMode: currentMode ?? null,
+              availableModes,
+            });
           }
         },
         setAcpModesPending: (sessionId, pending) =>
@@ -911,7 +935,10 @@ export const useChatStore = createSelectors(
           // `session/load` doesn't re-advertise models).
           const at = get().sessions[sessionId]?.agentType;
           if (availableModels.length > 0 && at) {
-            saveCachedAcpModels(at, { currentModel: currentModel ?? null, availableModels });
+            saveCachedAcpModels(at, {
+              currentModel: currentModel ?? null,
+              availableModels,
+            });
           }
         },
         setAcpModel: (sessionId, modelId) => {
@@ -963,7 +990,8 @@ export const useChatStore = createSelectors(
             const session = s.sessions[sessionId];
             if (!session) return;
             session.messages = messages.map((m, i) => {
-              const split = m.role === "user" ? splitAtlasContext(m.content) : null;
+              const split =
+                m.role === "user" ? splitAtlasContext(m.content) : null;
               return {
                 id: `msg-${Date.now()}-${i}`,
                 role: m.role,
@@ -980,7 +1008,9 @@ export const useChatStore = createSelectors(
                 fileChanges: [],
                 plan: null,
                 timestamp: m.timestamp ?? new Date().toISOString(),
-                ...(m.role === "assistant" && m.model ? { model: m.model } : {}),
+                ...(m.role === "assistant" && m.model
+                  ? { model: m.model }
+                  : {}),
                 ...(split && split.context !== null
                   ? {
                       atlasProse: split.prose,
@@ -1011,11 +1041,12 @@ export const useChatStore = createSelectors(
             }
             // Recompute the cached preview/count from the loaded transcript
             // so the sidebar doesn't have to scan messages on every chunk.
-            session.firstUserContent =
-              messages.find((m) => m.role === "user")?.content;
+            session.firstUserContent = messages.find(
+              (m) => m.role === "user",
+            )?.content;
             session.userMessageCount = messages.reduce(
               (n, m) => n + (m.role === "user" ? 1 : 0),
-              0
+              0,
             );
             // Intentionally NOT touching `updatedAt`. This action is called
             // when loading a historical transcript from disk into a tab —
@@ -1091,7 +1122,8 @@ export const useChatStore = createSelectors(
             if (!session) return;
             // Drop a result belonging to a turn already superseded by a newer
             // send (turnSeq 0 = native/legacy, always current).
-            if (turnSeq !== 0 && turnSeq < (session.currentTurnSeq ?? 0)) return;
+            if (turnSeq !== 0 && turnSeq < (session.currentTurnSeq ?? 0))
+              return;
             const msg = session.messages.find((m) => m.id === messageId);
             if (!msg) return;
             msg.suggestions = {
@@ -1214,7 +1246,7 @@ export const useChatStore = createSelectors(
           set((s) => {
             for (const sid of Object.keys(s.pendingPermissions)) {
               const list = s.pendingPermissions[sid].filter(
-                (r) => r.agentId !== agentId
+                (r) => r.agentId !== agentId,
               );
               if (list.length === 0) delete s.pendingPermissions[sid];
               else s.pendingPermissions[sid] = list;
@@ -1229,8 +1261,8 @@ export const useChatStore = createSelectors(
             applyDeltaToDraft(s, env);
           }),
       },
-    }))
-  )
+    })),
+  ),
 );
 
 // ── Draft-mutating helpers ────────────────────────────────────────────────
@@ -1261,7 +1293,11 @@ function stampProducingModel(
   return msg;
 }
 
-function appendTextToDraft(s: ChatDraft, acpSessionId: string, text: string): void {
+function appendTextToDraft(
+  s: ChatDraft,
+  acpSessionId: string,
+  text: string,
+): void {
   if (!text) return;
   const tid = findTabByAcpSession(s.sessions, acpSessionId);
   if (!tid) return;
@@ -1304,10 +1340,16 @@ function appendTextToDraft(s: ChatDraft, acpSessionId: string, text: string): vo
     last.content += text;
     return;
   }
-  session.messages.push(stampProducingModel(session, makeAssistantTextMessage(text)));
+  session.messages.push(
+    stampProducingModel(session, makeAssistantTextMessage(text)),
+  );
 }
 
-function appendThoughtToDraft(s: ChatDraft, acpSessionId: string, text: string): void {
+function appendThoughtToDraft(
+  s: ChatDraft,
+  acpSessionId: string,
+  text: string,
+): void {
   if (!text) return;
   const tid = findTabByAcpSession(s.sessions, acpSessionId);
   if (!tid) return;
@@ -1317,7 +1359,9 @@ function appendThoughtToDraft(s: ChatDraft, acpSessionId: string, text: string):
     last.thinking = (last.thinking ?? "") + text;
     return;
   }
-  session.messages.push(stampProducingModel(session, makeAssistantThinkingMessage(text)));
+  session.messages.push(
+    stampProducingModel(session, makeAssistantThinkingMessage(text)),
+  );
 }
 
 /** A terminal (idle/error) delta carries the `turn_seq` of the turn it ends.
@@ -1329,13 +1373,17 @@ function appendThoughtToDraft(s: ChatDraft, acpSessionId: string, text: string):
  *  drops the actor + the driver-side guard (M6 — these used to leak for the
  *  whole process lifetime). UI state removal proceeds regardless. */
 function dropBackendSession(session: ChatSession | undefined): void {
-  if (!session?.acpAgentId || !session.acpSessionId || session.disconnected) return;
+  if (!session?.acpAgentId || !session.acpSessionId || session.disconnected)
+    return;
   void agents
     .dropSession(session.acpAgentId, session.acpSessionId)
     .catch(() => {});
 }
 
-function isStaleTurn(session: ChatSession, turnSeq: number | undefined): boolean {
+function isStaleTurn(
+  session: ChatSession,
+  turnSeq: number | undefined,
+): boolean {
   if (!turnSeq) return false;
   return turnSeq < (session.currentTurnSeq ?? 0);
 }
@@ -1389,24 +1437,24 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       // Reject a terminal for a turn already superseded by a newer send —
       // don't flip to idle or inject an empty-turn placeholder for stale turns.
       if (isStaleTurn(session, env.turn_seq)) return;
-                // Empty-turn detection: if no assistant content arrived
-                // between the last user message and turn-end, insert a
-                // placeholder so the UI doesn't show a vanishing spinner.
-                let lastUserIdx = -1;
-                for (let i = session.messages.length - 1; i >= 0; i--) {
-                  if (session.messages[i].role === "user") {
-                    lastUserIdx = i;
-                    break;
-                  }
-                }
-                const responded = session.messages
+      // Empty-turn detection: if no assistant content arrived
+      // between the last user message and turn-end, insert a
+      // placeholder so the UI doesn't show a vanishing spinner.
+      let lastUserIdx = -1;
+      for (let i = session.messages.length - 1; i >= 0; i--) {
+        if (session.messages[i].role === "user") {
+          lastUserIdx = i;
+          break;
+        }
+      }
+      const responded = session.messages
         .slice(lastUserIdx + 1)
         .some(
           (m) =>
             m.role === "assistant" &&
             ((m.content && m.content.length > 0) ||
               m.toolCalls.length > 0 ||
-              (m.thinking && m.thinking.length > 0))
+              (m.thinking && m.thinking.length > 0)),
         );
       if (!responded && env.stop_reason !== "cancelled") {
         const label =
@@ -1423,7 +1471,8 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       for (const msg of session.messages) {
         for (const tc of msg.toolCalls) {
           if (tc.status === "pending" || tc.status === "running") {
-            tc.status = env.stop_reason === "cancelled" ? "failed" : "completed";
+            tc.status =
+              env.stop_reason === "cancelled" ? "failed" : "completed";
           }
         }
       }
@@ -1439,8 +1488,7 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
         }
       }
       session.status =
-        env.stop_reason === "end_turn" ||
-        env.stop_reason === "cancelled"
+        env.stop_reason === "end_turn" || env.stop_reason === "cancelled"
           ? "idle"
           : "error";
       session.stopping = undefined;
@@ -1455,7 +1503,11 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
           output: session.usage.output_tokens ?? 0,
           cost: session.usage.cost ?? 0,
         };
-        const prev = session.lastUsageSnapshot ?? { input: 0, output: 0, cost: 0 };
+        const prev = session.lastUsageSnapshot ?? {
+          input: 0,
+          output: 0,
+          cost: 0,
+        };
         const turn = {
           input: Math.max(0, cum.input - prev.input),
           output: Math.max(0, cum.output - prev.output),
@@ -1513,7 +1565,11 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
         if (m.role !== "assistant") continue;
         const chips = extractNextSteps(m.content);
         if (chips.length > 0) {
-          m.suggestions = { turnSeq: env.turn_seq ?? 0, status: "ready", chips };
+          m.suggestions = {
+            turnSeq: env.turn_seq ?? 0,
+            status: "ready",
+            chips,
+          };
         }
         break;
       }
@@ -1525,9 +1581,7 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       // in-process and shares this error delta, so its provider errors (e.g. a
       // Gemini HTTP 400) were being mislabeled as ACP failures. Use a neutral
       // prefix.
-      session.messages.push(
-        makeAssistantTextMessage(`Error: ${env.error}`)
-      );
+      session.messages.push(makeAssistantTextMessage(`Error: ${env.error}`));
       session.status = "error";
       session.stopping = undefined;
       session.retryStatus = undefined;
@@ -1648,11 +1702,7 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       // message (text/thinking intervened) do we start a fresh tool
       // message.
       const last = session.messages[session.messages.length - 1];
-      if (
-        last &&
-        last.role === "assistant" &&
-        last.mode === "tool"
-      ) {
+      if (last && last.role === "assistant" && last.mode === "tool") {
         last.toolCalls.push(toChatToolCall(env.tool_call));
         return;
       }
@@ -1660,7 +1710,7 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
         stampProducingModel(
           session,
           makeAssistantToolMessage(toChatToolCall(env.tool_call)),
-        )
+        ),
       );
       return;
     }
@@ -1670,13 +1720,15 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
         id: `plan-${idx}`,
         description: e.content,
         status:
-          (e.status as "pending" | "in_progress" | "completed") ??
-          "pending",
+          (e.status as "pending" | "in_progress" | "completed") ?? "pending",
       }));
       if (last && last.role === "assistant") {
         last.plan = planSteps;
       } else {
-        const fresh = stampProducingModel(session, makeAssistantTextMessage(""));
+        const fresh = stampProducingModel(
+          session,
+          makeAssistantTextMessage(""),
+        );
         fresh.plan = planSteps;
         session.messages.push(fresh);
       }
@@ -1736,7 +1788,8 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       // full "provider/model" we pushed, so applying it here would re-prefix
       // the value every cycle ("google/google/google/…") via the composer's
       // re-push. Ignore the echo for cersei — the UI is the source of truth.
-      if (session.agentType !== "cersei") session.acpCurrentModel = env.model_id;
+      if (session.agentType !== "cersei")
+        session.acpCurrentModel = env.model_id;
       return;
     }
     default:

--- a/src/features/chat/stores/recent-files-store.ts
+++ b/src/features/chat/stores/recent-files-store.ts
@@ -61,7 +61,7 @@ export const useRecentFilesStore = createSelectors(
       },
       hydrate: (items) => set({ items }),
     },
-  }))
+  })),
 );
 
 // Singleton event listener — installed lazily on first store read so
@@ -80,6 +80,6 @@ export function ensureRecentFilesListener(): void {
         return;
       }
       useRecentFilesStore.setState({ items: e.payload.items });
-    }
+    },
   );
 }

--- a/src/features/claude-setup/components/claude-login-dialog.tsx
+++ b/src/features/claude-setup/components/claude-login-dialog.tsx
@@ -145,9 +145,7 @@ function ChoiceButton({
       className={cn(
         "group flex items-start gap-3 rounded-sm border border-border-default bg-bg-base px-3 py-2.5 text-left",
         "transition-colors",
-        runnable
-          ? "hover:bg-bg-hover"
-          : "opacity-50 cursor-not-allowed",
+        runnable ? "hover:bg-bg-hover" : "opacity-50 cursor-not-allowed",
       )}
     >
       <span className="flex-1 min-w-0">

--- a/src/features/claude-setup/components/claude-setup-banner.tsx
+++ b/src/features/claude-setup/components/claude-setup-banner.tsx
@@ -1,4 +1,11 @@
-import { Check, Download, Loader2, LogIn, RefreshCw, TriangleAlert } from "lucide-react";
+import {
+  Check,
+  Download,
+  Loader2,
+  LogIn,
+  RefreshCw,
+  TriangleAlert,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useClaudeSetupStore } from "../stores/claude-setup-store";
 
@@ -24,7 +31,10 @@ export function ClaudeSetupBanner() {
     case "checking":
       content = (
         <StatusPill>
-          <Loader2 size={11} className="animate-spin text-[var(--accent-primary)]" />
+          <Loader2
+            size={11}
+            className="animate-spin text-[var(--accent-primary)]"
+          />
           <span>Checking Claude Code…</span>
         </StatusPill>
       );
@@ -42,7 +52,10 @@ export function ClaudeSetupBanner() {
     case "installing":
       content = (
         <StatusPill>
-          <Loader2 size={11} className="animate-spin text-[var(--accent-primary)]" />
+          <Loader2
+            size={11}
+            className="animate-spin text-[var(--accent-primary)]"
+          />
           <span>Installing Claude Code…</span>
         </StatusPill>
       );
@@ -79,7 +92,10 @@ export function ClaudeSetupBanner() {
     case "authing":
       content = (
         <ActionPill onClick={() => void refreshStatus()} variant="muted">
-          <Loader2 size={11} className="animate-spin text-[var(--accent-primary)]" />
+          <Loader2
+            size={11}
+            className="animate-spin text-[var(--accent-primary)]"
+          />
           <span>Waiting for sign-in…</span>
           <RefreshCw size={11} className="ml-1 opacity-70" />
         </ActionPill>

--- a/src/features/claude-setup/stores/claude-setup-store.ts
+++ b/src/features/claude-setup/stores/claude-setup-store.ts
@@ -155,7 +155,8 @@ export const useClaudeSetupStore = createSelectors(
           source: "atlas",
           kind: "claude-status",
           summary: `claude status: installed=${status.installed} authed=${status.authenticated} (${status.auth_summary ?? "no detail"})`,
-          status: status.installed && status.authenticated ? "success" : "failure",
+          status:
+            status.installed && status.authenticated ? "success" : "failure",
           payload: {
             installed: status.installed,
             authenticated: status.authenticated,
@@ -210,7 +211,8 @@ export const useClaudeSetupStore = createSelectors(
       const progressUnlisten = await listenClaudeInstallProgress((p) => {
         set((s) => {
           const next = [...s.installLog, p.line];
-          if (next.length > LOG_LINE_CAP) next.splice(0, next.length - LOG_LINE_CAP);
+          if (next.length > LOG_LINE_CAP)
+            next.splice(0, next.length - LOG_LINE_CAP);
           return { installLog: next };
         });
       });
@@ -319,7 +321,8 @@ export const useClaudeSetupStore = createSelectors(
           logEvent({
             source: "atlas",
             kind: "claude-signin-subprocess-failed",
-            summary: p.message ?? "Sign-in subprocess didn't complete successfully.",
+            summary:
+              p.message ?? "Sign-in subprocess didn't complete successfully.",
             status: "failure",
             payload: { methodId, message: p.message },
           });
@@ -336,7 +339,8 @@ export const useClaudeSetupStore = createSelectors(
         logEvent({
           source: "atlas",
           kind: "claude-signin-subprocess-done",
-          summary: "Sign-in subprocess exited successfully; probing claude_status…",
+          summary:
+            "Sign-in subprocess exited successfully; probing claude_status…",
           status: "success",
           payload: { methodId },
         });

--- a/src/features/editor-notion/components/bubble-menu.tsx
+++ b/src/features/editor-notion/components/bubble-menu.tsx
@@ -63,10 +63,7 @@ export function AtlasBubbleMenu({ editor }: AtlasBubbleMenuProps) {
           e.preventDefault();
           props.onClick();
         }}
-        className={cn(
-          "atlas-bubble-btn",
-          props.isActive && "is-active",
-        )}
+        className={cn("atlas-bubble-btn", props.isActive && "is-active")}
       >
         <Icon size={13} strokeWidth={1.7} />
       </button>
@@ -156,7 +153,9 @@ export function AtlasBubbleMenu({ editor }: AtlasBubbleMenuProps) {
             icon: LinkIcon,
             isActive: editor.isActive("link"),
             onClick: () => {
-              const existing = editor.getAttributes("link").href as string | undefined;
+              const existing = editor.getAttributes("link").href as
+                | string
+                | undefined;
               setLinkUrl(existing ?? "");
               setLinkOpen(true);
             },
@@ -165,13 +164,15 @@ export function AtlasBubbleMenu({ editor }: AtlasBubbleMenuProps) {
             title: "H1",
             icon: Heading1,
             isActive: editor.isActive("heading", { level: 1 }),
-            onClick: () => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+            onClick: () =>
+              editor.chain().focus().toggleHeading({ level: 1 }).run(),
           })}
           {tool({
             title: "H2",
             icon: Heading2,
             isActive: editor.isActive("heading", { level: 2 }),
-            onClick: () => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+            onClick: () =>
+              editor.chain().focus().toggleHeading({ level: 2 }).run(),
           })}
           {tool({
             title: "Bullet list",

--- a/src/features/editor-notion/components/slash-menu.tsx
+++ b/src/features/editor-notion/components/slash-menu.tsx
@@ -53,69 +53,145 @@ interface SlashMenuProps {
 export const SLASH_ITEMS: SlashItem[] = [
   // ── Basic ────────────────────────────────────────────────────────
   {
-    id: "p", group: "Basic", title: "Text", hint: "Plain paragraph", icon: Type,
+    id: "p",
+    group: "Basic",
+    title: "Text",
+    hint: "Plain paragraph",
+    icon: Type,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).setParagraph().run(),
   },
   {
-    id: "h1", group: "Basic", title: "Heading 1", hint: "Big section title", kbd: "# space", icon: Heading1,
+    id: "h1",
+    group: "Basic",
+    title: "Heading 1",
+    hint: "Big section title",
+    kbd: "# space",
+    icon: Heading1,
     command: ({ editor, range }) =>
-      editor.chain().focus().deleteRange(range).setNode("heading", { level: 1 }).run(),
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode("heading", { level: 1 })
+        .run(),
   },
   {
-    id: "h2", group: "Basic", title: "Heading 2", hint: "Medium section", kbd: "## space", icon: Heading2,
+    id: "h2",
+    group: "Basic",
+    title: "Heading 2",
+    hint: "Medium section",
+    kbd: "## space",
+    icon: Heading2,
     command: ({ editor, range }) =>
-      editor.chain().focus().deleteRange(range).setNode("heading", { level: 2 }).run(),
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode("heading", { level: 2 })
+        .run(),
   },
   {
-    id: "h3", group: "Basic", title: "Heading 3", hint: "Small section", kbd: "### space", icon: Heading3,
+    id: "h3",
+    group: "Basic",
+    title: "Heading 3",
+    hint: "Small section",
+    kbd: "### space",
+    icon: Heading3,
     command: ({ editor, range }) =>
-      editor.chain().focus().deleteRange(range).setNode("heading", { level: 3 }).run(),
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode("heading", { level: 3 })
+        .run(),
   },
   {
-    id: "ul", group: "Basic", title: "Bullet list", hint: "Bulleted items", kbd: "- space", icon: List,
+    id: "ul",
+    group: "Basic",
+    title: "Bullet list",
+    hint: "Bulleted items",
+    kbd: "- space",
+    icon: List,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).toggleBulletList().run(),
   },
   {
-    id: "ol", group: "Basic", title: "Numbered list", hint: "Ordered items", kbd: "1. space", icon: ListOrdered,
+    id: "ol",
+    group: "Basic",
+    title: "Numbered list",
+    hint: "Ordered items",
+    kbd: "1. space",
+    icon: ListOrdered,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
   },
   // ── Rich ─────────────────────────────────────────────────────────
   {
-    id: "todo", group: "Rich", title: "To-do", hint: "Checkboxes", kbd: "[] space", icon: CheckSquare,
+    id: "todo",
+    group: "Rich",
+    title: "To-do",
+    hint: "Checkboxes",
+    kbd: "[] space",
+    icon: CheckSquare,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).toggleTaskList().run(),
   },
   {
-    id: "toggle", group: "Rich", title: "Toggle", hint: "Collapsible section", icon: Quote,
+    id: "toggle",
+    group: "Rich",
+    title: "Toggle",
+    hint: "Collapsible section",
+    icon: Quote,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).setToggle().run(),
   },
   {
-    id: "quote", group: "Rich", title: "Quote", hint: "Indented quote", kbd: "> space", icon: Quote,
+    id: "quote",
+    group: "Rich",
+    title: "Quote",
+    hint: "Indented quote",
+    kbd: "> space",
+    icon: Quote,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
   },
   {
-    id: "callout", group: "Rich", title: "Callout", hint: "Highlighted block", icon: Quote,
+    id: "callout",
+    group: "Rich",
+    title: "Callout",
+    hint: "Highlighted block",
+    icon: Quote,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).setCallout().run(),
   },
   {
-    id: "divider", group: "Rich", title: "Divider", hint: "Horizontal rule", kbd: "---", icon: Minus,
+    id: "divider",
+    group: "Rich",
+    title: "Divider",
+    hint: "Horizontal rule",
+    kbd: "---",
+    icon: Minus,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
   },
   {
-    id: "code", group: "Rich", title: "Code block", hint: "Syntax-highlighted", kbd: "``` space", icon: Code,
+    id: "code",
+    group: "Rich",
+    title: "Code block",
+    hint: "Syntax-highlighted",
+    kbd: "``` space",
+    icon: Code,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
   },
   // ── Embed ────────────────────────────────────────────────────────
   {
-    id: "table", group: "Embed", title: "Table", hint: "Inline grid", icon: TableIcon,
+    id: "table",
+    group: "Embed",
+    title: "Table",
+    hint: "Inline grid",
+    icon: TableIcon,
     command: ({ editor, range }) =>
       editor
         .chain()
@@ -125,20 +201,37 @@ export const SLASH_ITEMS: SlashItem[] = [
         .run(),
   },
   {
-    id: "img", group: "Embed", title: "Image", hint: "Paste a URL", icon: ImageIcon,
+    id: "img",
+    group: "Embed",
+    title: "Image",
+    hint: "Paste a URL",
+    icon: ImageIcon,
     // Phase D will wire a real image upload. For now insert a placeholder
     // link that the user can swap to a URL.
     command: ({ editor, range }) =>
-      editor.chain().focus().deleteRange(range).insertContent("![alt](url)").run(),
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent("![alt](url)")
+        .run(),
   },
   {
-    id: "mention", group: "Embed", title: "Mention", hint: "Person, page or commit", kbd: "@", icon: AtSign,
+    id: "mention",
+    group: "Embed",
+    title: "Mention",
+    hint: "Person, page or commit",
+    kbd: "@",
+    icon: AtSign,
     command: ({ editor, range }) =>
       editor.chain().focus().deleteRange(range).insertContent("@").run(),
   },
 ];
 
-export function filterSlashItems(query: string, items: SlashItem[] = SLASH_ITEMS): SlashItem[] {
+export function filterSlashItems(
+  query: string,
+  items: SlashItem[] = SLASH_ITEMS,
+): SlashItem[] {
   if (!query) return items;
   const q = query.toLowerCase();
   return items.filter(
@@ -167,7 +260,9 @@ export const SlashMenu = forwardRef<SlashMenuRef, SlashMenuProps>(
             return true;
           }
           if (event.key === "ArrowUp") {
-            setSelectedIndex((i) => (i - 1 + items.length) % Math.max(1, items.length));
+            setSelectedIndex(
+              (i) => (i - 1 + items.length) % Math.max(1, items.length),
+            );
             return true;
           }
           if (event.key === "Enter" || event.key === "Tab") {

--- a/src/features/editor-notion/components/tiptap-editor.tsx
+++ b/src/features/editor-notion/components/tiptap-editor.tsx
@@ -11,11 +11,7 @@ import { EditorContent, useEditor, type Editor } from "@tiptap/react";
 import "../tiptap.css";
 import { cn } from "@/lib/utils";
 import { buildExtensions } from "../lib/extensions";
-import {
-  dropCachedDoc,
-  getCachedDoc,
-  setCachedDoc,
-} from "../lib/blocks-cache";
+import { dropCachedDoc, getCachedDoc, setCachedDoc } from "../lib/blocks-cache";
 import { AtlasBubbleMenu } from "./bubble-menu";
 
 export interface TiptapEditorHandle {
@@ -68,7 +64,14 @@ export interface TiptapEditorProps {
  */
 export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
   function TiptapEditor(
-    { documentId, initialMarkdown, editable = true, onDirty, className, placeholder },
+    {
+      documentId,
+      initialMarkdown,
+      editable = true,
+      onDirty,
+      className,
+      placeholder,
+    },
     ref,
   ) {
     const extensions = useMemo(
@@ -215,7 +218,10 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
     );
 
     return (
-      <div className={cn("atlas-tiptap", className)} style={{ position: "relative" }}>
+      <div
+        className={cn("atlas-tiptap", className)}
+        style={{ position: "relative" }}
+      >
         <EditorContent editor={editor} />
         {editable && editor && viewReady && <AtlasBubbleMenu editor={editor} />}
       </div>

--- a/src/features/editor-notion/extensions/callout.tsx
+++ b/src/features/editor-notion/extensions/callout.tsx
@@ -78,11 +78,17 @@ export const Callout = Node.create({
     return {
       markdown: {
         serialize(
-          state: { write: (s: string) => void; renderContent: (n: unknown) => void; closeBlock: (n: unknown) => void },
+          state: {
+            write: (s: string) => void;
+            renderContent: (n: unknown) => void;
+            closeBlock: (n: unknown) => void;
+          },
           node: { attrs: { emoji?: string } },
         ) {
           const emoji = node.attrs.emoji ?? "💡";
-          state.write(`<aside class="atlas-callout" data-emoji="${emoji}">\n\n`);
+          state.write(
+            `<aside class="atlas-callout" data-emoji="${emoji}">\n\n`,
+          );
           state.renderContent(node);
           state.write(`\n</aside>`);
           state.closeBlock(node);

--- a/src/features/editor-notion/extensions/code-block.tsx
+++ b/src/features/editor-notion/extensions/code-block.tsx
@@ -58,7 +58,11 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
           onClick={handleCopy}
           title="Copy"
         >
-          {copied ? <Check size={11} strokeWidth={1.7} /> : <Copy size={11} strokeWidth={1.7} />}
+          {copied ? (
+            <Check size={11} strokeWidth={1.7} />
+          ) : (
+            <Copy size={11} strokeWidth={1.7} />
+          )}
           {copied ? " Copied" : ""}
         </button>
       </div>
@@ -66,9 +70,7 @@ function CodeBlockView({ node, updateAttributes }: NodeViewProps) {
           types — wrap in <pre> for the design's monospace block frame
           and let lowlight paint hljs token classes inside. */}
       <pre>
-        <NodeViewContent
-          className={`hljs language-${language}`}
-        />
+        <NodeViewContent className={`hljs language-${language}`} />
       </pre>
     </NodeViewWrapper>
   );

--- a/src/features/editor-notion/extensions/mention.tsx
+++ b/src/features/editor-notion/extensions/mention.tsx
@@ -68,7 +68,11 @@ function createPopup(initialScope: "knowledge" | null = null): PopupState {
 }
 
 function destroyPopup(popup: PopupState) {
-  try { popup.root.unmount(); } catch { /* ignore */ }
+  try {
+    popup.root.unmount();
+  } catch {
+    /* ignore */
+  }
   popup.el.remove();
 }
 
@@ -196,8 +200,7 @@ function buildSuggestion(
     command: ({ editor: ed, range, props }) => {
       const m = props as unknown as MentionData;
       const label = mentionLabel(m);
-      ed
-        .chain()
+      ed.chain()
         .focus()
         .insertContentAt(range, [
           {
@@ -222,7 +225,9 @@ function buildSuggestion(
               .focus()
               .deleteRange({ from: props.range.from, to: props.range.to })
               .run();
-          } catch { /* ignore */ }
+          } catch {
+            /* ignore */
+          }
         };
         renderPopup(popup);
       },

--- a/src/features/editor-notion/extensions/slash-suggestion.tsx
+++ b/src/features/editor-notion/extensions/slash-suggestion.tsx
@@ -70,7 +70,11 @@ function positionPopup(popup: Popup, rect: DOMRect | null) {
   popup.el.style.top = `${top}px`;
 }
 
-function render(popup: Popup, items: SlashItem[], command: (it: SlashItem) => void) {
+function render(
+  popup: Popup,
+  items: SlashItem[],
+  command: (it: SlashItem) => void,
+) {
   // Forwarding the ref through ReactRenderer is finicky; use a plain
   // root + ref callback so onKeyDown can dispatch synchronously.
   const Menu = SlashMenu as ComponentType<{
@@ -78,9 +82,7 @@ function render(popup: Popup, items: SlashItem[], command: (it: SlashItem) => vo
     command: (it: SlashItem) => void;
     ref?: React.Ref<SlashMenuRef>;
   }>;
-  popup.root.render(
-    <Menu items={items} command={command} ref={popup.ref} />,
-  );
+  popup.root.render(<Menu items={items} command={command} ref={popup.ref} />);
 }
 
 export interface SlashExtensionOptions {

--- a/src/features/editor-notion/extensions/toggle.tsx
+++ b/src/features/editor-notion/extensions/toggle.tsx
@@ -53,7 +53,11 @@ export const Toggle = Node.create({
         class: "atlas-toggle",
         ...(node.attrs.open ? { open: "" } : {}),
       }),
-      ["summary", { class: "atlas-toggle-summary" }, node.attrs.title as string],
+      [
+        "summary",
+        { class: "atlas-toggle-summary" },
+        node.attrs.title as string,
+      ],
       ["div", { class: "atlas-toggle-body" }, 0],
     ];
   },
@@ -104,7 +108,10 @@ function ToggleView({ node, updateAttributes }: NodeViewProps) {
   const [draft, setDraft] = useState(title);
 
   return (
-    <NodeViewWrapper className="atlas-toggle" data-open={open ? "true" : "false"}>
+    <NodeViewWrapper
+      className="atlas-toggle"
+      data-open={open ? "true" : "false"}
+    >
       <div className="atlas-toggle-header" contentEditable={false}>
         <button
           type="button"

--- a/src/features/editor-notion/lib/extensions.ts
+++ b/src/features/editor-notion/lib/extensions.ts
@@ -69,7 +69,8 @@ export function buildExtensions(opts: BuildExtensionsOpts = {}) {
       HTMLAttributes: { rel: "noopener noreferrer" },
     }),
     Placeholder.configure({
-      placeholder: opts.placeholder ?? "Press '/' for blocks, or just start writing…",
+      placeholder:
+        opts.placeholder ?? "Press '/' for blocks, or just start writing…",
       emptyEditorClass: "is-editor-empty",
       emptyNodeClass: "is-empty",
     }),

--- a/src/features/editor-notion/lib/outline.ts
+++ b/src/features/editor-notion/lib/outline.ts
@@ -140,11 +140,13 @@ export function jumpToHeading(editor: Editor, pos: number): void {
   // Fallback: dispatch a scroll-into-view tr at the position.
   try {
     const { state } = view;
-    const tr = state.tr.setSelection(
-      // setTextSelection via tr.doc helper isn't on Transaction; let the
-      // chain command do it instead.
-      state.selection,
-    ).scrollIntoView();
+    const tr = state.tr
+      .setSelection(
+        // setTextSelection via tr.doc helper isn't on Transaction; let the
+        // chain command do it instead.
+        state.selection,
+      )
+      .scrollIntoView();
     void tr;
     editor.chain().focus().setTextSelection(pos).scrollIntoView().run();
   } catch {

--- a/src/features/editor-notion/tiptap.css
+++ b/src/features/editor-notion/tiptap.css
@@ -152,15 +152,23 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 80ms, border-color 80ms;
+  transition:
+    background 80ms,
+    border-color 80ms;
 }
 
-.atlas-tiptap .ProseMirror ul[data-type="taskList"] input[type="checkbox"]:checked {
+.atlas-tiptap
+  .ProseMirror
+  ul[data-type="taskList"]
+  input[type="checkbox"]:checked {
   background: var(--text-primary);
   border-color: var(--text-primary);
 }
 
-.atlas-tiptap .ProseMirror ul[data-type="taskList"] input[type="checkbox"]:checked::after {
+.atlas-tiptap
+  .ProseMirror
+  ul[data-type="taskList"]
+  input[type="checkbox"]:checked::after {
   content: "";
   width: 7px;
   height: 4px;
@@ -169,7 +177,11 @@
   transform: rotate(-45deg) translate(1px, -1px);
 }
 
-.atlas-tiptap .ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div {
+.atlas-tiptap
+  .ProseMirror
+  ul[data-type="taskList"]
+  li[data-checked="true"]
+  > div {
   color: var(--text-muted);
   text-decoration: line-through;
 }
@@ -281,7 +293,8 @@
 }
 
 .atlas-slash-iconwrap {
-  width: 26px; height: 26px;
+  width: 26px;
+  height: 26px;
   border-radius: 6px;
   background: var(--bg-elevated-2);
   border: 1px solid var(--border-subtle);
@@ -344,7 +357,9 @@
   background: transparent;
   border: 0;
   cursor: pointer;
-  transition: background-color 80ms, color 80ms;
+  transition:
+    background-color 80ms,
+    color 80ms;
 }
 
 .atlas-bubble-btn:hover {
@@ -523,7 +538,9 @@
   color: var(--text-tertiary);
   cursor: pointer;
   font-size: 11px;
-  transition: color 80ms, background-color 80ms;
+  transition:
+    color 80ms,
+    background-color 80ms;
 }
 
 .atlas-tiptap .atlas-code-copy:hover {
@@ -554,16 +571,31 @@
    AgentRL code block (atlas-knowledge.jsx:695–698). */
 .atlas-tiptap .hljs-keyword,
 .atlas-tiptap .hljs-built_in,
-.atlas-tiptap .hljs-tag .hljs-name { color: #c084fc; }
+.atlas-tiptap .hljs-tag .hljs-name {
+  color: #c084fc;
+}
 .atlas-tiptap .hljs-title,
-.atlas-tiptap .hljs-title.function_ { color: #7170ff; }
+.atlas-tiptap .hljs-title.function_ {
+  color: #7170ff;
+}
 .atlas-tiptap .hljs-string,
-.atlas-tiptap .hljs-attr { color: #5cc28a; }
-.atlas-tiptap .hljs-number { color: #f5b73c; }
-.atlas-tiptap .hljs-comment { color: var(--text-muted); font-style: italic; }
+.atlas-tiptap .hljs-attr {
+  color: #5cc28a;
+}
+.atlas-tiptap .hljs-number {
+  color: #f5b73c;
+}
+.atlas-tiptap .hljs-comment {
+  color: var(--text-muted);
+  font-style: italic;
+}
 .atlas-tiptap .hljs-type,
-.atlas-tiptap .hljs-class { color: #4c8df6; }
-.atlas-tiptap .hljs-meta { color: #d97757; }
+.atlas-tiptap .hljs-class {
+  color: #4c8df6;
+}
+.atlas-tiptap .hljs-meta {
+  color: #d97757;
+}
 
 /* ── Inline mention chip ──────────────────────────────────────── */
 
@@ -610,7 +642,9 @@
   background: transparent;
   border: 0;
   cursor: pointer;
-  transition: background-color 80ms, color 80ms;
+  transition:
+    background-color 80ms,
+    color 80ms;
 }
 
 .atlas-block-handle-btn:hover {

--- a/src/features/editor/components/editor-panel.tsx
+++ b/src/features/editor/components/editor-panel.tsx
@@ -1,11 +1,35 @@
 import { useEffect, useRef, useCallback } from "react";
-import { EditorView, keymap, lineNumbers, highlightActiveLine, drawSelection } from "@codemirror/view";
-import { EditorState, Compartment, Transaction, type Extension } from "@codemirror/state";
-import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
-import { bracketMatching, foldGutter, indentOnInput, syntaxHighlighting } from "@codemirror/language";
+import {
+  EditorView,
+  keymap,
+  lineNumbers,
+  highlightActiveLine,
+  drawSelection,
+} from "@codemirror/view";
+import {
+  EditorState,
+  Compartment,
+  Transaction,
+  type Extension,
+} from "@codemirror/state";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
+import {
+  bracketMatching,
+  foldGutter,
+  indentOnInput,
+  syntaxHighlighting,
+} from "@codemirror/language";
 import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
 import { getEditorTheme } from "../themes/themes";
-import { buildEditorChromeTheme, buildHighlightStyle } from "../themes/build-cm-theme";
+import {
+  buildEditorChromeTheme,
+  buildHighlightStyle,
+} from "../themes/build-cm-theme";
 import { useEditorStore } from "../stores/editor-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
@@ -32,7 +56,10 @@ const blameCompartment = new Compartment();
 
 function themeExtensions(themeId: string | undefined | null): Extension {
   const theme = getEditorTheme(themeId);
-  return [buildEditorChromeTheme(theme), syntaxHighlighting(buildHighlightStyle(theme))];
+  return [
+    buildEditorChromeTheme(theme),
+    syntaxHighlighting(buildHighlightStyle(theme)),
+  ];
 }
 
 // Language extension loader — lazy imports for tree-shaking
@@ -105,12 +132,21 @@ interface EditorPanelProps {
   containerHeight: number;
 }
 
-export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelProps) {
+export function EditorPanel({
+  tabId,
+  filePath,
+  containerHeight,
+}: EditorPanelProps) {
   const path = filePath ?? "";
   const isUntitled = path.startsWith("untitled:");
   const buffer = useEditorStore((s) => s.buffers[path]);
-  const { openBuffer, setDirty, markSaved, reloadBuffer, markExternallyChanged } =
-    useEditorStore.use.actions();
+  const {
+    openBuffer,
+    setDirty,
+    markSaved,
+    reloadBuffer,
+    markExternallyChanged,
+  } = useEditorStore.use.actions();
   const projectPath = useProjectStore.use.currentProject()?.path ?? "";
   const layoutActions = useLayoutStore.use.actions();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -133,7 +169,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     void (async () => {
       try {
         const content = await invoke<string>("read_file_content", { path });
-        const mtime = await invoke<number>("file_mtime_ms", { path }).catch(() => 0);
+        const mtime = await invoke<number>("file_mtime_ms", { path }).catch(
+          () => 0,
+        );
         openBuffer(path, content, mtime);
       } catch {
         openBuffer(path, `// Failed to read: ${path}`);
@@ -160,7 +198,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
         if (!chosen) return; // user cancelled
         const newPath = chosen as string;
         await invoke("write_file_content", { path: newPath, content });
-        const mtime = await invoke<number>("file_mtime_ms", { path: newPath }).catch(() => 0);
+        const mtime = await invoke<number>("file_mtime_ms", {
+          path: newPath,
+        }).catch(() => 0);
         // Carry the freshly-saved content over to the new buffer key.
         openBuffer(newPath, content, mtime);
         markSaved(newPath, content, mtime);
@@ -188,7 +228,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     }
     try {
       await invoke("write_file_content", { path, content });
-      const mtime = await invoke<number>("file_mtime_ms", { path }).catch(() => 0);
+      const mtime = await invoke<number>("file_mtime_ms", { path }).catch(
+        () => 0,
+      );
       markSaved(path, content, mtime);
       logEvent({
         source: "editor",
@@ -214,7 +256,15 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     } catch (err) {
       console.error("Save failed:", err);
     }
-  }, [path, markSaved, isUntitled, projectPath, openBuffer, layoutActions, tabId]);
+  }, [
+    path,
+    markSaved,
+    isUntitled,
+    projectPath,
+    openBuffer,
+    layoutActions,
+    tabId,
+  ]);
 
   onSaveRef.current = handleSave;
 
@@ -275,7 +325,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     if (!path || isUntitled) return;
     const buf = useEditorStore.getState().buffers[path];
     if (!buf) return;
-    const mtime = await invoke<number>("file_mtime_ms", { path }).catch(() => 0);
+    const mtime = await invoke<number>("file_mtime_ms", { path }).catch(
+      () => 0,
+    );
     if (!mtime || mtime <= buf.diskMtimeMs) return;
     let content: string;
     try {
@@ -286,7 +338,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     // Re-read the buffer: it may have changed (dirty/gone) during the awaits.
     const cur = useEditorStore.getState().buffers[path];
     if (!cur) return;
-    const liveDoc = viewRef.current?.state.doc.toString() ?? cur.originalContent;
+    const liveDoc =
+      viewRef.current?.state.doc.toString() ?? cur.originalContent;
     if (content === liveDoc) {
       // Content matches what's shown (e.g. our own save) — just record mtime.
       reloadBuffer(path, content, mtime);
@@ -300,7 +353,14 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     replaceViewDoc(content);
     refreshDiffGutter();
     refreshBlameRef.current();
-  }, [path, isUntitled, reloadBuffer, markExternallyChanged, replaceViewDoc, refreshDiffGutter]);
+  }, [
+    path,
+    isUntitled,
+    reloadBuffer,
+    markExternallyChanged,
+    replaceViewDoc,
+    refreshDiffGutter,
+  ]);
   const revalidateRef = useRef(revalidate);
   revalidateRef.current = revalidate;
 
@@ -314,7 +374,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     } catch {
       return;
     }
-    const mtime = await invoke<number>("file_mtime_ms", { path }).catch(() => 0);
+    const mtime = await invoke<number>("file_mtime_ms", { path }).catch(
+      () => 0,
+    );
     reloadBuffer(path, content, mtime);
     replaceViewDoc(content);
     refreshDiffGutter();
@@ -342,7 +404,10 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   useEffect(() => {
     if (!buffer || isUntitled) return;
     void revalidateRef.current();
-    const un = listen("atlas:explorer:changed", () => void revalidateRef.current());
+    const un = listen(
+      "atlas:explorer:changed",
+      () => void revalidateRef.current(),
+    );
     const onActive = () => void revalidateRef.current();
     window.addEventListener("atlas:window-active", onActive);
     return () => {
@@ -366,7 +431,8 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     // Seed from the freshest store content — a disk revalidation may have
     // reloaded the buffer between mount and this (async) view creation.
     const originalContent =
-      useEditorStore.getState().buffers[path]?.originalContent ?? buffer.originalContent;
+      useEditorStore.getState().buffers[path]?.originalContent ??
+      buffer.originalContent;
     let cancelled = false;
 
     (async () => {
@@ -376,12 +442,18 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
       const view = new EditorView({
         doc: originalContent,
         extensions: [
-          themeCompartment.of(themeExtensions(useProjectStore.getState().settings.codeEditorTheme)),
+          themeCompartment.of(
+            themeExtensions(
+              useProjectStore.getState().settings.codeEditorTheme,
+            ),
+          ),
           langExt,
           lineNumbers(),
           diffGutter(),
           blameCompartment.of(
-            useProjectStore.getState().settings.gitBlameInline ? blameInline() : [],
+            useProjectStore.getState().settings.gitBlameInline
+              ? blameInline()
+              : [],
           ),
           highlightActiveLine(),
           drawSelection(),
@@ -391,7 +463,13 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
           history(),
           highlightSelectionMatches(),
           keymap.of([
-            { key: "Mod-s", run: () => { onSaveRef.current(); return true; } },
+            {
+              key: "Mod-s",
+              run: () => {
+                onSaveRef.current();
+                return true;
+              },
+            },
             indentWithTab,
             ...defaultKeymap,
             ...historyKeymap,
@@ -403,7 +481,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
               if (dirtyTimerRef.current) clearTimeout(dirtyTimerRef.current);
               dirtyTimerRef.current = setTimeout(() => {
                 const current = update.view.state.doc.toString();
-                const orig = useEditorStore.getState().buffers[path]?.originalContent ?? "";
+                const orig =
+                  useEditorStore.getState().buffers[path]?.originalContent ??
+                  "";
                 setDirty(path, current !== orig);
               }, DIRTY_CHECK_DEBOUNCE);
             }
@@ -443,7 +523,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
-    view.dispatch({ effects: themeCompartment.reconfigure(themeExtensions(codeEditorTheme)) });
+    view.dispatch({
+      effects: themeCompartment.reconfigure(themeExtensions(codeEditorTheme)),
+    });
   }, [codeEditorTheme]);
 
   // Live-toggle inline blame: reconfigure the compartment in place; turning it
@@ -453,7 +535,9 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     const view = viewRef.current;
     if (!view) return;
     view.dispatch({
-      effects: blameCompartment.reconfigure(gitBlameInline ? blameInline() : []),
+      effects: blameCompartment.reconfigure(
+        gitBlameInline ? blameInline() : [],
+      ),
     });
     if (gitBlameInline) refreshBlameRef.current();
   }, [gitBlameInline]);
@@ -466,12 +550,19 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     );
   }
 
-  const editorHeight = containerHeight > TOOLBAR_HEIGHT
-    ? containerHeight - TOOLBAR_HEIGHT
-    : window.innerHeight - 140;
+  const editorHeight =
+    containerHeight > TOOLBAR_HEIGHT
+      ? containerHeight - TOOLBAR_HEIGHT
+      : window.innerHeight - 140;
 
   return (
-    <div style={{ background: "#000000", height: containerHeight || "100%", overflow: "hidden" }}>
+    <div
+      style={{
+        background: "#000000",
+        height: containerHeight || "100%",
+        overflow: "hidden",
+      }}
+    >
       {/* Breadcrumb toolbar */}
       <div
         className="flex items-center px-3 border-b border-border-default bg-bg-primary overflow-hidden"
@@ -502,10 +593,17 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   );
 }
 
-function Breadcrumbs({ filePath, projectPath }: { filePath: string; projectPath: string }) {
-  const relative = projectPath && filePath.startsWith(projectPath)
-    ? filePath.slice(projectPath.length + 1)
-    : filePath;
+function Breadcrumbs({
+  filePath,
+  projectPath,
+}: {
+  filePath: string;
+  projectPath: string;
+}) {
+  const relative =
+    projectPath && filePath.startsWith(projectPath)
+      ? filePath.slice(projectPath.length + 1)
+      : filePath;
   const segments = relative.split("/").filter(Boolean);
 
   return (
@@ -514,8 +612,15 @@ function Breadcrumbs({ filePath, projectPath }: { filePath: string; projectPath:
         const isLast = i === segments.length - 1;
         return (
           <span key={i} className="flex items-center shrink-0">
-            {i > 0 && <ChevronRight size={10} className="text-text-tertiary mx-0.5 shrink-0" />}
-            <span className={`text-[11px] font-mono ${isLast ? "text-text-primary" : "text-text-tertiary"}`}>
+            {i > 0 && (
+              <ChevronRight
+                size={10}
+                className="text-text-tertiary mx-0.5 shrink-0"
+              />
+            )}
+            <span
+              className={`text-[11px] font-mono ${isLast ? "text-text-primary" : "text-text-tertiary"}`}
+            >
               {segment}
             </span>
           </span>

--- a/src/features/editor/lib/blame-inline.ts
+++ b/src/features/editor/lib/blame-inline.ts
@@ -7,9 +7,19 @@
 // already reports as uncommitted) falls back to "You · Uncommitted changes"
 // instead of ever showing another commit's info.
 
-import { EditorView, Decoration, WidgetType, ViewPlugin } from "@codemirror/view";
+import {
+  EditorView,
+  Decoration,
+  WidgetType,
+  ViewPlugin,
+} from "@codemirror/view";
 import type { DecorationSet, ViewUpdate } from "@codemirror/view";
-import { StateField, StateEffect, RangeSet, RangeValue } from "@codemirror/state";
+import {
+  StateField,
+  StateEffect,
+  RangeSet,
+  RangeValue,
+} from "@codemirror/state";
 import type { Extension, Text } from "@codemirror/state";
 import type { BlameLine } from "@/features/git/lib/git-blame-api";
 
@@ -52,7 +62,8 @@ const blameField = StateField.define<BlameState>({
   create: () => null,
   update(value, tr) {
     for (const e of tr.effects) {
-      if (e.is(setBlame)) return e.value.length === 0 ? null : buildSet(tr.state.doc, e.value);
+      if (e.is(setBlame))
+        return e.value.length === 0 ? null : buildSet(tr.state.doc, e.value);
     }
     if (value === null || !tr.docChanged) return value;
     // Shift markers through the edit, then drop every line the edit touched so
@@ -62,9 +73,11 @@ const blameField = StateField.define<BlameState>({
     tr.changes.iterChangedRanges((_fromA, _toA, fromB, toB) => {
       const first = tr.state.doc.lineAt(fromB).number;
       const last = tr.state.doc.lineAt(toB).number;
-      for (let n = first; n <= last; n++) touched.add(tr.state.doc.line(n).from);
+      for (let n = first; n <= last; n++)
+        touched.add(tr.state.doc.line(n).from);
     });
-    if (touched.size) set = set.update({ filter: (from) => !touched.has(from) });
+    if (touched.size)
+      set = set.update({ filter: (from) => !touched.has(from) });
     return set;
   },
 });
@@ -103,7 +116,11 @@ class BlameWidget extends WidgetType {
   }
 }
 
-function blameTextFor(state: BlameState, doc: Text, head: number): string | null {
+function blameTextFor(
+  state: BlameState,
+  doc: Text,
+  head: number,
+): string | null {
   if (state === null) return null;
   const line = doc.lineAt(head);
   let found: BlameLine | null = null;
@@ -129,7 +146,12 @@ const blameDecorations = ViewPlugin.fromClass(
       const blameChanged = update.transactions.some((tr) =>
         tr.effects.some((e) => e.is(setBlame)),
       );
-      if (update.docChanged || update.selectionSet || update.focusChanged || blameChanged) {
+      if (
+        update.docChanged ||
+        update.selectionSet ||
+        update.focusChanged ||
+        blameChanged
+      ) {
         this.decorations = this.build(update.view);
       }
     }
@@ -142,7 +164,10 @@ const blameDecorations = ViewPlugin.fromClass(
       );
       if (text === null) return Decoration.none;
       const line = view.state.doc.lineAt(view.state.selection.main.head);
-      const deco = Decoration.widget({ widget: new BlameWidget(text), side: 1 });
+      const deco = Decoration.widget({
+        widget: new BlameWidget(text),
+        side: 1,
+      });
       return Decoration.set([deco.range(line.to)]);
     }
   },

--- a/src/features/editor/lib/diff-gutter.ts
+++ b/src/features/editor/lib/diff-gutter.ts
@@ -30,7 +30,10 @@ const ADDED = new BarMarker("cm-changebar-added");
 const CHANGED = new BarMarker("cm-changebar-changed");
 const DELETED = new BarMarker("cm-changebar-deleted");
 
-function buildMarkers(doc: Text, status: DiffLineStatus): RangeSet<GutterMarker> {
+function buildMarkers(
+  doc: Text,
+  status: DiffLineStatus,
+): RangeSet<GutterMarker> {
   const total = doc.lines;
   const entries: { pos: number; marker: GutterMarker }[] = [];
   const add = (lineNo: number, marker: GutterMarker) => {
@@ -101,6 +104,9 @@ export function diffGutter(): Extension {
 }
 
 /** Convenience: dispatch a line-status update onto a view. */
-export function applyDiffStatus(view: EditorView, status: DiffLineStatus): void {
+export function applyDiffStatus(
+  view: EditorView,
+  status: DiffLineStatus,
+): void {
   view.dispatch({ effects: setDiffStatus.of(status) });
 }

--- a/src/features/editor/stores/editor-store.ts
+++ b/src/features/editor/stores/editor-store.ts
@@ -37,14 +37,35 @@ interface EditorActions {
 function detectLanguage(path: string): string {
   const ext = path.split(".").pop()?.toLowerCase() ?? "";
   const map: Record<string, string> = {
-    ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
-    rs: "rust", py: "python", go: "go", rb: "ruby", java: "java",
-    json: "json", toml: "toml", yaml: "yaml", yml: "yaml",
-    md: "markdown", html: "html", css: "css", scss: "scss",
-    sh: "shell", zsh: "shell", bash: "shell",
-    sql: "sql", xml: "xml", svg: "xml",
-    c: "c", cpp: "cpp", h: "c", hpp: "cpp",
-    swift: "swift", kt: "kotlin",
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    rs: "rust",
+    py: "python",
+    go: "go",
+    rb: "ruby",
+    java: "java",
+    json: "json",
+    toml: "toml",
+    yaml: "yaml",
+    yml: "yaml",
+    md: "markdown",
+    html: "html",
+    css: "css",
+    scss: "scss",
+    sh: "shell",
+    zsh: "shell",
+    bash: "shell",
+    sql: "sql",
+    xml: "xml",
+    svg: "xml",
+    c: "c",
+    cpp: "cpp",
+    h: "c",
+    hpp: "cpp",
+    swift: "swift",
+    kt: "kotlin",
   };
   return map[ext] ?? "plaintext";
 }
@@ -109,7 +130,8 @@ export const useEditorStore = createSelectors(
             delete s.buffers[path];
             if (s.activeBufferPath === path) {
               const keys = Object.keys(s.buffers);
-              s.activeBufferPath = keys.length > 0 ? keys[keys.length - 1] : null;
+              s.activeBufferPath =
+                keys.length > 0 ? keys[keys.length - 1] : null;
             }
           }),
         setActive: (path) =>
@@ -117,6 +139,6 @@ export const useEditorStore = createSelectors(
             s.activeBufferPath = path;
           }),
       },
-    }))
-  )
+    })),
+  ),
 );

--- a/src/features/editor/themes/build-cm-theme.ts
+++ b/src/features/editor/themes/build-cm-theme.ts
@@ -75,7 +75,7 @@ export function buildEditorChromeTheme(theme: EditorColorTheme): Extension {
         padding: "0 4px",
       },
     },
-    { dark: theme.dark }
+    { dark: theme.dark },
   );
 }
 
@@ -91,13 +91,19 @@ export function buildHighlightStyle(theme: EditorColorTheme): HighlightStyle {
     { tag: [tags.string, tags.special(tags.string)], color: c.string },
     { tag: tags.number, color: c.number },
     { tag: [tags.typeName, tags.className], color: c.type },
-    { tag: [tags.function(tags.variableName), tags.function(tags.propertyName)], color: c.func },
+    {
+      tag: [tags.function(tags.variableName), tags.function(tags.propertyName)],
+      color: c.func,
+    },
     { tag: tags.variableName, color: c.variable },
     { tag: tags.operator, color: c.operator },
     { tag: tags.punctuation, color: c.operator },
     { tag: tags.tagName, color: c.tagName },
     { tag: tags.attributeName, color: c.attributeName },
-    { tag: [tags.constant(tags.variableName), tags.standard(tags.variableName)], color: c.constant },
+    {
+      tag: [tags.constant(tags.variableName), tags.standard(tags.variableName)],
+      color: c.constant,
+    },
     { tag: tags.regexp, color: c.regexp },
     { tag: tags.escape, color: c.escape },
     { tag: tags.definition(tags.variableName), color: c.definition },

--- a/src/features/editor/themes/themes.ts
+++ b/src/features/editor/themes/themes.ts
@@ -248,11 +248,19 @@ const vesper: EditorColorTheme = {
   },
 };
 
-export const EDITOR_THEMES: EditorColorTheme[] = [atlas, dracula, oneDark, monokai, vesper];
+export const EDITOR_THEMES: EditorColorTheme[] = [
+  atlas,
+  dracula,
+  oneDark,
+  monokai,
+  vesper,
+];
 
 export const DEFAULT_EDITOR_THEME_ID = "atlas";
 
-export function getEditorTheme(id: string | undefined | null): EditorColorTheme {
+export function getEditorTheme(
+  id: string | undefined | null,
+): EditorColorTheme {
   return EDITOR_THEMES.find((t) => t.id === id) ?? atlas;
 }
 
@@ -264,7 +272,9 @@ export function getEditorTheme(id: string | undefined | null): EditorColorTheme 
  * background to `--bg-base`, ignoring whatever `bg`/`gutterBg`/`contextBg` a
  * theme declares. Uses the CSS var (not a literal) so it tracks the interface.
  */
-export function resolveEditorColors(theme: EditorColorTheme): EditorThemeColors {
+export function resolveEditorColors(
+  theme: EditorColorTheme,
+): EditorThemeColors {
   return {
     ...theme.colors,
     bg: "var(--bg-base)",

--- a/src/features/explorer/components/file-tree-confirm-delete.tsx
+++ b/src/features/explorer/components/file-tree-confirm-delete.tsx
@@ -58,22 +58,29 @@ export function FileTreeConfirmDelete({
           }}
         >
           <Dialog.Title className="text-[13px] font-semibold text-text-primary">
-            {title ?? (multi ? `Delete ${count} items?` : `Delete ${isDir ? "folder" : "file"}?`)}
+            {title ??
+              (multi
+                ? `Delete ${count} items?`
+                : `Delete ${isDir ? "folder" : "file"}?`)}
           </Dialog.Title>
           <p className="text-[12px] text-text-secondary leading-relaxed">
-            {body ?? (multi ? (
-              <>
-                <span className="font-mono text-text-primary">{name}</span> and{" "}
-                {count - 1} other {count - 1 === 1 ? "item" : "items"} will be
-                permanently deleted. This can't be undone.
-              </>
-            ) : (
-              <>
-                <span className="font-mono text-text-primary">{name}</span> will be
-                permanently {isDir ? "removed along with everything inside it" : "deleted"}.
-                This can't be undone.
-              </>
-            ))}
+            {body ??
+              (multi ? (
+                <>
+                  <span className="font-mono text-text-primary">{name}</span>{" "}
+                  and {count - 1} other {count - 1 === 1 ? "item" : "items"}{" "}
+                  will be permanently deleted. This can't be undone.
+                </>
+              ) : (
+                <>
+                  <span className="font-mono text-text-primary">{name}</span>{" "}
+                  will be permanently{" "}
+                  {isDir
+                    ? "removed along with everything inside it"
+                    : "deleted"}
+                  . This can't be undone.
+                </>
+              ))}
           </p>
           <div className="flex items-center justify-end gap-2 mt-1">
             <button

--- a/src/features/explorer/components/file-tree.tsx
+++ b/src/features/explorer/components/file-tree.tsx
@@ -17,7 +17,10 @@ import { cn } from "@/lib/utils";
 import { PanelSkeleton } from "@/components/panel-skeleton";
 import { TreeRow } from "./tree-row";
 import { openFile } from "@/lib/open-file";
-import { useFileTreeDragDrop, ROOT_DROP } from "../hooks/use-file-tree-drag-drop";
+import {
+  useFileTreeDragDrop,
+  ROOT_DROP,
+} from "../hooks/use-file-tree-drag-drop";
 import { useExternalFileDrop } from "../hooks/use-external-file-drop";
 import { ROW_HEIGHT } from "../lib/tree-constants";
 import {
@@ -42,7 +45,13 @@ interface FlatRow {
 
 /** Tab types whose `data.filePath` points at a file on disk — these must be
  *  re-pointed/closed when that file is renamed or deleted. */
-const FILE_TAB_TYPES = new Set(["editor", "media", "svg", "pdf", "unsupported"]);
+const FILE_TAB_TYPES = new Set([
+  "editor",
+  "media",
+  "svg",
+  "pdf",
+  "unsupported",
+]);
 
 /** Map a git porcelain status char to a gutter-dot color, matching the
  *  Source Control panel's convention (`changes-view.tsx:statusBadge`). */
@@ -92,7 +101,9 @@ export function FileTree() {
   const tabs = useLayoutStore.use.tabs();
   const { closeTab } = useLayoutStore.use.actions();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [deleteTargets, setDeleteTargets] = useState<{ path: string; name: string; isDir: boolean }[] | null>(null);
+  const [deleteTargets, setDeleteTargets] = useState<
+    { path: string; name: string; isDir: boolean }[] | null
+  >(null);
 
   // Active editor tab's file path — used to highlight the matching
   // row in the tree (pill style like the screenshot).
@@ -120,7 +131,14 @@ export function FileTree() {
     if (!pendingNewEntry) return base;
     if (rootPath && pendingNewEntry.parentDir === rootPath) {
       return [
-        { node: null, ghost: { parentDir: rootPath, isDir: pendingNewEntry.isDir, depth: 0 } },
+        {
+          node: null,
+          ghost: {
+            parentDir: rootPath,
+            isDir: pendingNewEntry.isDir,
+            depth: 0,
+          },
+        },
         ...base,
       ];
     }
@@ -132,7 +150,11 @@ export function FileTree() {
     const next: FlatRow[] = [...base];
     next.splice(idx + 1, 0, {
       node: null,
-      ghost: { parentDir: pendingNewEntry.parentDir, isDir: pendingNewEntry.isDir, depth: parentDepth + 1 },
+      ghost: {
+        parentDir: pendingNewEntry.parentDir,
+        isDir: pendingNewEntry.isDir,
+        depth: parentDepth + 1,
+      },
     });
     return next;
   }, [tree, pendingNewEntry, rootPath]);
@@ -217,7 +239,14 @@ export function FileTree() {
         handleOpenFile(path, node.entry.name);
       }
     },
-    [flat, selectionAnchor, toggleSelection, setSelection, toggleExpand, handleOpenFile],
+    [
+      flat,
+      selectionAnchor,
+      toggleSelection,
+      setSelection,
+      toggleExpand,
+      handleOpenFile,
+    ],
   );
 
   const handlePickFolder = async () => {
@@ -279,7 +308,11 @@ export function FileTree() {
       await reconcileDirectory(dirOfPath(oldPath));
       // Re-point recent-files entries so the mention picker shows the new name
       // (the file-index search already self-updates via the fs watcher).
-      void invoke("recent_files_rename", { oldPath, newPath, workspaceId: activeWorkspaceId() }).catch(() => {});
+      void invoke("recent_files_rename", {
+        oldPath,
+        newPath,
+        workspaceId: activeWorkspaceId(),
+      }).catch(() => {});
       // If the renamed file is open in ANY file-backed viewer (editor, media,
       // svg, pdf, unsupported), swap those tabs to the new path — otherwise the
       // viewer keeps loading the old (now-missing) path and 404s. Re-opening
@@ -333,7 +366,11 @@ export function FileTree() {
         if (clipboard.isCut) {
           await invoke("fs_rename", { from: src, to: destPath });
           await reconcileDirectory(dirOfPath(src));
-          void invoke("recent_files_rename", { oldPath: src, newPath: destPath, workspaceId: activeWorkspaceId() }).catch(() => {});
+          void invoke("recent_files_rename", {
+            oldPath: src,
+            newPath: destPath,
+            workspaceId: activeWorkspaceId(),
+          }).catch(() => {});
         } else {
           await invoke("fs_copy", { from: src, to: destPath });
         }
@@ -383,7 +420,10 @@ export function FileTree() {
       try {
         const destPath = await resolveCollision(src, destDir);
         await invoke("fs_rename", { from: src, to: destPath });
-        void invoke("recent_files_rename", { oldPath: src, newPath: destPath }).catch(() => {});
+        void invoke("recent_files_rename", {
+          oldPath: src,
+          newPath: destPath,
+        }).catch(() => {});
         // Refresh both ends — the source's old parent loses the entry
         // and the destination gains it. The fs-watcher would catch
         // both eventually but the user expects an immediate update.
@@ -502,7 +542,9 @@ export function FileTree() {
   // longer in view, e.g. after its folder was collapsed).
   const selectionEntries = (): FileEntry[] => {
     const byPath = new Map(
-      flat.filter((r) => r.node).map((r) => [r.node!.entry.path, r.node!.entry] as const),
+      flat
+        .filter((r) => r.node)
+        .map((r) => [r.node!.entry.path, r.node!.entry] as const),
     );
     return selectedPaths.map(
       (p) =>
@@ -523,7 +565,8 @@ export function FileTree() {
     // batchable actions (cut/copy/delete/copy-path) operate on the whole
     // selection; single-row actions (rename/duplicate/new/paste) always
     // act on `entry`.
-    const multi = selectedPaths.length > 1 && selectedPaths.includes(entry.path);
+    const multi =
+      selectedPaths.length > 1 && selectedPaths.includes(entry.path);
     const targets = multi ? selectionEntries() : [entry];
     const targetPaths = targets.map((t) => t.path);
     const countSuffix = multi ? ` (${targets.length})` : "";
@@ -533,17 +576,23 @@ export function FileTree() {
           <>
             <ContextMenuItem onSelect={() => beginNewEntry(entry.path, false)}>
               New File
-              <ContextMenuShortcut><KbdCombo combo="⌘N" /></ContextMenuShortcut>
+              <ContextMenuShortcut>
+                <KbdCombo combo="⌘N" />
+              </ContextMenuShortcut>
             </ContextMenuItem>
             <ContextMenuItem onSelect={() => beginNewEntry(entry.path, true)}>
               New Folder
-              <ContextMenuShortcut><KbdCombo combo="⌥⌘N" /></ContextMenuShortcut>
+              <ContextMenuShortcut>
+                <KbdCombo combo="⌥⌘N" />
+              </ContextMenuShortcut>
             </ContextMenuItem>
             <ContextMenuSeparator />
           </>
         ) : (
           <>
-            <ContextMenuItem onSelect={() => handleOpenFile(entry.path, entry.name)}>
+            <ContextMenuItem
+              onSelect={() => handleOpenFile(entry.path, entry.name)}
+            >
               Open
             </ContextMenuItem>
             <ContextMenuSeparator />
@@ -551,7 +600,9 @@ export function FileTree() {
         )}
         <ContextMenuItem onSelect={() => handleRevealInFinder(entry.path)}>
           Reveal in Finder
-          <ContextMenuShortcut><KbdCombo combo="⌥⌘R" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⌥⌘R" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         {!isDir && (
           <ContextMenuItem onSelect={() => handleOpenInDefaultApp(entry.path)}>
@@ -566,30 +617,42 @@ export function FileTree() {
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => setClipboard(targetPaths, true)}>
           Cut{countSuffix}
-          <ContextMenuShortcut><KbdCombo combo="⌘X" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⌘X" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => setClipboard(targetPaths, false)}>
           Copy{countSuffix}
-          <ContextMenuShortcut><KbdCombo combo="⌘C" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⌘C" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => void handleDuplicate(entry.path)}>
           Duplicate
-          <ContextMenuShortcut><KbdCombo combo="⌘D" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⌘D" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         {isDir && clipboard && (
           <ContextMenuItem onSelect={() => void handlePaste(entry.path)}>
             Paste
-            <ContextMenuShortcut><KbdCombo combo="⌘V" /></ContextMenuShortcut>
+            <ContextMenuShortcut>
+              <KbdCombo combo="⌘V" />
+            </ContextMenuShortcut>
           </ContextMenuItem>
         )}
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => handleCopyPath(targetPaths)}>
           Copy Path{countSuffix}
-          <ContextMenuShortcut><KbdCombo combo="⌥⌘C" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⌥⌘C" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => handleCopyRelativePath(targetPaths)}>
           Copy Relative Path{countSuffix}
-          <ContextMenuShortcut><KbdCombo combo="⇧⌥⌘C" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⇧⌥⌘C" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => void handleAddToGitignore(entry.path)}>
@@ -597,12 +660,18 @@ export function FileTree() {
         </ContextMenuItem>
         <ContextMenuItem onSelect={() => beginRename(entry.path)}>
           Rename
-          <ContextMenuShortcut><KbdCombo combo="↵" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="↵" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem
           onSelect={() =>
             setDeleteTargets(
-              targets.map((t) => ({ path: t.path, name: t.name, isDir: t.is_dir })),
+              targets.map((t) => ({
+                path: t.path,
+                name: t.name,
+                isDir: t.is_dir,
+              })),
             )
           }
         >
@@ -630,7 +699,9 @@ export function FileTree() {
       {rootPath && clipboard && (
         <ContextMenuItem onSelect={() => void handlePaste(rootPath)}>
           Paste
-          <ContextMenuShortcut><KbdCombo combo="⌘V" /></ContextMenuShortcut>
+          <ContextMenuShortcut>
+            <KbdCombo combo="⌘V" />
+          </ContextMenuShortcut>
         </ContextMenuItem>
       )}
       <ContextMenuSeparator />
@@ -645,7 +716,9 @@ export function FileTree() {
         </ContextMenuItem>
       )}
       <ContextMenuSeparator />
-      <ContextMenuItem onSelect={() => collapseAll()}>Collapse All</ContextMenuItem>
+      <ContextMenuItem onSelect={() => collapseAll()}>
+        Collapse All
+      </ContextMenuItem>
     </ContextMenuContent>
   );
 
@@ -703,7 +776,12 @@ export function FileTree() {
                 Empty folder
               </div>
             ) : (
-              <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+              <div
+                style={{
+                  height: virtualizer.getTotalSize(),
+                  position: "relative",
+                }}
+              >
                 {virtualizer.getVirtualItems().map((virtualRow) => {
                   const row = flat[virtualRow.index];
 
@@ -721,14 +799,22 @@ export function FileTree() {
                         initialValue=""
                         onCommit={(name) => {
                           if (row.ghost!.isDir) {
-                            void handleNewFolderCommit(row.ghost!.parentDir, name);
+                            void handleNewFolderCommit(
+                              row.ghost!.parentDir,
+                              name,
+                            );
                           } else {
-                            void handleNewFileCommit(row.ghost!.parentDir, name);
+                            void handleNewFileCommit(
+                              row.ghost!.parentDir,
+                              name,
+                            );
                           }
                         }}
                         onCancel={endNewEntry}
                         onClick={() => {}}
-                        style={{ transform: `translateY(${virtualRow.start}px)` }}
+                        style={{
+                          transform: `translateY(${virtualRow.start}px)`,
+                        }}
                       />
                     );
                   }
@@ -746,7 +832,8 @@ export function FileTree() {
                   const isSelected = selectedPaths.includes(node.entry.path);
                   const isActive = !isDir && node.entry.path === activeFilePath;
                   const isCut =
-                    clipboard?.isCut === true && clipboard.paths.includes(node.entry.path);
+                    clipboard?.isCut === true &&
+                    clipboard.paths.includes(node.entry.path);
                   const isRenaming = pendingRenamePath === node.entry.path;
 
                   return (
@@ -774,21 +861,33 @@ export function FileTree() {
                             name={node.entry.name}
                             title={node.entry.path}
                             editingMode={isRenaming ? "rename" : undefined}
-                            initialValue={isRenaming ? node.entry.name : undefined}
-                            onCommit={(name) => void handleRenameCommit(node.entry.path, name)}
+                            initialValue={
+                              isRenaming ? node.entry.name : undefined
+                            }
+                            onCommit={(name) =>
+                              void handleRenameCommit(node.entry.path, name)
+                            }
                             onCancel={endRename}
                             isCut={isCut}
                             dataPath={node.entry.path}
-                            isDropTarget={isDir && dropTargetPath === node.entry.path}
-                            isDragging={dragState.draggedItem?.path === node.entry.path}
+                            isDropTarget={
+                              isDir && dropTargetPath === node.entry.path
+                            }
+                            isDragging={
+                              dragState.draggedItem?.path === node.entry.path
+                            }
                             gitColor={gitColor}
                             onClick={(e) => handleRowClick(node, e)}
                             onRename={() => beginRename(node.entry.path)}
-                            style={{ transform: `translateY(${virtualRow.start}px)` }}
+                            style={{
+                              transform: `translateY(${virtualRow.start}px)`,
+                            }}
                           />
                         </div>
                       </ContextMenuTrigger>
-                      <ContextMenuContent>{rowMenuItems(node.entry)}</ContextMenuContent>
+                      <ContextMenuContent>
+                        {rowMenuItems(node.entry)}
+                      </ContextMenuContent>
                     </ContextMenu>
                   );
                 })}
@@ -819,7 +918,9 @@ export function FileTree() {
               })),
             );
           }}
-          onOpenChange={(open) => { if (!open) setDeleteTargets(null); }}
+          onOpenChange={(open) => {
+            if (!open) setDeleteTargets(null);
+          }}
         />
       )}
     </div>
@@ -868,7 +969,9 @@ async function pathExists(path: string): Promise<boolean> {
     const lastSlash = path.lastIndexOf("/");
     const parent = lastSlash > 0 ? path.slice(0, lastSlash) : "/";
     const name = path.slice(lastSlash + 1);
-    const entries = await invoke<Array<{ name: string }>>("read_directory", { path: parent });
+    const entries = await invoke<Array<{ name: string }>>("read_directory", {
+      path: parent,
+    });
     return entries.some((e) => e.name === name);
   } catch {
     return false;

--- a/src/features/explorer/components/tree-row.tsx
+++ b/src/features/explorer/components/tree-row.tsx
@@ -194,8 +194,14 @@ export function TreeRow({
           down chevron (its children then carry their own dots). A changed file
           shows the dot in its (otherwise empty) gutter slot. */}
       {!isEditing && gitColor && (!isDir || !isExpanded) ? (
-        <span className="w-3 shrink-0 flex items-center justify-center" aria-hidden>
-          <span className="rounded-full" style={{ width: 6, height: 6, background: gitColor }} />
+        <span
+          className="w-3 shrink-0 flex items-center justify-center"
+          aria-hidden
+        >
+          <span
+            className="rounded-full"
+            style={{ width: 6, height: 6, background: gitColor }}
+          />
         </span>
       ) : isDir ? (
         <ChevronRight

--- a/src/features/explorer/hooks/use-file-tree-drag-drop.ts
+++ b/src/features/explorer/hooks/use-file-tree-drag-drop.ts
@@ -69,9 +69,13 @@ export function useFileTreeDragDrop(opts: {
   const itemRef = useRef<DraggedItem | null>(null);
   const overRef = useRef<string | null>(null);
   const draggingRef = useRef(false);
-  const pendingRef = useRef<{ x: number; y: number; item: DraggedItem } | null>(null);
+  const pendingRef = useRef<{ x: number; y: number; item: DraggedItem } | null>(
+    null,
+  );
   const previewRef = useRef<HTMLDivElement | null>(null);
-  const autoExpandRef = useRef<{ path: string; timeoutId: number } | null>(null);
+  const autoExpandRef = useRef<{ path: string; timeoutId: number } | null>(
+    null,
+  );
   const detachRef = useRef<(() => void) | null>(null);
 
   const clearAutoExpand = useCallback(() => {
@@ -120,63 +124,72 @@ export function useFileTreeDragDrop(opts: {
 
   // Resolve the destination directory under the cursor. Returns a real
   // directory path, the ROOT_DROP sentinel, or null (no valid target).
-  const resolveTarget = useCallback((x: number, y: number, dragged: DraggedItem) => {
-    const el = document.elementFromPoint(x, y);
-    const rowEl = el?.closest<HTMLElement>("[data-tree-path]");
-    if (rowEl) {
-      const path = rowEl.getAttribute("data-tree-path");
-      if (!path) return null;
-      const isDir = rowEl.getAttribute("data-tree-is-dir") === "true";
-      // Refuse dropping a folder onto itself or a descendant.
-      if (path === dragged.path || (dragged.isDir && path.startsWith(dragged.path + "/"))) {
-        return null;
+  const resolveTarget = useCallback(
+    (x: number, y: number, dragged: DraggedItem) => {
+      const el = document.elementFromPoint(x, y);
+      const rowEl = el?.closest<HTMLElement>("[data-tree-path]");
+      if (rowEl) {
+        const path = rowEl.getAttribute("data-tree-path");
+        if (!path) return null;
+        const isDir = rowEl.getAttribute("data-tree-is-dir") === "true";
+        // Refuse dropping a folder onto itself or a descendant.
+        if (
+          path === dragged.path ||
+          (dragged.isDir && path.startsWith(dragged.path + "/"))
+        ) {
+          return null;
+        }
+        if (isDir) {
+          scheduleAutoExpand(path);
+          return path;
+        }
+        // Over a file → target its parent directory.
+        clearAutoExpand();
+        const parent = dirOfPath(path);
+        return parent === rootRef.current ? ROOT_DROP : parent;
       }
-      if (isDir) {
-        scheduleAutoExpand(path);
-        return path;
+      if (el?.closest("[data-tree-root]")) {
+        clearAutoExpand();
+        return ROOT_DROP;
       }
-      // Over a file → target its parent directory.
       clearAutoExpand();
-      const parent = dirOfPath(path);
-      return parent === rootRef.current ? ROOT_DROP : parent;
-    }
-    if (el?.closest("[data-tree-root]")) {
-      clearAutoExpand();
-      return ROOT_DROP;
-    }
-    clearAutoExpand();
-    return null;
-  }, [scheduleAutoExpand, clearAutoExpand]);
+      return null;
+    },
+    [scheduleAutoExpand, clearAutoExpand],
+  );
 
-  const beginDrag = useCallback((x: number, y: number, item: DraggedItem) => {
-    draggingRef.current = true;
-    itemRef.current = item;
+  const beginDrag = useCallback(
+    (x: number, y: number, item: DraggedItem) => {
+      draggingRef.current = true;
+      itemRef.current = item;
 
-    const preview = document.createElement("div");
-    preview.textContent = item.name;
-    preview.style.cssText = [
-      "position:fixed",
-      "pointer-events:none",
-      "z-index:9999",
-      "padding:3px 9px",
-      "border-radius:6px",
-      "font-size:12px",
-      "font-family:var(--font-mono,monospace)",
-      "line-height:1.4",
-      "white-space:nowrap",
-      "color:var(--text-secondary)",
-      "background:var(--bg-elevated)",
-      "border:1px solid var(--border-default)",
-      "box-shadow:0 4px 14px rgba(0,0,0,0.3)",
-      "backdrop-filter:blur(12px)",
-    ].join(";");
-    document.body.appendChild(preview);
-    previewRef.current = preview;
-    document.body.style.cursor = "grabbing";
-    positionPreview(x, y);
+      const preview = document.createElement("div");
+      preview.textContent = item.name;
+      preview.style.cssText = [
+        "position:fixed",
+        "pointer-events:none",
+        "z-index:9999",
+        "padding:3px 9px",
+        "border-radius:6px",
+        "font-size:12px",
+        "font-family:var(--font-mono,monospace)",
+        "line-height:1.4",
+        "white-space:nowrap",
+        "color:var(--text-secondary)",
+        "background:var(--bg-elevated)",
+        "border:1px solid var(--border-default)",
+        "box-shadow:0 4px 14px rgba(0,0,0,0.3)",
+        "backdrop-filter:blur(12px)",
+      ].join(";");
+      document.body.appendChild(preview);
+      previewRef.current = preview;
+      document.body.style.cursor = "grabbing";
+      positionPreview(x, y);
 
-    setDragState({ isDragging: true, draggedItem: item, dragOverPath: null });
-  }, [positionPreview]);
+      setDragState({ isDragging: true, draggedItem: item, dragOverPath: null });
+    },
+    [positionPreview],
+  );
 
   const onContainerMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -190,12 +203,19 @@ export function useFileTreeDragDrop(opts: {
       if (!path) return;
       const isDir = rowEl.getAttribute("data-tree-is-dir") === "true";
       const name = path.slice(path.lastIndexOf("/") + 1);
-      pendingRef.current = { x: e.clientX, y: e.clientY, item: { path, name, isDir } };
+      pendingRef.current = {
+        x: e.clientX,
+        y: e.clientY,
+        item: { path, name, isDir },
+      };
 
       const onMouseMove = (ev: MouseEvent) => {
         const pending = pendingRef.current;
         if (pending && !draggingRef.current) {
-          if (Math.hypot(ev.clientX - pending.x, ev.clientY - pending.y) > DRAG_THRESHOLD) {
+          if (
+            Math.hypot(ev.clientX - pending.x, ev.clientY - pending.y) >
+            DRAG_THRESHOLD
+          ) {
             beginDrag(ev.clientX, ev.clientY, pending.item);
           }
           return;
@@ -228,7 +248,10 @@ export function useFileTreeDragDrop(opts: {
             ce.stopPropagation();
             ce.preventDefault();
           };
-          window.addEventListener("click", suppress, { capture: true, once: true });
+          window.addEventListener("click", suppress, {
+            capture: true,
+            once: true,
+          });
           window.setTimeout(() => {
             window.removeEventListener("click", suppress, { capture: true });
           }, 0);

--- a/src/features/explorer/stores/explorer-store.ts
+++ b/src/features/explorer/stores/explorer-store.ts
@@ -110,14 +110,15 @@ export const useExplorerStore = createSelectors(
             s.loading = true;
           });
           try {
-            const entries = await invoke<FileEntry[]>("read_directory", { path });
-            const nodes: TreeNode[] = applyHiddenFilter(entries)
-              .map((e) => ({
-                entry: e,
-                children: e.is_dir ? null : [],
-                expanded: false,
-                depth: 0,
-              }));
+            const entries = await invoke<FileEntry[]>("read_directory", {
+              path,
+            });
+            const nodes: TreeNode[] = applyHiddenFilter(entries).map((e) => ({
+              entry: e,
+              children: e.is_dir ? null : [],
+              expanded: false,
+              depth: 0,
+            }));
             set((s) => {
               s.tree = nodes;
               s.loading = false;
@@ -143,17 +144,18 @@ export const useExplorerStore = createSelectors(
 
           if (node.children === null) {
             try {
-              const entries = await invoke<FileEntry[]>("read_directory", { path });
+              const entries = await invoke<FileEntry[]>("read_directory", {
+                path,
+              });
               set((s) => {
                 const n = findNode(s.tree, path);
                 if (n) {
-                  n.children = applyHiddenFilter(entries)
-                    .map((e) => ({
-                      entry: e,
-                      children: e.is_dir ? null : [],
-                      expanded: false,
-                      depth: n.depth + 1,
-                    }));
+                  n.children = applyHiddenFilter(entries).map((e) => ({
+                    entry: e,
+                    children: e.is_dir ? null : [],
+                    expanded: false,
+                    depth: n.depth + 1,
+                  }));
                   n.expanded = true;
                 }
               });
@@ -172,7 +174,9 @@ export const useExplorerStore = createSelectors(
           // Root re-walk if this is the project root.
           if (state.rootPath === dirPath) {
             try {
-              const entries = await invoke<FileEntry[]>("read_directory", { path: dirPath });
+              const entries = await invoke<FileEntry[]>("read_directory", {
+                path: dirPath,
+              });
               set((s) => {
                 s.tree = reconcileChildren(s.tree, entries, 0);
               });
@@ -184,11 +188,17 @@ export const useExplorerStore = createSelectors(
           }
           // Sub-dir: only refetch if it's currently loaded (children !== null).
           const existing = findNode(state.tree, dirPath);
-          if (!existing || !existing.entry.is_dir || existing.children === null) {
+          if (
+            !existing ||
+            !existing.entry.is_dir ||
+            existing.children === null
+          ) {
             return;
           }
           try {
-            const entries = await invoke<FileEntry[]>("read_directory", { path: dirPath });
+            const entries = await invoke<FileEntry[]>("read_directory", {
+              path: dirPath,
+            });
             set((s) => {
               const n = findNode(s.tree, dirPath);
               if (!n || n.children === null) return;
@@ -294,8 +304,8 @@ export const useExplorerStore = createSelectors(
           });
         },
       },
-    }))
-  )
+    })),
+  ),
 );
 
 function collapseAllNodes(nodes: TreeNode[]): void {

--- a/src/features/feedback/lib/feedback-links.ts
+++ b/src/features/feedback/lib/feedback-links.ts
@@ -17,10 +17,7 @@ const PREFIX: Record<FeedbackCategory, string> = {
 const MAX_BODY = 4000;
 
 /** A prefilled "new issue" URL carrying whatever the user has typed so far. */
-export function issueUrl(
-  category: FeedbackCategory,
-  message: string,
-): string {
+export function issueUrl(category: FeedbackCategory, message: string): string {
   const text = message.trim();
   const first = text.split("\n")[0]?.slice(0, 90) || "Feedback";
   const title = `${PREFIX[category]} ${first}`;

--- a/src/features/feedback/stores/feedback-store.ts
+++ b/src/features/feedback/stores/feedback-store.ts
@@ -68,13 +68,12 @@ const useFeedbackStoreBase = create<FeedbackState>()((set, get) => ({
   source: "status-bar",
 
   actions: {
-    openPanel: (source) => set({ open: true, source, error: null, sent: false }),
+    openPanel: (source) =>
+      set({ open: true, source, error: null, sent: false }),
     // Draft survives on purpose — see the module note.
     closePanel: () => set({ open: false }),
     toggle: (source) =>
-      get().open
-        ? get().actions.closePanel()
-        : get().actions.openPanel(source),
+      get().open ? get().actions.closePanel() : get().actions.openPanel(source),
 
     setCategory: (category) => set({ category }),
     setMessage: (message) => set({ message }),

--- a/src/features/file-picker/components/file-picker.tsx
+++ b/src/features/file-picker/components/file-picker.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Image as ImageIcon, Film, Music, FileCode, FileX, RotateCw } from "lucide-react";
+import {
+  Image as ImageIcon,
+  Film,
+  Music,
+  FileCode,
+  FileX,
+  RotateCw,
+} from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { cn } from "@/lib/utils";
 import { useProjectStore } from "@/features/project/stores/project-store";
@@ -64,7 +71,9 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
       const status = await ensureFileIndex(project?.path);
       if (cancelled) return;
       setIndexing(status ? !status.indexed : false);
-      const r = await fileIndex.search("", RESULT_LIMIT).catch(() => [] as FileMatch[]);
+      const r = await fileIndex
+        .search("", RESULT_LIMIT)
+        .catch(() => [] as FileMatch[]);
       if (cancelled) return;
       setResults(r);
       if (project && r.length) cacheFileList(project.path, r);
@@ -82,12 +91,15 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
     setReindexing(true);
     setIndexing(true);
     await openFileIndex(project.path).catch(() => {});
-    const r = await fileIndex.search(query, RESULT_LIMIT).catch(() => [] as FileMatch[]);
+    const r = await fileIndex
+      .search(query, RESULT_LIMIT)
+      .catch(() => [] as FileMatch[]);
     setResults(r);
     setSelected(0);
     setIndexing(false);
     setReindexing(false);
-    if (project && query.trim() === "" && r.length) cacheFileList(project.path, r);
+    if (project && query.trim() === "" && r.length)
+      cacheFileList(project.path, r);
   };
 
   // Debounced backend search on query change.
@@ -121,7 +133,8 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
         .search(query, RESULT_LIMIT)
         .then((r) => {
           setResults(r);
-          if (project && query.trim() === "" && r.length) cacheFileList(project.path, r);
+          if (project && query.trim() === "" && r.length)
+            cacheFileList(project.path, r);
         })
         .catch(() => {});
     }).then((un) => {
@@ -179,7 +192,7 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
           className={cn(
             "fixed left-1/2 top-[18%] z-50 -translate-x-1/2",
             "w-[640px] max-w-[92vw] rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] shadow-2xl",
-            "flex flex-col overflow-hidden"
+            "flex flex-col overflow-hidden",
           )}
         >
           <Dialog.Title className="sr-only">Open file</Dialog.Title>
@@ -193,7 +206,10 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
             disabled={!project}
             className="px-4 h-11 bg-transparent border-b border-[var(--border-default)] text-sm text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] outline-none"
           />
-          <div ref={scrollRef} className="max-h-[420px] overflow-y-auto hide-scrollbar">
+          <div
+            ref={scrollRef}
+            className="max-h-[420px] overflow-y-auto hide-scrollbar"
+          >
             {showEmpty ? (
               <div className="px-4 py-3 text-[11px] text-[var(--text-tertiary)]">
                 {!project
@@ -234,11 +250,13 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
                         "flex items-center gap-2 px-3 text-left cursor-pointer transition-colors",
                         active
                           ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
-                          : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                          : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]",
                       )}
                     >
                       <KindIcon kind={classifyFile(m.path)} />
-                      <span className="truncate text-[12px] font-mono">{m.rel}</span>
+                      <span className="truncate text-[12px] font-mono">
+                        {m.rel}
+                      </span>
                     </button>
                   );
                 })}
@@ -253,13 +271,18 @@ export function FilePicker({ open, onOpenChange }: FilePickerProps) {
                 title="Rebuild the file index"
                 className={cn(
                   "flex items-center gap-1 rounded px-1 -ml-1 transition-colors",
-                  "hover:text-[var(--text-secondary)] disabled:opacity-40 disabled:cursor-default cursor-pointer outline-none"
+                  "hover:text-[var(--text-secondary)] disabled:opacity-40 disabled:cursor-default cursor-pointer outline-none",
                 )}
               >
-                <RotateCw size={10} className={cn(reindexing && "animate-spin")} />
+                <RotateCw
+                  size={10}
+                  className={cn(reindexing && "animate-spin")}
+                />
                 Reindex
               </button>
-              <span>{results.length} match{results.length === 1 ? "" : "es"}</span>
+              <span>
+                {results.length} match{results.length === 1 ? "" : "es"}
+              </span>
             </div>
             <span>↑↓ navigate · ↵ open · esc close</span>
           </div>

--- a/src/features/git/components/changed-files-tree.tsx
+++ b/src/features/git/components/changed-files-tree.tsx
@@ -1,5 +1,11 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronRight, ChevronDown, GitCommit, GitBranch, Search } from "lucide-react";
+import {
+  ChevronRight,
+  ChevronDown,
+  GitCommit,
+  GitBranch,
+  Search,
+} from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
@@ -30,7 +36,7 @@ function CommitPicker({
 }) {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
-  const selected = commit ? log.find((c) => c.hash === commit) ?? null : null;
+  const selected = commit ? (log.find((c) => c.hash === commit) ?? null) : null;
   const label = commit
     ? selected
       ? `${selected.short_hash} · ${selected.message}`
@@ -68,15 +74,27 @@ function CommitPicker({
             <span className="max-w-[70px] truncate">{branch}</span>
           </span>
         )}
-        <span className="min-w-0 flex-1 truncate text-left font-mono">{label}</span>
-        <ChevronDown size={11} className="shrink-0 text-[var(--text-tertiary)]" />
+        <span className="min-w-0 flex-1 truncate text-left font-mono">
+          {label}
+        </span>
+        <ChevronDown
+          size={11}
+          className="shrink-0 text-[var(--text-tertiary)]"
+        />
       </button>
       {open && (
         <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} aria-hidden />
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
           <div className="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] shadow-[var(--shadow-overlay)]">
             <div className="flex h-7 items-center gap-1.5 border-b border-[var(--border-subtle)] px-2">
-              <Search size={11} className="shrink-0 text-[var(--text-tertiary)]" />
+              <Search
+                size={11}
+                className="shrink-0 text-[var(--text-tertiary)]"
+              />
               <input
                 autoFocus
                 value={q}
@@ -92,7 +110,9 @@ function CommitPicker({
                 onClick={() => pick("")}
                 className={cn(
                   "flex w-full items-center px-2 py-1.5 text-left text-[10px] hover:bg-[var(--bg-hover)]",
-                  !commit ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)]",
+                  !commit
+                    ? "text-[var(--text-primary)]"
+                    : "text-[var(--text-secondary)]",
                 )}
               >
                 Working tree
@@ -104,15 +124,21 @@ function CommitPicker({
                   onClick={() => pick(c.hash)}
                   className={cn(
                     "flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[10px] hover:bg-[var(--bg-hover)]",
-                    c.hash === commit ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)]",
+                    c.hash === commit
+                      ? "text-[var(--text-primary)]"
+                      : "text-[var(--text-secondary)]",
                   )}
                 >
-                  <span className="shrink-0 font-mono text-[var(--text-tertiary)]">{c.short_hash}</span>
+                  <span className="shrink-0 font-mono text-[var(--text-tertiary)]">
+                    {c.short_hash}
+                  </span>
                   <span className="min-w-0 flex-1 truncate">{c.message}</span>
                 </button>
               ))}
               {filtered.length === 0 && (
-                <div className="px-2 py-2 text-[10px] text-[var(--text-tertiary)]">No commits</div>
+                <div className="px-2 py-2 text-[10px] text-[var(--text-tertiary)]">
+                  No commits
+                </div>
               )}
             </div>
           </div>
@@ -208,11 +234,7 @@ function collapseChains(dir: DirNode) {
     if (child.isDir) collapseChains(child);
   }
   // Root keeps its (empty) name; only fold interior dirs.
-  if (
-    dir.name !== "" &&
-    dir.children.length === 1 &&
-    dir.children[0].isDir
-  ) {
+  if (dir.name !== "" && dir.children.length === 1 && dir.children[0].isDir) {
     const only = dir.children[0];
     dir.name = `${dir.name}/${only.name}`;
     dir.path = only.path;
@@ -233,7 +255,11 @@ interface FlatRow {
   depth: number;
 }
 
-function flatten(dir: DirNode, collapsed: Set<string>, depth: number): FlatRow[] {
+function flatten(
+  dir: DirNode,
+  collapsed: Set<string>,
+  depth: number,
+): FlatRow[] {
   const out: FlatRow[] = [];
   for (const child of dir.children) {
     out.push({ node: child, depth });
@@ -258,7 +284,8 @@ export const ChangedFilesTree = memo(function ChangedFilesTree({
 
   // Populate the commit picker (recent history) on first mount.
   useEffect(() => {
-    if (repoPath && log.length === 0) void gitActions.loadLog(repoPath).catch(() => {});
+    if (repoPath && log.length === 0)
+      void gitActions.loadLog(repoPath).catch(() => {});
   }, [repoPath, log.length, gitActions]);
 
   // In commit-browse mode, list the files that commit changed.
@@ -269,7 +296,8 @@ export const ChangedFilesTree = memo(function ChangedFilesTree({
     staleTime: 30_000,
   });
 
-  const openFile = (path: string) => openGitDiff(repoPath, path, staged, commit);
+  const openFile = (path: string) =>
+    openGitDiff(repoPath, path, staged, commit);
 
   // Switch the whole diff tab to a different commit (or the working tree) for
   // the currently-open file.
@@ -279,7 +307,10 @@ export const ChangedFilesTree = memo(function ChangedFilesTree({
   const tree = useMemo(() => {
     const seen = new Set<string>();
     const source: { path: string; status: string }[] = commit
-      ? (commitFilesQuery.data ?? []).map((f) => ({ path: f.path, status: f.status }))
+      ? (commitFilesQuery.data ?? []).map((f) => ({
+          path: f.path,
+          status: f.status,
+        }))
       : files
           .filter((f) => f.staged === staged)
           .map((f) => ({ path: f.path, status: f.status }));
@@ -293,10 +324,7 @@ export const ChangedFilesTree = memo(function ChangedFilesTree({
     return buildTree(scoped);
   }, [files, staged, currentFile, commit, commitFilesQuery.data]);
 
-  const rows = useMemo(
-    () => flatten(tree, collapsed, 0),
-    [tree, collapsed],
-  );
+  const rows = useMemo(() => flatten(tree, collapsed, 0), [tree, collapsed]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
@@ -318,13 +346,23 @@ export const ChangedFilesTree = memo(function ChangedFilesTree({
     <div className="flex h-full w-full flex-col border-r border-[var(--border-default)] bg-[var(--bg-secondary)]">
       <div className="flex h-8 shrink-0 items-center gap-1.5 border-b border-[var(--border-default)] px-2">
         <GitCommit size={12} className="shrink-0 text-[var(--text-tertiary)]" />
-        <CommitPicker commit={commit} branch={branch} log={log} onPick={onPickCommit} />
+        <CommitPicker
+          commit={commit}
+          branch={branch}
+          log={log}
+          onPick={onPickCommit}
+        />
         <span className="shrink-0 text-[10px] tabular-nums text-[var(--text-tertiary)]">
           {rows.filter((r) => !r.node.isDir).length}
         </span>
       </div>
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto hide-scrollbar py-1">
-        <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-auto hide-scrollbar py-1"
+      >
+        <div
+          style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+        >
           {virtualizer.getVirtualItems().map((vr) => {
             const { node, depth } = rows[vr.index];
             const pad = 6 + depth * 12;
@@ -342,7 +380,11 @@ export const ChangedFilesTree = memo(function ChangedFilesTree({
                   className={`${common.className} text-[11px] text-[var(--text-tertiary)]`}
                   style={common.style}
                 >
-                  {open ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+                  {open ? (
+                    <ChevronDown size={11} />
+                  ) : (
+                    <ChevronRight size={11} />
+                  )}
                   <span className="truncate font-mono">{node.name}</span>
                 </button>
               );

--- a/src/features/git/components/commit-avatar.tsx
+++ b/src/features/git/components/commit-avatar.tsx
@@ -10,7 +10,7 @@ async function sha256(text: string): Promise<string> {
   if (cached) return cached;
   const buf = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(text)
+    new TextEncoder().encode(text),
   );
   const bytes = Array.from(new Uint8Array(buf));
   const hex = bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
@@ -24,7 +24,11 @@ interface CommitAvatarProps {
   className?: string;
 }
 
-export function CommitAvatar({ email, size = 16, className }: CommitAvatarProps) {
+export function CommitAvatar({
+  email,
+  size = 16,
+  className,
+}: CommitAvatarProps) {
   const [hash, setHash] = useState<string | null>(() => {
     if (!email) return null;
     return hashCache.get(email.trim().toLowerCase()) ?? null;

--- a/src/features/git/components/commit-node.tsx
+++ b/src/features/git/components/commit-node.tsx
@@ -73,7 +73,7 @@ export const CommitRowView = memo(function CommitRowView({
         "group flex items-center cursor-pointer select-none",
         selected
           ? "bg-[var(--accent-primary)]/15 text-[var(--text-primary)]"
-          : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]"
+          : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]",
       )}
       style={{ height: ROW_HEIGHT }}
     >
@@ -108,7 +108,7 @@ export const CommitRowView = memo(function CommitRowView({
       <div
         className={cn(
           "flex-1 min-w-0 flex items-center gap-2 pl-0",
-          compact ? "pr-3" : "pr-4"
+          compact ? "pr-3" : "pr-4",
         )}
       >
         {/* Refs + message — flexes to fill remaining space */}
@@ -118,7 +118,7 @@ export const CommitRowView = memo(function CommitRowView({
               key={`${r.kind}:${r.name}`}
               className={cn(
                 "px-1 h-[14px] rounded-sm border text-[9px] font-mono leading-none flex items-center shrink-0",
-                badgeClass(r.kind, r.isCurrent)
+                badgeClass(r.kind, r.isCurrent),
               )}
               title={`${r.kind}: ${r.name}`}
             >
@@ -128,7 +128,7 @@ export const CommitRowView = memo(function CommitRowView({
           <span
             className={cn(
               "text-[12px] truncate",
-              selected ? "text-[var(--text-primary)] font-medium" : ""
+              selected ? "text-[var(--text-primary)] font-medium" : "",
             )}
           >
             {row.message}

--- a/src/features/git/components/diff-minimap.tsx
+++ b/src/features/git/components/diff-minimap.tsx
@@ -45,7 +45,10 @@ function rowKind(r: DiffRow): Kind {
  * mutation (no React re-render per scroll event). When the rendered content is
  * taller than the strip, the canvas pans with the editor scroll (Atom-style).
  */
-export const DiffMinimap = memo(function DiffMinimap({ rows, scrollRef }: DiffMinimapProps) {
+export const DiffMinimap = memo(function DiffMinimap({
+  rows,
+  scrollRef,
+}: DiffMinimapProps) {
   const boxRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);
@@ -68,7 +71,10 @@ export const DiffMinimap = memo(function DiffMinimap({ rows, scrollRef }: DiffMi
       // Bound the canvas pixel height to a safe limit; shrink the line height
       // (denser blobs) for very large diffs rather than overflow the canvas.
       const maxLogical = Math.floor(16384 / dpr);
-      const lineH = n * LINE_H > maxLogical ? Math.max(1, Math.floor(maxLogical / n)) : LINE_H;
+      const lineH =
+        n * LINE_H > maxLogical
+          ? Math.max(1, Math.floor(maxLogical / n))
+          : LINE_H;
       const charH = Math.max(1, lineH - 1);
       const contentH = n * lineH;
       geom.current = { lineH, contentH };
@@ -95,14 +101,22 @@ export const DiffMinimap = memo(function DiffMinimap({ rows, scrollRef }: DiffMi
         const side = row.right ?? row.left;
         if (!side) continue;
         // Tabs → 2 cols so indentation reads; runs of non-space become blocks.
-        const text = side.segments.map((s) => s.text).join("").replace(/\t/g, "  ");
+        const text = side.segments
+          .map((s) => s.text)
+          .join("")
+          .replace(/\t/g, "  ");
         ctx.fillStyle = TEXT[kind];
         runRe.lastIndex = 0;
         let m: RegExpExecArray | null;
         while ((m = runRe.exec(text))) {
           const rx = m.index * CHAR_W;
           if (rx >= WIDTH) break;
-          ctx.fillRect(rx, y, Math.min(m[0].length * CHAR_W, WIDTH - rx), charH);
+          ctx.fillRect(
+            rx,
+            y,
+            Math.min(m[0].length * CHAR_W, WIDTH - rx),
+            charH,
+          );
         }
       }
     };

--- a/src/features/git/components/diff-view.tsx
+++ b/src/features/git/components/diff-view.tsx
@@ -72,8 +72,14 @@ export function DiffView({
   }, [allFiles, filters, query, langFilter, sortMode]);
 
   const rows = useMemo(() => buildRows(files, collapsed), [files, collapsed]);
-  const totalAdd = useMemo(() => files.reduce((s, f) => s + f.additions, 0), [files]);
-  const totalDel = useMemo(() => files.reduce((s, f) => s + f.deletions, 0), [files]);
+  const totalAdd = useMemo(
+    () => files.reduce((s, f) => s + f.additions, 0),
+    [files],
+  );
+  const totalDel = useMemo(
+    () => files.reduce((s, f) => s + f.deletions, 0),
+    [files],
+  );
   const anyExpanded = files.some((f) => !collapsed.has(f.path));
 
   const virtualizer = useVirtualizer({
@@ -107,12 +113,18 @@ export function DiffView({
         <div className="flex items-center gap-0.5">
           <button
             onClick={() =>
-              setCollapsed(anyExpanded ? new Set(files.map((f) => f.path)) : new Set())
+              setCollapsed(
+                anyExpanded ? new Set(files.map((f) => f.path)) : new Set(),
+              )
             }
             className="p-1 rounded hover:bg-bg-hover text-text-tertiary cursor-pointer"
             title={anyExpanded ? "Collapse all" : "Expand all"}
           >
-            {anyExpanded ? <FoldVertical size={10} /> : <UnfoldVertical size={10} />}
+            {anyExpanded ? (
+              <FoldVertical size={10} />
+            ) : (
+              <UnfoldVertical size={10} />
+            )}
           </button>
           {onRefresh && (
             <button
@@ -137,16 +149,26 @@ export function DiffView({
           />
         </div>
         <button
-          onClick={() => setSortMode(sortMode === "most-changes" ? "default" : "most-changes")}
+          onClick={() =>
+            setSortMode(
+              sortMode === "most-changes" ? "default" : "most-changes",
+            )
+          }
           className={cn(
             "p-1 rounded transition-colors cursor-pointer",
-            sortMode === "most-changes" ? "text-accent bg-bg-selected" : "text-text-tertiary hover:bg-bg-hover",
+            sortMode === "most-changes"
+              ? "text-accent bg-bg-selected"
+              : "text-text-tertiary hover:bg-bg-hover",
           )}
           title="Sort by most changes"
         >
           <ArrowDownWideNarrow size={11} />
         </button>
-        <LangFilterPopover languages={languages} active={langFilter} onSelect={setLangFilter} />
+        <LangFilterPopover
+          languages={languages}
+          active={langFilter}
+          onSelect={setLangFilter}
+        />
       </div>
     </div>
   ) : null;
@@ -159,10 +181,17 @@ export function DiffView({
     <div className={cn("flex flex-col min-h-0 min-w-0", className)}>
       {header}
       {files.length === 0 ? (
-        <div className="px-3 py-8 text-center text-[11px] text-text-tertiary">{emptyLabel}</div>
+        <div className="px-3 py-8 text-center text-[11px] text-text-tertiary">
+          {emptyLabel}
+        </div>
       ) : (
-        <div ref={scrollRef} className="flex-1 min-h-0 min-w-0 overflow-auto hide-scrollbar px-3 py-2">
-          <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+        <div
+          ref={scrollRef}
+          className="flex-1 min-h-0 min-w-0 overflow-auto hide-scrollbar px-3 py-2"
+        >
+          <div
+            style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          >
             {virtualizer.getVirtualItems().map((vr) => {
               const row = rows[vr.index];
               // No fixed `height` — rows are MEASURED (`measureElement` below),
@@ -237,7 +266,11 @@ export function DiffView({
                     data-index={vr.index}
                     ref={virtualizer.measureElement}
                     // Empty spacer — keep an explicit height so it measures 8px.
-                    style={{ ...base, height: 8, backgroundColor: "var(--diff-context-bg, #0a0a0a)" }}
+                    style={{
+                      ...base,
+                      height: 8,
+                      backgroundColor: "var(--diff-context-bg, #0a0a0a)",
+                    }}
                     className="border-x border-b border-border-default rounded-b-md"
                   />
                 );
@@ -295,7 +328,13 @@ export function DiffView({
 /** Renders a diff line's code text with cheap, synchronous syntax highlighting
  *  (lowlight → `.diff-syntax` themed token spans). Falls back to plain text for
  *  unsupported languages / empty lines so it can never break the row. */
-function DiffCode({ content, language }: { content: string; language: string }) {
+function DiffCode({
+  content,
+  language,
+}: {
+  content: string;
+  language: string;
+}) {
   const tokens = highlightDiffLine(language, content);
   if (!tokens) {
     return (
@@ -330,7 +369,9 @@ function LangFilterPopover({
         <button
           className={cn(
             "p-1 rounded transition-colors cursor-pointer",
-            active ? "text-accent bg-bg-selected" : "text-text-tertiary hover:bg-bg-hover",
+            active
+              ? "text-accent bg-bg-selected"
+              : "text-text-tertiary hover:bg-bg-hover",
           )}
           title="Filter by language"
         >
@@ -380,7 +421,9 @@ function FileListPopover({
   onOpen?: (path: string) => void;
 }) {
   const [search, setSearch] = useState("");
-  const filtered = files.filter((f) => f.path.toLowerCase().includes(search.toLowerCase()));
+  const filtered = files.filter((f) =>
+    f.path.toLowerCase().includes(search.toLowerCase()),
+  );
   return (
     <Popover.Root onOpenChange={() => setSearch("")}>
       <Popover.Trigger asChild>
@@ -425,7 +468,9 @@ function FileListPopover({
               </button>
             ))}
             {filtered.length === 0 && (
-              <div className="px-3 py-2 text-[10px] text-text-tertiary text-center">No files found</div>
+              <div className="px-3 py-2 text-[10px] text-text-tertiary text-center">
+                No files found
+              </div>
             )}
           </div>
         </Popover.Content>

--- a/src/features/git/components/git-diff-panel.tsx
+++ b/src/features/git/components/git-diff-panel.tsx
@@ -19,7 +19,11 @@ import {
   warmDiffHighlightWorker,
   type LineTokens,
 } from "../lib/diff-highlight-cache";
-import { gitDiffStructured, type DiffSide, type DiffRow } from "../lib/git-diff-api";
+import {
+  gitDiffStructured,
+  type DiffSide,
+  type DiffRow,
+} from "../lib/git-diff-api";
 import {
   Panel,
   PanelGroup,
@@ -137,7 +141,9 @@ function CellContent({
         <span
           key={key++}
           className={t.cls ?? undefined}
-          style={e ? { background: emphBg(isLeft), borderRadius: 2 } : undefined}
+          style={
+            e ? { background: emphBg(isLeft), borderRadius: 2 } : undefined
+          }
         >
           {slice}
         </span>,
@@ -296,7 +302,9 @@ export function GitDiffPanel({
   const treePanelRef = useRef<ImperativePanelHandle>(null);
   const [treeCollapsed, setTreeCollapsed] = useState(false);
   const toggleTree = () =>
-    treeCollapsed ? treePanelRef.current?.expand() : treePanelRef.current?.collapse();
+    treeCollapsed
+      ? treePanelRef.current?.expand()
+      : treePanelRef.current?.collapse();
 
   const queryKey = ["git-diff", repoPath, file, staged, commit] as const;
   const { data, isLoading, refetch } = useQuery({
@@ -363,7 +371,8 @@ export function GitDiffPanel({
   const jump = (dir: 1 | -1) => {
     if (changeBlocks.length === 0) return;
     const next =
-      (blockCursorRef.current + dir + changeBlocks.length) % changeBlocks.length;
+      (blockCursorRef.current + dir + changeBlocks.length) %
+      changeBlocks.length;
     blockCursorRef.current = next;
     virtualizer.scrollToIndex(changeBlocks[next], { align: "center" });
   };
@@ -401,7 +410,10 @@ export function GitDiffPanel({
       else if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) dx = e.deltaX;
       else return; // vertical intent → let the native scroller handle it
       const paneInner = (el.clientWidth - CENTER_W) / 2 - LINE_NO_W - CODE_PAD;
-      const maxSx = Math.max(0, Math.ceil(maxLineLen * monoCharWidth() - paneInner));
+      const maxSx = Math.max(
+        0,
+        Math.ceil(maxLineLen * monoCharWidth() - paneInner),
+      );
       if (maxSx <= 0) return;
       e.preventDefault();
       const next = Math.min(maxSx, Math.max(0, scrollXRef.current + dx));
@@ -434,114 +446,141 @@ export function GitDiffPanel({
         onCollapse={() => setTreeCollapsed(true)}
         onExpand={() => setTreeCollapsed(false)}
       >
-        <ChangedFilesTree repoPath={repoPath} staged={staged} currentFile={file} commit={commit} />
+        <ChangedFilesTree
+          repoPath={repoPath}
+          staged={staged}
+          currentFile={file}
+          commit={commit}
+        />
       </Panel>
       <PanelResizeHandle className="w-px bg-border-default hover:bg-accent data-[resize-handle-active]:bg-accent transition-colors cursor-col-resize" />
 
       {/* Main column: toolbar + diff body */}
       <Panel className="min-w-0">
-      <div className="flex h-full min-w-0 flex-col">
-      {/* Toolbar */}
-      <div className="flex h-8 shrink-0 items-center gap-2 border-b border-[var(--border-default)] px-3">
-        <button
-          onClick={toggleTree}
-          className="-ml-1 rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer"
-          title={treeCollapsed ? "Show changed files" : "Hide changed files"}
-        >
-          {treeCollapsed ? <PanelLeftOpen size={12} /> : <PanelLeftClose size={12} />}
-        </button>
-        <FileCode2 size={12} className="shrink-0 text-[var(--text-tertiary)]" />
-        <span className="truncate font-mono text-[11px] text-[var(--text-secondary)]">
-          {file || "Git Diff"}
-        </span>
-        {staged && (
-          <span className="shrink-0 rounded bg-[var(--bg-elevated)] px-1.5 py-px text-[9px] uppercase tracking-wide text-[var(--text-tertiary)]">
-            staged
-          </span>
-        )}
-        {stats && (
-          <span className="shrink-0 font-mono text-[10px]">
-            <span className="text-[var(--status-success)]">+{stats.additions}</span>{" "}
-            <span className="text-[var(--status-error)]">-{stats.deletions}</span>
-          </span>
-        )}
-        {!!file && (
-        <div className="ml-auto flex items-center gap-0.5">
-          <span className="mr-1 font-mono text-[10px] text-[var(--text-tertiary)] tabular-nums">
-            {diffCount} diff{diffCount !== 1 ? "s" : ""}
-          </span>
-          <button
-            onClick={() => jump(-1)}
-            disabled={diffCount === 0}
-            className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30 cursor-pointer"
-            title="Previous change"
-          >
-            <ChevronUp size={12} />
-          </button>
-          <button
-            onClick={() => jump(1)}
-            disabled={diffCount === 0}
-            className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30 cursor-pointer"
-            title="Next change"
-          >
-            <ChevronDown size={12} />
-          </button>
-          <button
-            onClick={() => void refetch()}
-            className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer"
-            title="Refresh"
-          >
-            <RefreshCw size={11} />
-          </button>
-          <button
-            onClick={() => void openFile(`${repoPath}/${file}`)}
-            className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer"
-            title="Open in editor"
-          >
-            <ExternalLink size={11} />
-          </button>
-        </div>
-        )}
-      </div>
-
-      {/* Body */}
-      {!file ? (
-        <div className="flex flex-1 items-center justify-center px-3 text-center text-[11px] text-[var(--text-tertiary)]">
-          Pick a file from the left to view its diff — or choose a commit to browse.
-        </div>
-      ) : isLoading ? (
-        <div className="px-3 py-8 text-center text-[11px] text-[var(--text-tertiary)]">
-          Loading diff…
-        </div>
-      ) : data?.isBinary ? (
-        <div className="px-3 py-8 text-center text-[11px] text-[var(--text-tertiary)]">
-          Binary file — no text diff to show.
-        </div>
-      ) : rows.length === 0 ? (
-        <div className="px-3 py-8 text-center text-[11px] text-[var(--text-tertiary)]">
-          No changes.
-        </div>
-      ) : (
-        <div className="flex min-h-0 flex-1">
-        <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto hide-scrollbar">
-          <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
-            {items.map((vr) => (
-              <DiffRow
-                key={vr.index}
-                row={rows[vr.index]}
-                prev={rows[vr.index - 1]}
-                next={rows[vr.index + 1]}
-                hlMap={hlMap}
-                top={vr.start}
-              />
-            ))}
+        <div className="flex h-full min-w-0 flex-col">
+          {/* Toolbar */}
+          <div className="flex h-8 shrink-0 items-center gap-2 border-b border-[var(--border-default)] px-3">
+            <button
+              onClick={toggleTree}
+              className="-ml-1 rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer"
+              title={
+                treeCollapsed ? "Show changed files" : "Hide changed files"
+              }
+            >
+              {treeCollapsed ? (
+                <PanelLeftOpen size={12} />
+              ) : (
+                <PanelLeftClose size={12} />
+              )}
+            </button>
+            <FileCode2
+              size={12}
+              className="shrink-0 text-[var(--text-tertiary)]"
+            />
+            <span className="truncate font-mono text-[11px] text-[var(--text-secondary)]">
+              {file || "Git Diff"}
+            </span>
+            {staged && (
+              <span className="shrink-0 rounded bg-[var(--bg-elevated)] px-1.5 py-px text-[9px] uppercase tracking-wide text-[var(--text-tertiary)]">
+                staged
+              </span>
+            )}
+            {stats && (
+              <span className="shrink-0 font-mono text-[10px]">
+                <span className="text-[var(--status-success)]">
+                  +{stats.additions}
+                </span>{" "}
+                <span className="text-[var(--status-error)]">
+                  -{stats.deletions}
+                </span>
+              </span>
+            )}
+            {!!file && (
+              <div className="ml-auto flex items-center gap-0.5">
+                <span className="mr-1 font-mono text-[10px] text-[var(--text-tertiary)] tabular-nums">
+                  {diffCount} diff{diffCount !== 1 ? "s" : ""}
+                </span>
+                <button
+                  onClick={() => jump(-1)}
+                  disabled={diffCount === 0}
+                  className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30 cursor-pointer"
+                  title="Previous change"
+                >
+                  <ChevronUp size={12} />
+                </button>
+                <button
+                  onClick={() => jump(1)}
+                  disabled={diffCount === 0}
+                  className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-30 cursor-pointer"
+                  title="Next change"
+                >
+                  <ChevronDown size={12} />
+                </button>
+                <button
+                  onClick={() => void refetch()}
+                  className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer"
+                  title="Refresh"
+                >
+                  <RefreshCw size={11} />
+                </button>
+                <button
+                  onClick={() => void openFile(`${repoPath}/${file}`)}
+                  className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer"
+                  title="Open in editor"
+                >
+                  <ExternalLink size={11} />
+                </button>
+              </div>
+            )}
           </div>
+
+          {/* Body */}
+          {!file ? (
+            <div className="flex flex-1 items-center justify-center px-3 text-center text-[11px] text-[var(--text-tertiary)]">
+              Pick a file from the left to view its diff — or choose a commit to
+              browse.
+            </div>
+          ) : isLoading ? (
+            <div className="px-3 py-8 text-center text-[11px] text-[var(--text-tertiary)]">
+              Loading diff…
+            </div>
+          ) : data?.isBinary ? (
+            <div className="px-3 py-8 text-center text-[11px] text-[var(--text-tertiary)]">
+              Binary file — no text diff to show.
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="px-3 py-8 text-center text-[11px] text-[var(--text-tertiary)]">
+              No changes.
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1">
+              <div
+                ref={scrollRef}
+                className="min-h-0 flex-1 overflow-auto hide-scrollbar"
+              >
+                <div
+                  style={{
+                    height: virtualizer.getTotalSize(),
+                    position: "relative",
+                  }}
+                >
+                  {items.map((vr) => (
+                    <DiffRow
+                      key={vr.index}
+                      row={rows[vr.index]}
+                      prev={rows[vr.index - 1]}
+                      next={rows[vr.index + 1]}
+                      hlMap={hlMap}
+                      top={vr.start}
+                    />
+                  ))}
+                </div>
+              </div>
+              {/* Right: change minimap synced to the diff scroll position */}
+              <DiffMinimap rows={rows} scrollRef={scrollRef} />
+            </div>
+          )}
         </div>
-        {/* Right: change minimap synced to the diff scroll position */}
-        <DiffMinimap rows={rows} scrollRef={scrollRef} />
-        </div>
-      )}
-      </div>
       </Panel>
     </PanelGroup>
   );

--- a/src/features/git/components/git-graph-panel.tsx
+++ b/src/features/git/components/git-graph-panel.tsx
@@ -11,21 +11,13 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import * as Dialog from "@radix-ui/react-dialog";
-import {
-  RefreshCw,
-  GitBranch,
-  Maximize2,
-  Minimize2,
-} from "lucide-react";
+import { RefreshCw, GitBranch, Maximize2, Minimize2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useGitStore } from "@/features/git/stores/git-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
 import { CommitRowView } from "./commit-node";
-import {
-  ROW_HEIGHT,
-  type BuiltGraph,
-} from "../lib/git-graph";
+import { ROW_HEIGHT, type BuiltGraph } from "../lib/git-graph";
 
 const DEFAULT_LIMIT = 1000;
 
@@ -77,7 +69,9 @@ export function GitGraphPanel() {
     let unlisten: (() => void) | null = null;
     listen("atlas:git-changed", () => {
       if (cancelled) return;
-      queryClient.invalidateQueries({ queryKey: ["git-graph-signature", path] });
+      queryClient.invalidateQueries({
+        queryKey: ["git-graph-signature", path],
+      });
     }).then((un) => {
       if (cancelled) un();
       else unlisten = un;
@@ -237,7 +231,7 @@ function GraphView({
             onClick={onRefresh}
             className={cn(
               "p-1 rounded hover:bg-bg-hover text-text-tertiary hover:text-text-primary transition-colors cursor-pointer",
-              refreshing && "animate-spin"
+              refreshing && "animate-spin",
             )}
             title="Refresh"
           >
@@ -253,13 +247,19 @@ function GraphView({
           className="absolute inset-0 overflow-auto hide-scrollbar"
         >
           {isLoading && (
-            <div className="px-3 py-3 text-[11px] text-text-tertiary">Loading…</div>
+            <div className="px-3 py-3 text-[11px] text-text-tertiary">
+              Loading…
+            </div>
           )}
           {rows.length === 0 && !isLoading && (
-            <div className="px-3 py-3 text-[11px] text-text-tertiary">No commits.</div>
+            <div className="px-3 py-3 text-[11px] text-text-tertiary">
+              No commits.
+            </div>
           )}
           {rows.length > 0 && (
-            <div style={{ height: totalSize, width: "100%", position: "relative" }}>
+            <div
+              style={{ height: totalSize, width: "100%", position: "relative" }}
+            >
               {items.map((v) => {
                 const row = rows[v.index];
                 return (

--- a/src/features/git/components/git-manager/branch-switcher.tsx
+++ b/src/features/git/components/git-manager/branch-switcher.tsx
@@ -29,7 +29,17 @@ export function BranchSwitcher() {
   };
 
   return (
-    <Popover.Root open={open} onOpenChange={(o) => { setOpen(o); if (!o) { setQuery(""); setCreating(false); setNewName(""); } }}>
+    <Popover.Root
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) {
+          setQuery("");
+          setCreating(false);
+          setNewName("");
+        }
+      }}
+    >
       <Popover.Trigger asChild>
         <button
           className="flex items-center gap-1.5 h-6 px-2 rounded text-[11px] font-medium text-text-secondary hover:text-text-primary hover:bg-bg-hover transition-colors cursor-pointer min-w-0"
@@ -73,12 +83,20 @@ export function BranchSwitcher() {
                   // Remote-tracking refs (origin/foo) must be checked out by their
                   // short name so git creates a local tracking branch instead of
                   // landing in detached HEAD.
-                  const target = b.isRemote ? b.name.slice(b.name.indexOf("/") + 1) : b.name;
+                  const target = b.isRemote
+                    ? b.name.slice(b.name.indexOf("/") + 1)
+                    : b.name;
                   void run(() => actions.checkout(target));
                   setOpen(false);
                 }}
               >
-                <Check size={12} className={cn("shrink-0", b.isCurrent ? "text-accent" : "opacity-0")} />
+                <Check
+                  size={12}
+                  className={cn(
+                    "shrink-0",
+                    b.isCurrent ? "text-accent" : "opacity-0",
+                  )}
+                />
                 <span className="truncate flex-1 font-mono">{b.name}</span>
                 {b.isRemote && (
                   <span className="shrink-0 text-[8px] font-mono uppercase tracking-wide text-text-tertiary border border-border-default rounded px-1">
@@ -87,7 +105,8 @@ export function BranchSwitcher() {
                 )}
                 {(b.ahead > 0 || b.behind > 0) && (
                   <span className="shrink-0 text-[9px] font-mono text-text-tertiary">
-                    {b.ahead > 0 && `↑${b.ahead}`} {b.behind > 0 && `↓${b.behind}`}
+                    {b.ahead > 0 && `↑${b.ahead}`}{" "}
+                    {b.behind > 0 && `↓${b.behind}`}
                   </span>
                 )}
                 {!b.isCurrent && !b.isRemote && (
@@ -117,7 +136,9 @@ export function BranchSwitcher() {
               </div>
             ))}
             {filtered.length === 0 && (
-              <div className="px-3 py-2 text-[10px] text-text-tertiary text-center">No branches</div>
+              <div className="px-3 py-2 text-[10px] text-text-tertiary text-center">
+                No branches
+              </div>
             )}
           </div>
 

--- a/src/features/git/components/git-manager/changes-view.tsx
+++ b/src/features/git/components/git-manager/changes-view.tsx
@@ -31,7 +31,8 @@ function statusBadge(status: string): { letter: string; cls: string } {
   if (s.includes("delet")) return { letter: "D", cls: "text-error" };
   if (s.includes("add") || s.includes("new") || s.includes("untrack"))
     return { letter: "A", cls: "text-success" };
-  if (s.includes("renam")) return { letter: "R", cls: "text-[var(--status-info)]" };
+  if (s.includes("renam"))
+    return { letter: "R", cls: "text-[var(--status-info)]" };
   if (s.includes("conflict") || s.includes("unmerg"))
     return { letter: "!", cls: "text-error" };
   return { letter: "M", cls: "text-[var(--status-warning)]" };
@@ -67,12 +68,19 @@ function FileRow({
         selected ? "bg-bg-selected" : "hover:bg-bg-hover",
       )}
     >
-      <span className={cn("shrink-0 w-3 text-center font-mono text-[10px] font-semibold", badge.cls)}>
+      <span
+        className={cn(
+          "shrink-0 w-3 text-center font-mono text-[10px] font-semibold",
+          badge.cls,
+        )}
+      >
         {badge.letter}
       </span>
       <span className="truncate flex-1 min-w-0 font-mono">
         {dir && <span className="text-text-tertiary">{dir}</span>}
-        <span className="text-text-secondary group-hover:text-text-primary">{name}</span>
+        <span className="text-text-secondary group-hover:text-text-primary">
+          {name}
+        </span>
       </span>
       <div className="flex items-center opacity-0 group-hover:opacity-100 shrink-0">
         {onOpenDiff && (
@@ -174,14 +182,20 @@ export function ChangesView() {
   // untracked files have no HEAD to restore to, so reverting deletes them:
   // text additions delete directly; binary additions (e.g. `.png`, no diff to
   // review) ask for confirmation first since the bytes can't be recovered.
-  const [confirmDelete, setConfirmDelete] = useState<GitFileStatus | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<GitFileStatus | null>(
+    null,
+  );
   // Bulk revert of every unstaged change — discards tracked edits AND deletes
   // added files, so it always confirms first (unlike "Stage all").
   const [confirmRevertAll, setConfirmRevertAll] = useState(false);
   const revertAll = () =>
     run(async () => {
-      const tracked = unstaged.filter((f) => !isAddedStatus(f.status)).map((f) => f.path);
-      const added = unstaged.filter((f) => isAddedStatus(f.status)).map((f) => f.path);
+      const tracked = unstaged
+        .filter((f) => !isAddedStatus(f.status))
+        .map((f) => f.path);
+      const added = unstaged
+        .filter((f) => isAddedStatus(f.status))
+        .map((f) => f.path);
       if (tracked.length) await actions.discard(tracked);
       if (added.length) await actions.discardAdded(added);
     });
@@ -199,7 +213,11 @@ export function ChangesView() {
   const doCommit = () =>
     run(async () => {
       if (!summary.trim()) return;
-      await actions.commit(summary.trim(), description.trim() || undefined, amend);
+      await actions.commit(
+        summary.trim(),
+        description.trim() || undefined,
+        amend,
+      );
       setSummary("");
       setDescription("");
       setAmend(false);
@@ -209,7 +227,14 @@ export function ChangesView() {
   const openFile = (p: string) => {
     if (!currentProject) return;
     const full = `${currentProject.path}/${p}`;
-    addTab({ id: `editor-${full}`, type: "editor", title: p.split("/").pop() ?? p, closable: true, dirty: false, data: { filePath: full } });
+    addTab({
+      id: `editor-${full}`,
+      type: "editor",
+      title: p.split("/").pop() ?? p,
+      closable: true,
+      dirty: false,
+      data: { filePath: full },
+    });
   };
 
   const inProgressLabel = inProgress
@@ -236,9 +261,15 @@ export function ChangesView() {
     <div className="h-full flex flex-col min-w-0">
       {inProgressLabel && (
         <div className="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-[var(--status-warning)]/30 bg-[var(--status-warning)]/10 text-[11px]">
-          <AlertTriangle size={12} className="text-[var(--status-warning)] shrink-0" />
+          <AlertTriangle
+            size={12}
+            className="text-[var(--status-warning)] shrink-0"
+          />
           <span className="flex-1 text-text-secondary">
-            Resolving <span className="font-medium text-text-primary">{inProgressLabel}</span>
+            Resolving{" "}
+            <span className="font-medium text-text-primary">
+              {inProgressLabel}
+            </span>
           </span>
           <button
             onClick={() => run(() => actions.opControl(opKind, "continue"))}
@@ -265,7 +296,9 @@ export function ChangesView() {
                 Staged ({staged.length})
               </span>
               <button
-                onClick={() => run(() => actions.unstageFiles(staged.map((f) => f.path)))}
+                onClick={() =>
+                  run(() => actions.unstageFiles(staged.map((f) => f.path)))
+                }
                 className="text-[10px] text-text-tertiary hover:text-text-primary"
               >
                 Unstage all
@@ -276,10 +309,16 @@ export function ChangesView() {
                 key={f.path}
                 file={f}
                 selected={selected === f.path}
-                onSelect={() => setSelected((cur) => (cur === f.path ? null : f.path))}
+                onSelect={() =>
+                  setSelected((cur) => (cur === f.path ? null : f.path))
+                }
                 action="unstage"
                 onAction={() => run(() => actions.unstageFiles([f.path]))}
-                onOpenDiff={repoPath ? () => openGitDiff(repoPath, f.path, true) : undefined}
+                onOpenDiff={
+                  repoPath
+                    ? () => openGitDiff(repoPath, f.path, true)
+                    : undefined
+                }
                 onOpenInEditor={() => openFile(f.path)}
               />
             ))}
@@ -295,7 +334,9 @@ export function ChangesView() {
             {unstaged.length > 0 && (
               <div className="flex items-center gap-1.5">
                 <button
-                  onClick={() => run(() => actions.stageFiles(unstaged.map((f) => f.path)))}
+                  onClick={() =>
+                    run(() => actions.stageFiles(unstaged.map((f) => f.path)))
+                  }
                   className="text-[10px] text-text-tertiary hover:text-text-primary"
                 >
                   Stage all
@@ -316,11 +357,17 @@ export function ChangesView() {
               key={f.path}
               file={f}
               selected={selected === f.path}
-              onSelect={() => setSelected((cur) => (cur === f.path ? null : f.path))}
+              onSelect={() =>
+                setSelected((cur) => (cur === f.path ? null : f.path))
+              }
               action="stage"
               onAction={() => run(() => actions.stageFiles([f.path]))}
               onDiscard={() => handleRevert(f)}
-              onOpenDiff={repoPath ? () => openGitDiff(repoPath, f.path, false) : undefined}
+              onOpenDiff={
+                repoPath
+                  ? () => openGitDiff(repoPath, f.path, false)
+                  : undefined
+              }
               onOpenInEditor={() => openFile(f.path)}
             />
           ))}
@@ -403,7 +450,8 @@ export function ChangesView() {
         name={confirmDelete?.path.split("/").pop() ?? ""}
         isDir={false}
         onConfirm={() => {
-          if (confirmDelete) void run(() => actions.discardAdded([confirmDelete.path]));
+          if (confirmDelete)
+            void run(() => actions.discardAdded([confirmDelete.path]));
           setConfirmDelete(null);
         }}
         onOpenChange={(open) => {
@@ -421,9 +469,11 @@ export function ChangesView() {
           <>
             All{" "}
             <span className="font-mono text-text-primary">
-              {unstaged.length} unstaged change{unstaged.length === 1 ? "" : "s"}
+              {unstaged.length} unstaged change
+              {unstaged.length === 1 ? "" : "s"}
             </span>{" "}
-            will be discarded and any newly added files deleted. This can't be undone.
+            will be discarded and any newly added files deleted. This can't be
+            undone.
           </>
         }
         onConfirm={() => {

--- a/src/features/git/components/git-manager/git-manager-panel.tsx
+++ b/src/features/git/components/git-manager/git-manager-panel.tsx
@@ -168,7 +168,9 @@ function ToolbarBtn({
       {busy ? <Loader2 size={12} className="animate-spin" /> : icon}
       {label && <span>{label}</span>}
       {badge !== undefined && (
-        <span className="font-mono text-[9px] text-text-secondary">{badge}</span>
+        <span className="font-mono text-[9px] text-text-secondary">
+          {badge}
+        </span>
       )}
     </button>
   );

--- a/src/features/git/components/git-manager/history-view.tsx
+++ b/src/features/git/components/git-manager/history-view.tsx
@@ -54,18 +54,26 @@ export function HistoryView() {
             >
               <ArrowLeft size={13} />
             </button>
-            <span className="font-mono text-[11px] text-text-secondary">{selected.shortHash}</span>
+            <span className="font-mono text-[11px] text-text-secondary">
+              {selected.shortHash}
+            </span>
             <div className="ml-auto flex items-center gap-0.5">
               <button
                 onClick={() => {
-                  void navigator.clipboard.writeText(selected.hash).catch(() => {});
+                  void navigator.clipboard
+                    .writeText(selected.hash)
+                    .catch(() => {});
                   setCopied(true);
                   setTimeout(() => setCopied(false), 1200);
                 }}
                 className="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-bg-hover"
                 title="Copy SHA"
               >
-                {copied ? <Check size={12} className="text-success" /> : <Copy size={12} />}
+                {copied ? (
+                  <Check size={12} className="text-success" />
+                ) : (
+                  <Copy size={12} />
+                )}
               </button>
               <button
                 onClick={() => run(() => actions.cherryPick(selected.hash))}
@@ -81,13 +89,20 @@ export function HistoryView() {
               >
                 <Undo2 size={12} />
               </button>
-              <ResetMenu onReset={(mode) => run(() => actions.reset(selected.hash, mode))} />
+              <ResetMenu
+                onReset={(mode) =>
+                  run(() => actions.reset(selected.hash, mode))
+                }
+              />
               <button
                 onClick={() => {
-                  useReviewStore.getState().actions.requestReview("commit", selected.hash);
+                  useReviewStore
+                    .getState()
+                    .actions.requestReview("commit", selected.hash);
                   const layout = useLayoutStore.getState();
                   layout.actions.setRightSection("review-agents");
-                  if (!layout.rightPanel.visible) layout.actions.toggleRightPanel();
+                  if (!layout.rightPanel.visible)
+                    layout.actions.toggleRightPanel();
                 }}
                 className="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-bg-hover"
                 title="Review this commit with AI"
@@ -113,7 +128,9 @@ export function HistoryView() {
                 className="w-full h-7 rounded border border-border-default bg-bg-input px-2 text-[11px] font-mono text-text-primary outline-none focus:border-border-focus"
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && tagName.trim()) {
-                    void run(() => actions.createTag(tagName.trim(), selected.hash));
+                    void run(() =>
+                      actions.createTag(tagName.trim(), selected.hash),
+                    );
                     setTagging(false);
                     setTagName("");
                   } else if (e.key === "Escape") {
@@ -125,7 +142,9 @@ export function HistoryView() {
             </div>
           )}
           <div className="px-3 pb-2">
-            <div className="text-[12px] text-text-primary font-medium">{selected.subject}</div>
+            <div className="text-[12px] text-text-primary font-medium">
+              {selected.subject}
+            </div>
             {selected.body && (
               <pre className="mt-1 max-h-32 overflow-y-auto hide-scrollbar whitespace-pre-wrap break-words font-sans text-[11px] text-text-tertiary">
                 {selected.body}
@@ -137,7 +156,11 @@ export function HistoryView() {
             <CommitSessions sha={selected.hash} />
           </div>
         </div>
-        <DiffView diff={selected.diff} className="flex-1 min-h-0" emptyLabel="No file changes" />
+        <DiffView
+          diff={selected.diff}
+          className="flex-1 min-h-0"
+          emptyLabel="No file changes"
+        />
       </div>
     );
   }
@@ -146,7 +169,9 @@ export function HistoryView() {
   return (
     <div className="h-full overflow-y-auto hide-scrollbar">
       {log.length === 0 ? (
-        <div className="px-3 py-8 text-center text-[11px] text-text-tertiary">No history</div>
+        <div className="px-3 py-8 text-center text-[11px] text-text-tertiary">
+          No history
+        </div>
       ) : (
         log.map((c) => (
           <button
@@ -167,9 +192,17 @@ export function HistoryView() {
   );
 }
 
-function ResetMenu({ onReset }: { onReset: (mode: "soft" | "mixed" | "hard") => void }) {
+function ResetMenu({
+  onReset,
+}: {
+  onReset: (mode: "soft" | "mixed" | "hard") => void;
+}) {
   const [open, setOpen] = useState(false);
-  const item = (mode: "soft" | "mixed" | "hard", label: string, desc: string) => (
+  const item = (
+    mode: "soft" | "mixed" | "hard",
+    label: string,
+    desc: string,
+  ) => (
     <button
       onClick={() => {
         onReset(mode);
@@ -185,7 +218,12 @@ function ResetMenu({ onReset }: { onReset: (mode: "soft" | "mixed" | "hard") => 
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <button
-          className={cn("p-1 rounded hover:bg-bg-hover", open ? "text-text-primary" : "text-text-tertiary hover:text-text-primary")}
+          className={cn(
+            "p-1 rounded hover:bg-bg-hover",
+            open
+              ? "text-text-primary"
+              : "text-text-tertiary hover:text-text-primary",
+          )}
           title="Reset current branch to this commit"
         >
           <RotateCcw size={12} />
@@ -237,7 +275,10 @@ function CommitSessions({ sha }: { sha: string }) {
     if (!repoPath) return;
     let cancelled = false;
     setSessions([]);
-    invoke<CommitSession[]>("capture_commit_sessions", { projectPath: repoPath, commitSha: sha })
+    invoke<CommitSession[]>("capture_commit_sessions", {
+      projectPath: repoPath,
+      commitSha: sha,
+    })
       .then((found) => {
         if (!cancelled) setSessions(found);
       })
@@ -257,8 +298,21 @@ function CommitSessions({ sha }: { sha: string }) {
     // The sha travels with the request so the Session lands on this commit's
     // Checkpoint rather than at the top of a conversation that may have
     // produced several.
-    useArtifactsStore.getState().actions.openSession({ sessionId, projectPath: repoPath, commitSha: sha });
-    addTab({ id: "artifacts", type: "artifacts", title: "Timeline", closable: true, dirty: false, data: {} });
+    useArtifactsStore
+      .getState()
+      .actions.openSession({
+        sessionId,
+        projectPath: repoPath,
+        commitSha: sha,
+      });
+    addTab({
+      id: "artifacts",
+      type: "artifacts",
+      title: "Timeline",
+      closable: true,
+      dirty: false,
+      data: {},
+    });
   };
 
   return (
@@ -274,13 +328,17 @@ function CommitSessions({ sha }: { sha: string }) {
           title="Open this Session in the Timeline"
         >
           <div className="flex items-start gap-1.5">
-            <Sparkles size={11} className="mt-0.5 shrink-0 text-text-tertiary" />
+            <Sparkles
+              size={11}
+              className="mt-0.5 shrink-0 text-text-tertiary"
+            />
             <span className="text-[11px] text-text-secondary group-hover:text-text-primary line-clamp-2">
               {s.title ?? "Untitled session"}
             </span>
           </div>
           <div className="mt-0.5 pl-[18px] text-[9px] text-text-tertiary truncate">
-            {s.messageCount} message{s.messageCount === 1 ? "" : "s"} · {s.toolCallCount} tool call
+            {s.messageCount} message{s.messageCount === 1 ? "" : "s"} ·{" "}
+            {s.toolCallCount} tool call
             {s.toolCallCount === 1 ? "" : "s"}
             {s.files.length > 0 && ` · ${s.files.join(", ")}`}
           </div>

--- a/src/features/git/components/git-manager/merge-branch-dialog.tsx
+++ b/src/features/git/components/git-manager/merge-branch-dialog.tsx
@@ -99,7 +99,9 @@ export function MergeBranchDialog({
       // MERGE_HEAD is set), so an error here usually means "conflicts to
       // resolve" rather than an outright failure.
       if (wasConflicts) {
-        toast.warning(`Merged ${selected} with conflicts — resolve them to finish`);
+        toast.warning(
+          `Merged ${selected} with conflicts — resolve them to finish`,
+        );
       } else {
         toast.error(String(e));
       }
@@ -134,7 +136,9 @@ export function MergeBranchDialog({
             </Dialog.Title>
             <Dialog.Description className="text-[11px] text-text-tertiary mt-1">
               Choose a branch to merge into{" "}
-              <span className="font-mono">{branch || "the current branch"}</span>
+              <span className="font-mono">
+                {branch || "the current branch"}
+              </span>
               .
             </Dialog.Description>
           </div>
@@ -170,7 +174,10 @@ export function MergeBranchDialog({
                 >
                   <Check
                     size={12}
-                    className={cn("shrink-0", isSel ? "text-accent" : "opacity-0")}
+                    className={cn(
+                      "shrink-0",
+                      isSel ? "text-accent" : "opacity-0",
+                    )}
                   />
                   <span className="truncate flex-1 font-mono">{b.name}</span>
                   {b.isRemote && (

--- a/src/features/git/components/git-manager/stashes-view.tsx
+++ b/src/features/git/components/git-manager/stashes-view.tsx
@@ -35,14 +35,18 @@ export function StashesView() {
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto hide-scrollbar">
         {stashes.length === 0 ? (
-          <div className="px-3 py-8 text-center text-[11px] text-text-tertiary">No stashes</div>
+          <div className="px-3 py-8 text-center text-[11px] text-text-tertiary">
+            No stashes
+          </div>
         ) : (
           stashes.map((s) => (
             <div
               key={s.index}
               className="group flex flex-col gap-1 px-3 py-2 border-b border-border-subtle"
             >
-              <span className="text-[11px] text-text-secondary truncate">{s.message}</span>
+              <span className="text-[11px] text-text-secondary truncate">
+                {s.message}
+              </span>
               <div className="flex items-center gap-2">
                 <span className="text-[9px] font-mono text-text-tertiary flex-1">
                   stash@{`{${s.index}}`} {s.branch && `· ${s.branch}`}

--- a/src/features/git/lib/diff-highlight-cache.ts
+++ b/src/features/git/lib/diff-highlight-cache.ts
@@ -101,7 +101,10 @@ function fallbackTokenize(
     let i = 0;
     const CHUNK = 200;
     const w2 = window as Window & {
-      requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => number;
+      requestIdleCallback?: (
+        cb: () => void,
+        opts?: { timeout?: number },
+      ) => number;
     };
     const step = () => {
       const end = Math.min(unique.length, i + CHUNK);

--- a/src/features/git/lib/diff-highlight-core.ts
+++ b/src/features/git/lib/diff-highlight-core.ts
@@ -67,14 +67,20 @@ function lowlight(): ReturnType<typeof createLowlight> {
  * token runs, or `null` when the id is empty, the line is empty/too long, or
  * highlighting produced nothing worth coloring — the caller renders raw text.
  */
-export function tokenizeLine(hljsId: string, content: string): DiffToken[] | null {
+export function tokenizeLine(
+  hljsId: string,
+  content: string,
+): DiffToken[] | null {
   if (!hljsId || !content || content.length > MAX_LEN) return null;
   try {
     const tree = lowlight().highlight(hljsId, content) as Root;
     const tokens = flatten(tree.children, null);
     // Single unclassed run == nothing to highlight; let the caller fast-path to
     // plain text (and skip the wrapper class).
-    if (tokens.length === 0 || (tokens.length === 1 && tokens[0].cls === null)) {
+    if (
+      tokens.length === 0 ||
+      (tokens.length === 1 && tokens[0].cls === null)
+    ) {
       return null;
     }
     return tokens;

--- a/src/features/git/lib/diff-highlight.ts
+++ b/src/features/git/lib/diff-highlight.ts
@@ -6,7 +6,11 @@
 //
 // See `diff-highlight-core.ts` for the per-line (not per-file) tradeoff.
 
-import { hljsIdForLanguage, tokenizeLine, type DiffToken } from "./diff-highlight-core";
+import {
+  hljsIdForLanguage,
+  tokenizeLine,
+  type DiffToken,
+} from "./diff-highlight-core";
 
 export type { DiffToken };
 

--- a/src/features/git/lib/diff.ts
+++ b/src/features/git/lib/diff.ts
@@ -26,12 +26,34 @@ export interface DiffLine {
 export function getLanguage(path: string): string {
   const ext = path.split(".").pop()?.toLowerCase() ?? "";
   const map: Record<string, string> = {
-    ts: "TypeScript", tsx: "TypeScript", js: "JavaScript", jsx: "JavaScript",
-    py: "Python", rs: "Rust", go: "Go", rb: "Ruby", java: "Java",
-    c: "C", h: "C", cpp: "C++", hpp: "C++", swift: "Swift", kt: "Kotlin",
-    css: "CSS", scss: "CSS", html: "HTML", json: "JSON", toml: "TOML",
-    yaml: "YAML", yml: "YAML", md: "Markdown", mdx: "Markdown",
-    sh: "Shell", sql: "SQL", xml: "XML", svg: "XML",
+    ts: "TypeScript",
+    tsx: "TypeScript",
+    js: "JavaScript",
+    jsx: "JavaScript",
+    py: "Python",
+    rs: "Rust",
+    go: "Go",
+    rb: "Ruby",
+    java: "Java",
+    c: "C",
+    h: "C",
+    cpp: "C++",
+    hpp: "C++",
+    swift: "Swift",
+    kt: "Kotlin",
+    css: "CSS",
+    scss: "CSS",
+    html: "HTML",
+    json: "JSON",
+    toml: "TOML",
+    yaml: "YAML",
+    yml: "YAML",
+    md: "Markdown",
+    mdx: "Markdown",
+    sh: "Shell",
+    sql: "SQL",
+    xml: "XML",
+    svg: "XML",
   };
   return map[ext] ?? ext.toUpperCase();
 }
@@ -45,10 +67,12 @@ export function parseDiff(raw: string): DiffFile[] {
     const lines = section.split("\n");
     const headerMatch = lines[0]?.match(/a\/(.+?) b\/(.+)/);
     const path = headerMatch?.[2] ?? headerMatch?.[1] ?? "unknown";
-    let additions = 0, deletions = 0;
+    let additions = 0,
+      deletions = 0;
     const hunks: DiffHunk[] = [];
     let currentHunk: DiffHunk | null = null;
-    let oldLine = 0, newLine = 0;
+    let oldLine = 0,
+      newLine = 0;
 
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i];
@@ -56,16 +80,46 @@ export function parseDiff(raw: string): DiffFile[] {
       if (hunkMatch) {
         oldLine = parseInt(hunkMatch[1], 10);
         newLine = parseInt(hunkMatch[2], 10);
-        currentHunk = { header: line, oldStart: oldLine, newStart: newLine, lines: [] };
+        currentHunk = {
+          header: line,
+          oldStart: oldLine,
+          newStart: newLine,
+          lines: [],
+        };
         hunks.push(currentHunk);
         continue;
       }
       if (!currentHunk) continue;
-      if (line.startsWith("+")) { currentHunk.lines.push({ type: "add", content: line.slice(1), newLine: newLine++ }); additions++; }
-      else if (line.startsWith("-")) { currentHunk.lines.push({ type: "remove", content: line.slice(1), oldLine: oldLine++ }); deletions++; }
-      else if (line.startsWith(" ")) { currentHunk.lines.push({ type: "context", content: line.slice(1), oldLine: oldLine++, newLine: newLine++ }); }
+      if (line.startsWith("+")) {
+        currentHunk.lines.push({
+          type: "add",
+          content: line.slice(1),
+          newLine: newLine++,
+        });
+        additions++;
+      } else if (line.startsWith("-")) {
+        currentHunk.lines.push({
+          type: "remove",
+          content: line.slice(1),
+          oldLine: oldLine++,
+        });
+        deletions++;
+      } else if (line.startsWith(" ")) {
+        currentHunk.lines.push({
+          type: "context",
+          content: line.slice(1),
+          oldLine: oldLine++,
+          newLine: newLine++,
+        });
+      }
     }
-    files.push({ path, additions, deletions, hunks, language: getLanguage(path) });
+    files.push({
+      path,
+      additions,
+      deletions,
+      hunks,
+      language: getLanguage(path),
+    });
   }
   return files;
 }
@@ -75,14 +129,18 @@ export type VirtualRow =
   | { kind: "diff-line"; line: DiffLine; fileIndex: number }
   | { kind: "file-footer"; fileIndex: number };
 
-export function buildRows(files: DiffFile[], collapsedFiles: Set<string>): VirtualRow[] {
+export function buildRows(
+  files: DiffFile[],
+  collapsedFiles: Set<string>,
+): VirtualRow[] {
   const rows: VirtualRow[] = [];
   for (let fi = 0; fi < files.length; fi++) {
     const file = files[fi];
     rows.push({ kind: "file-header", file, fileIndex: fi });
     if (collapsedFiles.has(file.path)) continue;
     for (const hunk of file.hunks) {
-      for (const line of hunk.lines) rows.push({ kind: "diff-line", line, fileIndex: fi });
+      for (const line of hunk.lines)
+        rows.push({ kind: "diff-line", line, fileIndex: fi });
     }
     rows.push({ kind: "file-footer", fileIndex: fi });
   }

--- a/src/features/git/lib/git-blame-api.ts
+++ b/src/features/git/lib/git-blame-api.ts
@@ -16,6 +16,9 @@ export interface BlameLine {
   committed: boolean;
 }
 
-export function gitBlameFile(repoPath: string, file: string): Promise<BlameLine[]> {
+export function gitBlameFile(
+  repoPath: string,
+  file: string,
+): Promise<BlameLine[]> {
   return invoke<BlameLine[]>("git_blame_file", { path: repoPath, file });
 }

--- a/src/features/git/lib/git-diff-api.ts
+++ b/src/features/git/lib/git-diff-api.ts
@@ -60,8 +60,14 @@ export interface CommitFile {
 }
 
 /** Files changed by a single commit (for the diff viewer's commit browser). */
-export function gitCommitChangedFiles(repoPath: string, sha: string): Promise<CommitFile[]> {
-  return invoke<CommitFile[]>("git_commit_changed_files", { path: repoPath, sha });
+export function gitCommitChangedFiles(
+  repoPath: string,
+  sha: string,
+): Promise<CommitFile[]> {
+  return invoke<CommitFile[]>("git_commit_changed_files", {
+    path: repoPath,
+    sha,
+  });
 }
 
 export function gitDiffLineStatus(
@@ -69,7 +75,11 @@ export function gitDiffLineStatus(
   file: string,
   staged: boolean,
 ): Promise<DiffLineStatus> {
-  return invoke<DiffLineStatus>("git_diff_line_status", { path: repoPath, file, staged });
+  return invoke<DiffLineStatus>("git_diff_line_status", {
+    path: repoPath,
+    file,
+    staged,
+  });
 }
 
 /**

--- a/src/features/git/stores/git-store.ts
+++ b/src/features/git/stores/git-store.ts
@@ -203,7 +203,11 @@ interface GitActions {
     discard: (paths: string[]) => Promise<void>;
     /** Revert ADDED files by deleting them (no HEAD to restore to). */
     discardAdded: (paths: string[]) => Promise<void>;
-    commit: (summary: string, description?: string, amend?: boolean) => Promise<void>;
+    commit: (
+      summary: string,
+      description?: string,
+      amend?: boolean,
+    ) => Promise<void>;
     fetch: () => Promise<void>;
     pull: (rebase: boolean) => Promise<void>;
     push: (forceWithLease?: boolean, followTags?: boolean) => Promise<void>;
@@ -217,7 +221,11 @@ interface GitActions {
     reset: (target: string, mode: "soft" | "mixed" | "hard") => Promise<void>;
     revert: (sha: string) => Promise<void>;
     cherryPick: (sha: string) => Promise<void>;
-    createTag: (name: string, target?: string, message?: string) => Promise<void>;
+    createTag: (
+      name: string,
+      target?: string,
+      message?: string,
+    ) => Promise<void>;
     deleteTag: (name: string) => Promise<void>;
     opControl: (
       kind: "merge" | "rebase" | "cherry-pick" | "revert",
@@ -308,7 +316,10 @@ export const useGitStore = createSelectors(
           },
           loadLog: async (path) => {
             try {
-              const entries = await invoke<GitLogEntry[]>("git_log", { path, limit: 100 });
+              const entries = await invoke<GitLogEntry[]>("git_log", {
+                path,
+                limit: 100,
+              });
               set((s) => {
                 s.log = entries;
               });
@@ -332,7 +343,9 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             try {
-              const branches = await invoke<GitBranch[]>("git_list_branches", { path: p });
+              const branches = await invoke<GitBranch[]>("git_list_branches", {
+                path: p,
+              });
               set((s) => {
                 s.branches = branches;
               });
@@ -344,7 +357,9 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             try {
-              const b = await invoke<BranchInfo[]>("git_branches_full", { path: p });
+              const b = await invoke<BranchInfo[]>("git_branches_full", {
+                path: p,
+              });
               set((s) => {
                 s.branchesFull = b;
               });
@@ -356,7 +371,9 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             try {
-              const stashes = await invoke<StashEntry[]>("git_stash_list", { path: p });
+              const stashes = await invoke<StashEntry[]>("git_stash_list", {
+                path: p,
+              });
               set((s) => {
                 s.stashes = stashes;
               });
@@ -368,7 +385,9 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             try {
-              const remotes = await invoke<RemoteInfo[]>("git_remotes", { path: p });
+              const remotes = await invoke<RemoteInfo[]>("git_remotes", {
+                path: p,
+              });
               set((s) => {
                 s.remotes = remotes;
               });
@@ -392,10 +411,14 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             try {
-              const ip = await invoke<InProgress>("git_inprogress", { path: p });
+              const ip = await invoke<InProgress>("git_inprogress", {
+                path: p,
+              });
               set((s) => {
                 s.inProgress =
-                  ip.merge || ip.rebase || ip.cherryPick || ip.revert ? ip : null;
+                  ip.merge || ip.rebase || ip.cherryPick || ip.revert
+                    ? ip
+                    : null;
               });
             } catch {
               /* ignore */
@@ -405,7 +428,10 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             try {
-              const detail = await invoke<CommitDetail>("git_show", { path: p, sha });
+              const detail = await invoke<CommitDetail>("git_show", {
+                path: p,
+                sha,
+              });
               set((s) => {
                 s.selectedCommit = detail;
               });
@@ -436,7 +462,12 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             await invoke("git_checkout", { path: p, branch });
-            logEvent({ source: "git", kind: "checkout", summary: branch, payload: { branch } });
+            logEvent({
+              source: "git",
+              kind: "checkout",
+              summary: branch,
+              payload: { branch },
+            });
             // Switching branches changes HEAD + working-tree status — update
             // now; the watcher (HEAD move) reconciles branch lists shortly.
             await get().actions.refreshStatusNow(p);
@@ -446,7 +477,12 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             await invoke("git_create_branch", { path: p, name });
-            logEvent({ source: "git", kind: "branch-create", summary: name, payload: { name } });
+            logEvent({
+              source: "git",
+              kind: "branch-create",
+              summary: name,
+              payload: { name },
+            });
           },
           renameBranch: async (oldName, newName) => {
             const p = repo();
@@ -457,7 +493,12 @@ export const useGitStore = createSelectors(
             const p = repo();
             if (!p) return;
             await invoke("git_branch_delete", { path: p, name, force });
-            logEvent({ source: "git", kind: "branch-delete", summary: name, payload: { name } });
+            logEvent({
+              source: "git",
+              kind: "branch-delete",
+              summary: name,
+              payload: { name },
+            });
           },
           mergeBranch: async (branch) => {
             const p = repo();
@@ -469,7 +510,10 @@ export const useGitStore = createSelectors(
             if (!p) {
               return { kind: "invalid", commitCount: 0, conflictedFiles: 0 };
             }
-            return invoke<MergePreview>("git_merge_preview", { path: p, branch });
+            return invoke<MergePreview>("git_merge_preview", {
+              path: p,
+              branch,
+            });
           },
           stageFiles: async (paths) => {
             const p = repo();
@@ -504,8 +548,18 @@ export const useGitStore = createSelectors(
           commit: async (summary, description, amend = false) => {
             const p = repo();
             if (!p) return;
-            await invoke("git_commit_ex", { path: p, summary, description: description ?? null, amend });
-            logEvent({ source: "git", kind: "commit", summary: summary.slice(0, 120), payload: {} });
+            await invoke("git_commit_ex", {
+              path: p,
+              summary,
+              description: description ?? null,
+              amend,
+            });
+            logEvent({
+              source: "git",
+              kind: "commit",
+              summary: summary.slice(0, 120),
+              payload: {},
+            });
             // Commit clears the staged set and moves HEAD — refresh the
             // status/diff now; the watcher still reconciles branch ahead/behind.
             await get().actions.refreshStatusNow(p);
@@ -547,7 +601,10 @@ export const useGitStore = createSelectors(
           stashPush: async (message) => {
             const p = repo();
             if (!p) return;
-            await invoke("git_stash_push", { path: p, message: message ?? null });
+            await invoke("git_stash_push", {
+              path: p,
+              message: message ?? null,
+            });
             await get().actions.loadStashes();
           },
           stashApply: async (index) => {

--- a/src/features/github/components/github-panel.tsx
+++ b/src/features/github/components/github-panel.tsx
@@ -29,7 +29,9 @@ export function GithubPanel() {
     setLoading(true);
     setError(null);
     try {
-      const repos = await invoke<GithubRepo[]>("search_github", { query: query.trim() });
+      const repos = await invoke<GithubRepo[]>("search_github", {
+        query: query.trim(),
+      });
       setResults(repos);
     } catch (e) {
       setError(String(e));
@@ -68,21 +70,27 @@ export function GithubPanel() {
     } catch (e) {
       console.error("Clone failed:", e);
     }
-    setCloning((s) => { const n = new Set(s); n.delete(repo.full_name); return n; });
+    setCloning((s) => {
+      const n = new Set(s);
+      n.delete(repo.full_name);
+      return n;
+    });
   };
 
   return (
     <div className="h-full flex flex-col">
       {/* Search */}
       <div className="flex items-center gap-1.5 h-[32px] shrink-0 border-b border-border-default bg-bg-primary px-3">
-          <Search size={11} className="text-text-tertiary shrink-0" />
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") handleSearch(); }}
-            placeholder="Search GitHub repositories..."
-            className="flex-1 bg-transparent outline-none text-[11px] text-text-primary placeholder:text-text-tertiary"
-          />
+        <Search size={11} className="text-text-tertiary shrink-0" />
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSearch();
+          }}
+          placeholder="Search GitHub repositories..."
+          className="flex-1 bg-transparent outline-none text-[11px] text-text-primary placeholder:text-text-tertiary"
+        />
       </div>
 
       {/* Results */}
@@ -96,37 +104,55 @@ export function GithubPanel() {
         {error && (
           <div className="px-3 py-6 text-center">
             <p className="text-[11px] text-error">{error}</p>
-            <button onClick={handleSearch} className="mt-1 text-[10px] text-accent hover:underline cursor-pointer">Retry</button>
+            <button
+              onClick={handleSearch}
+              className="mt-1 text-[10px] text-accent hover:underline cursor-pointer"
+            >
+              Retry
+            </button>
           </div>
         )}
 
         {!loading && !error && results.length === 0 && !query.trim() && (
           <div className="px-3 py-8 text-center">
             <Github size={16} className="text-text-tertiary mx-auto mb-2" />
-            <p className="text-[11px] text-text-tertiary">Search for repositories</p>
+            <p className="text-[11px] text-text-tertiary">
+              Search for repositories
+            </p>
           </div>
         )}
 
         {!loading && !error && results.length === 0 && query.trim() && (
-          <div className="px-3 py-6 text-center text-[11px] text-text-tertiary">No repositories found</div>
+          <div className="px-3 py-6 text-center text-[11px] text-text-tertiary">
+            No repositories found
+          </div>
         )}
 
         {results.map((repo) => {
           const isCloning = cloning.has(repo.full_name);
           const isCloned = cloned.has(repo.full_name);
           return (
-            <div key={repo.full_name} className="px-3 py-2.5 border-b border-border-default hover:bg-bg-hover group">
+            <div
+              key={repo.full_name}
+              className="px-3 py-2.5 border-b border-border-default hover:bg-bg-hover group"
+            >
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5">
-                    <span className="text-[11px] font-medium text-accent truncate">{repo.full_name}</span>
+                    <span className="text-[11px] font-medium text-accent truncate">
+                      {repo.full_name}
+                    </span>
                   </div>
                   {repo.description && (
-                    <p className="text-[10px] text-text-tertiary mt-0.5 line-clamp-2">{repo.description}</p>
+                    <p className="text-[10px] text-text-tertiary mt-0.5 line-clamp-2">
+                      {repo.description}
+                    </p>
                   )}
                   <div className="flex items-center gap-3 mt-1">
                     {repo.language && (
-                      <span className="text-[9px] text-text-tertiary">{repo.language}</span>
+                      <span className="text-[9px] text-text-tertiary">
+                        {repo.language}
+                      </span>
                     )}
                     <span className="flex items-center gap-0.5 text-[9px] text-text-tertiary">
                       <Star size={8} /> {repo.stars.toLocaleString()}
@@ -151,11 +177,25 @@ export function GithubPanel() {
                       disabled={isCloning || isCloned}
                       className={cn(
                         "p-1 rounded cursor-pointer",
-                        isCloned ? "text-success" : isCloning ? "text-accent" : "text-text-tertiary hover:text-text-primary hover:bg-bg-active"
+                        isCloned
+                          ? "text-success"
+                          : isCloning
+                            ? "text-accent"
+                            : "text-text-tertiary hover:text-text-primary hover:bg-bg-active",
                       )}
-                      title={isCloned ? "Cloned" : isCloning ? "Cloning..." : "Clone to .atlas/repos/"}
+                      title={
+                        isCloned
+                          ? "Cloned"
+                          : isCloning
+                            ? "Cloning..."
+                            : "Clone to .atlas/repos/"
+                      }
                     >
-                      {isCloning ? <Loader2 size={11} className="animate-spin" /> : <Download size={11} />}
+                      {isCloning ? (
+                        <Loader2 size={11} className="animate-spin" />
+                      ) : (
+                        <Download size={11} />
+                      )}
                     </button>
                   )}
                 </div>

--- a/src/features/hint-nav/components/hint-overlay.tsx
+++ b/src/features/hint-nav/components/hint-overlay.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Kbd } from "@/ui/kbd";
 import { useHintStore } from "../stores/hint-store";
-import { scanTargets, HINT_OVERLAY_ATTR, type HintTarget } from "../lib/scan-targets";
+import {
+  scanTargets,
+  HINT_OVERLAY_ATTR,
+  type HintTarget,
+} from "../lib/scan-targets";
 import { generateLabels } from "../lib/generate-labels";
 import { activate } from "../lib/activate-target";
 
@@ -57,7 +61,8 @@ export function HintOverlay() {
       toggleRef.current();
     };
     window.addEventListener("keydown", onKey, { capture: true });
-    return () => window.removeEventListener("keydown", onKey, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKey, { capture: true });
   }, []);
 
   // Scan + label on open; clear on close.
@@ -77,7 +82,7 @@ export function HintOverlay() {
   // Re-measure rects on scroll/resize (rAF-throttled) so badges track the UI.
   const remeasure = useCallback(() => {
     setTargets((prev) =>
-      prev.map((t) => ({ el: t.el, rect: t.el.getBoundingClientRect() }))
+      prev.map((t) => ({ el: t.el, rect: t.el.getBoundingClientRect() })),
     );
   }, []);
   useEffect(() => {
@@ -92,7 +97,10 @@ export function HintOverlay() {
     };
     // capture:true catches scrolls from any inner scroll container (scroll
     // events don't bubble).
-    window.addEventListener("scroll", schedule, { capture: true, passive: true });
+    window.addEventListener("scroll", schedule, {
+      capture: true,
+      passive: true,
+    });
     window.addEventListener("resize", schedule);
     return () => {
       if (raf) cancelAnimationFrame(raf);
@@ -103,11 +111,16 @@ export function HintOverlay() {
 
   // Scroll the scrollable element under the viewport centre (arrow keys).
   const scrollActive = useCallback((dy: number) => {
-    const el = document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2);
+    const el = document.elementFromPoint(
+      window.innerWidth / 2,
+      window.innerHeight / 2,
+    );
     let node: HTMLElement | null = el as HTMLElement | null;
     while (node && node !== document.body) {
       const style = getComputedStyle(node);
-      const scrollable = /(auto|scroll)/.test(style.overflowY) && node.scrollHeight > node.clientHeight;
+      const scrollable =
+        /(auto|scroll)/.test(style.overflowY) &&
+        node.scrollHeight > node.clientHeight;
       if (scrollable) {
         node.scrollBy({ top: dy });
         return;
@@ -159,7 +172,8 @@ export function HintOverlay() {
       setTyped(next);
     };
     window.addEventListener("keydown", onKey, { capture: true });
-    return () => window.removeEventListener("keydown", onKey, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKey, { capture: true });
   }, [open, scrollActive]);
 
   if (!open) return null;
@@ -199,7 +213,9 @@ export function HintOverlay() {
             }}
           >
             {typed && (
-              <span style={{ opacity: 0.4 }}>{label.slice(0, typed.length)}</span>
+              <span style={{ opacity: 0.4 }}>
+                {label.slice(0, typed.length)}
+              </span>
             )}
             <span>{label.slice(typed.length)}</span>
           </span>

--- a/src/features/hint-nav/lib/activate-target.ts
+++ b/src/features/hint-nav/lib/activate-target.ts
@@ -5,11 +5,15 @@ function isFocusTarget(el: HTMLElement): boolean {
   if (tag === "input" || tag === "textarea" || tag === "select") return true;
   if (el.isContentEditable) return true;
   // CodeMirror's editable surface.
-  if (el.classList.contains("cm-content") || el.closest(".cm-editor")) return true;
+  if (el.classList.contains("cm-content") || el.closest(".cm-editor"))
+    return true;
   return false;
 }
 
-export function activate(el: HTMLElement, opts: { focusOnly?: boolean } = {}): void {
+export function activate(
+  el: HTMLElement,
+  opts: { focusOnly?: boolean } = {},
+): void {
   el.scrollIntoView({ block: "nearest", inline: "nearest" });
 
   if (opts.focusOnly || isFocusTarget(el)) {

--- a/src/features/hint-nav/lib/generate-labels.ts
+++ b/src/features/hint-nav/lib/generate-labels.ts
@@ -9,7 +9,10 @@
 // Home-row + easy reaches first, so the most common targets get the easiest keys.
 export const HINT_ALPHABET = "fjdkslaghrueiwovncm";
 
-export function generateLabels(count: number, alphabet = HINT_ALPHABET): string[] {
+export function generateLabels(
+  count: number,
+  alphabet = HINT_ALPHABET,
+): string[] {
   const chars = alphabet.split("");
   const n = chars.length;
   if (count <= 0) return [];

--- a/src/features/hint-nav/lib/scan-targets.ts
+++ b/src/features/hint-nav/lib/scan-targets.ts
@@ -58,7 +58,13 @@ export function scanTargets(): HintTarget[] {
     const rect = el.getBoundingClientRect();
     // Off-screen or zero-size → not a hint target.
     if (rect.width < 4 || rect.height < 4) continue;
-    if (rect.bottom <= 0 || rect.right <= 0 || rect.top >= vh || rect.left >= vw) continue;
+    if (
+      rect.bottom <= 0 ||
+      rect.right <= 0 ||
+      rect.top >= vh ||
+      rect.left >= vw
+    )
+      continue;
 
     const style = getComputedStyle(el);
     if (isHidden(el, style)) continue;
@@ -80,8 +86,14 @@ export function scanTargets(): HintTarget[] {
   const cx = vw / 2;
   const cy = vh / 2;
   deduped.sort((a, b) => {
-    const da = Math.hypot(a.rect.left + a.rect.width / 2 - cx, a.rect.top + a.rect.height / 2 - cy);
-    const db = Math.hypot(b.rect.left + b.rect.width / 2 - cx, b.rect.top + b.rect.height / 2 - cy);
+    const da = Math.hypot(
+      a.rect.left + a.rect.width / 2 - cx,
+      a.rect.top + a.rect.height / 2 - cy,
+    );
+    const db = Math.hypot(
+      b.rect.left + b.rect.width / 2 - cx,
+      b.rect.top + b.rect.height / 2 - cy,
+    );
     return da - db;
   });
 

--- a/src/features/hint-nav/stores/hint-store.ts
+++ b/src/features/hint-nav/stores/hint-store.ts
@@ -25,10 +25,19 @@ export const useHintStore = createSelectors(
     immer((set) => ({
       open: false,
       actions: {
-        open: () => set((s) => { s.open = true; }),
-        close: () => set((s) => { s.open = false; }),
-        toggle: () => set((s) => { s.open = !s.open; }),
+        open: () =>
+          set((s) => {
+            s.open = true;
+          }),
+        close: () =>
+          set((s) => {
+            s.open = false;
+          }),
+        toggle: () =>
+          set((s) => {
+            s.open = !s.open;
+          }),
       },
-    }))
-  )
+    })),
+  ),
 );

--- a/src/features/knowledge/components/cover-picker.tsx
+++ b/src/features/knowledge/components/cover-picker.tsx
@@ -16,12 +16,36 @@ interface CoverPickerProps {
 /** Synthetic prefixes the renderer detects to paint a gradient instead
  *  of loading an image off disk. */
 export const GRADIENTS: Array<{ id: string; css: string; label: string }> = [
-  { id: "gradient:slate-1", label: "Slate fade", css: "linear-gradient(135deg, #1f1f1f, #2a2a2a 60%, #161616)" },
-  { id: "gradient:warm-1", label: "Warm ember", css: "linear-gradient(135deg, #2a1d18, #382318 60%, #1d1411)" },
-  { id: "gradient:moss-1", label: "Moss",        css: "linear-gradient(135deg, #1a2422, #1f2e2a 60%, #131c1a)" },
-  { id: "gradient:dusk-1", label: "Dusk",        css: "linear-gradient(135deg, #1d1d2a, #232336 60%, #14141d)" },
-  { id: "gradient:rose-1", label: "Rose",        css: "linear-gradient(135deg, #271922, #36202d 60%, #1a1218)" },
-  { id: "gradient:gold-1", label: "Honey",       css: "linear-gradient(135deg, #2a2317, #36301a 60%, #1a1610)" },
+  {
+    id: "gradient:slate-1",
+    label: "Slate fade",
+    css: "linear-gradient(135deg, #1f1f1f, #2a2a2a 60%, #161616)",
+  },
+  {
+    id: "gradient:warm-1",
+    label: "Warm ember",
+    css: "linear-gradient(135deg, #2a1d18, #382318 60%, #1d1411)",
+  },
+  {
+    id: "gradient:moss-1",
+    label: "Moss",
+    css: "linear-gradient(135deg, #1a2422, #1f2e2a 60%, #131c1a)",
+  },
+  {
+    id: "gradient:dusk-1",
+    label: "Dusk",
+    css: "linear-gradient(135deg, #1d1d2a, #232336 60%, #14141d)",
+  },
+  {
+    id: "gradient:rose-1",
+    label: "Rose",
+    css: "linear-gradient(135deg, #271922, #36202d 60%, #1a1218)",
+  },
+  {
+    id: "gradient:gold-1",
+    label: "Honey",
+    css: "linear-gradient(135deg, #2a2317, #36301a 60%, #1a1610)",
+  },
 ];
 
 export function gradientCss(id: string): string | null {
@@ -60,7 +84,9 @@ export function CoverPicker({
   const handleUpload = async () => {
     try {
       const selected = await openFileDialog({
-        filters: [{ name: "Image", extensions: ["jpg", "jpeg", "png", "webp"] }],
+        filters: [
+          { name: "Image", extensions: ["jpg", "jpeg", "png", "webp"] },
+        ],
         multiple: false,
       });
       if (!selected || Array.isArray(selected)) return;
@@ -100,7 +126,10 @@ export function CoverPicker({
         padding: 8,
       }}
     >
-      <div className="eyebrow" style={{ fontSize: 9.5, padding: "4px 4px 6px" }}>
+      <div
+        className="eyebrow"
+        style={{ fontSize: 9.5, padding: "4px 4px 6px" }}
+      >
         Gradient
       </div>
       <div

--- a/src/features/knowledge/components/editor-footer.tsx
+++ b/src/features/knowledge/components/editor-footer.tsx
@@ -105,7 +105,10 @@ export function EditorFooter({
   const handleExportNoteHtml = () =>
     run("note-html", async () => {
       if (!entryId) return;
-      const target = await pickSavePath(`${entryId.split("/").pop()}.html`, "html");
+      const target = await pickSavePath(
+        `${entryId.split("/").pop()}.html`,
+        "html",
+      );
       if (!target) return;
       await invoke("knowledge_export_note_html", {
         projectPath,
@@ -151,7 +154,8 @@ export function EditorFooter({
 
   const hasNote = !!entryId;
   const isBusy = busy !== null;
-  const busyLabel = busy === "server" ? "Building…" : busy ? "Exporting…" : null;
+  const busyLabel =
+    busy === "server" ? "Building…" : busy ? "Exporting…" : null;
 
   return (
     <div
@@ -165,10 +169,12 @@ export function EditorFooter({
       }}
     >
       <span>
-        <span className="mono tnum">{wordCount.toLocaleString("en-US")}</span> words
+        <span className="mono tnum">{wordCount.toLocaleString("en-US")}</span>{" "}
+        words
       </span>
       <span>
-        <span className="mono tnum">{charCount.toLocaleString("en-US")}</span> chars
+        <span className="mono tnum">{charCount.toLocaleString("en-US")}</span>{" "}
+        chars
       </span>
       <span>
         <span className="mono">~{readMinutes}m</span> read

--- a/src/features/knowledge/components/editor-topbar.tsx
+++ b/src/features/knowledge/components/editor-topbar.tsx
@@ -60,7 +60,11 @@ export function EditorTopbar({
       >
         {breadcrumbs.map((segment, i) => (
           <span key={i} className="flex items-center" style={{ gap: 6 }}>
-            <Folder size={11} className="text-text-muted shrink-0" strokeWidth={1.5} />
+            <Folder
+              size={11}
+              className="text-text-muted shrink-0"
+              strokeWidth={1.5}
+            />
             <span className="truncate">{segment}</span>
             <ChevronRight size={10} className="text-text-muted shrink-0" />
           </span>
@@ -74,7 +78,10 @@ export function EditorTopbar({
         </span>
       </div>
 
-      <span className="pill pill-bare" style={{ height: 18, fontSize: 9.5, padding: "0 6px" }}>
+      <span
+        className="pill pill-bare"
+        style={{ height: 18, fontSize: 9.5, padding: "0 6px" }}
+      >
         {kind}
       </span>
 

--- a/src/features/knowledge/components/icon-picker.tsx
+++ b/src/features/knowledge/components/icon-picker.tsx
@@ -14,19 +14,90 @@ interface IconPickerProps {
 const GROUPS: Array<{ label: string; emojis: string[] }> = [
   {
     label: "Documents",
-    emojis: ["📄", "📝", "📖", "📕", "📗", "📘", "📙", "📚", "📓", "📔", "📋", "📑", "📰", "🗒️", "🗂️", "🗃️", "🗄️"],
+    emojis: [
+      "📄",
+      "📝",
+      "📖",
+      "📕",
+      "📗",
+      "📘",
+      "📙",
+      "📚",
+      "📓",
+      "📔",
+      "📋",
+      "📑",
+      "📰",
+      "🗒️",
+      "🗂️",
+      "🗃️",
+      "🗄️",
+    ],
   },
   {
     label: "Symbols",
-    emojis: ["✦", "✧", "✩", "✪", "✫", "★", "☆", "❖", "◆", "◇", "●", "○", "▲", "△", "■", "□", "▪", "▫"],
+    emojis: [
+      "✦",
+      "✧",
+      "✩",
+      "✪",
+      "✫",
+      "★",
+      "☆",
+      "❖",
+      "◆",
+      "◇",
+      "●",
+      "○",
+      "▲",
+      "△",
+      "■",
+      "□",
+      "▪",
+      "▫",
+    ],
   },
   {
     label: "Tech",
-    emojis: ["💻", "🖥️", "⌨️", "🖱️", "💾", "💿", "🧠", "⚙️", "🔧", "🛠️", "🔩", "🧪", "🧬", "🧮", "📡", "🛰️"],
+    emojis: [
+      "💻",
+      "🖥️",
+      "⌨️",
+      "🖱️",
+      "💾",
+      "💿",
+      "🧠",
+      "⚙️",
+      "🔧",
+      "🛠️",
+      "🔩",
+      "🧪",
+      "🧬",
+      "🧮",
+      "📡",
+      "🛰️",
+    ],
   },
   {
     label: "Concepts",
-    emojis: ["💡", "🔥", "⚡", "✨", "🌟", "🎯", "🚀", "🛸", "🌐", "🧭", "🗺️", "📌", "📍", "🎨", "🏗️", "🧱"],
+    emojis: [
+      "💡",
+      "🔥",
+      "⚡",
+      "✨",
+      "🌟",
+      "🎯",
+      "🚀",
+      "🛸",
+      "🌐",
+      "🧭",
+      "🗺️",
+      "📌",
+      "📍",
+      "🎨",
+      "🏗️",
+      "🧱",
+    ],
   },
   {
     label: "People",
@@ -38,7 +109,12 @@ const GROUPS: Array<{ label: string; emojis: string[] }> = [
   },
 ];
 
-export function IconPicker({ value, anchorRect, onPick, onClose }: IconPickerProps) {
+export function IconPicker({
+  value,
+  anchorRect,
+  onPick,
+  onClose,
+}: IconPickerProps) {
   const [draft, setDraft] = useState(value ?? "");
   const popRef = useRef<HTMLDivElement>(null);
 
@@ -122,8 +198,7 @@ export function IconPicker({ value, anchorRect, onPick, onClose }: IconPickerPro
                   width: 30,
                   height: 30,
                   borderRadius: 5,
-                  background:
-                    value === e ? "var(--bg-active)" : "transparent",
+                  background: value === e ? "var(--bg-active)" : "transparent",
                   border: 0,
                   fontSize: 18,
                   lineHeight: 1,
@@ -133,10 +208,12 @@ export function IconPicker({ value, anchorRect, onPick, onClose }: IconPickerPro
                   justifyContent: "center",
                 }}
                 onMouseEnter={(ev) => {
-                  if (value !== e) ev.currentTarget.style.background = "var(--bg-hover)";
+                  if (value !== e)
+                    ev.currentTarget.style.background = "var(--bg-hover)";
                 }}
                 onMouseLeave={(ev) => {
-                  if (value !== e) ev.currentTarget.style.background = "transparent";
+                  if (value !== e)
+                    ev.currentTarget.style.background = "transparent";
                 }}
               >
                 {e}

--- a/src/features/knowledge/components/knowledge-finder.tsx
+++ b/src/features/knowledge/components/knowledge-finder.tsx
@@ -46,7 +46,11 @@ export function KnowledgeFinder({
     const out: Result[] = [];
     for (const e of entries) {
       if (!e.title.toLowerCase().includes(s)) continue;
-      out.push({ id: e.id, title: e.title || "Untitled", icon: e.icon || "📄" });
+      out.push({
+        id: e.id,
+        title: e.title || "Untitled",
+        icon: e.icon || "📄",
+      });
       if (out.length >= MAX_RESULTS) break;
     }
     return out;
@@ -111,7 +115,9 @@ export function KnowledgeFinder({
         {q.trim() && (
           <div className="max-h-[340px] overflow-y-auto hide-scrollbar py-1">
             {results.length === 0 ? (
-              <div className="px-3 py-3 text-[12px] text-text-tertiary">No matches</div>
+              <div className="px-3 py-3 text-[12px] text-text-tertiary">
+                No matches
+              </div>
             ) : (
               results.map((r, i) => (
                 <button
@@ -123,7 +129,9 @@ export function KnowledgeFinder({
                     i === active ? "bg-bg-hover" : "hover:bg-bg-hover/60",
                   )}
                 >
-                  <span className="shrink-0 text-[13px] leading-none">{r.icon}</span>
+                  <span className="shrink-0 text-[13px] leading-none">
+                    {r.icon}
+                  </span>
                   <span className="truncate text-[12px] font-medium text-text-primary">
                     {r.title}
                   </span>

--- a/src/features/knowledge/components/knowledge-graph.tsx
+++ b/src/features/knowledge/components/knowledge-graph.tsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Application,
   Container,
@@ -109,9 +103,15 @@ export function KnowledgeGraph() {
     void invoke<GraphLayout>("knowledge_graph_layout_load", {
       projectPath: currentProject.path,
     })
-      .then((l) => { if (!cancelled) setLayout(l ?? { positions: {} }); })
-      .catch(() => { if (!cancelled) setLayout({ positions: {} }); });
-    return () => { cancelled = true; };
+      .then((l) => {
+        if (!cancelled) setLayout(l ?? { positions: {} });
+      })
+      .catch(() => {
+        if (!cancelled) setLayout({ positions: {} });
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [currentProject?.path]);
 
   // Override node titles with `meta.title` when set — the wire-side
@@ -286,7 +286,11 @@ function GraphCanvas({
       })
       .then(() => {
         if (disposed) {
-          try { app.destroy(true, { children: true }); } catch { /* ignore */ }
+          try {
+            app.destroy(true, { children: true });
+          } catch {
+            /* ignore */
+          }
           return;
         }
         const pushViewport = (v: Viewport) => {
@@ -319,12 +323,24 @@ function GraphCanvas({
     return () => {
       disposed = true;
       if (teardown) {
-        try { teardown(); } catch { /* ignore */ }
+        try {
+          teardown();
+        } catch {
+          /* ignore */
+        }
       }
       if (createdApp) {
-        try { createdApp.destroy(true, { children: true }); } catch { /* ignore */ }
+        try {
+          createdApp.destroy(true, { children: true });
+        } catch {
+          /* ignore */
+        }
       }
-      try { host.removeChild(canvas); } catch { /* ignore */ }
+      try {
+        host.removeChild(canvas);
+      } catch {
+        /* ignore */
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graph, width, height]);
@@ -360,10 +376,18 @@ function buildScene(
   engine.constraintIterations = 7;
 
   const walls = [
-    Matter.Bodies.rectangle(width / 2, height + 50, width + 200, 100, { isStatic: true }),
-    Matter.Bodies.rectangle(width / 2, -50, width + 200, 100, { isStatic: true }),
-    Matter.Bodies.rectangle(-50, height / 2, 100, height + 200, { isStatic: true }),
-    Matter.Bodies.rectangle(width + 50, height / 2, 100, height + 200, { isStatic: true }),
+    Matter.Bodies.rectangle(width / 2, height + 50, width + 200, 100, {
+      isStatic: true,
+    }),
+    Matter.Bodies.rectangle(width / 2, -50, width + 200, 100, {
+      isStatic: true,
+    }),
+    Matter.Bodies.rectangle(-50, height / 2, 100, height + 200, {
+      isStatic: true,
+    }),
+    Matter.Bodies.rectangle(width + 50, height / 2, 100, height + 200, {
+      isStatic: true,
+    }),
   ];
   Matter.Composite.add(engine.world, walls);
 
@@ -390,7 +414,10 @@ function buildScene(
   // Obsidian-style spider seed: force-directed initial positions so hubs sit
   // central and leaves fan out, instead of a flat ring. Saved layouts win.
   const seedMap = forceLayout(
-    graph.nodes.map((nd) => ({ id: nd.id, degree: nd.inDegree + nd.outDegree })),
+    graph.nodes.map((nd) => ({
+      id: nd.id,
+      degree: nd.inDegree + nd.outDegree,
+    })),
     graph.edges,
     width,
     height,
@@ -491,24 +518,28 @@ function buildScene(
   syncMouseToViewport();
 
   // While the user is dragging a node, light up its neighbours live.
-  Matter.Events.on(mouseConstraint, "startdrag", (ev: Matter.IEvent<Matter.MouseConstraint>) => {
-    const dragged = (ev as unknown as { body?: Matter.Body }).body;
-    if (!dragged) return;
-    for (const node of nodesById.values()) {
-      if (node.body !== dragged) continue;
-      const ns = new Set<string>();
-      for (const e of graph.edges) {
-        if (e.from === node.id) ns.add(e.to);
-        else if (e.to === node.id) ns.add(e.from);
+  Matter.Events.on(
+    mouseConstraint,
+    "startdrag",
+    (ev: Matter.IEvent<Matter.MouseConstraint>) => {
+      const dragged = (ev as unknown as { body?: Matter.Body }).body;
+      if (!dragged) return;
+      for (const node of nodesById.values()) {
+        if (node.body !== dragged) continue;
+        const ns = new Set<string>();
+        for (const e of graph.edges) {
+          if (e.from === node.id) ns.add(e.to);
+          else if (e.to === node.id) ns.add(e.from);
+        }
+        sceneRef.current = {
+          ...sceneRef.current,
+          draggingId: node.id,
+          draggingNeighbors: ns,
+        };
+        break;
       }
-      sceneRef.current = {
-        ...sceneRef.current,
-        draggingId: node.id,
-        draggingNeighbors: ns,
-      };
-      break;
-    }
-  });
+    },
+  );
   Matter.Events.on(mouseConstraint, "enddrag", () => {
     sceneRef.current = {
       ...sceneRef.current,
@@ -523,16 +554,30 @@ function buildScene(
   //   • Space + left-click drag   — flips into a hard "pan mode" that
   //     removes Matter's MouseConstraint and disables Pixi interaction
   //     for the duration, then restores both on release.
-  let panStart: { startX: number; startY: number; origX: number; origY: number } | null = null;
+  let panStart: {
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+  } | null = null;
   let panMode = false;
-  let panOrigin: { startX: number; startY: number; origX: number; origY: number } | null = null;
+  let panOrigin: {
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+  } | null = null;
   let spaceHeld = false;
   const stageEventMode = app.stage.eventMode;
   const canvas = app.canvas as HTMLCanvasElement;
 
   const setCursor = () => {
     const grabbing = panStart !== null || panMode;
-    canvas.style.cursor = grabbing ? "grabbing" : spaceHeld ? "grab" : "default";
+    canvas.style.cursor = grabbing
+      ? "grabbing"
+      : spaceHeld
+        ? "grab"
+        : "default";
   };
 
   const onContext = (e: Event) => e.preventDefault();
@@ -578,7 +623,11 @@ function buildScene(
   const onPointerUp = (e: PointerEvent) => {
     if (!panStart) return;
     panStart = null;
-    try { canvas.releasePointerCapture(e.pointerId); } catch { /* ignore */ }
+    try {
+      canvas.releasePointerCapture(e.pointerId);
+    } catch {
+      /* ignore */
+    }
     setCursor();
   };
 
@@ -656,7 +705,10 @@ function buildScene(
   // ── Sleep/wake ────────────────────────────────────────────────
   let awake = true;
   let sleepFrames = 0;
-  const wake = () => { awake = true; sleepFrames = 0; };
+  const wake = () => {
+    awake = true;
+    sleepFrames = 0;
+  };
   window.addEventListener("pointerdown", wake);
   window.addEventListener("pointermove", wake);
   window.addEventListener("wheel", wake, { passive: true });
@@ -698,7 +750,8 @@ function buildScene(
     if (!awake && scene === lastScene) return;
     lastScene = scene;
 
-    const { selectedId, neighbors, draggingId, draggingNeighbors, zoom } = scene;
+    const { selectedId, neighbors, draggingId, draggingNeighbors, zoom } =
+      scene;
     // Drag-highlight uses the same visual treatment as selection.
     // Selection wins if both are active.
     const focusId = selectedId ?? draggingId;
@@ -726,10 +779,22 @@ function buildScene(
       }
       node.graphics.clear();
       if (isFocused) {
-        node.graphics.circle(node.body.position.x, node.body.position.y, drawRadius + 3 * inv);
-        node.graphics.stroke({ width: 2 * inv, color: COLOR_PRIMARY, alpha: 0.6 });
+        node.graphics.circle(
+          node.body.position.x,
+          node.body.position.y,
+          drawRadius + 3 * inv,
+        );
+        node.graphics.stroke({
+          width: 2 * inv,
+          color: COLOR_PRIMARY,
+          alpha: 0.6,
+        });
       }
-      node.graphics.circle(node.body.position.x, node.body.position.y, drawRadius);
+      node.graphics.circle(
+        node.body.position.x,
+        node.body.position.y,
+        drawRadius,
+      );
       node.graphics.fill({ color, alpha });
 
       // Parallax: counter-scale the label so it stays a constant readable
@@ -773,7 +838,11 @@ function buildScene(
       }
       edge.graphics.moveTo(a.body.position.x, a.body.position.y);
       edge.graphics.lineTo(b.body.position.x, b.body.position.y);
-      edge.graphics.stroke({ width: (touchesFocus ? 2 : 1) * inv, color, alpha });
+      edge.graphics.stroke({
+        width: (touchesFocus ? 2 : 1) * inv,
+        color,
+        alpha,
+      });
     }
   };
   app.ticker.add(tick);
@@ -849,7 +918,9 @@ function LoadingState() {
 function EmptyState() {
   return (
     <div className="h-full w-full flex flex-col items-center justify-center text-text-tertiary gap-2">
-      <div className="text-[12px]">No notes yet — create some and reference them with</div>
+      <div className="text-[12px]">
+        No notes yet — create some and reference them with
+      </div>
       <div className="mono text-[11px] text-text-muted">[[note-id]]</div>
       <div className="text-[12px]">to see them connect here.</div>
     </div>

--- a/src/features/knowledge/components/knowledge-inspector.tsx
+++ b/src/features/knowledge/components/knowledge-inspector.tsx
@@ -160,10 +160,7 @@ export function KnowledgeInspector({
               Pages linking here · {backlinks.length}
             </div>
             {backlinks.length === 0 ? (
-              <div
-                className="text-text-muted italic"
-                style={{ fontSize: 11 }}
-              >
+              <div className="text-text-muted italic" style={{ fontSize: 11 }}>
                 No backlinks yet. Reference this page from another note with
                 <span className="mono"> [[note-id]] </span>
                 and it'll show up here.
@@ -187,10 +184,20 @@ export function KnowledgeInspector({
                       textAlign: "left",
                       cursor: "pointer",
                     }}
-                    onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; }}
-                    onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.background = "var(--bg-hover)";
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.background = "transparent";
+                    }}
                   >
-                    <span style={{ fontSize: 14, lineHeight: 1, color: "var(--text-tertiary)" }}>
+                    <span
+                      style={{
+                        fontSize: 14,
+                        lineHeight: 1,
+                        color: "var(--text-tertiary)",
+                      }}
+                    >
                       ›
                     </span>
                     <div style={{ minWidth: 0 }}>

--- a/src/features/knowledge/components/knowledge-list.tsx
+++ b/src/features/knowledge/components/knowledge-list.tsx
@@ -7,10 +7,7 @@ import { useKnowledgeStore } from "../stores/knowledge-store";
 import { useKnowledgeMetaStore } from "../stores/knowledge-meta-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
-import {
-  KnowledgeTree,
-  type KnowledgeTreeHandle,
-} from "./knowledge-tree";
+import { KnowledgeTree, type KnowledgeTreeHandle } from "./knowledge-tree";
 import {
   FoldVertical,
   UnfoldVertical,
@@ -166,7 +163,11 @@ export function KnowledgeList() {
             className="p-1 rounded hover:bg-bg-hover text-text-tertiary hover:text-text-secondary transition-colors"
             title={anyExpanded ? "Collapse all" : "Expand all"}
           >
-            {anyExpanded ? <FoldVertical size={11} /> : <UnfoldVertical size={11} />}
+            {anyExpanded ? (
+              <FoldVertical size={11} />
+            ) : (
+              <UnfoldVertical size={11} />
+            )}
           </button>
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
@@ -174,7 +175,8 @@ export function KnowledgeList() {
                 disabled={exporting || entries.length === 0}
                 className={cn(
                   "p-1 rounded hover:bg-bg-hover text-text-tertiary hover:text-text-secondary transition-colors outline-none",
-                  (exporting || entries.length === 0) && "opacity-40 pointer-events-none",
+                  (exporting || entries.length === 0) &&
+                    "opacity-40 pointer-events-none",
                 )}
                 title="Export knowledge"
               >

--- a/src/features/knowledge/components/knowledge-panel.tsx
+++ b/src/features/knowledge/components/knowledge-panel.tsx
@@ -3,7 +3,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useKnowledgeStore } from "../stores/knowledge-store";
-import { useKnowledgeMetaStore, usePageMeta } from "../stores/knowledge-meta-store";
+import {
+  useKnowledgeMetaStore,
+  usePageMeta,
+} from "../stores/knowledge-meta-store";
 import {
   useKnowledgeLinksStore,
   useBacklinks,
@@ -67,7 +70,12 @@ export function KnowledgePanel() {
   const [activeRepoName, setActiveRepoName] = useState<string | null>(null);
   const [repoReadme, setRepoReadme] = useState<string | null>(null);
   const [clonedRepos, setClonedRepos] = useState<
-    Array<{ name: string; display_name: string; path: string; has_readme: boolean }>
+    Array<{
+      name: string;
+      display_name: string;
+      path: string;
+      has_readme: boolean;
+    }>
   >([]);
   // KB panel layout is hoisted into layout-store so tab switches don't
   // reset sidebar/inspector visibility or column widths — same model the
@@ -88,10 +96,7 @@ export function KnowledgePanel() {
   // the panel border; mousedown captures pointer + listens for global
   // mousemove until release. `from` is the side being resized.
   const startResize = useCallback(
-    (
-      e: React.MouseEvent,
-      from: "sidebar" | "inspector",
-    ) => {
+    (e: React.MouseEvent, from: "sidebar" | "inspector") => {
       e.preventDefault();
       const startX = e.clientX;
       const startW = from === "sidebar" ? sidebarWidth : inspectorWidth;
@@ -115,7 +120,12 @@ export function KnowledgePanel() {
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
-    [sidebarWidth, inspectorWidth, setKnowledgeSidebarWidth, setKnowledgeInspectorWidth],
+    [
+      sidebarWidth,
+      inspectorWidth,
+      setKnowledgeSidebarWidth,
+      setKnowledgeInspectorWidth,
+    ],
   );
   const [recentIds, setRecentIds] = useState<string[]>([]);
   const [editorInstance, setEditorInstance] = useState<Editor | null>(null);
@@ -138,8 +148,11 @@ export function KnowledgePanel() {
     clearDocCache();
   }, [currentProject?.path]);
 
-  const { bind: bindMeta, unbind: unbindMeta, drop: dropMeta } =
-    useKnowledgeMetaStore.use.actions();
+  const {
+    bind: bindMeta,
+    unbind: unbindMeta,
+    drop: dropMeta,
+  } = useKnowledgeMetaStore.use.actions();
   const {
     bind: bindLinks,
     unbind: unbindLinks,
@@ -153,17 +166,28 @@ export function KnowledgePanel() {
       loadEntries(currentProject.path);
       void bindMeta(currentProject.path);
       void bindLinks(currentProject.path);
-      invoke<Array<{ name: string; display_name: string; path: string; has_readme: boolean }>>(
-        "list_cloned_repos",
-        { projectPath: currentProject.path },
-      )
+      invoke<
+        Array<{
+          name: string;
+          display_name: string;
+          path: string;
+          has_readme: boolean;
+        }>
+      >("list_cloned_repos", { projectPath: currentProject.path })
         .then(setClonedRepos)
         .catch(() => {});
     } else {
       unbindMeta();
       unbindLinks();
     }
-  }, [currentProject?.path, loadEntries, bindMeta, unbindMeta, bindLinks, unbindLinks]);
+  }, [
+    currentProject?.path,
+    loadEntries,
+    bindMeta,
+    unbindMeta,
+    bindLinks,
+    unbindLinks,
+  ]);
 
   useEffect(() => {
     setIsDirty(false);
@@ -173,7 +197,10 @@ export function KnowledgePanel() {
   useEffect(() => {
     if (!activeEntryId) return;
     setRecentIds((prev) => {
-      const next = [activeEntryId, ...prev.filter((id) => id !== activeEntryId)];
+      const next = [
+        activeEntryId,
+        ...prev.filter((id) => id !== activeEntryId),
+      ];
       return next.slice(0, RECENTS_MAX);
     });
   }, [activeEntryId]);
@@ -263,7 +290,12 @@ export function KnowledgePanel() {
   // (so it doesn't hijack the shortcut for other tabs / the app).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "f") {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.key === "f"
+      ) {
         if (!rootRef.current?.contains(document.activeElement)) return;
         e.preventDefault();
         setFinderOpen(true);
@@ -323,14 +355,21 @@ export function KnowledgePanel() {
     const other = paths.filter((p) => !/\.(md|markdown)$/i.test(p));
     if (md.length) {
       try {
-        const res = await invoke<{ notes_imported: number; files_copied: number }>(
-          "import_into_knowledge",
-          { projectPath: currentProject.path, sources: md },
-        );
+        const res = await invoke<{
+          notes_imported: number;
+          files_copied: number;
+        }>("import_into_knowledge", {
+          projectPath: currentProject.path,
+          sources: md,
+        });
         await loadEntries(currentProject.path);
-        toast.success(`Imported ${res.notes_imported} note${res.notes_imported === 1 ? "" : "s"}`);
+        toast.success(
+          `Imported ${res.notes_imported} note${res.notes_imported === 1 ? "" : "s"}`,
+        );
       } catch (e) {
-        toast.error(`Import failed: ${e instanceof Error ? e.message : String(e)}`);
+        toast.error(
+          `Import failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     }
     other.forEach(openInCodeMirror);
@@ -344,17 +383,24 @@ export function KnowledgePanel() {
     const dir = await open({ directory: true });
     if (!dir || Array.isArray(dir)) return;
     try {
-      const res = await invoke<{ notes_imported: number; files_copied: number }>(
-        "import_into_knowledge",
-        { projectPath: currentProject.path, sources: [dir] },
-      );
+      const res = await invoke<{
+        notes_imported: number;
+        files_copied: number;
+      }>("import_into_knowledge", {
+        projectPath: currentProject.path,
+        sources: [dir],
+      });
       await loadEntries(currentProject.path);
       toast.success(
         `Imported ${res.notes_imported} note${res.notes_imported === 1 ? "" : "s"}` +
-          (res.files_copied ? ` + ${res.files_copied} file${res.files_copied === 1 ? "" : "s"}` : ""),
+          (res.files_copied
+            ? ` + ${res.files_copied} file${res.files_copied === 1 ? "" : "s"}`
+            : ""),
       );
     } catch (e) {
-      toast.error(`Import failed: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Import failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }, [currentProject, loadEntries]);
 
@@ -507,7 +553,11 @@ export function KnowledgePanel() {
   );
 
   return (
-    <div ref={rootRef} className="relative h-full flex" style={{ background: "var(--bg-canvas)" }}>
+    <div
+      ref={rootRef}
+      className="relative h-full flex"
+      style={{ background: "var(--bg-canvas)" }}
+    >
       {finderOpen && (
         <KnowledgeFinder
           entries={sidebarEntries}
@@ -569,10 +619,12 @@ export function KnowledgePanel() {
           <>
             <RepoTopbar
               name={
-                clonedRepos.find((r) => r.name === activeRepoName)?.display_name ??
-                activeRepoName
+                clonedRepos.find((r) => r.name === activeRepoName)
+                  ?.display_name ?? activeRepoName
               }
-              path={clonedRepos.find((r) => r.name === activeRepoName)?.path ?? ""}
+              path={
+                clonedRepos.find((r) => r.name === activeRepoName)?.path ?? ""
+              }
               onToggleSidebar={toggleKnowledgeSidebar}
               sidebarHidden={!showSidebar}
               onToggleInspector={toggleKnowledgeInspector}
@@ -590,7 +642,11 @@ export function KnowledgePanel() {
                 </div>
               </div>
             ) : (
-              <RepoEmpty path={clonedRepos.find((r) => r.name === activeRepoName)?.path ?? ""} />
+              <RepoEmpty
+                path={
+                  clonedRepos.find((r) => r.name === activeRepoName)?.path ?? ""
+                }
+              />
             )}
           </>
         ) : activeEntry ? (
@@ -688,7 +744,8 @@ export function KnowledgePanel() {
                             cursor: "pointer",
                           }}
                           onMouseEnter={(e) => {
-                            e.currentTarget.style.background = "var(--bg-hover)";
+                            e.currentTarget.style.background =
+                              "var(--bg-hover)";
                           }}
                           onMouseLeave={(e) => {
                             e.currentTarget.style.background = "var(--bg-base)";
@@ -749,7 +806,11 @@ export function KnowledgePanel() {
             style={{ width: 4, marginLeft: -2, marginRight: -2, zIndex: 5 }}
           />
           <KnowledgeInspector
-            outline={outline.map((h) => ({ id: h.id, label: h.label, level: h.level }))}
+            outline={outline.map((h) => ({
+              id: h.id,
+              label: h.label,
+              level: h.level,
+            }))}
             activeHeadingId={activeHeadingId}
             onJumpToHeading={(id) => {
               if (!editorInstance) return;
@@ -863,7 +924,9 @@ function PageHeaderWithIcon({
             position: "relative",
             cursor: "pointer",
           }}
-          onClick={(e) => setCoverAnchor(e.currentTarget.getBoundingClientRect())}
+          onClick={(e) =>
+            setCoverAnchor(e.currentTarget.getBoundingClientRect())
+          }
           title="Click to change cover"
         />
       ) : null}
@@ -881,7 +944,9 @@ function PageHeaderWithIcon({
         {!cover && (
           <button
             type="button"
-            onClick={(e) => setCoverAnchor(e.currentTarget.getBoundingClientRect())}
+            onClick={(e) =>
+              setCoverAnchor(e.currentTarget.getBoundingClientRect())
+            }
             style={{
               background: "transparent",
               border: 0,
@@ -902,7 +967,9 @@ function PageHeaderWithIcon({
       <div className="flex items-start" style={{ gap: 14, marginTop: 10 }}>
         <button
           title="Change icon"
-          onClick={(e) => setIconAnchor(e.currentTarget.getBoundingClientRect())}
+          onClick={(e) =>
+            setIconAnchor(e.currentTarget.getBoundingClientRect())
+          }
           style={{
             width: 44,
             height: 44,
@@ -993,7 +1060,12 @@ function RepoTopbar({
   return (
     <div
       className="flex items-center shrink-0 border-b border-border-subtle"
-      style={{ height: 36, gap: 8, padding: "0 14px", background: "var(--bg-canvas)" }}
+      style={{
+        height: 36,
+        gap: 8,
+        padding: "0 14px",
+        background: "var(--bg-canvas)",
+      }}
     >
       {onToggleSidebar && (
         <button
@@ -1012,7 +1084,10 @@ function RepoTopbar({
       >
         {name}
       </span>
-      <span className="pill pill-bare" style={{ height: 18, fontSize: 9.5, padding: "0 6px" }}>
+      <span
+        className="pill pill-bare"
+        style={{ height: 18, fontSize: 9.5, padding: "0 6px" }}
+      >
         REPO
       </span>
       <button
@@ -1067,4 +1142,3 @@ function RepoEmpty({ path }: { path: string }) {
     </div>
   );
 }
-

--- a/src/features/knowledge/components/knowledge-sidebar.tsx
+++ b/src/features/knowledge/components/knowledge-sidebar.tsx
@@ -72,7 +72,12 @@ export function KnowledgeSidebar({
   width = 260,
 }: KnowledgeSidebarProps) {
   const [clonedRepos, setClonedRepos] = useState<
-    Array<{ name: string; display_name: string; path: string; has_readme: boolean }>
+    Array<{
+      name: string;
+      display_name: string;
+      path: string;
+      has_readme: boolean;
+    }>
   >([]);
 
   // Imperative handle on the KnowledgeTree so the header can drive
@@ -83,10 +88,14 @@ export function KnowledgeSidebar({
   const [recentsCollapsed, setRecentsCollapsed] = useState(false);
 
   const loadRepos = useCallback(() => {
-    invoke<Array<{ name: string; display_name: string; path: string; has_readme: boolean }>>(
-      "list_cloned_repos",
-      { projectPath },
-    )
+    invoke<
+      Array<{
+        name: string;
+        display_name: string;
+        path: string;
+        has_readme: boolean;
+      }>
+    >("list_cloned_repos", { projectPath })
       .then(setClonedRepos)
       .catch(() => {});
   }, [projectPath]);
@@ -296,7 +305,6 @@ export function KnowledgeSidebar({
             )}
           </div>
         )}
-
       </div>
 
       {/* Repositories — bottom section */}
@@ -339,7 +347,9 @@ export function KnowledgeSidebar({
                     className="text-text-muted shrink-0"
                     strokeWidth={1.5}
                   />
-                  <span className="truncate flex-1 text-left">{repo.display_name}</span>
+                  <span className="truncate flex-1 text-left">
+                    {repo.display_name}
+                  </span>
                   <button
                     type="button"
                     onClick={(e) => {

--- a/src/features/knowledge/components/knowledge-tree.tsx
+++ b/src/features/knowledge/components/knowledge-tree.tsx
@@ -55,11 +55,13 @@ interface KnowledgeTreeProps {
  * Visually identical to the project explorer: same row height, indent,
  * chevron, hover/active states. See plans/lexical-wibbling-elephant.md.
  */
-export const KnowledgeTree = forwardRef<KnowledgeTreeHandle, KnowledgeTreeProps>(
-  function KnowledgeTree(
-    { entries, activeEntryId, onSelect, onDelete, onExpandedCountChange },
-    ref,
-  ) {
+export const KnowledgeTree = forwardRef<
+  KnowledgeTreeHandle,
+  KnowledgeTreeProps
+>(function KnowledgeTree(
+  { entries, activeEntryId, onSelect, onDelete, onExpandedCountChange },
+  ref,
+) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -76,7 +78,10 @@ export const KnowledgeTree = forwardRef<KnowledgeTreeHandle, KnowledgeTreeProps>
   // the same paper/note twice (e.g. when a research import races with
   // a manual save) and React keys must be unique.
   const dirMap = useMemo(() => {
-    const map = new Map<string, { dirs: Set<string>; files: KnowledgeTreeEntry[] }>();
+    const map = new Map<
+      string,
+      { dirs: Set<string>; files: KnowledgeTreeEntry[] }
+    >();
     const ensure = (path: string) => {
       if (!map.has(path)) map.set(path, { dirs: new Set(), files: [] });
       return map.get(path)!;
@@ -112,14 +117,24 @@ export const KnowledgeTree = forwardRef<KnowledgeTreeHandle, KnowledgeTreeProps>
       const node = dirMap.get(path);
       if (!node) return;
       const dirs = Array.from(node.dirs).sort();
-      const files = [...node.files].sort((a, b) => a.title.localeCompare(b.title));
+      const files = [...node.files].sort((a, b) =>
+        a.title.localeCompare(b.title),
+      );
       for (const dir of dirs) {
-        const name = dir.includes("/") ? dir.substring(dir.lastIndexOf("/") + 1) : dir;
+        const name = dir.includes("/")
+          ? dir.substring(dir.lastIndexOf("/") + 1)
+          : dir;
         out.push({ key: dir, name, depth, isDir: true });
         if (expanded.has(dir)) walk(dir, depth + 1);
       }
       for (const file of files) {
-        out.push({ key: file.id, name: file.title, depth, isDir: false, entry: file });
+        out.push({
+          key: file.id,
+          name: file.title,
+          depth,
+          isDir: false,
+          entry: file,
+        });
       }
     };
     walk("", 0);
@@ -134,7 +149,7 @@ export const KnowledgeTree = forwardRef<KnowledgeTreeHandle, KnowledgeTreeProps>
   });
 
   // Every directory key that exists in the dirMap (excluding the
-   // virtual root ""). Used by `expandAll()`.
+  // virtual root ""). Used by `expandAll()`.
   const allDirKeys = useMemo(() => {
     const keys: string[] = [];
     for (const key of dirMap.keys()) {
@@ -170,7 +185,10 @@ export const KnowledgeTree = forwardRef<KnowledgeTreeHandle, KnowledgeTreeProps>
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-auto hide-scrollbar px-1.5 pb-2 min-h-0">
+    <div
+      ref={scrollRef}
+      className="flex-1 overflow-auto hide-scrollbar px-1.5 pb-2 min-h-0"
+    >
       <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const node = flat[virtualRow.index];
@@ -220,5 +238,4 @@ export const KnowledgeTree = forwardRef<KnowledgeTreeHandle, KnowledgeTreeProps>
       </div>
     </div>
   );
-  },
-);
+});

--- a/src/features/knowledge/components/page-properties.tsx
+++ b/src/features/knowledge/components/page-properties.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useRef, useState } from "react";
-import { Flame, User, Tag, Calendar, Clock, Link as LinkIcon, X, Plus, ChevronRight } from "lucide-react";
+import {
+  Flame,
+  User,
+  Tag,
+  Calendar,
+  Clock,
+  Link as LinkIcon,
+  X,
+  Plus,
+  ChevronRight,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   usePageMeta,
@@ -38,8 +48,14 @@ export function PageProperties({
   const summaryParts: string[] = [];
   if (meta.status) summaryParts.push(meta.status);
   if (meta.owner) summaryParts.push(`@${meta.owner}`);
-  if (meta.tags && meta.tags.length > 0) summaryParts.push(`#${meta.tags[0]}${meta.tags.length > 1 ? ` +${meta.tags.length - 1}` : ""}`);
-  const summary = summaryParts.length > 0 ? summaryParts.join(" · ") : "Add status, owner, tags…";
+  if (meta.tags && meta.tags.length > 0)
+    summaryParts.push(
+      `#${meta.tags[0]}${meta.tags.length > 1 ? ` +${meta.tags.length - 1}` : ""}`,
+    );
+  const summary =
+    summaryParts.length > 0
+      ? summaryParts.join(" · ")
+      : "Add status, owner, tags…";
 
   return (
     <div
@@ -132,7 +148,10 @@ export function PageProperties({
             </span>
           </Row>
           <Row icon={LinkIcon} label="References">
-            <span className="mono" style={{ fontSize: 11.5, color: "var(--text-secondary)" }}>
+            <span
+              className="mono"
+              style={{ fontSize: 11.5, color: "var(--text-secondary)" }}
+            >
               {referencesLabel}
             </span>
           </Row>
@@ -262,7 +281,9 @@ function StatusEditor({
               outline: "none",
             }}
           />
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 6 }}>
+          <div
+            style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 6 }}
+          >
             {STATUS_PRESETS.map((p) => (
               <button
                 key={p}
@@ -438,7 +459,11 @@ function TagsEditor({
             else if (e.key === "Escape") {
               setDraft("");
               setAdding(false);
-            } else if (e.key === "Backspace" && draft === "" && tags.length > 0) {
+            } else if (
+              e.key === "Backspace" &&
+              draft === "" &&
+              tags.length > 0
+            ) {
               onChange(tags.slice(0, -1));
             }
           }}

--- a/src/features/knowledge/components/readme-view.tsx
+++ b/src/features/knowledge/components/readme-view.tsx
@@ -33,10 +33,14 @@ export const ReadmeView = memo(function ReadmeView({ source }: Props) {
             </h2>
           ),
           h3: (p) => (
-            <h3 className="text-[16px] font-semibold mt-6 mb-2">{p.children}</h3>
+            <h3 className="text-[16px] font-semibold mt-6 mb-2">
+              {p.children}
+            </h3>
           ),
           h4: (p) => (
-            <h4 className="text-[14px] font-semibold mt-4 mb-1.5">{p.children}</h4>
+            <h4 className="text-[14px] font-semibold mt-4 mb-1.5">
+              {p.children}
+            </h4>
           ),
           p: (p) => <p className="my-3">{p.children}</p>,
           a: (p) => (
@@ -47,8 +51,12 @@ export const ReadmeView = memo(function ReadmeView({ source }: Props) {
               className="text-[var(--accent-primary)] underline hover:opacity-80"
             />
           ),
-          ul: (p) => <ul className="list-disc pl-6 space-y-1 my-3">{p.children}</ul>,
-          ol: (p) => <ol className="list-decimal pl-6 space-y-1 my-3">{p.children}</ol>,
+          ul: (p) => (
+            <ul className="list-disc pl-6 space-y-1 my-3">{p.children}</ul>
+          ),
+          ol: (p) => (
+            <ol className="list-decimal pl-6 space-y-1 my-3">{p.children}</ol>
+          ),
           li: (p) => <li className="leading-relaxed">{p.children}</li>,
           img: (p) => (
             // eslint-disable-next-line jsx-a11y/alt-text
@@ -95,7 +103,9 @@ export const ReadmeView = memo(function ReadmeView({ source }: Props) {
           hr: () => <hr className="my-6 border-[var(--border-subtle)]" />,
           table: (p) => (
             <div className="my-4 rounded-md border border-[var(--border-default)] overflow-x-auto">
-              <table className="w-full text-[13px] border-collapse">{p.children}</table>
+              <table className="w-full text-[13px] border-collapse">
+                {p.children}
+              </table>
             </div>
           ),
           thead: (p) => (

--- a/src/features/knowledge/stores/knowledge-links-store.ts
+++ b/src/features/knowledge/stores/knowledge-links-store.ts
@@ -44,7 +44,8 @@ const store = create<KnowledgeLinksState>()((set, get) => ({
       unlisten = await listen<{ projectPath: string }>(
         "atlas:knowledge:links-changed",
         (event) => {
-          if (!projectPath || event.payload?.projectPath !== projectPath) return;
+          if (!projectPath || event.payload?.projectPath !== projectPath)
+            return;
           set((s) => ({ rev: s.rev + 1 }));
         },
       );
@@ -101,7 +102,10 @@ export function useBacklinks(entryId: string | null): Backlink[] {
 export function useLinkCounts(entryId: string | null): LinkCounts {
   const projectPath = useKnowledgeLinksStore.use.projectPath();
   const rev = useKnowledgeLinksStore.use.rev();
-  const [counts, setCounts] = useState<LinkCounts>({ backlinks: 0, forwardlinks: 0 });
+  const [counts, setCounts] = useState<LinkCounts>({
+    backlinks: 0,
+    forwardlinks: 0,
+  });
   useEffect(() => {
     let cancelled = false;
     if (!projectPath || !entryId) {

--- a/src/features/knowledge/stores/knowledge-meta-store.ts
+++ b/src/features/knowledge/stores/knowledge-meta-store.ts
@@ -92,7 +92,9 @@ const store = create<KnowledgeMetaState>()((set, get) => ({
       // metadata file changed under us, but don't toggle loading.
       if (get().projectPath === projectPath && unlisten) {
         try {
-          const file = await invoke<MetaFile>("knowledge_meta_load", { projectPath });
+          const file = await invoke<MetaFile>("knowledge_meta_load", {
+            projectPath,
+          });
           set({ pages: mapPages(file.pages) });
           republishMentionCache();
         } catch {
@@ -103,7 +105,9 @@ const store = create<KnowledgeMetaState>()((set, get) => ({
       get().actions.unbind();
       set({ projectPath, loading: true, pages: {} });
       try {
-        const file = await invoke<MetaFile>("knowledge_meta_load", { projectPath });
+        const file = await invoke<MetaFile>("knowledge_meta_load", {
+          projectPath,
+        });
         set({ pages: mapPages(file.pages), loading: false });
         republishMentionCache();
       } catch {

--- a/src/features/knowledge/stores/knowledge-store.ts
+++ b/src/features/knowledge/stores/knowledge-store.ts
@@ -33,7 +33,11 @@ interface KnowledgeState {
     /** Save an explicit (workspace path, note id, content) triple. The caller
      *  captures all three atomically so a workspace switch can never cross the
      *  content of one workspace into another's file. */
-    saveEntry: (projectPath: string, id: string, content: string) => Promise<void>;
+    saveEntry: (
+      projectPath: string,
+      id: string,
+      content: string,
+    ) => Promise<void>;
     createEntry: (projectPath: string) => Promise<void>;
     deleteEntry: (projectPath: string, id: string) => Promise<void>;
     createDir: (projectPath: string, dirName: string) => Promise<void>;
@@ -56,19 +60,26 @@ export const useKnowledgeStore = createSelectors(
           const current = get();
 
           // Skip update if entries haven't changed (prevent unnecessary re-renders)
-          const unchanged = current.entries.length === newEntries.length &&
-            current.entries.every((e, i) => e.id === newEntries[i]?.id && e.updated_at === newEntries[i]?.updated_at);
+          const unchanged =
+            current.entries.length === newEntries.length &&
+            current.entries.every(
+              (e, i) =>
+                e.id === newEntries[i]?.id &&
+                e.updated_at === newEntries[i]?.updated_at,
+            );
           if (unchanged && !current.loading) return;
 
-          const activeStillExists = newEntries.find((e) => e.id === current.activeEntryId);
+          const activeStillExists = newEntries.find(
+            (e) => e.id === current.activeEntryId,
+          );
           set({
             entries: newEntries,
             loading: false,
             activeEntryId: activeStillExists
               ? current.activeEntryId
-              : newEntries[0]?.id ?? null,
-            editContent: activeStillExists?.content
-              ?? newEntries[0]?.content ?? "",
+              : (newEntries[0]?.id ?? null),
+            editContent:
+              activeStillExists?.content ?? newEntries[0]?.content ?? "",
           });
           // Mirror the new entry set into the Rust mention cache so
           // the @-picker doesn't have to ship the full knowledge
@@ -103,10 +114,16 @@ export const useKnowledgeStore = createSelectors(
           // the saved `id` only — if the store has since been swapped to another
           // workspace (different `entries`), this is a harmless no-op rather
           // than a cross-workspace mutation.
-          const title = content.split("\n")[0]?.replace(/^#+\s*/, "").slice(0, 60) || "note";
+          const title =
+            content
+              .split("\n")[0]
+              ?.replace(/^#+\s*/, "")
+              .slice(0, 60) || "note";
           set({
             entries: get().entries.map((e) =>
-              e.id === id ? { ...e, content, title, updated_at: new Date().toISOString() } : e
+              e.id === id
+                ? { ...e, content, title, updated_at: new Date().toISOString() }
+                : e,
             ),
           });
           invoke("log_interaction", {
@@ -178,5 +195,5 @@ export const useKnowledgeStore = createSelectors(
         }
       },
     },
-  }))
+  })),
 );

--- a/src/features/layout/components/app-layout.tsx
+++ b/src/features/layout/components/app-layout.tsx
@@ -1,9 +1,5 @@
 import { useEffect } from "react";
-import {
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-} from "react-resizable-panels";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useLayoutStore } from "../stores/layout-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store";
@@ -101,7 +97,13 @@ export function AppLayout() {
                     no error boundary tears down the whole React root (looks like
                     a full app reload). Defaults sum to 100 for the 3-panel case;
                     RRP normalizes the 1-/2-panel cases. */}
-                <Panel id="atlas-left" order={1} defaultSize={18} minSize={14} maxSize={28}>
+                <Panel
+                  id="atlas-left"
+                  order={1}
+                  defaultSize={18}
+                  minSize={14}
+                  maxSize={28}
+                >
                   <LeftPanel />
                 </Panel>
                 <PanelResizeHandle className="w-px bg-border-default hover:bg-accent data-[resize-handle-active]:bg-accent transition-colors cursor-col-resize" />
@@ -115,7 +117,13 @@ export function AppLayout() {
             {showRight && (
               <>
                 <PanelResizeHandle className="w-px bg-border-default hover:bg-accent data-[resize-handle-active]:bg-accent transition-colors cursor-col-resize" />
-                <Panel id="atlas-right" order={3} defaultSize={18} minSize={12} maxSize={30}>
+                <Panel
+                  id="atlas-right"
+                  order={3}
+                  defaultSize={18}
+                  minSize={12}
+                  maxSize={30}
+                >
                   <RightPanel />
                 </Panel>
               </>
@@ -129,25 +137,27 @@ export function AppLayout() {
       {/* OVERLAY mode only (unpinned). When docked, the sidebar is the in-flow
           column above and there is no scrim/rail. */}
       {!sidebarPinned && (
-      <>
-      {/* Scrim — subtle dim + click-to-close (the frosted rail carries the
+        <>
+          {/* Scrim — subtle dim + click-to-close (the frosted rail carries the
           depth, same as the notification overlay). Only interactive while open;
           fades via `opacity` (compositor-only, no layout). */}
-      <div
-        className={cn(
-          // Strong dim + blur so the (possibly lagging) main content is HIDDEN
-          // while the switcher is open and during its enter/exit — the animation
-          // reads as a clean focus transition rather than exposing a mid-load
-          // centre. Both are compositor-cheap once established.
-          "absolute inset-0 z-[55] bg-black/28 backdrop-blur-md transition-opacity ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          // Closing is 50% slower than opening (300 → 450ms).
-          sidebarOpen ? "opacity-100 duration-300" : "opacity-0 pointer-events-none duration-[450ms]",
-        )}
-        onClick={() => setSidebarOpen(false)}
-        aria-hidden
-      />
+          <div
+            className={cn(
+              // Strong dim + blur so the (possibly lagging) main content is HIDDEN
+              // while the switcher is open and during its enter/exit — the animation
+              // reads as a clean focus transition rather than exposing a mid-load
+              // centre. Both are compositor-cheap once established.
+              "absolute inset-0 z-[55] bg-black/28 backdrop-blur-md transition-opacity ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+              // Closing is 50% slower than opening (300 → 450ms).
+              sidebarOpen
+                ? "opacity-100 duration-300"
+                : "opacity-0 pointer-events-none duration-[450ms]",
+            )}
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden
+          />
 
-      {/* Workspace rail — an OVERLAY (Linear-style), toggled by Cmd+⇧. Always
+          {/* Workspace rail — an OVERLAY (Linear-style), toggled by Cmd+⇧. Always
           mounted; it sits ABOVE the content (never in flow), so toggling it does
           zero layout work on the shell — the content underneath stays perfectly
           still. It SLIDES (GPU `translateX`) AND FADES (`opacity`) together for a
@@ -161,21 +171,21 @@ export function AppLayout() {
           NOT set `will-change` here (it would isolate the layer and flatten the
           backdrop to nothing — the panel would look merely transparent). Closed =
           parked off the left edge, transparent. */}
-      <div
-        className={cn(
-          "absolute left-0 top-0 h-screen w-[244px] z-[60] border-r border-[var(--border-default)] bg-[var(--bg-elevated)]/60 backdrop-blur-2xl shadow-[var(--shadow-overlay)] transition-[transform,opacity] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none [backface-visibility:hidden]",
-          // Closing (slide-out) is 50% slower than opening (300 → 450ms).
-          sidebarOpen ? "duration-300" : "duration-[450ms]",
-        )}
-        style={{
-          transform: sidebarOpen ? "translateX(0)" : "translateX(-244px)",
-          opacity: sidebarOpen ? 1 : 0,
-        }}
-        aria-hidden={!sidebarOpen}
-      >
-        <WorkspaceSidebar />
-      </div>
-      </>
+          <div
+            className={cn(
+              "absolute left-0 top-0 h-screen w-[244px] z-[60] border-r border-[var(--border-default)] bg-[var(--bg-elevated)]/60 backdrop-blur-2xl shadow-[var(--shadow-overlay)] transition-[transform,opacity] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none [backface-visibility:hidden]",
+              // Closing (slide-out) is 50% slower than opening (300 → 450ms).
+              sidebarOpen ? "duration-300" : "duration-[450ms]",
+            )}
+            style={{
+              transform: sidebarOpen ? "translateX(0)" : "translateX(-244px)",
+              opacity: sidebarOpen ? 1 : 0,
+            }}
+            aria-hidden={!sidebarOpen}
+          >
+            <WorkspaceSidebar />
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/features/layout/components/center-panel.tsx
+++ b/src/features/layout/components/center-panel.tsx
@@ -1,8 +1,22 @@
-import { useEffect, useRef, useState, useCallback, useMemo, memo, lazy, Suspense, Fragment } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+  memo,
+  lazy,
+  Suspense,
+  Fragment,
+} from "react";
 import { cn } from "@/lib/utils";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
-import { useLayoutStore, type Tab, type WorkspaceView } from "../stores/layout-store";
+import {
+  useLayoutStore,
+  type Tab,
+  type WorkspaceView,
+} from "../stores/layout-store";
 import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store";
 // Chat is the default landing surface — always loaded so the first paint
 // shows the agent UI without a Suspense flash.
@@ -15,24 +29,96 @@ import { UnsupportedView } from "@/features/unsupported/components/unsupported-v
 // them eager added multi-second parse cost to cold start on machines that
 // don't have them in the OS file cache yet. The Suspense fallback in the
 // tab content area absorbs the brief load.
-const TerminalPanel = lazy(() => import("@/features/terminal/components/terminal-panel").then(m => ({ default: m.TerminalPanel })));
-const EditorPanel = lazy(() => import("@/features/editor/components/editor-panel").then(m => ({ default: m.EditorPanel })));
-const BrowserPanel = lazy(() => import("@/features/browser/components/browser-panel").then(m => ({ default: m.BrowserPanel })));
-const MediaViewer = lazy(() => import("@/features/media/components/media-viewer").then(m => ({ default: m.MediaViewer })));
-const SvgViewer = lazy(() => import("@/features/svg/components/svg-viewer").then(m => ({ default: m.SvgViewer })));
-const PdfViewer = lazy(() => import("@/features/pdf/components/pdf-viewer").then(m => ({ default: m.PdfViewer })));
-const GitDiffPanel = lazy(() => import("@/features/git/components/git-diff-panel").then(m => ({ default: m.GitDiffPanel })));
-const CanvasPanel = lazy(() => import("@/features/canvas/components/canvas-panel").then(m => ({ default: m.CanvasPanel })));
-const KnowledgePanel = lazy(() => import("@/features/knowledge/components/knowledge-panel").then(m => ({ default: m.KnowledgePanel })));
-const KnowledgeGraph = lazy(() => import("@/features/knowledge/components/knowledge-graph").then(m => ({ default: m.KnowledgeGraph })));
-const ResearchPanel = lazy(() => import("@/features/research/components/research-panel").then(m => ({ default: m.ResearchPanel })));
-const SettingsPanel = lazy(() => import("@/features/settings/components/settings-panel").then(m => ({ default: m.SettingsPanel })));
-const LogPanel = lazy(() => import("@/features/log/components/log-panel").then(m => ({ default: m.LogPanel })));
-const PomodoroPanel = lazy(() => import("@/features/pomodoro/components/pomodoro-panel").then(m => ({ default: m.PomodoroPanel })));
-const MissionControlPanel = lazy(() => import("@/features/mission-control/components/mission-control-panel").then(m => ({ default: m.MissionControlPanel })));
-const ArtifactsPanel = lazy(() => import("@/features/artifacts/components/artifacts-panel").then(m => ({ default: m.ArtifactsPanel })));
-const ModelChatPanel = lazy(() => import("@/features/model-chat/components/model-chat-panel").then(m => ({ default: m.ModelChatPanel })));
-const MemoryPanel = lazy(() => import("@/features/memory/components/memory-panel").then(m => ({ default: m.MemoryPanel })));
+const TerminalPanel = lazy(() =>
+  import("@/features/terminal/components/terminal-panel").then((m) => ({
+    default: m.TerminalPanel,
+  })),
+);
+const EditorPanel = lazy(() =>
+  import("@/features/editor/components/editor-panel").then((m) => ({
+    default: m.EditorPanel,
+  })),
+);
+const BrowserPanel = lazy(() =>
+  import("@/features/browser/components/browser-panel").then((m) => ({
+    default: m.BrowserPanel,
+  })),
+);
+const MediaViewer = lazy(() =>
+  import("@/features/media/components/media-viewer").then((m) => ({
+    default: m.MediaViewer,
+  })),
+);
+const SvgViewer = lazy(() =>
+  import("@/features/svg/components/svg-viewer").then((m) => ({
+    default: m.SvgViewer,
+  })),
+);
+const PdfViewer = lazy(() =>
+  import("@/features/pdf/components/pdf-viewer").then((m) => ({
+    default: m.PdfViewer,
+  })),
+);
+const GitDiffPanel = lazy(() =>
+  import("@/features/git/components/git-diff-panel").then((m) => ({
+    default: m.GitDiffPanel,
+  })),
+);
+const CanvasPanel = lazy(() =>
+  import("@/features/canvas/components/canvas-panel").then((m) => ({
+    default: m.CanvasPanel,
+  })),
+);
+const KnowledgePanel = lazy(() =>
+  import("@/features/knowledge/components/knowledge-panel").then((m) => ({
+    default: m.KnowledgePanel,
+  })),
+);
+const KnowledgeGraph = lazy(() =>
+  import("@/features/knowledge/components/knowledge-graph").then((m) => ({
+    default: m.KnowledgeGraph,
+  })),
+);
+const ResearchPanel = lazy(() =>
+  import("@/features/research/components/research-panel").then((m) => ({
+    default: m.ResearchPanel,
+  })),
+);
+const SettingsPanel = lazy(() =>
+  import("@/features/settings/components/settings-panel").then((m) => ({
+    default: m.SettingsPanel,
+  })),
+);
+const LogPanel = lazy(() =>
+  import("@/features/log/components/log-panel").then((m) => ({
+    default: m.LogPanel,
+  })),
+);
+const PomodoroPanel = lazy(() =>
+  import("@/features/pomodoro/components/pomodoro-panel").then((m) => ({
+    default: m.PomodoroPanel,
+  })),
+);
+const MissionControlPanel = lazy(() =>
+  import("@/features/mission-control/components/mission-control-panel").then(
+    (m) => ({ default: m.MissionControlPanel }),
+  ),
+);
+const ArtifactsPanel = lazy(() =>
+  import("@/features/artifacts/components/artifacts-panel").then((m) => ({
+    default: m.ArtifactsPanel,
+  })),
+);
+const ModelChatPanel = lazy(() =>
+  import("@/features/model-chat/components/model-chat-panel").then((m) => ({
+    default: m.ModelChatPanel,
+  })),
+);
+const MemoryPanel = lazy(() =>
+  import("@/features/memory/components/memory-panel").then((m) => ({
+    default: m.MemoryPanel,
+  })),
+);
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { PanelSkeleton } from "@/components/panel-skeleton";
 import { AtlasIcon } from "@/components/atlas-icon";
@@ -149,8 +235,23 @@ export function CenterPanel() {
   const tabHistory = useLayoutStore.use.tabHistory();
   const tabHistoryIndex = useLayoutStore.use.tabHistoryIndex();
   const mirrorView: WorkspaceView = useMemo(
-    () => ({ tabs, groupOrder, activeByGroup, focusedGroupId, tabHistory, tabHistoryIndex, activeTabId: activeByGroup[focusedGroupId] ?? null }),
-    [tabs, groupOrder, activeByGroup, focusedGroupId, tabHistory, tabHistoryIndex],
+    () => ({
+      tabs,
+      groupOrder,
+      activeByGroup,
+      focusedGroupId,
+      tabHistory,
+      tabHistoryIndex,
+      activeTabId: activeByGroup[focusedGroupId] ?? null,
+    }),
+    [
+      tabs,
+      groupOrder,
+      activeByGroup,
+      focusedGroupId,
+      tabHistory,
+      tabHistoryIndex,
+    ],
   );
 
   // Running-tab ids (shallow-equal so streaming chunks don't churn it),
@@ -160,10 +261,13 @@ export function CenterPanel() {
       Object.entries(s.sessions)
         .filter(([, sess]) => sess.status === "running")
         .map(([id]) => id)
-        .sort()
-    )
+        .sort(),
+    ),
   );
-  const runningTabIds = useMemo(() => new Set(runningTabIdsArray), [runningTabIdsArray]);
+  const runningTabIds = useMemo(
+    () => new Set(runningTabIdsArray),
+    [runningTabIdsArray],
+  );
 
   if (!currentProject) return <WelcomeScreen />;
 
@@ -271,7 +375,7 @@ const TabColumn = memo(function TabColumn({
   const tabHistoryIndex = view.tabHistoryIndex;
   const tabs = useMemo(
     () => tabsAll.filter((t) => GROUP_OF(t) === groupId),
-    [tabsAll, groupId]
+    [tabsAll, groupId],
   );
   const activeId = view.activeByGroup[groupId] ?? null;
   const isFocused = isActive && view.focusedGroupId === groupId;
@@ -292,9 +396,7 @@ const TabColumn = memo(function TabColumn({
 
   return (
     <div
-      className={cn(
-        "h-full flex flex-col overflow-hidden bg-bg-surface"
-      )}
+      className={cn("h-full flex flex-col overflow-hidden bg-bg-surface")}
       onMouseDownCapture={() => setFocusedGroup(groupId)}
     >
       {tabBarVisible && (
@@ -303,7 +405,7 @@ const TabColumn = memo(function TabColumn({
             "flex items-stretch h-[29px] shrink-0 bg-bg-base border-b border-border-default transition-opacity",
             // When split, dim the UNFOCUSED columns' tab bars so the focused
             // one stands out (the focused pane also shows a white dot, below).
-            !soloColumn && !isFocused && "opacity-45"
+            !soloColumn && !isFocused && "opacity-45",
           )}
         >
           <div className="flex items-center justify-center gap-0.5 w-[44px] border-r border-border-default shrink-0">
@@ -314,7 +416,7 @@ const TabColumn = memo(function TabColumn({
                 "flex items-center justify-center w-6 h-6 rounded transition-colors outline-none",
                 canGoBack
                   ? "text-text-secondary hover:text-text-primary hover:bg-bg-hover cursor-pointer"
-                  : "text-text-tertiary/40 cursor-not-allowed"
+                  : "text-text-tertiary/40 cursor-not-allowed",
               )}
               title="Back"
             >
@@ -327,7 +429,7 @@ const TabColumn = memo(function TabColumn({
                 "flex items-center justify-center w-6 h-6 rounded transition-colors outline-none",
                 canGoForward
                   ? "text-text-secondary hover:text-text-primary hover:bg-bg-hover cursor-pointer"
-                  : "text-text-tertiary/40 cursor-not-allowed"
+                  : "text-text-tertiary/40 cursor-not-allowed",
               )}
               title="Forward"
             >
@@ -346,33 +448,53 @@ const TabColumn = memo(function TabColumn({
                   role="tab"
                   tabIndex={0}
                   onClick={() => setActiveTab(tab.id)}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setActiveTab(tab.id); }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ")
+                      setActiveTab(tab.id);
+                  }}
                   className={cn(
                     "group relative flex items-center gap-1.5 pl-3 h-full text-[12px] font-medium shrink-0 cursor-pointer select-none border-r border-border-default",
                     "transition-[padding-right,background-color,color] duration-150",
                     tab.closable ? "pr-3 hover:pr-7" : "pr-3",
                     isActive
                       ? "text-text-primary bg-bg-surface"
-                      : "text-text-tertiary bg-bg-base hover:text-text-secondary hover:bg-bg-hover"
+                      : "text-text-tertiary bg-bg-base hover:text-text-secondary hover:bg-bg-hover",
                   )}
                 >
                   {isRunning ? (
-                    <Loader2 size={12} className="animate-spin text-accent shrink-0" />
+                    <Loader2
+                      size={12}
+                      className="animate-spin text-accent shrink-0"
+                    />
                   ) : (
-                    <Icon size={12} className={cn("shrink-0", isActive ? "text-text-secondary" : "text-text-tertiary")} />
+                    <Icon
+                      size={12}
+                      className={cn(
+                        "shrink-0",
+                        isActive ? "text-text-secondary" : "text-text-tertiary",
+                      )}
+                    />
                   )}
-                  <span className={cn("truncate max-w-[140px] leading-none", tab.dirty && "italic")}>
+                  <span
+                    className={cn(
+                      "truncate max-w-[140px] leading-none",
+                      tab.dirty && "italic",
+                    )}
+                  >
                     {tab.title}
                   </span>
                   {tab.closable && (
                     <button
-                      onClick={(e) => { e.stopPropagation(); closeTab(tab.id); }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        closeTab(tab.id);
+                      }}
                       title="Close tab"
                       className={cn(
                         "absolute right-1.5 top-1/2 -translate-y-1/2",
                         "inline-flex items-center justify-center w-4 h-4 rounded-full",
                         "text-text-tertiary opacity-0 group-hover:opacity-100",
-                        "hover:bg-[#ffffff22] hover:text-text-primary transition-opacity duration-150"
+                        "hover:bg-[#ffffff22] hover:text-text-primary transition-opacity duration-150",
                       )}
                     >
                       <X size={10} strokeWidth={2.2} />
@@ -387,7 +509,10 @@ const TabColumn = memo(function TabColumn({
             <div
               aria-hidden
               className="pointer-events-none absolute right-full top-0 h-full w-8"
-              style={{ background: "linear-gradient(to right, transparent, var(--bg-base))" }}
+              style={{
+                background:
+                  "linear-gradient(to right, transparent, var(--bg-base))",
+              }}
             />
             {/* Selected-pane indicator: a white dot before the +/x actions. */}
             {!soloColumn && isFocused && (
@@ -441,7 +566,7 @@ const TabContentContainer = memo(function TabContentContainer({
   const tabsAll = view.tabs;
   const tabs = useMemo(
     () => tabsAll.filter((t) => GROUP_OF(t) === groupId),
-    [tabsAll, groupId]
+    [tabsAll, groupId],
   );
   const activeTabId = view.activeByGroup[groupId] ?? null;
   const activeTab = tabs.find((t) => t.id === activeTabId);
@@ -481,7 +606,12 @@ const TabContentContainer = memo(function TabContentContainer({
   }
 
   if (!activeTab) {
-    return <div ref={ref} style={{ flex: "1 1 0%", minHeight: 0, overflow: "hidden" }} />;
+    return (
+      <div
+        ref={ref}
+        style={{ flex: "1 1 0%", minHeight: 0, overflow: "hidden" }}
+      />
+    );
   }
 
   // Persist expensive tabs across tab switches within this column. For a
@@ -496,15 +626,28 @@ const TabContentContainer = memo(function TabContentContainer({
       PERSISTENT_TYPES.has(t.type) &&
       (isActive || !IDLE_EXPENSIVE_TYPES.has(t.type)),
   );
-  const activeIsNonPersistent = !persistentTabs.find((t) => t.id === activeTab.id);
+  const activeIsNonPersistent = !persistentTabs.find(
+    (t) => t.id === activeTab.id,
+  );
 
   return (
-    <div ref={ref} style={{ flex: "1 1 0%", minHeight: 0, overflow: "hidden", position: "relative" }}>
+    <div
+      ref={ref}
+      style={{
+        flex: "1 1 0%",
+        minHeight: 0,
+        overflow: "hidden",
+        position: "relative",
+      }}
+    >
       <Suspense fallback={<PanelLoading />}>
         {persistentTabs.map((tab) => {
           const isActive = tab.id === activeTab.id;
           return (
-            <div key={tab.id} style={{ display: isActive ? "contents" : "none" }}>
+            <div
+              key={tab.id}
+              style={{ display: isActive ? "contents" : "none" }}
+            >
               {tab.type === "editor" ? (
                 <EditorPanel
                   tabId={tab.id}
@@ -516,13 +659,22 @@ const TabContentContainer = memo(function TabContentContainer({
               ) : tab.type === "knowledge" ? (
                 <KnowledgePanel />
               ) : tab.type === "browser" ? (
-                <BrowserPanel tabId={tab.id} groupId={GROUP_OF(tab)} initialUrl={tab.data.url as string | undefined} />
+                <BrowserPanel
+                  tabId={tab.id}
+                  groupId={GROUP_OF(tab)}
+                  initialUrl={tab.data.url as string | undefined}
+                />
               ) : tab.type === "knowledge-graph" ? (
                 <KnowledgeGraph />
               ) : tab.type === "pdf" ? (
-                <PdfViewer filePath={tab.data.filePath as string} tabId={tab.id} />
+                <PdfViewer
+                  filePath={tab.data.filePath as string}
+                  tabId={tab.id}
+                />
               ) : tab.type === "settings" ? (
-                <SettingsPanel initialSection={tab.data.section as string | undefined} />
+                <SettingsPanel
+                  initialSection={tab.data.section as string | undefined}
+                />
               ) : (
                 <TerminalPanel tabId={tab.id} />
               )}
@@ -561,7 +713,11 @@ function TabContent({ tab }: { tab: Tab }) {
     case "browser":
       return <BrowserPanel initialUrl={tab.data.url as string | undefined} />;
     case "settings":
-      return <SettingsPanel initialSection={tab.data.section as string | undefined} />;
+      return (
+        <SettingsPanel
+          initialSection={tab.data.section as string | undefined}
+        />
+      );
     case "log":
       return <LogPanel />;
     case "pomodoro":
@@ -575,7 +731,9 @@ function TabContent({ tab }: { tab: Tab }) {
     case "svg":
       return <SvgViewer filePath={tab.data.filePath as string} />;
     case "pdf":
-      return <PdfViewer filePath={tab.data.filePath as string} tabId={tab.id} />;
+      return (
+        <PdfViewer filePath={tab.data.filePath as string} tabId={tab.id} />
+      );
     case "diff":
       return (
         <GitDiffPanel
@@ -609,7 +767,11 @@ function PlaceholderContent({ tab }: { tab: Tab }) {
   );
 }
 
-const NEW_TAB_OPTIONS: Array<{ type: TabType; label: string; icon: React.ElementType }> = [
+const NEW_TAB_OPTIONS: Array<{
+  type: TabType;
+  label: string;
+  icon: React.ElementType;
+}> = [
   { type: "chat", label: "Agents", icon: AtlasIcon },
   { type: "model-chat", label: "Chat", icon: MessageSquare },
   { type: "terminal", label: "Terminal", icon: Terminal },
@@ -641,10 +803,10 @@ function NewTabDropdown({
           dirty: false,
           data: {},
         },
-        groupId
+        groupId,
       );
     },
-    [addTab, groupId]
+    [addTab, groupId],
   );
 
   return (

--- a/src/features/layout/components/layout-switcher.tsx
+++ b/src/features/layout/components/layout-switcher.tsx
@@ -86,7 +86,9 @@ export function LayoutSwitcher({
                 )}
               >
                 <LayoutThumbnail template={t} />
-                <div className="mt-2 text-[12px] font-medium text-[var(--text-primary)]">{t.name}</div>
+                <div className="mt-2 text-[12px] font-medium text-[var(--text-primary)]">
+                  {t.name}
+                </div>
                 <div className="text-[10px] text-[var(--text-tertiary)] leading-snug line-clamp-2">
                   {t.description}
                 </div>

--- a/src/features/layout/components/layout-thumbnail.tsx
+++ b/src/features/layout/components/layout-thumbnail.tsx
@@ -25,7 +25,8 @@ const TYPE_ICON: Partial<Record<TabType, LucideIcon>> = {
 };
 
 function ColIcon({ type }: { type: TabType }) {
-  if (type === "chat") return <AtlasIcon size={12} className="rounded-[2px] opacity-80" />;
+  if (type === "chat")
+    return <AtlasIcon size={12} className="rounded-[2px] opacity-80" />;
   const Icon = TYPE_ICON[type] ?? MessageSquare;
   return <Icon size={12} className="text-[var(--text-tertiary)]" />;
 }

--- a/src/features/layout/components/left-panel.tsx
+++ b/src/features/layout/components/left-panel.tsx
@@ -12,7 +12,7 @@ import { useUsageReport } from "@/features/monitor/stores/usage-report-store";
 const UsagePanel = lazy(() =>
   import("@/features/monitor/components/usage-panel").then((m) => ({
     default: m.UsagePanel,
-  }))
+  })),
 );
 
 /**
@@ -24,7 +24,9 @@ const UsagePanel = lazy(() =>
  * "Usage" report stays docked at the bottom.
  */
 export function LeftPanel() {
-  const usagePanelVisible = useLayoutStore((s) => s.leftPanel.usagePanelVisible);
+  const usagePanelVisible = useLayoutStore(
+    (s) => s.leftPanel.usagePanelVisible,
+  );
   const { toggleUsagePanel } = useLayoutStore.use.actions();
   const cwd = useProjectStore((s) => s.currentProject?.path ?? null);
   const loadUsage = useUsageReport((s) => s.load);
@@ -77,7 +79,10 @@ export function LeftPanel() {
             >
               <ChevronDown
                 size={12}
-                className={cn("transition-transform", !usagePanelVisible && "-rotate-90")}
+                className={cn(
+                  "transition-transform",
+                  !usagePanelVisible && "-rotate-90",
+                )}
               />
             </button>
           </div>

--- a/src/features/layout/components/right-panel.tsx
+++ b/src/features/layout/components/right-panel.tsx
@@ -12,25 +12,29 @@ import { GitCommit, GitCompare, Github, CheckCheck } from "lucide-react";
 // active branches — keeping it lazy stops the right panel from blocking
 // the post-`hydrate` render.
 const GitManagerPanel = lazy(() =>
-  import("@/features/git/components/git-manager/git-manager-panel").then((m) => ({
-    default: m.GitManagerPanel,
-  }))
+  import("@/features/git/components/git-manager/git-manager-panel").then(
+    (m) => ({
+      default: m.GitManagerPanel,
+    }),
+  ),
 );
 // xyflow + the layout pass are heavy; load only when the user opens the tab.
 const GitGraphPanel = lazy(() =>
   import("@/features/git/components/git-graph-panel").then((m) => ({
     default: m.GitGraphPanel,
-  }))
+  })),
 );
 const GithubPanel = lazy(() =>
   import("@/features/github/components/github-panel").then((m) => ({
     default: m.GithubPanel,
-  }))
+  })),
 );
 const ReviewAgentsPanel = lazy(() =>
-  import("@/features/review-agents/components/review-agents-panel").then((m) => ({
-    default: m.ReviewAgentsPanel,
-  }))
+  import("@/features/review-agents/components/review-agents-panel").then(
+    (m) => ({
+      default: m.ReviewAgentsPanel,
+    }),
+  ),
 );
 
 const sections = [
@@ -55,7 +59,7 @@ export function RightPanel() {
               "flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium transition-colors cursor-pointer shrink-0 whitespace-nowrap",
               activeSection === s.id
                 ? "text-text-primary bg-bg-selected"
-                : "text-text-tertiary hover:text-text-secondary hover:bg-bg-hover"
+                : "text-text-tertiary hover:text-text-secondary hover:bg-bg-hover",
             )}
           >
             <s.icon size={12} />
@@ -68,13 +72,17 @@ export function RightPanel() {
         className={cn(
           "flex-1 min-h-0",
           // Git Graph owns its own scrolling (via ReactFlow); other panels scroll vertically.
-          activeSection === "git-graph" ? "overflow-hidden" : "overflow-auto hide-scrollbar",
+          activeSection === "git-graph"
+            ? "overflow-hidden"
+            : "overflow-auto hide-scrollbar",
         )}
       >
         <Suspense
           fallback={
             <PanelSkeleton
-              label={activeSection === "changes" ? "Loading changes…" : "Loading…"}
+              label={
+                activeSection === "changes" ? "Loading changes…" : "Loading…"
+              }
             />
           }
         >

--- a/src/features/layout/stores/layout-store.ts
+++ b/src/features/layout/stores/layout-store.ts
@@ -127,11 +127,17 @@ interface LayoutActions {
     setChatSidebarWidth: (width: number) => void;
     setBashPanelWidth: (width: number) => void;
     setPlansPanelWidth: (width: number) => void;
-    setLeftSection: (section: LayoutState["leftPanel"]["activeSection"]) => void;
-    setRightSection: (section: LayoutState["rightPanel"]["activeSection"]) => void;
+    setLeftSection: (
+      section: LayoutState["leftPanel"]["activeSection"],
+    ) => void;
+    setRightSection: (
+      section: LayoutState["rightPanel"]["activeSection"],
+    ) => void;
     /** Make the right panel visible AND switch it to `section` (e.g. open the
      *  Source Control pane from the status bar). */
-    revealRightSection: (section: LayoutState["rightPanel"]["activeSection"]) => void;
+    revealRightSection: (
+      section: LayoutState["rightPanel"]["activeSection"],
+    ) => void;
     addTab: (tab: Tab, groupId?: string) => void;
     closeTab: (id: string) => void;
     setActiveTab: (id: string) => void;
@@ -269,7 +275,8 @@ function pushTabHistory(s: LayoutState, id: string): void {
  *  zen toggle). */
 function reconcileGroups(s: LayoutState): void {
   if (s.groupOrder.length === 0) s.groupOrder = [DEFAULT_GROUP];
-  for (const t of s.tabs) if (!s.groupOrder.includes(groupOf(t))) t.groupId = s.groupOrder[0];
+  for (const t of s.tabs)
+    if (!s.groupOrder.includes(groupOf(t))) t.groupId = s.groupOrder[0];
   for (const k of Object.keys(s.activeByGroup)) {
     if (!s.groupOrder.includes(k)) delete s.activeByGroup[k];
   }
@@ -279,7 +286,8 @@ function reconcileGroups(s: LayoutState): void {
       s.activeByGroup[g] = s.tabs.find((t) => groupOf(t) === g)?.id ?? null;
     }
   }
-  if (!s.groupOrder.includes(s.focusedGroupId)) s.focusedGroupId = s.groupOrder[0];
+  if (!s.groupOrder.includes(s.focusedGroupId))
+    s.focusedGroupId = s.groupOrder[0];
   syncActiveMirror(s);
 }
 
@@ -302,7 +310,15 @@ function welcomeView(wsId: string): WorkspaceView {
   const id = welcomeIdFor(wsId);
   return {
     tabs: [
-      { id, type: "chat", title: "Agents", closable: false, dirty: false, data: {}, groupId: DEFAULT_GROUP },
+      {
+        id,
+        type: "chat",
+        title: "Agents",
+        closable: false,
+        dirty: false,
+        data: {},
+        groupId: DEFAULT_GROUP,
+      },
     ],
     activeTabId: id,
     groupOrder: [DEFAULT_GROUP],
@@ -341,516 +357,599 @@ export const useLayoutStore = createSelectors(
   create<LayoutState & LayoutActions>()(
     persist(
       immer((set) => ({
-      ...initialState,
-      actions: {
-        toggleLeftPanel: () =>
-          set((s) => {
-            s.leftPanel.visible = !s.leftPanel.visible;
-          }),
-        toggleRightPanel: () =>
-          set((s) => {
-            s.rightPanel.visible = !s.rightPanel.visible;
-          }),
-        toggleBottomPanel: () =>
-          set((s) => {
-            s.bottomPanel.visible = !s.bottomPanel.visible;
-          }),
-        toggleChatSidebar: () =>
-          set((s) => {
-            s.chatSidebar.visible = !s.chatSidebar.visible;
-          }),
-        toggleModelChatSidebar: () =>
-          set((s) => {
-            s.modelChatSidebar.visible = !s.modelChatSidebar.visible;
-          }),
-        toggleUsagePanel: () =>
-          set((s) => {
-            s.leftPanel.usagePanelVisible = !s.leftPanel.usagePanelVisible;
-          }),
-        toggleKnowledgeSidebar: () =>
-          set((s) => {
-            s.knowledgePanel.showSidebar = !s.knowledgePanel.showSidebar;
-          }),
-        toggleKnowledgeInspector: () =>
-          set((s) => {
-            s.knowledgePanel.showInspector = !s.knowledgePanel.showInspector;
-          }),
-        setKnowledgeSidebarWidth: (width) =>
-          set((s) => {
-            s.knowledgePanel.sidebarWidth = Math.max(180, Math.min(width, 480));
-          }),
-        setKnowledgeInspectorWidth: (width) =>
-          set((s) => {
-            s.knowledgePanel.inspectorWidth = Math.max(220, Math.min(width, 520));
-          }),
-        setChatSidebarWidth: (width) =>
-          set((s) => {
-            s.chatSidebar.width = Math.max(160, Math.min(width, 420));
-          }),
-        setBashPanelWidth: (width) =>
-          set((s) => {
-            s.bashPanel.width = Math.max(200, Math.min(width, 480));
-          }),
-        setPlansPanelWidth: (width) =>
-          set((s) => {
-            s.plansPanel.width = Math.max(300, Math.min(width, 640));
-          }),
-        setLeftSection: (section) =>
-          set((s) => {
-            s.leftPanel.activeSection = section;
-          }),
-        setRightSection: (section) =>
-          set((s) => {
-            s.rightPanel.activeSection = section;
-          }),
-        revealRightSection: (section) =>
-          set((s) => {
-            s.rightPanel.visible = true;
-            s.rightPanel.activeSection = section;
-          }),
-        addTab: (tab, groupId) =>
-          set((s) => {
-            // chat: each session is its own tab. File-backed viewers (editor /
-            // diff / media / svg / pdf / unsupported) are one-per-FILE (deduped
-            // by id, which is `${type}:${path}`) so opening a different file
-            // always gets its own tab. Everything else is a singleton PER COLUMN
-            // (focus the existing instance in the target column, else open one).
-            const allowMultiple =
-              tab.type === "editor" ||
-              tab.type === "diff" ||
-              tab.type === "chat" ||
-              tab.type === "model-chat" ||
-              tab.type === "media" ||
-              tab.type === "svg" ||
-              tab.type === "pdf" ||
-              tab.type === "unsupported";
-
-            let targetId = tab.id;
-            // Where the tab lands: caller-specified column, else the focused one.
-            let targetGroup = groupId ?? s.focusedGroupId;
-            if (!s.groupOrder.includes(targetGroup)) targetGroup = s.focusedGroupId;
-
-            if (!allowMultiple) {
-              const existingInGroup = s.tabs.find(
-                (t) => t.type === tab.type && groupOf(t) === targetGroup,
+        ...initialState,
+        actions: {
+          toggleLeftPanel: () =>
+            set((s) => {
+              s.leftPanel.visible = !s.leftPanel.visible;
+            }),
+          toggleRightPanel: () =>
+            set((s) => {
+              s.rightPanel.visible = !s.rightPanel.visible;
+            }),
+          toggleBottomPanel: () =>
+            set((s) => {
+              s.bottomPanel.visible = !s.bottomPanel.visible;
+            }),
+          toggleChatSidebar: () =>
+            set((s) => {
+              s.chatSidebar.visible = !s.chatSidebar.visible;
+            }),
+          toggleModelChatSidebar: () =>
+            set((s) => {
+              s.modelChatSidebar.visible = !s.modelChatSidebar.visible;
+            }),
+          toggleUsagePanel: () =>
+            set((s) => {
+              s.leftPanel.usagePanelVisible = !s.leftPanel.usagePanelVisible;
+            }),
+          toggleKnowledgeSidebar: () =>
+            set((s) => {
+              s.knowledgePanel.showSidebar = !s.knowledgePanel.showSidebar;
+            }),
+          toggleKnowledgeInspector: () =>
+            set((s) => {
+              s.knowledgePanel.showInspector = !s.knowledgePanel.showInspector;
+            }),
+          setKnowledgeSidebarWidth: (width) =>
+            set((s) => {
+              s.knowledgePanel.sidebarWidth = Math.max(
+                180,
+                Math.min(width, 480),
               );
-              if (existingInGroup) {
-                targetId = existingInGroup.id; // focus the one already in this column
-              } else {
-                // New instance in the target column; ensure a unique id since
-                // callers may reuse a fixed id (e.g. "terminal", "settings").
-                targetId = uniqueTabId(s, tab.id);
-                s.tabs.push({ ...tab, id: targetId, groupId: targetGroup });
-              }
-            } else {
-              const existsById = s.tabs.find((t) => t.id === tab.id);
-              if (existsById) {
-                targetGroup = groupOf(existsById);
-              } else {
-                s.tabs.push({ ...tab, groupId: targetGroup });
-              }
-            }
-            s.focusedGroupId = targetGroup;
-            s.activeByGroup[targetGroup] = targetId;
-            pushTabHistory(s, targetId);
-            syncActiveMirror(s);
-          }),
-        closeTab: (id) =>
-          set((s) => {
-            const idx = s.tabs.findIndex((t) => t.id === id);
-            if (idx === -1) return;
-            const tab = s.tabs[idx];
-            if (!tab.closable) return;
-            const grp = groupOf(tab);
-            const groupIdxInGroup = s.tabs
-              .filter((t) => groupOf(t) === grp)
-              .findIndex((t) => t.id === id);
-            s.tabs.splice(idx, 1);
+            }),
+          setKnowledgeInspectorWidth: (width) =>
+            set((s) => {
+              s.knowledgePanel.inspectorWidth = Math.max(
+                220,
+                Math.min(width, 520),
+              );
+            }),
+          setChatSidebarWidth: (width) =>
+            set((s) => {
+              s.chatSidebar.width = Math.max(160, Math.min(width, 420));
+            }),
+          setBashPanelWidth: (width) =>
+            set((s) => {
+              s.bashPanel.width = Math.max(200, Math.min(width, 480));
+            }),
+          setPlansPanelWidth: (width) =>
+            set((s) => {
+              s.plansPanel.width = Math.max(300, Math.min(width, 640));
+            }),
+          setLeftSection: (section) =>
+            set((s) => {
+              s.leftPanel.activeSection = section;
+            }),
+          setRightSection: (section) =>
+            set((s) => {
+              s.rightPanel.activeSection = section;
+            }),
+          revealRightSection: (section) =>
+            set((s) => {
+              s.rightPanel.visible = true;
+              s.rightPanel.activeSection = section;
+            }),
+          addTab: (tab, groupId) =>
+            set((s) => {
+              // chat: each session is its own tab. File-backed viewers (editor /
+              // diff / media / svg / pdf / unsupported) are one-per-FILE (deduped
+              // by id, which is `${type}:${path}`) so opening a different file
+              // always gets its own tab. Everything else is a singleton PER COLUMN
+              // (focus the existing instance in the target column, else open one).
+              const allowMultiple =
+                tab.type === "editor" ||
+                tab.type === "diff" ||
+                tab.type === "chat" ||
+                tab.type === "model-chat" ||
+                tab.type === "media" ||
+                tab.type === "svg" ||
+                tab.type === "pdf" ||
+                tab.type === "unsupported";
 
-            const remaining = s.tabs.filter((t) => groupOf(t) === grp);
-            if (remaining.length === 0) {
-              if (s.groupOrder.length > 1) {
-                // The column emptied — collapse the split.
-                s.groupOrder = s.groupOrder.filter((g) => g !== grp);
-                delete s.activeByGroup[grp];
-                if (s.focusedGroupId === grp) s.focusedGroupId = s.groupOrder[0];
+              let targetId = tab.id;
+              // Where the tab lands: caller-specified column, else the focused one.
+              let targetGroup = groupId ?? s.focusedGroupId;
+              if (!s.groupOrder.includes(targetGroup))
+                targetGroup = s.focusedGroupId;
+
+              if (!allowMultiple) {
+                const existingInGroup = s.tabs.find(
+                  (t) => t.type === tab.type && groupOf(t) === targetGroup,
+                );
+                if (existingInGroup) {
+                  targetId = existingInGroup.id; // focus the one already in this column
+                } else {
+                  // New instance in the target column; ensure a unique id since
+                  // callers may reuse a fixed id (e.g. "terminal", "settings").
+                  targetId = uniqueTabId(s, tab.id);
+                  s.tabs.push({ ...tab, id: targetId, groupId: targetGroup });
+                }
               } else {
-                // Last column emptied — restore the permanent welcome chat.
-                s.tabs.push(WELCOME_TAB(grp));
-                s.activeByGroup[grp] = "welcome-chat";
+                const existsById = s.tabs.find((t) => t.id === tab.id);
+                if (existsById) {
+                  targetGroup = groupOf(existsById);
+                } else {
+                  s.tabs.push({ ...tab, groupId: targetGroup });
+                }
               }
-            } else if (s.activeByGroup[grp] === id) {
-              // Activate the neighbour at the same slot within the column.
-              const next = remaining[Math.min(groupIdxInGroup, remaining.length - 1)];
-              s.activeByGroup[grp] = next.id;
-            }
-            syncActiveMirror(s);
-          }),
-        setActiveTab: (id) =>
-          set((s) => {
-            const tab = s.tabs.find((t) => t.id === id);
-            const target = tab ? id : s.tabs[0]?.id ?? null;
-            if (target === null) return;
-            const grp = groupOf(s.tabs.find((t) => t.id === target));
-            s.focusedGroupId = grp;
-            s.activeByGroup[grp] = target;
-            pushTabHistory(s, target);
-            syncActiveMirror(s);
-          }),
-        toggleTabBar: () =>
-          set((s) => {
-            s.tabBarVisible = !s.tabBarVisible;
-          }),
-        navigateTabBack: () =>
-          set((s) => {
-            for (let i = s.tabHistoryIndex - 1; i >= 0; i--) {
-              const id = s.tabHistory[i];
+              s.focusedGroupId = targetGroup;
+              s.activeByGroup[targetGroup] = targetId;
+              pushTabHistory(s, targetId);
+              syncActiveMirror(s);
+            }),
+          closeTab: (id) =>
+            set((s) => {
+              const idx = s.tabs.findIndex((t) => t.id === id);
+              if (idx === -1) return;
+              const tab = s.tabs[idx];
+              if (!tab.closable) return;
+              const grp = groupOf(tab);
+              const groupIdxInGroup = s.tabs
+                .filter((t) => groupOf(t) === grp)
+                .findIndex((t) => t.id === id);
+              s.tabs.splice(idx, 1);
+
+              const remaining = s.tabs.filter((t) => groupOf(t) === grp);
+              if (remaining.length === 0) {
+                if (s.groupOrder.length > 1) {
+                  // The column emptied — collapse the split.
+                  s.groupOrder = s.groupOrder.filter((g) => g !== grp);
+                  delete s.activeByGroup[grp];
+                  if (s.focusedGroupId === grp)
+                    s.focusedGroupId = s.groupOrder[0];
+                } else {
+                  // Last column emptied — restore the permanent welcome chat.
+                  s.tabs.push(WELCOME_TAB(grp));
+                  s.activeByGroup[grp] = "welcome-chat";
+                }
+              } else if (s.activeByGroup[grp] === id) {
+                // Activate the neighbour at the same slot within the column.
+                const next =
+                  remaining[Math.min(groupIdxInGroup, remaining.length - 1)];
+                s.activeByGroup[grp] = next.id;
+              }
+              syncActiveMirror(s);
+            }),
+          setActiveTab: (id) =>
+            set((s) => {
               const tab = s.tabs.find((t) => t.id === id);
-              if (tab) {
-                s.tabHistoryIndex = i;
-                s.focusedGroupId = groupOf(tab);
-                s.activeByGroup[s.focusedGroupId] = id;
-                syncActiveMirror(s);
+              const target = tab ? id : (s.tabs[0]?.id ?? null);
+              if (target === null) return;
+              const grp = groupOf(s.tabs.find((t) => t.id === target));
+              s.focusedGroupId = grp;
+              s.activeByGroup[grp] = target;
+              pushTabHistory(s, target);
+              syncActiveMirror(s);
+            }),
+          toggleTabBar: () =>
+            set((s) => {
+              s.tabBarVisible = !s.tabBarVisible;
+            }),
+          navigateTabBack: () =>
+            set((s) => {
+              for (let i = s.tabHistoryIndex - 1; i >= 0; i--) {
+                const id = s.tabHistory[i];
+                const tab = s.tabs.find((t) => t.id === id);
+                if (tab) {
+                  s.tabHistoryIndex = i;
+                  s.focusedGroupId = groupOf(tab);
+                  s.activeByGroup[s.focusedGroupId] = id;
+                  syncActiveMirror(s);
+                  return;
+                }
+              }
+            }),
+          navigateTabForward: () =>
+            set((s) => {
+              for (
+                let i = s.tabHistoryIndex + 1;
+                i < s.tabHistory.length;
+                i++
+              ) {
+                const id = s.tabHistory[i];
+                const tab = s.tabs.find((t) => t.id === id);
+                if (tab) {
+                  s.tabHistoryIndex = i;
+                  s.focusedGroupId = groupOf(tab);
+                  s.activeByGroup[s.focusedGroupId] = id;
+                  syncActiveMirror(s);
+                  return;
+                }
+              }
+            }),
+          // ⌘1–9 — select the i-th tab WITHIN the focused column.
+          activateTabByIndex: (i) =>
+            set((s) => {
+              const groupTabs = s.tabs.filter(
+                (t) => groupOf(t) === s.focusedGroupId,
+              );
+              const target =
+                i < 0 ? groupTabs[groupTabs.length - 1] : groupTabs[i];
+              if (!target) return;
+              s.activeByGroup[s.focusedGroupId] = target.id;
+              pushTabHistory(s, target.id);
+              syncActiveMirror(s);
+            }),
+          cycleTab: (delta) =>
+            set((s) => {
+              const groupTabs = s.tabs.filter(
+                (t) => groupOf(t) === s.focusedGroupId,
+              );
+              if (groupTabs.length === 0) return;
+              const cur = s.activeByGroup[s.focusedGroupId];
+              const ci = Math.max(
+                0,
+                groupTabs.findIndex((t) => t.id === cur),
+              );
+              const next =
+                groupTabs[(ci + delta + groupTabs.length) % groupTabs.length];
+              s.activeByGroup[s.focusedGroupId] = next.id;
+              pushTabHistory(s, next.id);
+              syncActiveMirror(s);
+            }),
+          setFocusedGroup: (groupId) =>
+            set((s) => {
+              if (
+                !s.groupOrder.includes(groupId) ||
+                s.focusedGroupId === groupId
+              )
+                return;
+              s.focusedGroupId = groupId;
+              syncActiveMirror(s);
+            }),
+          focusAdjacentGroup: (delta) =>
+            set((s) => {
+              const i = s.groupOrder.indexOf(s.focusedGroupId);
+              const ni = i + delta;
+              if (ni < 0 || ni >= s.groupOrder.length) return;
+              s.focusedGroupId = s.groupOrder[ni];
+              syncActiveMirror(s);
+            }),
+          addGroup: () =>
+            set((s) => {
+              if (s.groupOrder.length >= MAX_GROUPS) return;
+              const gid = `split-${Date.now().toString(36)}-${Math.random()
+                .toString(36)
+                .slice(2, 5)}`;
+              const fi = s.groupOrder.indexOf(s.focusedGroupId);
+              s.groupOrder.splice(fi + 1, 0, gid);
+              s.activeByGroup[gid] = null;
+              s.focusedGroupId = gid;
+              syncActiveMirror(s);
+            }),
+          closeGroup: (groupId) =>
+            set((s) => {
+              if (s.groupOrder.length <= 1) return;
+              const gi = s.groupOrder.indexOf(groupId);
+              if (gi === -1) return;
+              const leftId = s.groupOrder[gi - 1] ?? s.groupOrder[gi + 1];
+              // Move the column's tabs to the neighbour (they remount there).
+              for (const t of s.tabs) {
+                if (groupOf(t) === groupId) t.groupId = leftId;
+              }
+              const moved = s.activeByGroup[groupId];
+              s.groupOrder.splice(gi, 1);
+              delete s.activeByGroup[groupId];
+              if (moved) s.activeByGroup[leftId] = moved;
+              s.focusedGroupId = leftId;
+              syncActiveMirror(s);
+            }),
+          toggleZenMode: () =>
+            set((s) => {
+              // Exit: restore the snapshot.
+              if (s.zen && s.zenPrev) {
+                const p = s.zenPrev;
+                s.leftPanel.visible = p.leftVisible;
+                s.rightPanel.visible = p.rightVisible;
+                s.groupOrder = p.groupOrder.length
+                  ? [...p.groupOrder]
+                  : [DEFAULT_GROUP];
+                s.activeByGroup = { ...p.activeByGroup };
+                s.focusedGroupId = p.focusedGroupId;
+                for (const t of s.tabs)
+                  t.groupId = p.tabGroups[t.id] ?? s.groupOrder[0];
+                s.zen = false;
+                s.zenPrev = null;
+                reconcileGroups(s);
                 return;
               }
-            }
-          }),
-        navigateTabForward: () =>
-          set((s) => {
-            for (let i = s.tabHistoryIndex + 1; i < s.tabHistory.length; i++) {
-              const id = s.tabHistory[i];
-              const tab = s.tabs.find((t) => t.id === id);
-              if (tab) {
-                s.tabHistoryIndex = i;
-                s.focusedGroupId = groupOf(tab);
-                s.activeByGroup[s.focusedGroupId] = id;
-                syncActiveMirror(s);
-                return;
-              }
-            }
-          }),
-        // ⌘1–9 — select the i-th tab WITHIN the focused column.
-        activateTabByIndex: (i) =>
-          set((s) => {
-            const groupTabs = s.tabs.filter((t) => groupOf(t) === s.focusedGroupId);
-            const target = i < 0 ? groupTabs[groupTabs.length - 1] : groupTabs[i];
-            if (!target) return;
-            s.activeByGroup[s.focusedGroupId] = target.id;
-            pushTabHistory(s, target.id);
-            syncActiveMirror(s);
-          }),
-        cycleTab: (delta) =>
-          set((s) => {
-            const groupTabs = s.tabs.filter((t) => groupOf(t) === s.focusedGroupId);
-            if (groupTabs.length === 0) return;
-            const cur = s.activeByGroup[s.focusedGroupId];
-            const ci = Math.max(0, groupTabs.findIndex((t) => t.id === cur));
-            const next = groupTabs[(ci + delta + groupTabs.length) % groupTabs.length];
-            s.activeByGroup[s.focusedGroupId] = next.id;
-            pushTabHistory(s, next.id);
-            syncActiveMirror(s);
-          }),
-        setFocusedGroup: (groupId) =>
-          set((s) => {
-            if (!s.groupOrder.includes(groupId) || s.focusedGroupId === groupId) return;
-            s.focusedGroupId = groupId;
-            syncActiveMirror(s);
-          }),
-        focusAdjacentGroup: (delta) =>
-          set((s) => {
-            const i = s.groupOrder.indexOf(s.focusedGroupId);
-            const ni = i + delta;
-            if (ni < 0 || ni >= s.groupOrder.length) return;
-            s.focusedGroupId = s.groupOrder[ni];
-            syncActiveMirror(s);
-          }),
-        addGroup: () =>
-          set((s) => {
-            if (s.groupOrder.length >= MAX_GROUPS) return;
-            const gid = `split-${Date.now().toString(36)}-${Math.random()
-              .toString(36)
-              .slice(2, 5)}`;
-            const fi = s.groupOrder.indexOf(s.focusedGroupId);
-            s.groupOrder.splice(fi + 1, 0, gid);
-            s.activeByGroup[gid] = null;
-            s.focusedGroupId = gid;
-            syncActiveMirror(s);
-          }),
-        closeGroup: (groupId) =>
-          set((s) => {
-            if (s.groupOrder.length <= 1) return;
-            const gi = s.groupOrder.indexOf(groupId);
-            if (gi === -1) return;
-            const leftId = s.groupOrder[gi - 1] ?? s.groupOrder[gi + 1];
-            // Move the column's tabs to the neighbour (they remount there).
-            for (const t of s.tabs) {
-              if (groupOf(t) === groupId) t.groupId = leftId;
-            }
-            const moved = s.activeByGroup[groupId];
-            s.groupOrder.splice(gi, 1);
-            delete s.activeByGroup[groupId];
-            if (moved) s.activeByGroup[leftId] = moved;
-            s.focusedGroupId = leftId;
-            syncActiveMirror(s);
-          }),
-        toggleZenMode: () =>
-          set((s) => {
-            // Exit: restore the snapshot.
-            if (s.zen && s.zenPrev) {
-              const p = s.zenPrev;
-              s.leftPanel.visible = p.leftVisible;
-              s.rightPanel.visible = p.rightVisible;
-              s.groupOrder = p.groupOrder.length ? [...p.groupOrder] : [DEFAULT_GROUP];
-              s.activeByGroup = { ...p.activeByGroup };
-              s.focusedGroupId = p.focusedGroupId;
-              for (const t of s.tabs) t.groupId = p.tabGroups[t.id] ?? s.groupOrder[0];
-              s.zen = false;
-              s.zenPrev = null;
-              reconcileGroups(s);
-              return;
-            }
-            // Enter: snapshot the current layout, then build Knowledge │ Chat │
-            // Browser with the side panels hidden.
-            const tabGroups: Record<string, string> = {};
-            for (const t of s.tabs) tabGroups[t.id] = groupOf(t);
-            s.zenPrev = {
-              groupOrder: [...s.groupOrder],
-              activeByGroup: { ...s.activeByGroup },
-              focusedGroupId: s.focusedGroupId,
-              tabGroups,
-              leftVisible: s.leftPanel.visible,
-              rightVisible: s.rightPanel.visible,
-            };
-            const G_KB = "zen-kb";
-            const G_CHAT = "zen-chat";
-            const G_BROWSER = "zen-browser";
-            // Reuse the existing singleton tab if present, else create one.
-            const ensure = (type: TabType, title: string, gid: string): string => {
-              const existing = s.tabs.find((x) => x.type === type);
-              if (existing) {
-                existing.groupId = gid;
-                return existing.id;
-              }
-              const id = `${type}-zen`;
-              s.tabs.push({ id, type, title, closable: true, dirty: false, data: {}, groupId: gid });
-              return id;
-            };
-            const kbId = ensure("knowledge", "Knowledge", G_KB);
-            // A chat tab always exists (welcome-chat is the non-closable baseline).
-            let chat = s.tabs.find((x) => x.type === "chat");
-            if (!chat) {
-              chat = { id: "chat-zen", type: "chat", title: "Chat", closable: true, dirty: false, data: {}, groupId: G_CHAT };
-              s.tabs.push(chat);
-            } else {
-              chat.groupId = G_CHAT;
-            }
-            const browserId = ensure("browser", "Browser", G_BROWSER);
-            s.groupOrder = [G_KB, G_CHAT, G_BROWSER];
-            s.activeByGroup = { [G_KB]: kbId, [G_CHAT]: chat.id, [G_BROWSER]: browserId };
-            s.focusedGroupId = G_CHAT;
-            s.leftPanel.visible = false;
-            s.rightPanel.visible = false;
-            s.zen = true;
-            syncActiveMirror(s);
-          }),
-        applyLayoutTemplate: (template) =>
-          set((s) => {
-            // Leaving zen if we were in it.
-            s.zen = false;
-            s.zenPrev = null;
-
-            // One column per template cell. Reuse an existing tab of the cell's
-            // type when present (preserve open work), else create one.
-            const order: string[] = [];
-            const active: Record<string, string | null> = {};
-            template.columns.forEach((col, i) => {
-              const gid = i === 0 ? DEFAULT_GROUP : `tpl-${i}`;
-              order.push(gid);
-              const existing = s.tabs.find((t) => t.type === col.type);
-              let id: string;
-              if (existing) {
-                existing.groupId = gid;
-                id = existing.id;
-              } else {
-                const ts = Date.now().toString(36);
-                id = `${col.type}-tpl-${i}-${ts}`;
-                // A fresh editor needs a buffer key or it renders blank; seed an
-                // untitled scratch buffer (same convention as ⌘N).
-                const data =
-                  col.type === "editor"
-                    ? { filePath: `untitled:tpl-${i}-${ts}` }
-                    : {};
+              // Enter: snapshot the current layout, then build Knowledge │ Chat │
+              // Browser with the side panels hidden.
+              const tabGroups: Record<string, string> = {};
+              for (const t of s.tabs) tabGroups[t.id] = groupOf(t);
+              s.zenPrev = {
+                groupOrder: [...s.groupOrder],
+                activeByGroup: { ...s.activeByGroup },
+                focusedGroupId: s.focusedGroupId,
+                tabGroups,
+                leftVisible: s.leftPanel.visible,
+                rightVisible: s.rightPanel.visible,
+              };
+              const G_KB = "zen-kb";
+              const G_CHAT = "zen-chat";
+              const G_BROWSER = "zen-browser";
+              // Reuse the existing singleton tab if present, else create one.
+              const ensure = (
+                type: TabType,
+                title: string,
+                gid: string,
+              ): string => {
+                const existing = s.tabs.find((x) => x.type === type);
+                if (existing) {
+                  existing.groupId = gid;
+                  return existing.id;
+                }
+                const id = `${type}-zen`;
                 s.tabs.push({
                   id,
-                  type: col.type,
-                  title: col.title,
-                  closable: col.type !== "chat",
+                  type,
+                  title,
+                  closable: true,
                   dirty: false,
-                  data,
+                  data: {},
                   groupId: gid,
                 });
+                return id;
+              };
+              const kbId = ensure("knowledge", "Knowledge", G_KB);
+              // A chat tab always exists (welcome-chat is the non-closable baseline).
+              let chat = s.tabs.find((x) => x.type === "chat");
+              if (!chat) {
+                chat = {
+                  id: "chat-zen",
+                  type: "chat",
+                  title: "Chat",
+                  closable: true,
+                  dirty: false,
+                  data: {},
+                  groupId: G_CHAT,
+                };
+                s.tabs.push(chat);
+              } else {
+                chat.groupId = G_CHAT;
               }
-              active[gid] = id;
-            });
+              const browserId = ensure("browser", "Browser", G_BROWSER);
+              s.groupOrder = [G_KB, G_CHAT, G_BROWSER];
+              s.activeByGroup = {
+                [G_KB]: kbId,
+                [G_CHAT]: chat.id,
+                [G_BROWSER]: browserId,
+              };
+              s.focusedGroupId = G_CHAT;
+              s.leftPanel.visible = false;
+              s.rightPanel.visible = false;
+              s.zen = true;
+              syncActiveMirror(s);
+            }),
+          applyLayoutTemplate: (template) =>
+            set((s) => {
+              // Leaving zen if we were in it.
+              s.zen = false;
+              s.zenPrev = null;
 
-            s.groupOrder = order;
-            s.activeByGroup = active;
-            s.focusedGroupId = order[Math.min(template.focus ?? order.length - 1, order.length - 1)];
-
-            // Park any OTHER open tabs in the first column (kept, not lost) and
-            // validate actives/focus.
-            reconcileGroups(s);
-
-            // Panels — left/right are explicitly controlled by templates;
-            // bottom (status bar) is only touched when a template opts in.
-            s.leftPanel.visible = !!template.panels.left;
-            s.rightPanel.visible = !!template.panels.right;
-            if (template.panels.bottom !== undefined) s.bottomPanel.visible = template.panels.bottom;
-            if (template.leftSection) s.leftPanel.activeSection = template.leftSection;
-            if (template.rightSection) s.rightPanel.activeSection = template.rightSection;
-          }),
-        setTabDirty: (id, dirty) =>
-          set((s) => {
-            const tab = s.tabs.find((t) => t.id === id);
-            if (tab) tab.dirty = dirty;
-          }),
-        // Persist the whole workspace layout (split columns + their tabs) per
-        // project so the AKB arrangement comes back on reopen. The Rust
-        // save/load commands store the JSON opaquely, so the shape is ours.
-        saveEditorState: (projectPath) => {
-          const state = useLayoutStore.getState();
-          // Zen mode is a transient overlay — don't persist its 3-column layout
-          // over the real workspace (the pre-zen snapshot stays saved, so
-          // quitting in zen reopens the underlying layout).
-          if (state.zen) return;
-          // Persist every closable tab (welcome-chat is the recreated baseline).
-          const tabs = state.tabs
-            .filter((t) => t.closable)
-            .map((t) => ({
-              id: t.id,
-              type: t.type,
-              title: t.title,
-              data: t.data,
-              groupId: groupOf(t),
-            }));
-          const data = {
-            version: 2,
-            tabs,
-            groupOrder: state.groupOrder,
-            activeByGroup: state.activeByGroup,
-            focusedGroupId: state.focusedGroupId,
-            activeTabId: state.activeTabId, // legacy readers
-          };
-          invoke("save_editor_state", {
-            projectPath,
-            stateJson: JSON.stringify(data),
-          }).catch(() => {});
-        },
-        flushEditorState: async (projectPath) => {
-          const state = useLayoutStore.getState();
-          if (state.zen) return;
-          const tabs = state.tabs
-            .filter((t) => t.closable)
-            .map((t) => ({
-              id: t.id,
-              type: t.type,
-              title: t.title,
-              data: t.data,
-              groupId: groupOf(t),
-            }));
-          const data = {
-            version: 2,
-            tabs,
-            groupOrder: state.groupOrder,
-            activeByGroup: state.activeByGroup,
-            focusedGroupId: state.focusedGroupId,
-            activeTabId: state.activeTabId,
-          };
-          await invoke("save_editor_state", {
-            projectPath,
-            stateJson: JSON.stringify(data),
-          }).catch(() => {});
-        },
-        commitWorkspaceView: (wsId) =>
-          set((s) => {
-            s.viewsByWs[wsId] = captureView(s);
-            s.currentViewWsId = wsId;
-          }),
-        loadWorkspaceView: (wsId) =>
-          set((s) => {
-            const v = s.viewsByWs[wsId] ?? welcomeView(wsId);
-            applyView(s, v);
-            s.currentViewWsId = wsId;
-          }),
-        removeWorkspaceView: (wsId) =>
-          set((s) => {
-            delete s.viewsByWs[wsId];
-          }),
-        loadEditorState: async (projectPath) => {
-          try {
-            const raw = await invoke<string>("load_editor_state", { projectPath });
-            const data = JSON.parse(raw) as {
-              tabs?: Array<{ id: string; type: string; title: string; data: Record<string, unknown>; groupId?: string }>;
-              groupOrder?: string[];
-              activeByGroup?: Record<string, string | null>;
-              focusedGroupId?: string;
-              activeTabId?: string;
-            };
-            if (data.tabs && data.tabs.length > 0) {
-              set((s) => {
-                // Restore the column structure (≤3). Falls back to the existing
-                // single "main" column for the legacy (v1) format.
-                if (data.groupOrder && data.groupOrder.length > 0) {
-                  s.groupOrder = data.groupOrder.slice(0, MAX_GROUPS);
-                  // If "main" (the welcome tab's column) was dropped, re-home it.
-                  if (!s.groupOrder.includes(DEFAULT_GROUP)) {
-                    const first = s.groupOrder[0];
-                    for (const t of s.tabs) if (groupOf(t) === DEFAULT_GROUP) t.groupId = first;
-                  }
-                }
-                // Add the saved tabs into their columns.
-                for (const saved of data.tabs!) {
-                  if (s.tabs.find((t) => t.id === saved.id)) continue;
-                  let gid = saved.groupId ?? DEFAULT_GROUP;
-                  if (!s.groupOrder.includes(gid)) gid = s.groupOrder[0];
+              // One column per template cell. Reuse an existing tab of the cell's
+              // type when present (preserve open work), else create one.
+              const order: string[] = [];
+              const active: Record<string, string | null> = {};
+              template.columns.forEach((col, i) => {
+                const gid = i === 0 ? DEFAULT_GROUP : `tpl-${i}`;
+                order.push(gid);
+                const existing = s.tabs.find((t) => t.type === col.type);
+                let id: string;
+                if (existing) {
+                  existing.groupId = gid;
+                  id = existing.id;
+                } else {
+                  const ts = Date.now().toString(36);
+                  id = `${col.type}-tpl-${i}-${ts}`;
+                  // A fresh editor needs a buffer key or it renders blank; seed an
+                  // untitled scratch buffer (same convention as ⌘N).
+                  const data =
+                    col.type === "editor"
+                      ? { filePath: `untitled:tpl-${i}-${ts}` }
+                      : {};
                   s.tabs.push({
-                    id: saved.id,
-                    type: saved.type as TabType,
-                    title: saved.title,
-                    closable: true,
+                    id,
+                    type: col.type,
+                    title: col.title,
+                    closable: col.type !== "chat",
                     dirty: false,
-                    data: saved.data,
+                    data,
                     groupId: gid,
                   });
                 }
-                // Reconcile: every tab in a live column; every column with a
-                // valid active tab; restore focus.
-                for (const t of s.tabs) if (!s.groupOrder.includes(groupOf(t))) t.groupId = s.groupOrder[0];
-                const saved = data.activeByGroup ?? {};
-                for (const g of s.groupOrder) {
-                  const want = saved[g];
-                  const valid = want && s.tabs.find((t) => t.id === want && groupOf(t) === g);
-                  if (valid) s.activeByGroup[g] = want!;
-                  else if (!s.activeByGroup[g] || !s.tabs.find((t) => t.id === s.activeByGroup[g] && groupOf(t) === g)) {
-                    s.activeByGroup[g] = s.tabs.find((t) => groupOf(t) === g)?.id ?? null;
-                  }
-                }
-                // Legacy: no per-group active map — fall back to activeTabId.
-                if (!data.activeByGroup && data.activeTabId && s.tabs.find((t) => t.id === data.activeTabId)) {
-                  s.activeByGroup[DEFAULT_GROUP] = data.activeTabId;
-                }
-                s.focusedGroupId =
-                  data.focusedGroupId && s.groupOrder.includes(data.focusedGroupId)
-                    ? data.focusedGroupId
-                    : s.groupOrder[0];
-                syncActiveMirror(s);
+                active[gid] = id;
               });
+
+              s.groupOrder = order;
+              s.activeByGroup = active;
+              s.focusedGroupId =
+                order[
+                  Math.min(template.focus ?? order.length - 1, order.length - 1)
+                ];
+
+              // Park any OTHER open tabs in the first column (kept, not lost) and
+              // validate actives/focus.
+              reconcileGroups(s);
+
+              // Panels — left/right are explicitly controlled by templates;
+              // bottom (status bar) is only touched when a template opts in.
+              s.leftPanel.visible = !!template.panels.left;
+              s.rightPanel.visible = !!template.panels.right;
+              if (template.panels.bottom !== undefined)
+                s.bottomPanel.visible = template.panels.bottom;
+              if (template.leftSection)
+                s.leftPanel.activeSection = template.leftSection;
+              if (template.rightSection)
+                s.rightPanel.activeSection = template.rightSection;
+            }),
+          setTabDirty: (id, dirty) =>
+            set((s) => {
+              const tab = s.tabs.find((t) => t.id === id);
+              if (tab) tab.dirty = dirty;
+            }),
+          // Persist the whole workspace layout (split columns + their tabs) per
+          // project so the AKB arrangement comes back on reopen. The Rust
+          // save/load commands store the JSON opaquely, so the shape is ours.
+          saveEditorState: (projectPath) => {
+            const state = useLayoutStore.getState();
+            // Zen mode is a transient overlay — don't persist its 3-column layout
+            // over the real workspace (the pre-zen snapshot stays saved, so
+            // quitting in zen reopens the underlying layout).
+            if (state.zen) return;
+            // Persist every closable tab (welcome-chat is the recreated baseline).
+            const tabs = state.tabs
+              .filter((t) => t.closable)
+              .map((t) => ({
+                id: t.id,
+                type: t.type,
+                title: t.title,
+                data: t.data,
+                groupId: groupOf(t),
+              }));
+            const data = {
+              version: 2,
+              tabs,
+              groupOrder: state.groupOrder,
+              activeByGroup: state.activeByGroup,
+              focusedGroupId: state.focusedGroupId,
+              activeTabId: state.activeTabId, // legacy readers
+            };
+            invoke("save_editor_state", {
+              projectPath,
+              stateJson: JSON.stringify(data),
+            }).catch(() => {});
+          },
+          flushEditorState: async (projectPath) => {
+            const state = useLayoutStore.getState();
+            if (state.zen) return;
+            const tabs = state.tabs
+              .filter((t) => t.closable)
+              .map((t) => ({
+                id: t.id,
+                type: t.type,
+                title: t.title,
+                data: t.data,
+                groupId: groupOf(t),
+              }));
+            const data = {
+              version: 2,
+              tabs,
+              groupOrder: state.groupOrder,
+              activeByGroup: state.activeByGroup,
+              focusedGroupId: state.focusedGroupId,
+              activeTabId: state.activeTabId,
+            };
+            await invoke("save_editor_state", {
+              projectPath,
+              stateJson: JSON.stringify(data),
+            }).catch(() => {});
+          },
+          commitWorkspaceView: (wsId) =>
+            set((s) => {
+              s.viewsByWs[wsId] = captureView(s);
+              s.currentViewWsId = wsId;
+            }),
+          loadWorkspaceView: (wsId) =>
+            set((s) => {
+              const v = s.viewsByWs[wsId] ?? welcomeView(wsId);
+              applyView(s, v);
+              s.currentViewWsId = wsId;
+            }),
+          removeWorkspaceView: (wsId) =>
+            set((s) => {
+              delete s.viewsByWs[wsId];
+            }),
+          loadEditorState: async (projectPath) => {
+            try {
+              const raw = await invoke<string>("load_editor_state", {
+                projectPath,
+              });
+              const data = JSON.parse(raw) as {
+                tabs?: Array<{
+                  id: string;
+                  type: string;
+                  title: string;
+                  data: Record<string, unknown>;
+                  groupId?: string;
+                }>;
+                groupOrder?: string[];
+                activeByGroup?: Record<string, string | null>;
+                focusedGroupId?: string;
+                activeTabId?: string;
+              };
+              if (data.tabs && data.tabs.length > 0) {
+                set((s) => {
+                  // Restore the column structure (≤3). Falls back to the existing
+                  // single "main" column for the legacy (v1) format.
+                  if (data.groupOrder && data.groupOrder.length > 0) {
+                    s.groupOrder = data.groupOrder.slice(0, MAX_GROUPS);
+                    // If "main" (the welcome tab's column) was dropped, re-home it.
+                    if (!s.groupOrder.includes(DEFAULT_GROUP)) {
+                      const first = s.groupOrder[0];
+                      for (const t of s.tabs)
+                        if (groupOf(t) === DEFAULT_GROUP) t.groupId = first;
+                    }
+                  }
+                  // Add the saved tabs into their columns.
+                  for (const saved of data.tabs!) {
+                    if (s.tabs.find((t) => t.id === saved.id)) continue;
+                    let gid = saved.groupId ?? DEFAULT_GROUP;
+                    if (!s.groupOrder.includes(gid)) gid = s.groupOrder[0];
+                    s.tabs.push({
+                      id: saved.id,
+                      type: saved.type as TabType,
+                      title: saved.title,
+                      closable: true,
+                      dirty: false,
+                      data: saved.data,
+                      groupId: gid,
+                    });
+                  }
+                  // Reconcile: every tab in a live column; every column with a
+                  // valid active tab; restore focus.
+                  for (const t of s.tabs)
+                    if (!s.groupOrder.includes(groupOf(t)))
+                      t.groupId = s.groupOrder[0];
+                  const saved = data.activeByGroup ?? {};
+                  for (const g of s.groupOrder) {
+                    const want = saved[g];
+                    const valid =
+                      want &&
+                      s.tabs.find((t) => t.id === want && groupOf(t) === g);
+                    if (valid) s.activeByGroup[g] = want!;
+                    else if (
+                      !s.activeByGroup[g] ||
+                      !s.tabs.find(
+                        (t) => t.id === s.activeByGroup[g] && groupOf(t) === g,
+                      )
+                    ) {
+                      s.activeByGroup[g] =
+                        s.tabs.find((t) => groupOf(t) === g)?.id ?? null;
+                    }
+                  }
+                  // Legacy: no per-group active map — fall back to activeTabId.
+                  if (
+                    !data.activeByGroup &&
+                    data.activeTabId &&
+                    s.tabs.find((t) => t.id === data.activeTabId)
+                  ) {
+                    s.activeByGroup[DEFAULT_GROUP] = data.activeTabId;
+                  }
+                  s.focusedGroupId =
+                    data.focusedGroupId &&
+                    s.groupOrder.includes(data.focusedGroupId)
+                      ? data.focusedGroupId
+                      : s.groupOrder[0];
+                  syncActiveMirror(s);
+                });
+              }
+            } catch {
+              // no saved state
             }
-          } catch {
-            // no saved state
-          }
+          },
         },
-      },
       })),
       {
         // Persist only durable UI layout preferences across app
@@ -883,7 +982,8 @@ export const useLayoutStore = createSelectors(
           // on the right) back to a valid default so the panel isn't blank.
           const LEFT = ["files", "knowledge"];
           const RIGHT = ["review-agents", "changes", "github", "git-graph"];
-          if (!LEFT.includes(leftPanel.activeSection)) leftPanel.activeSection = "files";
+          if (!LEFT.includes(leftPanel.activeSection))
+            leftPanel.activeSection = "files";
           if (!RIGHT.includes(rightPanel.activeSection))
             rightPanel.activeSection = "review-agents";
           return {
@@ -891,15 +991,21 @@ export const useLayoutStore = createSelectors(
             ...p,
             leftPanel,
             rightPanel,
-            knowledgePanel: { ...current.knowledgePanel, ...(p.knowledgePanel ?? {}) },
+            knowledgePanel: {
+              ...current.knowledgePanel,
+              ...(p.knowledgePanel ?? {}),
+            },
             bottomPanel: { ...current.bottomPanel, ...(p.bottomPanel ?? {}) },
             chatSidebar: { ...current.chatSidebar, ...(p.chatSidebar ?? {}) },
-            modelChatSidebar: { ...current.modelChatSidebar, ...(p.modelChatSidebar ?? {}) },
+            modelChatSidebar: {
+              ...current.modelChatSidebar,
+              ...(p.modelChatSidebar ?? {}),
+            },
             bashPanel: { ...current.bashPanel, ...(p.bashPanel ?? {}) },
             plansPanel: { ...current.plansPanel, ...(p.plansPanel ?? {}) },
           };
         },
       },
-    )
-  )
+    ),
+  ),
 );

--- a/src/features/log/components/log-panel.tsx
+++ b/src/features/log/components/log-panel.tsx
@@ -29,7 +29,11 @@ import {
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "@/lib/time-ago";
-import { useLogStore, type LogEntry, type LogSource } from "../stores/log-store";
+import {
+  useLogStore,
+  type LogEntry,
+  type LogSource,
+} from "../stores/log-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
 
 const SOURCES: LogSource[] = [
@@ -46,7 +50,10 @@ const SOURCES: LogSource[] = [
   "system",
 ];
 
-const SOURCE_COLOR: Record<LogSource, { text: string; bg: string; border: string }> = {
+const SOURCE_COLOR: Record<
+  LogSource,
+  { text: string; bg: string; border: string }
+> = {
   agent: {
     text: "text-[var(--accent-primary)]",
     bg: "bg-[var(--accent-primary-muted)]",
@@ -115,9 +122,11 @@ export function LogPanel() {
 
   const [search, setSearch] = useState("");
   const [activeSources, setActiveSources] = useState<Set<LogSource>>(
-    () => new Set(SOURCES)
+    () => new Set(SOURCES),
   );
-  const [projectScope, setProjectScope] = useState<"all" | "current">("current");
+  const [projectScope, setProjectScope] = useState<"all" | "current">(
+    "current",
+  );
   const [showPinnedOnly, setShowPinnedOnly] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -158,13 +167,25 @@ export function LogPanel() {
         if (e.projectPath !== currentProject.path) return false;
       }
       if (q) {
-        const hay =
-          (e.summary + " " + e.kind + " " + (e.projectName ?? "")).toLowerCase();
+        const hay = (
+          e.summary +
+          " " +
+          e.kind +
+          " " +
+          (e.projectName ?? "")
+        ).toLowerCase();
         if (!hay.includes(q)) return false;
       }
       return true;
     });
-  }, [merged, search, activeSources, projectScope, currentProject, showPinnedOnly]);
+  }, [
+    merged,
+    search,
+    activeSources,
+    projectScope,
+    currentProject,
+    showPinnedOnly,
+  ]);
 
   const toggleExpanded = (id: string) => {
     setExpanded((prev) => {
@@ -231,7 +252,7 @@ export function LogPanel() {
                 "inline-flex items-center px-1.5 h-[15px] rounded border text-[9px] font-mono leading-none",
                 c.text,
                 c.bg,
-                c.border
+                c.border,
               )}
             >
               {row.original.source}
@@ -287,7 +308,7 @@ export function LogPanel() {
                   "p-1 rounded hover:bg-[var(--bg-hover)] cursor-pointer transition-colors",
                   e.pinned
                     ? "text-[var(--accent-primary)] hover:text-[var(--accent-primary-hover)]"
-                    : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                    : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)]",
                 )}
                 title={e.pinned ? "Unpin" : "Pin (save)"}
               >
@@ -309,7 +330,7 @@ export function LogPanel() {
         size: 60,
       },
     ],
-    [expanded, copiedId, pin, unpin]
+    [expanded, copiedId, pin, unpin],
   );
 
   const table = useReactTable<LogEntry>({
@@ -359,7 +380,7 @@ export function LogPanel() {
             "flex items-center gap-1 px-2 h-6 rounded text-[10px] cursor-pointer outline-none transition-colors",
             showPinnedOnly
               ? "text-[var(--accent-primary)] bg-[var(--accent-primary-muted)]"
-              : "text-text-tertiary hover:text-text-primary hover:bg-bg-hover"
+              : "text-text-tertiary hover:text-text-primary hover:bg-bg-hover",
           )}
           title="Pinned only"
         >
@@ -396,7 +417,9 @@ export function LogPanel() {
                 style={cellStyle(h.column.id, h.getSize())}
                 className="truncate"
               >
-                {h.isPlaceholder ? null : flexRender(h.column.columnDef.header, h.getContext())}
+                {h.isPlaceholder
+                  ? null
+                  : flexRender(h.column.columnDef.header, h.getContext())}
               </div>
             ))}
           </div>
@@ -404,7 +427,10 @@ export function LogPanel() {
       </div>
 
       {/* Virtualized rows */}
-      <div ref={parentRef} className="flex-1 min-h-0 overflow-auto hide-scrollbar">
+      <div
+        ref={parentRef}
+        className="flex-1 min-h-0 overflow-auto hide-scrollbar"
+      >
         {rows.length === 0 ? (
           <div className="px-3 py-6 text-[11px] text-text-tertiary text-center">
             {merged.length === 0
@@ -439,7 +465,7 @@ export function LogPanel() {
                     onClick={() => toggleExpanded(row.original.id)}
                     className={cn(
                       "flex items-center px-3 cursor-pointer border-b border-[var(--border-subtle)] hover:bg-bg-hover",
-                      isExpanded && "bg-[var(--bg-elevated)]/40"
+                      isExpanded && "bg-[var(--bg-elevated)]/40",
                     )}
                     style={{ height: 32 }}
                   >
@@ -449,7 +475,10 @@ export function LogPanel() {
                         style={cellStyle(cell.column.id, cell.column.getSize())}
                         className="truncate flex items-center"
                       >
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
                       </div>
                     ))}
                   </div>
@@ -521,7 +550,7 @@ function SourceFilter({
                     "w-3 h-3 rounded-sm border flex items-center justify-center",
                     checked
                       ? "bg-[var(--accent-primary)] border-[var(--accent-primary)]"
-                      : "border-[var(--border-default)]"
+                      : "border-[var(--border-default)]",
                   )}
                 >
                   {checked && <Check size={9} className="text-white" />}
@@ -577,7 +606,9 @@ function ProjectScopeFilter({
                 value === v
                   ? "text-[var(--text-primary)] bg-[var(--bg-selected)]"
                   : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]",
-                v === "current" && !hasProject && "opacity-50 cursor-not-allowed"
+                v === "current" &&
+                  !hasProject &&
+                  "opacity-50 cursor-not-allowed",
               )}
             >
               {label}

--- a/src/features/log/lib/log.ts
+++ b/src/features/log/lib/log.ts
@@ -30,9 +30,7 @@ export function logEvent(entry: LogEventInput): void {
     }
     const { status, payload, ...rest } = entry;
     const merged: Record<string, unknown> | undefined =
-      status !== undefined
-        ? { ...(payload ?? {}), status }
-        : payload;
+      status !== undefined ? { ...(payload ?? {}), status } : payload;
     useLogStore.getState().actions.append({ ...rest, payload: merged });
   } catch {
     // Never let the log layer throw into the host call site.

--- a/src/features/log/stores/log-store.ts
+++ b/src/features/log/stores/log-store.ts
@@ -42,7 +42,7 @@ interface LogActions {
     append: (
       entry: Omit<LogEntry, "id" | "timestamp" | "pinned" | "projectName"> & {
         projectName?: string;
-      }
+      },
     ) => void;
     pin: (id: string) => Promise<void>;
     unpin: (id: string) => Promise<void>;
@@ -77,7 +77,9 @@ export const useLogStore = createSelectors(
           const projectPath = entry.projectPath ?? project?.path ?? undefined;
           const projectName =
             entry.projectName ??
-            (project && projectPath === project.path ? project.name : undefined);
+            (project && projectPath === project.path
+              ? project.name
+              : undefined);
           const full: LogEntry = {
             ...entry,
             id: genId(),
@@ -113,7 +115,9 @@ export const useLogStore = createSelectors(
             if (i !== -1) s.buffer[i].pinned = true;
           });
           try {
-            await invoke("append_pinned_log", { entryJson: JSON.stringify(target) });
+            await invoke("append_pinned_log", {
+              entryJson: JSON.stringify(target),
+            });
           } catch (err) {
             // eslint-disable-next-line no-console
             console.error("pin log entry failed", err);
@@ -127,7 +131,9 @@ export const useLogStore = createSelectors(
           });
           try {
             const remaining = get().pinned;
-            const body = remaining.map((e) => JSON.stringify(e)).join("\n") + (remaining.length ? "\n" : "");
+            const body =
+              remaining.map((e) => JSON.stringify(e)).join("\n") +
+              (remaining.length ? "\n" : "");
             await invoke("rewrite_pinned_log", { entriesJson: body });
           } catch (err) {
             // eslint-disable-next-line no-console
@@ -138,7 +144,9 @@ export const useLogStore = createSelectors(
           const project = useProjectStore.getState().currentProject?.path;
           set((s) => {
             // Keep entries from OTHER projects; clear the current project's.
-            s.buffer = project ? s.buffer.filter((e) => e.projectPath !== project) : [];
+            s.buffer = project
+              ? s.buffer.filter((e) => e.projectPath !== project)
+              : [];
           });
           if (project) {
             void invoke("clear_project_log", { project }).catch(() => {});
@@ -216,6 +224,6 @@ export const useLogStore = createSelectors(
           });
         },
       },
-    }))
-  )
+    })),
+  ),
 );

--- a/src/features/media/components/image-zoom-view.tsx
+++ b/src/features/media/components/image-zoom-view.tsx
@@ -25,18 +25,29 @@ const CHECKER: React.CSSProperties = {
 const MIN_SCALE = 1;
 const MAX_SCALE = 8;
 
-const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.min(hi, Math.max(lo, v));
 
 /**
  * Zoomable / pannable image. Wheel (or ⌘/Ctrl-wheel) zooms toward the cursor,
  * drag pans when zoomed in, double-click resets to fit. Scale is clamped to
  * [1, 8]; at 1× the image snaps back to centered/fit.
  */
-export function ImageZoomView({ src, alt, fill, checkerboard }: ImageZoomViewProps) {
+export function ImageZoomView({
+  src,
+  alt,
+  fill,
+  checkerboard,
+}: ImageZoomViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
-  const dragRef = useRef<{ x: number; y: number; ox: number; oy: number } | null>(null);
+  const dragRef = useRef<{
+    x: number;
+    y: number;
+    ox: number;
+    oy: number;
+  } | null>(null);
 
   const reset = useCallback(() => {
     setScale(1);
@@ -48,24 +59,21 @@ export function ImageZoomView({ src, alt, fill, checkerboard }: ImageZoomViewPro
     reset();
   }, [src, reset]);
 
-  const zoomAt = useCallback(
-    (factor: number, cx: number, cy: number) => {
-      setScale((prev) => {
-        const next = clamp(prev * factor, MIN_SCALE, MAX_SCALE);
-        const ratio = next / prev;
-        if (next === MIN_SCALE) {
-          setOffset({ x: 0, y: 0 });
-        } else {
-          setOffset((o) => ({
-            x: cx - ratio * (cx - o.x),
-            y: cy - ratio * (cy - o.y),
-          }));
-        }
-        return next;
-      });
-    },
-    []
-  );
+  const zoomAt = useCallback((factor: number, cx: number, cy: number) => {
+    setScale((prev) => {
+      const next = clamp(prev * factor, MIN_SCALE, MAX_SCALE);
+      const ratio = next / prev;
+      if (next === MIN_SCALE) {
+        setOffset({ x: 0, y: 0 });
+      } else {
+        setOffset((o) => ({
+          x: cx - ratio * (cx - o.x),
+          y: cy - ratio * (cy - o.y),
+        }));
+      }
+      return next;
+    });
+  }, []);
 
   // Non-passive wheel listener so we can preventDefault the page scroll.
   useEffect(() => {
@@ -88,7 +96,12 @@ export function ImageZoomView({ src, alt, fill, checkerboard }: ImageZoomViewPro
   const onPointerDown = (e: React.PointerEvent) => {
     if (scale <= 1) return;
     e.currentTarget.setPointerCapture(e.pointerId);
-    dragRef.current = { x: e.clientX, y: e.clientY, ox: offset.x, oy: offset.y };
+    dragRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+      ox: offset.x,
+      oy: offset.y,
+    };
   };
   const onPointerMove = (e: React.PointerEvent) => {
     const d = dragRef.current;

--- a/src/features/media/components/media-viewer.tsx
+++ b/src/features/media/components/media-viewer.tsx
@@ -34,7 +34,8 @@ export function MediaViewer({ filePath }: MediaViewerProps) {
   useEffect(() => {
     refreshMtime();
     window.addEventListener("atlas:window-active", refreshMtime);
-    return () => window.removeEventListener("atlas:window-active", refreshMtime);
+    return () =>
+      window.removeEventListener("atlas:window-active", refreshMtime);
   }, [refreshMtime]);
 
   const src = useMemo(() => {

--- a/src/features/memory/components/atlas-memory-view.tsx
+++ b/src/features/memory/components/atlas-memory-view.tsx
@@ -53,7 +53,11 @@ function latestPlan(items: ReplayItem[]): TodoItem[] | null {
   return null;
 }
 
-export function AtlasMemoryView({ projectPath }: { projectPath: string | null }) {
+export function AtlasMemoryView({
+  projectPath,
+}: {
+  projectPath: string | null;
+}) {
   const [sessions, setSessions] = useState<CerseiSessionMeta[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [transcript, setTranscript] = useState<ReplayItem[] | null>(null);
@@ -74,7 +78,10 @@ export function AtlasMemoryView({ projectPath }: { projectPath: string | null })
       if (!projectPath) return;
       setLoading(true);
       setTranscript(null);
-      invoke<ReplayItem[]>("cersei_session_transcript", { projectPath, sessionId: id })
+      invoke<ReplayItem[]>("cersei_session_transcript", {
+        projectPath,
+        sessionId: id,
+      })
         .then(setTranscript)
         .catch(() => setTranscript([]))
         .finally(() => setLoading(false));
@@ -86,12 +93,17 @@ export function AtlasMemoryView({ projectPath }: { projectPath: string | null })
     if (selected) loadTranscript(selected);
   }, [selected, loadTranscript]);
 
-  const plan = useMemo(() => (transcript ? latestPlan(transcript) : null), [transcript]);
+  const plan = useMemo(
+    () => (transcript ? latestPlan(transcript) : null),
+    [transcript],
+  );
 
   if (!projectPath) {
     return (
       <div className="h-full flex items-center justify-center">
-        <p className="text-[12px] text-[var(--text-tertiary)]">Open a project to view Atlas agent memory.</p>
+        <p className="text-[12px] text-[var(--text-tertiary)]">
+          Open a project to view Atlas agent memory.
+        </p>
       </div>
     );
   }
@@ -101,7 +113,8 @@ export function AtlasMemoryView({ projectPath }: { projectPath: string | null })
       <div className="h-full flex flex-col items-center justify-center gap-2 text-center px-6">
         <AtlasIcon size={20} />
         <p className="text-[12px] text-[var(--text-tertiary)]">
-          No Atlas agent sessions yet. Chat with the Atlas agent and its sessions + plans appear here.
+          No Atlas agent sessions yet. Chat with the Atlas agent and its
+          sessions + plans appear here.
         </p>
       </div>
     );
@@ -117,10 +130,14 @@ export function AtlasMemoryView({ projectPath }: { projectPath: string | null })
             onClick={() => setSelected(s.id)}
             className={cn(
               "flex w-full flex-col gap-0.5 border-b border-[var(--border-subtle)] px-3 py-2 text-left transition-colors",
-              s.id === selected ? "bg-[var(--bg-selected,var(--bg-hover))]" : "hover:bg-[var(--bg-hover)]",
+              s.id === selected
+                ? "bg-[var(--bg-selected,var(--bg-hover))]"
+                : "hover:bg-[var(--bg-hover)]",
             )}
           >
-            <span className="truncate text-[12px] text-[var(--text-primary)]">{s.preview || "Session"}</span>
+            <span className="truncate text-[12px] text-[var(--text-primary)]">
+              {s.preview || "Session"}
+            </span>
             <span className="text-[10px] text-[var(--text-tertiary)] tabular-nums">
               {s.message_count} msg{s.message_count === 1 ? "" : "s"}
               {s.last_modified ? ` · ${timeAgo(s.last_modified)}` : ""}
@@ -140,16 +157,29 @@ export function AtlasMemoryView({ projectPath }: { projectPath: string | null })
             {plan && (
               <div className="mb-4 rounded-md border border-[var(--border-default)] bg-[var(--bg-secondary)] px-3 py-2">
                 <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
-                  <ListTodo size={11} className="text-[var(--accent-primary)]" /> Plan
+                  <ListTodo
+                    size={11}
+                    className="text-[var(--accent-primary)]"
+                  />{" "}
+                  Plan
                 </div>
                 {plan.map((t, i) => (
                   <div key={i} className="flex items-start gap-2 py-0.5">
                     {t.status === "completed" ? (
-                      <CheckCircle2 size={12} className="mt-0.5 shrink-0 text-[var(--status-success)]" />
+                      <CheckCircle2
+                        size={12}
+                        className="mt-0.5 shrink-0 text-[var(--status-success)]"
+                      />
                     ) : t.status === "in_progress" ? (
-                      <Loader2 size={12} className="mt-0.5 shrink-0 animate-spin text-[var(--accent-primary)]" />
+                      <Loader2
+                        size={12}
+                        className="mt-0.5 shrink-0 animate-spin text-[var(--accent-primary)]"
+                      />
                     ) : (
-                      <Circle size={12} className="mt-0.5 shrink-0 text-[var(--text-tertiary)]" />
+                      <Circle
+                        size={12}
+                        className="mt-0.5 shrink-0 text-[var(--text-tertiary)]"
+                      />
                     )}
                     <span
                       className={cn(
@@ -183,7 +213,9 @@ function TranscriptItem({ item }: { item: ReplayItem }) {
     if (item.name === "TodoWrite") return null; // shown as the Plan block above
     return (
       <div className="rounded border border-l-2 border-[var(--border-default)] border-l-[var(--border-strong)] bg-[var(--bg-secondary)] px-3 py-1.5">
-        <span className="font-mono text-[11px] text-[var(--text-secondary)]">{item.name}</span>
+        <span className="font-mono text-[11px] text-[var(--text-secondary)]">
+          {item.name}
+        </span>
         {item.result && (
           <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-[var(--text-tertiary)]">
             {item.result}
@@ -192,7 +224,12 @@ function TranscriptItem({ item }: { item: ReplayItem }) {
       </div>
     );
   }
-  const roleLabel = item.kind === "user" ? "User" : item.kind === "thinking" ? "Thinking" : "Atlas";
+  const roleLabel =
+    item.kind === "user"
+      ? "User"
+      : item.kind === "thinking"
+        ? "Thinking"
+        : "Atlas";
   return (
     <div>
       <div className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
@@ -201,7 +238,9 @@ function TranscriptItem({ item }: { item: ReplayItem }) {
       <div
         className={cn(
           "text-[12px] leading-relaxed",
-          item.kind === "thinking" ? "italic text-[var(--text-tertiary)]" : "text-[var(--text-secondary)]",
+          item.kind === "thinking"
+            ? "italic text-[var(--text-tertiary)]"
+            : "text-[var(--text-secondary)]",
         )}
       >
         <Markdown>{item.text}</Markdown>

--- a/src/features/memory/components/memory-chat-view.tsx
+++ b/src/features/memory/components/memory-chat-view.tsx
@@ -21,7 +21,10 @@ import { timeAgo } from "@/lib/time-ago";
 import { openFile } from "@/lib/open-file";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { MessageItem } from "@/features/chat/components/message-item";
-import { ChatInput, type ChatInputHandle } from "@/features/chat/components/chat-input";
+import {
+  ChatInput,
+  type ChatInputHandle,
+} from "@/features/chat/components/chat-input";
 import { CHAT_PROVIDERS } from "@/features/settings/lib/providers";
 import { useByokStore } from "@/features/settings/stores/byok-store";
 import { useMemoryChatStore, type ChatMode } from "../stores/memory-chat-store";
@@ -34,16 +37,18 @@ type ProviderOpt = { id: string; name: string };
 // on-device model (Local) or a BYOK provider (Provider), chosen per chat.
 
 function openProviderSettings() {
-  void import("@/features/layout/stores/layout-store").then(({ useLayoutStore }) => {
-    useLayoutStore.getState().actions.addTab({
-      id: "settings",
-      type: "settings",
-      title: "Settings",
-      closable: true,
-      dirty: false,
-      data: { section: "providers" },
-    });
-  });
+  void import("@/features/layout/stores/layout-store").then(
+    ({ useLayoutStore }) => {
+      useLayoutStore.getState().actions.addTab({
+        id: "settings",
+        type: "settings",
+        title: "Settings",
+        closable: true,
+        dirty: false,
+        data: { section: "providers" },
+      });
+    },
+  );
 }
 
 export function MemoryChatView() {
@@ -61,7 +66,11 @@ export function MemoryChatView() {
   }, [init, byokLoaded, loadByok]);
 
   const configured: ProviderOpt[] = useMemo(
-    () => CHAT_PROVIDERS.filter((p) => !!byokKeys[p.id]).map((p) => ({ id: p.id, name: p.name })),
+    () =>
+      CHAT_PROVIDERS.filter((p) => !!byokKeys[p.id]).map((p) => ({
+        id: p.id,
+        name: p.name,
+      })),
     [byokKeys],
   );
   const localReady = phase === "ready";
@@ -71,7 +80,7 @@ export function MemoryChatView() {
   const makeNew = () =>
     newSession({
       mode: localReady ? "local" : "provider",
-      provider: localReady ? "" : configured[0]?.id ?? "",
+      provider: localReady ? "" : (configured[0]?.id ?? ""),
     });
 
   if (!showChat) {
@@ -147,14 +156,22 @@ function Sidebar({ onNew }: { onNew: () => void }) {
               >
                 <span className="shrink-0 inline-flex h-[15px] items-center">
                   {streaming[m.id] ? (
-                    <Loader2 size={10} className="animate-spin text-[var(--accent-primary,#60a5fa)]" />
+                    <Loader2
+                      size={10}
+                      className="animate-spin text-[var(--accent-primary,#60a5fa)]"
+                    />
                   ) : (
-                    <MessageSquare size={11} className="text-[var(--text-tertiary)]" />
+                    <MessageSquare
+                      size={11}
+                      className="text-[var(--text-tertiary)]"
+                    />
                   )}
                 </span>
                 <div className="flex-1 min-w-0 flex flex-col gap-0.5">
                   <div className="flex items-start gap-1.5">
-                    <span className="text-[11px] leading-snug line-clamp-2 flex-1">{m.title}</span>
+                    <span className="text-[11px] leading-snug line-clamp-2 flex-1">
+                      {m.title}
+                    </span>
                     <button
                       type="button"
                       onClick={(e) => {
@@ -211,7 +228,9 @@ function Conversation({
 
   const messages = session?.messages ?? [];
   const modelLabel =
-    session?.mode === "provider" ? `${session.provider} · ${session.model}` : "memory · local";
+    session?.mode === "provider"
+      ? `${session.provider} · ${session.model}`
+      : "memory · local";
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -220,7 +239,10 @@ function Conversation({
 
   return (
     <div className="flex min-w-0 min-h-0 flex-1 flex-col">
-      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto [overflow-anchor:none]">
+      <div
+        ref={scrollRef}
+        className="flex-1 min-h-0 overflow-y-auto [overflow-anchor:none]"
+      >
         {messages.length === 0 ? (
           <div className="h-full grid place-items-center text-[12px] text-[var(--text-tertiary)]">
             Ask about this codebase’s memory…
@@ -232,7 +254,11 @@ function Conversation({
                 <MessageItem
                   message={m}
                   model={m.role === "assistant" ? modelLabel : null}
-                  streaming={isStreaming && i === messages.length - 1 && m.role === "assistant"}
+                  streaming={
+                    isStreaming &&
+                    i === messages.length - 1 &&
+                    m.role === "assistant"
+                  }
                   isLastInGroup
                 />
                 {m.role === "assistant" && sourcesByMsg[m.id]?.length > 0 && (
@@ -276,7 +302,8 @@ function CodebaseIndexBanner({
   const status = useMemoryChatStore.use.codebaseStatus();
   const building = useMemoryChatStore.use.codebaseBuilding();
   const progress = useMemoryChatStore.use.codebaseProgress();
-  const { loadCodebaseStatus, buildCodebaseIndex } = useMemoryChatStore.use.actions();
+  const { loadCodebaseStatus, buildCodebaseIndex } =
+    useMemoryChatStore.use.actions();
 
   useEffect(() => {
     if (projectPath) void loadCodebaseStatus(projectPath);
@@ -289,17 +316,26 @@ function CodebaseIndexBanner({
     // local summaries when the local model is ready, else structural-only.
     const opts =
       mode === "provider" && provider && model
-        ? ({ mode: "incremental", backend: "provider", provider, model } as const)
+        ? ({
+            mode: "incremental",
+            backend: "provider",
+            provider,
+            model,
+          } as const)
         : localReady
           ? ({ mode: "incremental", backend: "local" } as const)
           : ({ mode: "incremental", backend: "structural" } as const);
     void buildCodebaseIndex(projectPath, opts);
   };
 
-  const lead = status?.indexed ? `Codebase: ${status.fileCount} files` : "Codebase not indexed";
+  const lead = status?.indexed
+    ? `Codebase: ${status.fileCount} files`
+    : "Codebase not indexed";
   const rest = status?.indexed
     ? (status.summaryCount ? ` · ${status.summaryCount} summarized` : "") +
-      (status.builtAtMs ? ` · updated ${timeAgo(new Date(status.builtAtMs).toISOString(), { suffix: true })}` : "")
+      (status.builtAtMs
+        ? ` · updated ${timeAgo(new Date(status.builtAtMs).toISOString(), { suffix: true })}`
+        : "")
     : " — answers may be outdated";
 
   return (
@@ -307,7 +343,9 @@ function CodebaseIndexBanner({
       <span className="flex min-w-0 items-center gap-2 truncate">
         <Boxes size={12} className="shrink-0 text-[var(--text-tertiary)]" />
         <span className="truncate">
-          <span className="font-semibold text-[var(--text-primary)]">{lead}</span>
+          <span className="font-semibold text-[var(--text-primary)]">
+            {lead}
+          </span>
           {rest && <span className="text-[var(--text-tertiary)]">{rest}</span>}
         </span>
       </span>
@@ -329,7 +367,11 @@ function CodebaseIndexBanner({
   );
 }
 
-function phaseLabel(p: { phase: string; current: number; total: number }): string {
+function phaseLabel(p: {
+  phase: string;
+  current: number;
+  total: number;
+}): string {
   if (p.phase === "scanning") return "Scanning…";
   if (p.phase === "summarizing") return `Summarizing ${p.current}/${p.total}`;
   if (p.phase === "embedding") return "Embedding…";
@@ -358,7 +400,10 @@ function Sources({ sources }: { sources: SourceRef[] }) {
             type="button"
             title={tip}
             onClick={() => openFile(s.filePath as string)}
-            className={cn(base, "hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer")}
+            className={cn(
+              base,
+              "hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer",
+            )}
           >
             <FileText size={9} />
             <span className="max-w-[160px] truncate">{s.title}</span>
@@ -382,7 +427,12 @@ function ModeToggle({
   providerReady: boolean;
   onMode: (m: ChatMode) => void;
 }) {
-  const seg = (m: ChatMode, label: string, Icon: typeof Cpu, enabled: boolean) => (
+  const seg = (
+    m: ChatMode,
+    label: string,
+    Icon: typeof Cpu,
+    enabled: boolean,
+  ) => (
     <button
       type="button"
       disabled={!enabled}
@@ -419,8 +469,20 @@ function ArcProgress({ pct, size = 13 }: { pct: number; size?: number }) {
   const clamped = Math.max(0, Math.min(100, pct));
   const off = c * (1 - clamped / 100);
   return (
-    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="-rotate-90 shrink-0">
-      <circle cx={size / 2} cy={size / 2} r={r} fill="none" strokeWidth="2" stroke="var(--border-default)" />
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="-rotate-90 shrink-0"
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        strokeWidth="2"
+        stroke="var(--border-default)"
+      />
       <circle
         cx={size / 2}
         cy={size / 2}
@@ -446,7 +508,9 @@ function InstallButton() {
   const error = useMemoryChatStore.use.modelError();
   const { downloadModel } = useMemoryChatStore.use.actions();
   const pct =
-    progress && progress.total > 0 ? Math.round((progress.received / progress.total) * 100) : 0;
+    progress && progress.total > 0
+      ? Math.round((progress.received / progress.total) * 100)
+      : 0;
 
   const pill =
     "inline-flex items-center gap-1.5 h-[26px] px-2.5 rounded-full border border-border-default bg-bg-elevated text-[10px] font-medium text-text-secondary";
@@ -469,8 +533,15 @@ function InstallButton() {
     <button
       type="button"
       onClick={() => void downloadModel()}
-      title={phase === "download-failed" ? error ?? "Download failed — retry" : "Download the local model"}
-      className={cn(pill, "shadow-[0_2px_8px_rgba(0,0,0,0.35)] hover:bg-bg-hover hover:text-text-primary transition-colors cursor-pointer")}
+      title={
+        phase === "download-failed"
+          ? (error ?? "Download failed — retry")
+          : "Download the local model"
+      }
+      className={cn(
+        pill,
+        "shadow-[0_2px_8px_rgba(0,0,0,0.35)] hover:bg-bg-hover hover:text-text-primary transition-colors cursor-pointer",
+      )}
     >
       <Download size={12} /> Install model
     </button>
@@ -493,7 +564,11 @@ function BackendPill() {
       }
       className="inline-flex items-center gap-1 h-[26px] px-2 rounded-full border border-border-default bg-bg-elevated text-[10px] font-medium text-text-tertiary"
     >
-      {metal ? <Zap size={11} className="text-text-secondary" /> : <Cpu size={11} />}
+      {metal ? (
+        <Zap size={11} className="text-text-secondary" />
+      ) : (
+        <Cpu size={11} />
+      )}
       {metal ? "Metal" : "CPU"}
     </span>
   );
@@ -557,54 +632,67 @@ function Composer({
       <div className="mx-auto w-full max-w-[760px]">
         {/* Tip peeks above the rounded input and tucks behind it (separate
             rounded-top surface, contrasting shade, no border). */}
-        <CodebaseIndexBanner mode={mode} provider={provider} model={model} localReady={localReady} />
-        <div className="relative z-10 overflow-hidden rounded-xl border border-[var(--border-default)] bg-[var(--bg-secondary)] shadow-[0_8px_24px_rgba(0,0,0,0.35)] focus-within:border-[var(--border-focus)]">
-        <ChatInput
-          ref={inputRef}
-          placeholder={disabled ? "Open a project to chat with its memory…" : "Ask about features, policies, changes…"}
-          onChange={(v) => setHasText(v.trim().length > 0)}
-          onSubmit={submit}
+        <CodebaseIndexBanner
+          mode={mode}
+          provider={provider}
+          model={model}
+          localReady={localReady}
         />
-        <div className="flex items-center justify-between gap-2 px-2 pb-2 pt-1">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <ModeToggle
-              mode={mode}
-              localReady={localReady}
-              providerReady={providerReady}
-              onMode={(m) => setMode(sessionId, m)}
-            />
-            {mode === "provider" && (
-              <ProviderModelSelector
-                configured={configured}
-                provider={provider}
-                model={model}
-                onProvider={(p) => setProvider(sessionId, p)}
-                onModel={(m) => setModel(sessionId, m)}
+        <div className="relative z-10 overflow-hidden rounded-xl border border-[var(--border-default)] bg-[var(--bg-secondary)] shadow-[0_8px_24px_rgba(0,0,0,0.35)] focus-within:border-[var(--border-focus)]">
+          <ChatInput
+            ref={inputRef}
+            placeholder={
+              disabled
+                ? "Open a project to chat with its memory…"
+                : "Ask about features, policies, changes…"
+            }
+            onChange={(v) => setHasText(v.trim().length > 0)}
+            onSubmit={submit}
+          />
+          <div className="flex items-center justify-between gap-2 px-2 pb-2 pt-1">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <ModeToggle
+                mode={mode}
+                localReady={localReady}
+                providerReady={providerReady}
+                onMode={(m) => setMode(sessionId, m)}
               />
-            )}
-            {mode === "local" && localReady && <BackendPill />}
-          </div>
-          {needsInstall ? (
-            <InstallButton />
-          ) : (
-            <button
-              type="button"
-              onClick={submit}
-              disabled={!running && (!hasText || disabled || !canSend)}
-              className={cn(
-                "flex items-center justify-center w-7 h-7 shrink-0 rounded-full transition-colors",
-                running
-                  ? "bg-[var(--bg-elevated,var(--bg-tertiary))] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-                  : !hasText || disabled || !canSend
-                    ? "bg-[var(--bg-elevated,var(--bg-tertiary))] text-[var(--text-tertiary)] cursor-not-allowed"
-                    : "bg-[var(--text-primary)] text-[var(--bg-base)] hover:opacity-90",
+              {mode === "provider" && (
+                <ProviderModelSelector
+                  configured={configured}
+                  provider={provider}
+                  model={model}
+                  onProvider={(p) => setProvider(sessionId, p)}
+                  onModel={(m) => setModel(sessionId, m)}
+                />
               )}
-              aria-label={running ? "Stop" : "Send"}
-            >
-              {running ? <Square size={11} strokeWidth={3} fill="currentColor" /> : <ArrowUp size={14} strokeWidth={2.5} />}
-            </button>
-          )}
-        </div>
+              {mode === "local" && localReady && <BackendPill />}
+            </div>
+            {needsInstall ? (
+              <InstallButton />
+            ) : (
+              <button
+                type="button"
+                onClick={submit}
+                disabled={!running && (!hasText || disabled || !canSend)}
+                className={cn(
+                  "flex items-center justify-center w-7 h-7 shrink-0 rounded-full transition-colors",
+                  running
+                    ? "bg-[var(--bg-elevated,var(--bg-tertiary))] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                    : !hasText || disabled || !canSend
+                      ? "bg-[var(--bg-elevated,var(--bg-tertiary))] text-[var(--text-tertiary)] cursor-not-allowed"
+                      : "bg-[var(--text-primary)] text-[var(--bg-base)] hover:opacity-90",
+                )}
+                aria-label={running ? "Stop" : "Send"}
+              >
+                {running ? (
+                  <Square size={11} strokeWidth={3} fill="currentColor" />
+                ) : (
+                  <ArrowUp size={14} strokeWidth={2.5} />
+                )}
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -643,7 +731,9 @@ function SetupGate({ byokLoaded }: { byokLoaded: boolean }) {
   }
 
   const pct =
-    progress && progress.total > 0 ? Math.round((progress.received / progress.total) * 100) : null;
+    progress && progress.total > 0
+      ? Math.round((progress.received / progress.total) * 100)
+      : null;
 
   return (
     <div className="h-full grid place-items-center p-8">
@@ -652,10 +742,13 @@ function SetupGate({ byokLoaded }: { byokLoaded: boolean }) {
           <Sparkles size={22} className="text-[var(--text-tertiary)]" />
         </div>
         <div>
-          <p className="text-sm font-medium text-[var(--text-primary)]">Chat with your codebase memory</p>
+          <p className="text-sm font-medium text-[var(--text-primary)]">
+            Chat with your codebase memory
+          </p>
           <p className="text-xs text-[var(--text-tertiary)] mt-1.5 leading-relaxed">
-            Ask about this project’s features, policies and changes. Run it on-device with a small
-            local model (~470&nbsp;MB), or use one of your configured providers.
+            Ask about this project’s features, policies and changes. Run it
+            on-device with a small local model (~470&nbsp;MB), or use one of
+            your configured providers.
           </p>
         </div>
 
@@ -694,7 +787,9 @@ function SetupGate({ byokLoaded }: { byokLoaded: boolean }) {
         )}
 
         {phase === "download-failed" && (
-          <p className="text-[11px] text-[var(--danger,#e5484d)]">{error ?? "Download failed"}</p>
+          <p className="text-[11px] text-[var(--danger,#e5484d)]">
+            {error ?? "Download failed"}
+          </p>
         )}
       </div>
     </div>

--- a/src/features/memory/components/memory-graph-canvas.tsx
+++ b/src/features/memory/components/memory-graph-canvas.tsx
@@ -120,9 +120,15 @@ export function MemoryGraphCanvas({
   useEffect(() => {
     let cancelled = false;
     void invoke<GraphLayout>("memory_graph_layout_load", { projectPath })
-      .then((l) => { if (!cancelled) setLayout(l ?? { positions: {} }); })
-      .catch(() => { if (!cancelled) setLayout({ positions: {} }); });
-    return () => { cancelled = true; };
+      .then((l) => {
+        if (!cancelled) setLayout(l ?? { positions: {} });
+      })
+      .catch(() => {
+        if (!cancelled) setLayout({ positions: {} });
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [projectPath]);
 
   useLayoutEffect(() => {
@@ -141,7 +147,11 @@ export function MemoryGraphCanvas({
   }, []);
 
   return (
-    <div ref={containerRef} className="h-full w-full relative" style={{ background: "var(--bg-canvas, var(--bg-base))" }}>
+    <div
+      ref={containerRef}
+      className="h-full w-full relative"
+      style={{ background: "var(--bg-canvas, var(--bg-base))" }}
+    >
       {size.width > 0 && size.height > 0 && layout !== undefined && (
         <Scene
           graph={graph}
@@ -228,7 +238,9 @@ function Scene({
       return seen;
     };
     const impact = selectedId ? reach(selectedId, adj.fwd) : new Set<string>();
-    const ancestors = selectedId ? reach(selectedId, adj.bwd) : new Set<string>();
+    const ancestors = selectedId
+      ? reach(selectedId, adj.bwd)
+      : new Set<string>();
     sceneRef.current = { ...sceneRef.current, selectedId, impact, ancestors };
   }, [selectedId, adj]);
 
@@ -276,7 +288,11 @@ function Scene({
       })
       .then(() => {
         if (disposed) {
-          try { app.destroy(true, { children: true }); } catch { /* ignore */ }
+          try {
+            app.destroy(true, { children: true });
+          } catch {
+            /* ignore */
+          }
           return;
         }
         const pushViewport = (v: Viewport) => {
@@ -289,15 +305,44 @@ function Scene({
             });
           }
         };
-        teardown = buildScene(app, graph, width, height, sceneRef, onSelect, onActivate, initialLayout, projectPath, pushViewport);
+        teardown = buildScene(
+          app,
+          graph,
+          width,
+          height,
+          sceneRef,
+          onSelect,
+          onActivate,
+          initialLayout,
+          projectPath,
+          pushViewport,
+        );
       })
-      .catch(() => { /* disposal handles fallout */ });
+      .catch(() => {
+        /* disposal handles fallout */
+      });
 
     return () => {
       disposed = true;
-      if (teardown) { try { teardown(); } catch { /* ignore */ } }
-      if (createdApp) { try { createdApp.destroy(true, { children: true }); } catch { /* ignore */ } }
-      try { host.removeChild(canvas); } catch { /* ignore */ }
+      if (teardown) {
+        try {
+          teardown();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (createdApp) {
+        try {
+          createdApp.destroy(true, { children: true });
+        } catch {
+          /* ignore */
+        }
+      }
+      try {
+        host.removeChild(canvas);
+      } catch {
+        /* ignore */
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graph, width, height]);
@@ -328,10 +373,18 @@ function buildScene(
   engine.constraintIterations = 7;
 
   const walls = [
-    Matter.Bodies.rectangle(width / 2, height + 50, width + 200, 100, { isStatic: true }),
-    Matter.Bodies.rectangle(width / 2, -50, width + 200, 100, { isStatic: true }),
-    Matter.Bodies.rectangle(-50, height / 2, 100, height + 200, { isStatic: true }),
-    Matter.Bodies.rectangle(width + 50, height / 2, 100, height + 200, { isStatic: true }),
+    Matter.Bodies.rectangle(width / 2, height + 50, width + 200, 100, {
+      isStatic: true,
+    }),
+    Matter.Bodies.rectangle(width / 2, -50, width + 200, 100, {
+      isStatic: true,
+    }),
+    Matter.Bodies.rectangle(-50, height / 2, 100, height + 200, {
+      isStatic: true,
+    }),
+    Matter.Bodies.rectangle(width + 50, height / 2, 100, height + 200, {
+      isStatic: true,
+    }),
   ];
   Matter.Composite.add(engine.world, walls);
 
@@ -418,7 +471,10 @@ function buildScene(
     });
     nodeLayer.addChild(graphics);
 
-    const label = new Text({ text: node.summary || node.title, style: styleFor("#c4c4c4") });
+    const label = new Text({
+      text: node.summary || node.title,
+      style: styleFor("#c4c4c4"),
+    });
     label.anchor.set(0.5, 0); // top-center: hangs below the disc
     labelLayer.addChild(label);
 
@@ -442,7 +498,10 @@ function buildScene(
   const mouse = Matter.Mouse.create(app.canvas as HTMLCanvasElement);
   const mouseConstraint = Matter.MouseConstraint.create(engine, {
     mouse,
-    constraint: { stiffness: 0.2, render: { visible: false } as Matter.IConstraintRenderDefinition },
+    constraint: {
+      stiffness: 0.2,
+      render: { visible: false } as Matter.IConstraintRenderDefinition,
+    },
   });
   Matter.Composite.add(engine.world, mouseConstraint);
 
@@ -450,39 +509,68 @@ function buildScene(
     const z = viewport.scale.x;
     const s = 1 / (RESOLUTION * z);
     Matter.Mouse.setScale(mouse, { x: s, y: s });
-    Matter.Mouse.setOffset(mouse, { x: -viewport.position.x / z, y: -viewport.position.y / z });
+    Matter.Mouse.setOffset(mouse, {
+      x: -viewport.position.x / z,
+      y: -viewport.position.y / z,
+    });
     onViewport({ x: viewport.position.x, y: viewport.position.y, scale: z });
   };
   syncMouseToViewport();
 
-  Matter.Events.on(mouseConstraint, "startdrag", (ev: Matter.IEvent<Matter.MouseConstraint>) => {
-    const dragged = (ev as unknown as { body?: Matter.Body }).body;
-    if (!dragged) return;
-    for (const node of nodesById.values()) {
-      if (node.body !== dragged) continue;
-      const ns = new Set<string>();
-      for (const e of graph.edges) {
-        if (e.from === node.id) ns.add(e.to);
-        else if (e.to === node.id) ns.add(e.from);
+  Matter.Events.on(
+    mouseConstraint,
+    "startdrag",
+    (ev: Matter.IEvent<Matter.MouseConstraint>) => {
+      const dragged = (ev as unknown as { body?: Matter.Body }).body;
+      if (!dragged) return;
+      for (const node of nodesById.values()) {
+        if (node.body !== dragged) continue;
+        const ns = new Set<string>();
+        for (const e of graph.edges) {
+          if (e.from === node.id) ns.add(e.to);
+          else if (e.to === node.id) ns.add(e.from);
+        }
+        sceneRef.current = {
+          ...sceneRef.current,
+          draggingId: node.id,
+          draggingNeighbors: ns,
+        };
+        break;
       }
-      sceneRef.current = { ...sceneRef.current, draggingId: node.id, draggingNeighbors: ns };
-      break;
-    }
-  });
+    },
+  );
   Matter.Events.on(mouseConstraint, "enddrag", () => {
-    sceneRef.current = { ...sceneRef.current, draggingId: null, draggingNeighbors: new Set() };
+    sceneRef.current = {
+      ...sceneRef.current,
+      draggingId: null,
+      draggingNeighbors: new Set(),
+    };
   });
 
-  let panStart: { startX: number; startY: number; origX: number; origY: number } | null = null;
+  let panStart: {
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+  } | null = null;
   let panMode = false;
-  let panOrigin: { startX: number; startY: number; origX: number; origY: number } | null = null;
+  let panOrigin: {
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+  } | null = null;
   let spaceHeld = false;
   const stageEventMode = app.stage.eventMode;
   const canvas = app.canvas as HTMLCanvasElement;
 
   const setCursor = () => {
     const grabbing = panStart !== null || panMode;
-    canvas.style.cursor = grabbing ? "grabbing" : spaceHeld ? "grab" : "default";
+    canvas.style.cursor = grabbing
+      ? "grabbing"
+      : spaceHeld
+        ? "grab"
+        : "default";
   };
   const onContext = (e: Event) => e.preventDefault();
   const onWheel = (e: WheelEvent) => {
@@ -491,7 +579,10 @@ function buildScene(
     const lx = e.clientX - rect.left;
     const ly = e.clientY - rect.top;
     const oldScale = viewport.scale.x;
-    const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, oldScale * Math.exp(-e.deltaY * ZOOM_STEP)));
+    const newScale = Math.min(
+      MAX_SCALE,
+      Math.max(MIN_SCALE, oldScale * Math.exp(-e.deltaY * ZOOM_STEP)),
+    );
     const worldX = (lx - viewport.position.x) / oldScale;
     const worldY = (ly - viewport.position.y) / oldScale;
     viewport.scale.set(newScale);
@@ -502,22 +593,35 @@ function buildScene(
   const onPointerDown = (e: PointerEvent) => {
     if (e.button !== 1 && e.button !== 2) return;
     e.preventDefault();
-    panStart = { startX: e.clientX, startY: e.clientY, origX: viewport.position.x, origY: viewport.position.y };
+    panStart = {
+      startX: e.clientX,
+      startY: e.clientY,
+      origX: viewport.position.x,
+      origY: viewport.position.y,
+    };
     canvas.setPointerCapture(e.pointerId);
     setCursor();
   };
   const onPointerMove = (e: PointerEvent) => {
     if (!panStart) return;
-    viewport.position.set(panStart.origX + (e.clientX - panStart.startX), panStart.origY + (e.clientY - panStart.startY));
+    viewport.position.set(
+      panStart.origX + (e.clientX - panStart.startX),
+      panStart.origY + (e.clientY - panStart.startY),
+    );
     syncMouseToViewport();
   };
   const onPointerUp = (e: PointerEvent) => {
     if (!panStart) return;
     panStart = null;
-    try { canvas.releasePointerCapture(e.pointerId); } catch { /* ignore */ }
+    try {
+      canvas.releasePointerCapture(e.pointerId);
+    } catch {
+      /* ignore */
+    }
     setCursor();
   };
-  const isSpaceKey = (e: KeyboardEvent) => e.code === "Space" || e.key === " " || e.key === "Spacebar";
+  const isSpaceKey = (e: KeyboardEvent) =>
+    e.code === "Space" || e.key === " " || e.key === "Spacebar";
   const onKeyDown = (e: KeyboardEvent) => {
     if (isSpaceKey(e) && !spaceHeld) {
       spaceHeld = true;
@@ -526,14 +630,22 @@ function buildScene(
     }
   };
   const onKeyUp = (e: KeyboardEvent) => {
-    if (isSpaceKey(e)) { spaceHeld = false; setCursor(); }
+    if (isSpaceKey(e)) {
+      spaceHeld = false;
+      setCursor();
+    }
   };
   const enterPanMode = (e: MouseEvent) => {
     if (panMode) return;
     panMode = true;
     Matter.Composite.remove(engine.world, mouseConstraint);
     app.stage.eventMode = "none";
-    panOrigin = { startX: e.clientX, startY: e.clientY, origX: viewport.position.x, origY: viewport.position.y };
+    panOrigin = {
+      startX: e.clientX,
+      startY: e.clientY,
+      origX: viewport.position.x,
+      origY: viewport.position.y,
+    };
     setCursor();
   };
   const exitPanMode = () => {
@@ -546,7 +658,10 @@ function buildScene(
   };
   const onPanMove = (ev: MouseEvent) => {
     if (!panMode || !panOrigin) return;
-    viewport.position.set(panOrigin.origX + (ev.clientX - panOrigin.startX), panOrigin.origY + (ev.clientY - panOrigin.startY));
+    viewport.position.set(
+      panOrigin.origX + (ev.clientX - panOrigin.startX),
+      panOrigin.origY + (ev.clientY - panOrigin.startY),
+    );
     syncMouseToViewport();
   };
   const onMaybeStartPan = (e: MouseEvent) => {
@@ -574,7 +689,10 @@ function buildScene(
 
   let awake = true;
   let sleepFrames = 0;
-  const wake = () => { awake = true; sleepFrames = 0; };
+  const wake = () => {
+    awake = true;
+    sleepFrames = 0;
+  };
   window.addEventListener("pointerdown", wake);
   window.addEventListener("pointermove", wake);
   window.addEventListener("wheel", wake, { passive: true });
@@ -600,16 +718,26 @@ function buildScene(
         count += 1;
       }
       const avg = count > 0 ? total / count : 0;
-      if (avg < 0.05) { sleepFrames += 1; if (sleepFrames > 30) awake = false; }
-      else sleepFrames = 0;
+      if (avg < 0.05) {
+        sleepFrames += 1;
+        if (sleepFrames > 30) awake = false;
+      } else sleepFrames = 0;
     }
 
     const scene = sceneRef.current;
     if (!awake && scene === lastScene) return;
     lastScene = scene;
 
-    const { selectedId, impact, ancestors, matched, draggingId, draggingNeighbors, cutoff, zoom } =
-      scene;
+    const {
+      selectedId,
+      impact,
+      ancestors,
+      matched,
+      draggingId,
+      draggingNeighbors,
+      cutoff,
+      zoom,
+    } = scene;
     const hasSelection = selectedId !== null;
     const hasDrag = !hasSelection && draggingId !== null;
     const hasMatches = !hasSelection && !hasDrag && matched.size > 0;
@@ -632,17 +760,47 @@ function buildScene(
         alpha = 0.05;
         labelDim = true;
       } else if (hasSelection) {
-        if (node.id === selectedId) { color = COLOR_IMPACT; drawRadius = node.radius * 1.25; ring = true; lit = true; }
-        else if (impact.has(node.id)) { color = COLOR_IMPACT; lit = true; }
-        else if (ancestors.has(node.id)) { color = COLOR_ANCESTOR; alpha = 0.95; lit = true; }
-        else { color = COLOR_MUTED; alpha = 0.28; labelDim = true; }
+        if (node.id === selectedId) {
+          color = COLOR_IMPACT;
+          drawRadius = node.radius * 1.25;
+          ring = true;
+          lit = true;
+        } else if (impact.has(node.id)) {
+          color = COLOR_IMPACT;
+          lit = true;
+        } else if (ancestors.has(node.id)) {
+          color = COLOR_ANCESTOR;
+          alpha = 0.95;
+          lit = true;
+        } else {
+          color = COLOR_MUTED;
+          alpha = 0.28;
+          labelDim = true;
+        }
       } else if (hasDrag) {
-        if (node.id === draggingId) { color = COLOR_PRIMARY; ring = true; lit = true; }
-        else if (draggingNeighbors.has(node.id)) { color = COLOR_PRIMARY; lit = true; }
-        else { color = COLOR_MUTED; alpha = 0.4; labelDim = true; }
+        if (node.id === draggingId) {
+          color = COLOR_PRIMARY;
+          ring = true;
+          lit = true;
+        } else if (draggingNeighbors.has(node.id)) {
+          color = COLOR_PRIMARY;
+          lit = true;
+        } else {
+          color = COLOR_MUTED;
+          alpha = 0.4;
+          labelDim = true;
+        }
       } else if (hasMatches) {
-        if (matched.has(node.id)) { color = COLOR_PRIMARY; drawRadius = node.radius * 1.15; ring = true; lit = true; }
-        else { color = COLOR_MUTED; alpha = 0.35; labelDim = true; }
+        if (matched.has(node.id)) {
+          color = COLOR_PRIMARY;
+          drawRadius = node.radius * 1.15;
+          ring = true;
+          lit = true;
+        } else {
+          color = COLOR_MUTED;
+          alpha = 0.35;
+          labelDim = true;
+        }
       } else {
         // Neutral: brightness grades with recency (newer = brighter).
         color = COLOR_SECONDARY;
@@ -651,10 +809,18 @@ function buildScene(
 
       node.graphics.clear();
       if (ring) {
-        node.graphics.circle(node.body.position.x, node.body.position.y, drawRadius + 3 * inv);
+        node.graphics.circle(
+          node.body.position.x,
+          node.body.position.y,
+          drawRadius + 3 * inv,
+        );
         node.graphics.stroke({ width: 2 * inv, color, alpha: 0.6 });
       }
-      node.graphics.circle(node.body.position.x, node.body.position.y, drawRadius);
+      node.graphics.circle(
+        node.body.position.x,
+        node.body.position.y,
+        drawRadius,
+      );
       node.graphics.fill({ color, alpha });
 
       // Parallax: counter-scale the label so it stays a constant readable
@@ -665,10 +831,19 @@ function buildScene(
         node.body.position.y + drawRadius + LABEL_GAP * inv,
       );
       if (!showLabels || future) node.label.alpha = 0;
-      else if (!hasSelection && !hasDrag && !hasMatches) { node.label.alpha = 0.85; node.label.style = styleFor("#c4c4c4"); }
-      else if (lit) { node.label.alpha = 1; node.label.style = styleFor("#fafafa"); }
-      else if (labelDim) { node.label.alpha = 0.25; node.label.style = styleFor("#5e5e5e"); }
-      else { node.label.alpha = 0.6; node.label.style = styleFor("#c4c4c4"); }
+      else if (!hasSelection && !hasDrag && !hasMatches) {
+        node.label.alpha = 0.85;
+        node.label.style = styleFor("#c4c4c4");
+      } else if (lit) {
+        node.label.alpha = 1;
+        node.label.style = styleFor("#fafafa");
+      } else if (labelDim) {
+        node.label.alpha = 0.25;
+        node.label.style = styleFor("#5e5e5e");
+      } else {
+        node.label.alpha = 0.6;
+        node.label.style = styleFor("#c4c4c4");
+      }
     }
 
     const litFwd = (id: string) => id === selectedId || impact.has(id);
@@ -683,7 +858,11 @@ function buildScene(
         // One endpoint not born yet — keep faint.
         edge.graphics.moveTo(a.body.position.x, a.body.position.y);
         edge.graphics.lineTo(b.body.position.x, b.body.position.y);
-        edge.graphics.stroke({ width: 1 * inv, color: COLOR_EDGE_DIM, alpha: 0.04 });
+        edge.graphics.stroke({
+          width: 1 * inv,
+          color: COLOR_EDGE_DIM,
+          alpha: 0.04,
+        });
         continue;
       }
 
@@ -692,13 +871,27 @@ function buildScene(
       let arrow: number | null = null; // arrowhead color when on an influence path
 
       if (hasSelection) {
-        if (litFwd(edge.from) && litFwd(edge.to)) { color = COLOR_IMPACT; alpha = 0.85; arrow = COLOR_IMPACT; }
-        else if (litBwd(edge.from) && litBwd(edge.to)) { color = COLOR_ANCESTOR; alpha = 0.7; arrow = COLOR_ANCESTOR; }
-        else { color = COLOR_EDGE_DIM; alpha = 0.12; }
+        if (litFwd(edge.from) && litFwd(edge.to)) {
+          color = COLOR_IMPACT;
+          alpha = 0.85;
+          arrow = COLOR_IMPACT;
+        } else if (litBwd(edge.from) && litBwd(edge.to)) {
+          color = COLOR_ANCESTOR;
+          alpha = 0.7;
+          arrow = COLOR_ANCESTOR;
+        } else {
+          color = COLOR_EDGE_DIM;
+          alpha = 0.12;
+        }
       } else if (hasDrag) {
         const touches = edge.from === draggingId || edge.to === draggingId;
-        if (touches) { color = COLOR_EDGE_SELECTED; alpha = 0.9; }
-        else { color = COLOR_EDGE_DIM; alpha = 0.15; }
+        if (touches) {
+          color = COLOR_EDGE_SELECTED;
+          alpha = 0.9;
+        } else {
+          color = COLOR_EDGE_DIM;
+          alpha = 0.15;
+        }
       } else if (hasMatches) {
         alpha = 0.12;
       }
@@ -709,7 +902,11 @@ function buildScene(
       const by = b.body.position.y;
       edge.graphics.moveTo(ax, ay);
       edge.graphics.lineTo(bx, by);
-      edge.graphics.stroke({ width: (arrow !== null ? 1.5 : 1) * inv, color, alpha });
+      edge.graphics.stroke({
+        width: (arrow !== null ? 1.5 : 1) * inv,
+        color,
+        alpha,
+      });
 
       if (arrow !== null) {
         // Arrowhead just outside the target node, pointing older → newer.
@@ -747,7 +944,10 @@ function buildScene(
     if (saveTimer) return;
     saveTimer = setTimeout(() => {
       saveTimer = null;
-      invoke("memory_graph_layout_save", { projectPath, layout: snapshotLayout() }).catch(() => {});
+      invoke("memory_graph_layout_save", {
+        projectPath,
+        layout: snapshotLayout(),
+      }).catch(() => {});
     }, 2000);
   };
   Matter.Events.on(engine, "afterUpdate", () => {
@@ -757,7 +957,10 @@ function buildScene(
   return () => {
     app.ticker.remove(tick);
     if (saveTimer) clearTimeout(saveTimer);
-    invoke("memory_graph_layout_save", { projectPath, layout: snapshotLayout() }).catch(() => {});
+    invoke("memory_graph_layout_save", {
+      projectPath,
+      layout: snapshotLayout(),
+    }).catch(() => {});
     canvas.removeEventListener("contextmenu", onContext);
     canvas.removeEventListener("wheel", onWheel);
     canvas.removeEventListener("pointerdown", onPointerDown);

--- a/src/features/memory/components/memory-graph-view.tsx
+++ b/src/features/memory/components/memory-graph-view.tsx
@@ -38,15 +38,8 @@ export function MemoryGraphView() {
   const results = useMemoryGraphStore.use.results();
   const matchedIds = useMemoryGraphStore.use.matchedIds();
   const selectedId = useMemoryGraphStore.use.selectedId();
-  const {
-    init,
-    download,
-    buildIndex,
-    runQuery,
-    setQuery,
-    clearQuery,
-    select,
-  } = useMemoryGraphStore.use.actions();
+  const { init, download, buildIndex, runQuery, setQuery, clearQuery, select } =
+    useMemoryGraphStore.use.actions();
 
   useEffect(() => {
     if (projectPath) void init(projectPath);
@@ -59,7 +52,10 @@ export function MemoryGraphView() {
   if (phase === "checking") {
     return (
       <Centered>
-        <Loader2 size={18} className="animate-spin text-[var(--text-tertiary)]" />
+        <Loader2
+          size={18}
+          className="animate-spin text-[var(--text-tertiary)]"
+        />
       </Centered>
     );
   }
@@ -77,8 +73,8 @@ export function MemoryGraphView() {
             </h3>
             <p className="text-[11px] leading-relaxed text-[var(--text-tertiary)]">
               Download a small on-device embedding model to index your Claude &
-              Codex memory, map how it relates, and query it in natural language.
-              Runs entirely locally — nothing leaves your machine.
+              Codex memory, map how it relates, and query it in natural
+              language. Runs entirely locally — nothing leaves your machine.
             </p>
           </div>
           <button
@@ -88,7 +84,9 @@ export function MemoryGraphView() {
             <Download size={13} />
             Download model
           </button>
-          <p className="text-[10px] text-[var(--text-ghost)] font-mono">{MODEL_LABEL}</p>
+          <p className="text-[10px] text-[var(--text-ghost)] font-mono">
+            {MODEL_LABEL}
+          </p>
         </div>
       </Centered>
     );
@@ -97,7 +95,8 @@ export function MemoryGraphView() {
   if (phase === "downloading") {
     const pct = progress
       ? Math.round(
-          ((progress.file_index + (progress.total ? progress.received / progress.total : 0)) /
+          ((progress.file_index +
+            (progress.total ? progress.received / progress.total : 0)) /
             Math.max(1, progress.file_count)) *
             100,
         )
@@ -105,9 +104,14 @@ export function MemoryGraphView() {
     return (
       <Centered>
         <div className="text-center max-w-[360px] px-6 w-full space-y-3">
-          <Loader2 size={20} className="animate-spin text-[var(--text-secondary)] mx-auto" />
+          <Loader2
+            size={20}
+            className="animate-spin text-[var(--text-secondary)] mx-auto"
+          />
           <div className="space-y-1.5">
-            <p className="text-[12px] text-[var(--text-primary)]">Downloading model…</p>
+            <p className="text-[12px] text-[var(--text-primary)]">
+              Downloading model…
+            </p>
             <div className="h-1.5 rounded-full bg-[var(--bg-elevated)] overflow-hidden">
               <div
                 className="h-full bg-[var(--accent-primary)] transition-[width] duration-200"
@@ -129,9 +133,14 @@ export function MemoryGraphView() {
     return (
       <Centered>
         <div className="text-center max-w-[340px] px-6 space-y-3">
-          <AlertTriangle size={20} className="text-[var(--status-error)] mx-auto" />
+          <AlertTriangle
+            size={20}
+            className="text-[var(--status-error)] mx-auto"
+          />
           <p className="text-[12px] text-[var(--text-secondary)]">
-            {phase === "download-failed" ? "Model download failed" : "Something went wrong"}
+            {phase === "download-failed"
+              ? "Model download failed"
+              : "Something went wrong"}
           </p>
           {error && (
             <p className="text-[10px] text-[var(--text-tertiary)] font-mono break-words">
@@ -140,7 +149,9 @@ export function MemoryGraphView() {
           )}
           <button
             onClick={() =>
-              phase === "download-failed" ? void download() : void init(projectPath)
+              phase === "download-failed"
+                ? void download()
+                : void init(projectPath)
             }
             className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md border border-[var(--border-default)] text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
           >
@@ -156,8 +167,13 @@ export function MemoryGraphView() {
     return (
       <Centered>
         <div className="text-center space-y-2">
-          <Loader2 size={18} className="animate-spin text-[var(--text-secondary)] mx-auto" />
-          <p className="text-[11px] text-[var(--text-tertiary)]">Indexing memory…</p>
+          <Loader2
+            size={18}
+            className="animate-spin text-[var(--text-secondary)] mx-auto"
+          />
+          <p className="text-[11px] text-[var(--text-tertiary)]">
+            Indexing memory…
+          </p>
         </div>
       </Centered>
     );
@@ -249,7 +265,10 @@ function GraphReady({
   const rafRef = useRef<number | undefined>(undefined);
 
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    const v = typeof localStorage !== "undefined" ? localStorage.getItem(VIEW_KEY) : null;
+    const v =
+      typeof localStorage !== "undefined"
+        ? localStorage.getItem(VIEW_KEY)
+        : null;
     // Tree is the default/initial view; only an explicit "graph" pref overrides.
     return v === "graph" ? "graph" : "tree";
   });
@@ -356,7 +375,12 @@ function GraphReady({
             spellCheck={false}
             className="flex-1 min-w-0 bg-transparent outline-none text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]"
           />
-          {querying && <Loader2 size={11} className="animate-spin text-[var(--text-tertiary)]" />}
+          {querying && (
+            <Loader2
+              size={11}
+              className="animate-spin text-[var(--text-tertiary)]"
+            />
+          )}
           {query && !querying && (
             <button
               onClick={onClearQuery}
@@ -438,10 +462,18 @@ function GraphReady({
           {selected && viewMode === "graph" && (
             <div className="absolute right-3 top-[26px] flex items-center gap-3 rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)]/90 backdrop-blur-sm px-2.5 h-7 text-[10px] text-[var(--text-tertiary)]">
               <span className="flex items-center gap-1">
-                <span className="w-2 h-2 rounded-full" style={{ background: "#fafafa" }} /> impacted
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ background: "#fafafa" }}
+                />{" "}
+                impacted
               </span>
               <span className="flex items-center gap-1">
-                <span className="w-2 h-2 rounded-full" style={{ background: "#6796e6" }} /> influenced by
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ background: "#6796e6" }}
+                />{" "}
+                influenced by
               </span>
             </div>
           )}
@@ -471,7 +503,8 @@ function GraphReady({
               </p>
               <p className="text-[9px] text-[var(--text-ghost)] mt-1.5 uppercase tracking-wide">
                 {selected.source} · {selected.kind}
-                {selected.timestampMs > 0 && ` · ${fmtDate(selected.timestampMs)}`}
+                {selected.timestampMs > 0 &&
+                  ` · ${fmtDate(selected.timestampMs)}`}
               </p>
             </button>
           )}
@@ -492,7 +525,9 @@ function GraphReady({
                   onClick={() => onSelect(active ? null : hit.id)}
                   className={cn(
                     "w-full text-left px-3 py-2 border-b border-[var(--border-subtle)] transition-colors flex flex-col gap-0.5",
-                    active ? "bg-[var(--bg-selected)]" : "hover:bg-[var(--bg-hover)]",
+                    active
+                      ? "bg-[var(--bg-selected)]"
+                      : "hover:bg-[var(--bg-hover)]",
                   )}
                 >
                   <div className="flex items-center gap-1.5 min-w-0">

--- a/src/features/memory/components/memory-panel.tsx
+++ b/src/features/memory/components/memory-panel.tsx
@@ -33,7 +33,11 @@ import { ClaudeIcon, CodexIcon } from "@/components/agent-icons";
 import { AtlasIcon } from "@/components/atlas-icon";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useMemoryStore } from "../stores/memory-store";
-import type { ClaudeMemory, CodexMemory, CodexThread } from "../lib/memory-types";
+import type {
+  ClaudeMemory,
+  CodexMemory,
+  CodexThread,
+} from "../lib/memory-types";
 
 // ── Panel shell ─────────────────────────────────────────────────────────────
 
@@ -42,7 +46,8 @@ export function MemoryPanel() {
   const sub = useMemoryStore.use.subTab();
   const data = useMemoryStore.use.agentMemory();
   const loading = useMemoryStore.use.agentMemoryLoading();
-  const { setSubTab, ensureProject, loadAgentMemory } = useMemoryStore.use.actions();
+  const { setSubTab, ensureProject, loadAgentMemory } =
+    useMemoryStore.use.actions();
   const setSub = setSubTab;
 
   // Cached: only fetches on first load / project change. Switching sub-tabs or
@@ -216,14 +221,18 @@ function PillSeg({
       <span className={cn(active ? "opacity-100" : "opacity-60")}>{icon}</span>
       {label}
       {count !== undefined && count > 0 && (
-        <span className="text-[9px] tabular-nums text-[var(--text-tertiary)]">{count}</span>
+        <span className="text-[9px] tabular-nums text-[var(--text-tertiary)]">
+          {count}
+        </span>
       )}
     </button>
   );
 }
 
 function Centered({ children }: { children: React.ReactNode }) {
-  return <div className="h-full flex items-center justify-center">{children}</div>;
+  return (
+    <div className="h-full flex items-center justify-center">{children}</div>
+  );
 }
 
 // ── Coding-agent combobox ────────────────────────────────────────────────────
@@ -256,9 +265,24 @@ function CodingAgentMenu({
 }) {
   const options = useMemo<CodingAgentOption[]>(
     () => [
-      { sub: "cersei", label: "Atlas", icon: <AtlasIcon size={14} />, count: cerseiCount },
-      { sub: "claude", label: "Claude Code", icon: <ClaudeIcon className="size-3.5" />, count: claudeCount },
-      { sub: "codex", label: "Codex", icon: <CodexIcon className="size-3.5" />, count: codexCount },
+      {
+        sub: "cersei",
+        label: "Atlas",
+        icon: <AtlasIcon size={14} />,
+        count: cerseiCount,
+      },
+      {
+        sub: "claude",
+        label: "Claude Code",
+        icon: <ClaudeIcon className="size-3.5" />,
+        count: claudeCount,
+      },
+      {
+        sub: "codex",
+        label: "Codex",
+        icon: <CodexIcon className="size-3.5" />,
+        count: codexCount,
+      },
     ],
     [claudeCount, codexCount, cerseiCount],
   );
@@ -281,7 +305,8 @@ function CodingAgentMenu({
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
@@ -302,7 +327,9 @@ function CodingAgentMenu({
 
   const selected = options.find((o) => o.sub === lastAgent) ?? options[0];
   const q = query.trim().toLowerCase();
-  const filtered = q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options;
+  const filtered = q
+    ? options.filter((o) => o.label.toLowerCase().includes(q))
+    : options;
 
   const choose = (s: AgentSub) => {
     setSub(s);
@@ -321,20 +348,30 @@ function CodingAgentMenu({
         )}
         title="Coding agents"
       >
-        <span className={cn(isAgentActive ? "opacity-100" : "opacity-60")}>{selected.icon}</span>
+        <span className={cn(isAgentActive ? "opacity-100" : "opacity-60")}>
+          {selected.icon}
+        </span>
         {selected.label}
         {selected.count > 0 && (
-          <span className="text-[9px] tabular-nums text-[var(--text-tertiary)]">{selected.count}</span>
+          <span className="text-[9px] tabular-nums text-[var(--text-tertiary)]">
+            {selected.count}
+          </span>
         )}
         <ChevronDown
           size={11}
-          className={cn("opacity-50 transition-transform", open && "rotate-180")}
+          className={cn(
+            "opacity-50 transition-transform",
+            open && "rotate-180",
+          )}
         />
       </button>
       {open && (
         <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1.5 z-[var(--z-max)] min-w-[210px] rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated,var(--bg-secondary))] p-1 shadow-lg">
           <div className="flex items-center gap-1.5 px-1.5 py-1">
-            <Search size={11} className="shrink-0 text-[var(--text-tertiary)]" />
+            <Search
+              size={11}
+              className="shrink-0 text-[var(--text-tertiary)]"
+            />
             <input
               ref={inputRef}
               value={query}
@@ -345,7 +382,9 @@ function CodingAgentMenu({
           </div>
           <div className="mb-1 h-px bg-[var(--border-default)]" />
           {filtered.length === 0 ? (
-            <div className="px-2 py-1.5 text-[10px] text-[var(--text-tertiary)]">No agents found</div>
+            <div className="px-2 py-1.5 text-[10px] text-[var(--text-tertiary)]">
+              No agents found
+            </div>
           ) : (
             filtered.map((o) => {
               const active = sub === o.sub;
@@ -367,7 +406,12 @@ function CodingAgentMenu({
                       {o.count}
                     </span>
                   )}
-                  {active && <Check size={11} className="shrink-0 text-[var(--accent-primary)]" />}
+                  {active && (
+                    <Check
+                      size={11}
+                      className="shrink-0 text-[var(--accent-primary)]"
+                    />
+                  )}
                 </button>
               );
             })
@@ -440,8 +484,7 @@ function ClaudeView({ claude }: { claude: ClaudeMemory | null }) {
   }, [claude]);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const selected =
-    items.find((i) => i.id === selectedId) ?? items[0] ?? null;
+  const selected = items.find((i) => i.id === selectedId) ?? items[0] ?? null;
 
   // Cross-tab navigation (e.g. from Timeline): select + scroll to the doc.
   const navTarget = useMemoryStore.use.navTarget();
@@ -458,9 +501,16 @@ function ClaudeView({ claude }: { claude: ClaudeMemory | null }) {
   }, [navTarget, items]);
 
   const grouped = useMemo(() => {
-    const order: ClaudeItem["section"][] = ["Instructions", "Index", "Memories"];
+    const order: ClaudeItem["section"][] = [
+      "Instructions",
+      "Index",
+      "Memories",
+    ];
     return order
-      .map((section) => ({ section, items: items.filter((i) => i.section === section) }))
+      .map((section) => ({
+        section,
+        items: items.filter((i) => i.section === section),
+      }))
       .filter((g) => g.items.length > 0);
   }, [items]);
 
@@ -469,7 +519,9 @@ function ClaudeView({ claude }: { claude: ClaudeMemory | null }) {
       <Centered>
         <div className="text-center space-y-1.5 max-w-[300px] px-4">
           <ClaudeIcon className="size-6 mx-auto opacity-40" />
-          <p className="text-[12px] text-[var(--text-secondary)]">No Claude memory yet</p>
+          <p className="text-[12px] text-[var(--text-secondary)]">
+            No Claude memory yet
+          </p>
           <p className="text-[11px] text-[var(--text-tertiary)] leading-relaxed">
             Claude Code writes per-project memory to{" "}
             <code className="text-[10px] break-all">
@@ -512,7 +564,10 @@ function ClaudeView({ claude }: { claude: ClaudeMemory | null }) {
                     {it.badge && (
                       <span
                         className="w-1.5 h-1.5 rounded-full shrink-0"
-                        style={{ background: KIND_TINT[it.badge] ?? "var(--text-tertiary)" }}
+                        style={{
+                          background:
+                            KIND_TINT[it.badge] ?? "var(--text-tertiary)",
+                        }}
                       />
                     )}
                     <span
@@ -606,7 +661,9 @@ function CodexView({ codex }: { codex: CodexMemory | null }) {
     }
     setQuery(""); // clear any filter so the row is in the list
     setExpandedId(rest);
-    requestAnimationFrame(() => rowRefs.current.get(rest)?.scrollIntoView({ block: "center" }));
+    requestAnimationFrame(() =>
+      rowRefs.current.get(rest)?.scrollIntoView({ block: "center" }),
+    );
   }, [navTarget]);
 
   const rows = useMemo(() => {
@@ -625,7 +682,10 @@ function CodexView({ codex }: { codex: CodexMemory | null }) {
   if (!codex) {
     return (
       <Centered>
-        <Loader2 size={18} className="animate-spin text-[var(--text-tertiary)]" />
+        <Loader2
+          size={18}
+          className="animate-spin text-[var(--text-tertiary)]"
+        />
       </Centered>
     );
   }
@@ -635,11 +695,13 @@ function CodexView({ codex }: { codex: CodexMemory | null }) {
       <Centered>
         <div className="text-center space-y-1.5 max-w-[320px] px-4">
           <CodexIcon className="size-6 mx-auto opacity-40" />
-          <p className="text-[12px] text-[var(--text-secondary)]">No Codex memory yet</p>
+          <p className="text-[12px] text-[var(--text-secondary)]">
+            No Codex memory yet
+          </p>
           <p className="text-[11px] text-[var(--text-tertiary)] leading-relaxed">
             Codex tracks per-project sessions in its state database and reads an{" "}
-            <code className="text-[10px]">AGENTS.md</code> if present. Run Codex in this
-            project to populate it.
+            <code className="text-[10px]">AGENTS.md</code> if present. Run Codex
+            in this project to populate it.
           </p>
         </div>
       </Centered>
@@ -694,7 +756,10 @@ function CodexView({ codex }: { codex: CodexMemory | null }) {
             <AgentsCard label="AGENTS.md · project" body={codex.agents_md} />
           )}
           {codex.global_agents_md && (
-            <AgentsCard label="AGENTS.md · global" body={codex.global_agents_md} />
+            <AgentsCard
+              label="AGENTS.md · global"
+              body={codex.global_agents_md}
+            />
           )}
         </div>
       )}
@@ -728,7 +793,9 @@ function CodexView({ codex }: { codex: CodexMemory | null }) {
                     if (el) rowRefs.current.set(k, el);
                     else rowRefs.current.delete(k);
                   }}
-                  onToggle={() => setExpandedId((cur) => (cur === k ? null : k))}
+                  onToggle={() =>
+                    setExpandedId((cur) => (cur === k ? null : k))
+                  }
                 />
               );
             })
@@ -762,7 +829,9 @@ function CodexRow({
         onClick={onToggle}
         className={cn(
           "w-full flex items-center h-[40px] px-3 text-left transition-colors",
-          expanded ? "bg-[var(--bg-elevated)]/50" : "hover:bg-[var(--bg-hover)]",
+          expanded
+            ? "bg-[var(--bg-elevated)]/50"
+            : "hover:bg-[var(--bg-hover)]",
         )}
       >
         <span className={cn(COL.session, "min-w-0 pr-3")}>
@@ -770,7 +839,12 @@ function CodexRow({
             {cleanTitle(t.title || t.first_user_message) || "Untitled session"}
           </span>
         </span>
-        <span className={cn(COL.model, "truncate font-mono text-[10px] text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            COL.model,
+            "truncate font-mono text-[10px] text-[var(--text-tertiary)]",
+          )}
+        >
           {t.model || "—"}
         </span>
         <span className={cn(COL.branch, "truncate")}>
@@ -791,15 +865,32 @@ function CodexRow({
             <span className="text-[var(--text-ghost)] text-[11px]">—</span>
           )}
         </span>
-        <span className={cn(COL.tokens, "text-right tabular-nums text-[11px] text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            COL.tokens,
+            "text-right tabular-nums text-[11px] text-[var(--text-tertiary)]",
+          )}
+        >
           {t.tokens_used ? formatTokens(t.tokens_used) : "—"}
         </span>
-        <span className={cn(COL.updated, "text-right text-[10px] text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            COL.updated,
+            "text-right text-[10px] text-[var(--text-tertiary)]",
+          )}
+        >
           {t.updated_at
-            ? timeAgo(new Date(t.updated_at * 1000).toISOString(), { suffix: true })
+            ? timeAgo(new Date(t.updated_at * 1000).toISOString(), {
+                suffix: true,
+              })
             : "—"}
         </span>
-        <span className={cn(COL.chevron, "flex items-center justify-end text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            COL.chevron,
+            "flex items-center justify-end text-[var(--text-tertiary)]",
+          )}
+        >
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
       </button>
@@ -816,15 +907,32 @@ function CodexDetail({ thread: t }: { thread: CodexThread }) {
       {/* Metadata chips */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 mb-3">
         <MetaChip icon={Cpu} label="Model" value={t.model || "—"} mono />
-        <MetaChip icon={GitBranch} label="Branch" value={t.git_branch || "—"} mono />
-        <MetaChip icon={ShieldCheck} label="Approval" value={t.approval_mode || "—"} />
+        <MetaChip
+          icon={GitBranch}
+          label="Branch"
+          value={t.git_branch || "—"}
+          mono
+        />
+        <MetaChip
+          icon={ShieldCheck}
+          label="Approval"
+          value={t.approval_mode || "—"}
+        />
         <MetaChip
           icon={Coins}
           label="Tokens"
           value={t.tokens_used ? t.tokens_used.toLocaleString() : "—"}
         />
-        <MetaChip icon={Clock} label="Started" value={fmtDateTime(t.created_at)} />
-        <MetaChip icon={Clock} label="Updated" value={fmtDateTime(t.updated_at)} />
+        <MetaChip
+          icon={Clock}
+          label="Started"
+          value={fmtDateTime(t.created_at)}
+        />
+        <MetaChip
+          icon={Clock}
+          label="Updated"
+          value={fmtDateTime(t.updated_at)}
+        />
       </div>
 
       {/* Full first-message content */}
@@ -839,7 +947,9 @@ function CodexDetail({ thread: t }: { thread: CodexThread }) {
           {message ? (
             <Markdown className="text-[12px]">{message}</Markdown>
           ) : (
-            <p className="text-[11px] text-[var(--text-tertiary)]">No message recorded.</p>
+            <p className="text-[11px] text-[var(--text-tertiary)]">
+              No message recorded.
+            </p>
           )}
         </div>
       </div>

--- a/src/features/memory/components/memory-policy-view.tsx
+++ b/src/features/memory/components/memory-policy-view.tsx
@@ -40,14 +40,20 @@ export function MemoryPolicyView() {
   const phase = useMemoryStore.use.policyPhase();
   const policies = useMemoryStore.use.policies() ?? [];
   const error = useMemoryStore.use.policyError();
-  const { ensureProject, loadPolicies: storeLoadPolicies, setPolicyPhase, updatePolicyValue } =
-    useMemoryStore.use.actions();
+  const {
+    ensureProject,
+    loadPolicies: storeLoadPolicies,
+    setPolicyPhase,
+    updatePolicyValue,
+  } = useMemoryStore.use.actions();
   const [progress, setProgress] = useState<DownloadProgress | null>(null);
 
   // ── Filters ──────────────────────────────────────────────────────────────
   const [matchF, setMatchF] = useState<"all" | "semantic" | "keyword">("all");
   const [strengthF, setStrengthF] = useState<"all" | "soft" | "strong">("all");
-  const [originF, setOriginF] = useState<"all" | "preference" | "codebase">("all");
+  const [originF, setOriginF] = useState<"all" | "preference" | "codebase">(
+    "all",
+  );
   const [query, setQuery] = useState("");
   const visible = policies.filter(
     (p) =>
@@ -55,7 +61,9 @@ export function MemoryPolicyView() {
       (strengthF === "all" || p.category === strengthF) &&
       (originF === "all" || p.origin === originF) &&
       (query.trim() === "" ||
-        `${p.key} ${p.value}`.toLowerCase().includes(query.trim().toLowerCase())),
+        `${p.key} ${p.value}`
+          .toLowerCase()
+          .includes(query.trim().toLowerCase())),
   );
 
   const loadPolicies = useCallback(
@@ -115,7 +123,10 @@ export function MemoryPolicyView() {
     return (
       <Centered>
         <div className="text-center space-y-2">
-          <Loader2 size={18} className="animate-spin text-[var(--text-tertiary)] mx-auto" />
+          <Loader2
+            size={18}
+            className="animate-spin text-[var(--text-tertiary)] mx-auto"
+          />
           <p className="text-[11px] text-[var(--text-tertiary)]">
             {phase === "loading" ? "Distilling preferences…" : "Checking…"}
           </p>
@@ -153,7 +164,8 @@ export function MemoryPolicyView() {
   if (phase === "downloading") {
     const pct = progress
       ? Math.round(
-          ((progress.file_index + (progress.total ? progress.received / progress.total : 0)) /
+          ((progress.file_index +
+            (progress.total ? progress.received / progress.total : 0)) /
             Math.max(1, progress.file_count)) *
             100,
         )
@@ -161,12 +173,22 @@ export function MemoryPolicyView() {
     return (
       <Centered>
         <div className="text-center max-w-[360px] px-6 w-full space-y-2">
-          <Loader2 size={20} className="animate-spin text-[var(--text-secondary)] mx-auto" />
-          <p className="text-[12px] text-[var(--text-primary)]">Downloading model…</p>
+          <Loader2
+            size={20}
+            className="animate-spin text-[var(--text-secondary)] mx-auto"
+          />
+          <p className="text-[12px] text-[var(--text-primary)]">
+            Downloading model…
+          </p>
           <div className="h-1.5 rounded-full bg-[var(--bg-elevated)] overflow-hidden">
-            <div className="h-full bg-[var(--accent-primary)] transition-[width] duration-200" style={{ width: `${pct}%` }} />
+            <div
+              className="h-full bg-[var(--accent-primary)] transition-[width] duration-200"
+              style={{ width: `${pct}%` }}
+            />
           </div>
-          <p className="text-[10px] text-[var(--text-tertiary)] font-mono">{pct}%</p>
+          <p className="text-[10px] text-[var(--text-tertiary)] font-mono">
+            {pct}%
+          </p>
         </div>
       </Centered>
     );
@@ -176,9 +198,18 @@ export function MemoryPolicyView() {
     return (
       <Centered>
         <div className="text-center max-w-[340px] px-6 space-y-3">
-          <AlertTriangle size={20} className="text-[var(--status-error)] mx-auto" />
-          <p className="text-[12px] text-[var(--text-secondary)]">Couldn't load policies</p>
-          {error && <p className="text-[10px] text-[var(--text-tertiary)] font-mono break-words">{error}</p>}
+          <AlertTriangle
+            size={20}
+            className="text-[var(--status-error)] mx-auto"
+          />
+          <p className="text-[12px] text-[var(--text-secondary)]">
+            Couldn't load policies
+          </p>
+          {error && (
+            <p className="text-[10px] text-[var(--text-tertiary)] font-mono break-words">
+              {error}
+            </p>
+          )}
           <button
             onClick={() => void init(projectPath)}
             className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md border border-[var(--border-default)] text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
@@ -213,8 +244,8 @@ export function MemoryPolicyView() {
       {policies.length === 0 ? (
         <Centered>
           <p className="text-[12px] text-[var(--text-tertiary)] max-w-[300px] text-center px-4">
-            No preferences detected yet. As Claude Code & Codex record how you like
-            to work, they'll surface here.
+            No preferences detected yet. As Claude Code & Codex record how you
+            like to work, they'll surface here.
           </p>
         </Centered>
       ) : (
@@ -224,17 +255,35 @@ export function MemoryPolicyView() {
             <FilterGroup
               value={originF}
               onChange={setOriginF}
-              options={[["all", "All"], ["preference", "Preferences"], ["codebase", "Codebase"]] as const}
+              options={
+                [
+                  ["all", "All"],
+                  ["preference", "Preferences"],
+                  ["codebase", "Codebase"],
+                ] as const
+              }
             />
             <FilterGroup
               value={matchF}
               onChange={setMatchF}
-              options={[["all", "Any match"], ["semantic", "Semantic"], ["keyword", "Keyword"]] as const}
+              options={
+                [
+                  ["all", "Any match"],
+                  ["semantic", "Semantic"],
+                  ["keyword", "Keyword"],
+                ] as const
+              }
             />
             <FilterGroup
               value={strengthF}
               onChange={setStrengthF}
-              options={[["all", "Any"], ["soft", "Soft"], ["strong", "Strong"]] as const}
+              options={
+                [
+                  ["all", "Any"],
+                  ["soft", "Soft"],
+                  ["strong", "Strong"],
+                ] as const
+              }
             />
             <input
               value={query}
@@ -258,7 +307,9 @@ export function MemoryPolicyView() {
                   No policies match these filters.
                 </div>
               ) : (
-                visible.map((p) => <PolicyRow key={p.id} policy={p} onSaved={onSaved} />)
+                visible.map((p) => (
+                  <PolicyRow key={p.id} policy={p} onSaved={onSaved} />
+                ))
               )}
             </div>
           </div>
@@ -321,7 +372,9 @@ function PolicyRow({
       onSaved(policy.id, draft);
       toast.success(`${policy.key} updated`);
     } catch (e) {
-      toast.error(`Couldn't update: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Couldn't update: ${e instanceof Error ? e.message : String(e)}`,
+      );
     } finally {
       setSaving(false);
     }
@@ -338,13 +391,21 @@ function PolicyRow({
                 ? "border-[var(--status-error)]/40 bg-[var(--status-error)]/10 text-[var(--status-error)]"
                 : "border-[var(--border-default)] bg-[var(--bg-elevated)] text-[var(--text-tertiary)]",
             )}
-            title={policy.category === "strong" ? "Strong rule — must follow" : "Soft preference — guidance"}
+            title={
+              policy.category === "strong"
+                ? "Strong rule — must follow"
+                : "Soft preference — guidance"
+            }
           >
             {policy.category}
           </span>
-          <span className="text-[12px] text-[var(--text-primary)] truncate">{policy.key}</span>
+          <span className="text-[12px] text-[var(--text-primary)] truncate">
+            {policy.key}
+          </span>
         </div>
-        <div className="text-[10px] text-[var(--text-tertiary)] truncate mt-0.5">{policy.hint}</div>
+        <div className="text-[10px] text-[var(--text-tertiary)] truncate mt-0.5">
+          {policy.hint}
+        </div>
       </div>
 
       <div className={cn(COL.value, "pr-3")}>
@@ -371,12 +432,20 @@ function PolicyRow({
         ) : (
           <ClaudeIcon className="size-3 shrink-0 opacity-70" />
         )}
-        <span className="text-[10px] text-[var(--text-tertiary)] truncate" title={policy.file_path}>
+        <span
+          className="text-[10px] text-[var(--text-tertiary)] truncate"
+          title={policy.file_path}
+        >
           {basename(policy.file_path)}
         </span>
       </div>
 
-      <div className={cn(COL.score, "text-right tabular-nums text-[10px] text-[var(--text-tertiary)]")}>
+      <div
+        className={cn(
+          COL.score,
+          "text-right tabular-nums text-[10px] text-[var(--text-tertiary)]",
+        )}
+      >
         {Math.round(policy.score * 100)}%
       </div>
 
@@ -389,7 +458,11 @@ function PolicyRow({
               className="flex items-center justify-center w-5 h-5 rounded text-[var(--status-success,#4d4d4d)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
               title="Save (Enter)"
             >
-              {saving ? <Loader2 size={12} className="animate-spin" /> : <Check size={13} />}
+              {saving ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Check size={13} />
+              )}
             </button>
             <button
               onClick={() => setDraft(policy.value)}
@@ -401,7 +474,9 @@ function PolicyRow({
           </>
         ) : (
           <button
-            onClick={() => sendToAgentChat(`Preference — ${policy.key}: ${policy.value}`)}
+            onClick={() =>
+              sendToAgentChat(`Preference — ${policy.key}: ${policy.value}`)
+            }
             className="flex items-center justify-center w-5 h-5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
             title="Send to agent chat"
           >

--- a/src/features/memory/components/memory-sharing-controls.tsx
+++ b/src/features/memory/components/memory-sharing-controls.tsx
@@ -7,7 +7,14 @@
 
 import { useEffect, useMemo } from "react";
 import * as Popover from "@radix-ui/react-popover";
-import { Share2, SlidersHorizontal, FileText, Server, Cpu, Check } from "lucide-react";
+import {
+  Share2,
+  SlidersHorizontal,
+  FileText,
+  Server,
+  Cpu,
+  Check,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ProviderModelSelector } from "./provider-pickers";
 import { useByokStore } from "@/features/settings/stores/byok-store";
@@ -90,8 +97,8 @@ export function MemorySharingControls({
           >
             <div className="eyebrow mb-2">Recent-session handoff</div>
             <p className="mb-2.5 text-[11px] leading-snug text-text-tertiary">
-              How the previous session's tail is summarized before it is injected
-              into the next agent.
+              How the previous session's tail is summarized before it is
+              injected into the next agent.
             </p>
 
             <div className="inline-flex items-center gap-0.5 rounded-full border border-border-default bg-bg-elevated p-0.5">

--- a/src/features/memory/components/memory-timeline-calendar.tsx
+++ b/src/features/memory/components/memory-timeline-calendar.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { MemoryTimeline } from "../lib/memory-timeline-api";
@@ -50,7 +57,10 @@ function addDays(ms: number, n: number): number {
   return d.getTime();
 }
 function fmtTime(ms: number): string {
-  return new Date(ms).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  return new Date(ms).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 export function MemoryTimelineCalendar({
@@ -87,7 +97,8 @@ export function MemoryTimelineCalendar({
       });
     }
     for (const s of data.sessions) {
-      if (s.agent !== "codex" || !s.branch || !branchSet.has(s.branch)) continue;
+      if (s.agent !== "codex" || !s.branch || !branchSet.has(s.branch))
+        continue;
       items.push({
         id: `session:${s.id}`,
         kind: "session",
@@ -100,7 +111,8 @@ export function MemoryTimelineCalendar({
     items.sort((a, b) => a.ts - b.ts);
 
     const commitCount = new Map<string, number>();
-    for (const c of data.commits) commitCount.set(c.branch, (commitCount.get(c.branch) ?? 0) + 1);
+    for (const c of data.commits)
+      commitCount.set(c.branch, (commitCount.get(c.branch) ?? 0) + 1);
 
     // Days that actually contain something (for empty-range skipping).
     const activityDays = [
@@ -111,12 +123,16 @@ export function MemoryTimelineCalendar({
 
   // The anchor day we're focused on (default: most recent activity, else today).
   const [anchorDay, setAnchorDay] = useState<number>(() =>
-    model.activityDays.length ? model.activityDays[model.activityDays.length - 1] : startOfDay(Date.now()),
+    model.activityDays.length
+      ? model.activityDays[model.activityDays.length - 1]
+      : startOfDay(Date.now()),
   );
   useEffect(() => {
     // When the project/data changes, snap to its latest activity day.
     setAnchorDay(
-      model.activityDays.length ? model.activityDays[model.activityDays.length - 1] : startOfDay(Date.now()),
+      model.activityDays.length
+        ? model.activityDays[model.activityDays.length - 1]
+        : startOfDay(Date.now()),
     );
   }, [model.activityDays]);
 
@@ -165,7 +181,9 @@ export function MemoryTimelineCalendar({
 
   // Active branch = hovered, else the selected branch row.
   const [hoverBranch, setHoverBranch] = useState<string | null>(null);
-  const selectedBranch = selectedId?.startsWith("branch:") ? selectedId.slice(7) : null;
+  const selectedBranch = selectedId?.startsWith("branch:")
+    ? selectedId.slice(7)
+    : null;
   const activeBranch = hoverBranch ?? selectedBranch;
 
   const hasHi = !!highlightIds && highlightIds.size > 0;
@@ -205,7 +223,9 @@ export function MemoryTimelineCalendar({
       const x2 = cr.left - base.left;
       const y2 = cr.top + cr.height / 2 - base.top;
       const dx = Math.max(40, (x2 - x1) * 0.5);
-      next.push(`M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`);
+      next.push(
+        `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`,
+      );
     }
     setPaths(next);
   }, [activeBranch, rangeStart, dayCards, tick, model.items]);
@@ -246,26 +266,36 @@ export function MemoryTimelineCalendar({
                   else branchRowRefs.current.delete(b.name);
                 }}
                 onMouseEnter={() => setHoverBranch(b.name)}
-                onMouseLeave={() => setHoverBranch((h) => (h === b.name ? null : h))}
+                onMouseLeave={() =>
+                  setHoverBranch((h) => (h === b.name ? null : h))
+                }
                 onClick={() => onSelect(sel ? null : `branch:${b.name}`)}
                 className={cn(
                   "w-full flex flex-col justify-center gap-0.5 px-3 py-2 border-b border-[var(--border-subtle)] text-left transition-colors",
-                  sel ? "bg-[var(--bg-selected)]" : "hover:bg-[var(--bg-hover)]",
+                  sel
+                    ? "bg-[var(--bg-selected)]"
+                    : "hover:bg-[var(--bg-hover)]",
                 )}
               >
                 <div className="flex items-center gap-1.5 min-w-0">
-                  <span className="w-2 h-2 rounded-sm shrink-0" style={{ background: MONO }} />
+                  <span
+                    className="w-2 h-2 rounded-sm shrink-0"
+                    style={{ background: MONO }}
+                  />
                   <span
                     className={cn(
                       "text-[11px] truncate",
-                      b.is_current ? "text-[var(--text-primary)] font-medium" : "text-[var(--text-secondary)]",
+                      b.is_current
+                        ? "text-[var(--text-primary)] font-medium"
+                        : "text-[var(--text-secondary)]",
                     )}
                   >
                     {b.name}
                   </span>
                 </div>
                 <span className="text-[9px] text-[var(--text-tertiary)] pl-3.5">
-                  {model.commitCount.get(b.name) ?? 0} commits{b.is_current ? " · current" : ""}
+                  {model.commitCount.get(b.name) ?? 0} commits
+                  {b.is_current ? " · current" : ""}
                 </span>
               </button>
             );
@@ -299,7 +329,9 @@ export function MemoryTimelineCalendar({
           >
             Today
           </button>
-          <span className="text-[12px] font-medium text-[var(--text-primary)] tabular-nums ml-1">{rangeLabel}</span>
+          <span className="text-[12px] font-medium text-[var(--text-primary)] tabular-nums ml-1">
+            {rangeLabel}
+          </span>
         </div>
 
         {/* Day-column headers */}
@@ -318,9 +350,9 @@ export function MemoryTimelineCalendar({
                   className={cn(
                     "text-[13px] tabular-nums leading-none",
                     isToday
-                      // `w-6 h-6` (was w-5) so two-digit dates (10–31) aren't
-                      // cramped/clipped inside the today circle.
-                      ? "text-[var(--bg-base)] bg-[var(--accent-primary)] rounded-full w-6 h-6 flex items-center justify-center font-semibold mt-0.5"
+                      ? // `w-6 h-6` (was w-5) so two-digit dates (10–31) aren't
+                        // cramped/clipped inside the today circle.
+                        "text-[var(--bg-base)] bg-[var(--accent-primary)] rounded-full w-6 h-6 flex items-center justify-center font-semibold mt-0.5"
                       : "text-[var(--text-secondary)]",
                   )}
                 >
@@ -353,11 +385,14 @@ export function MemoryTimelineCalendar({
                         else cardRefs.current.delete(c.id);
                       }}
                       onClick={(e) => {
-                        if ((e.metaKey || e.ctrlKey) && c.kind === "session") onActivate(c.id);
+                        if ((e.metaKey || e.ctrlKey) && c.kind === "session")
+                          onActivate(c.id);
                         else onSelect(sel ? null : c.id);
                       }}
                       onMouseEnter={() => setHoverBranch(c.branch)}
-                      onMouseLeave={() => setHoverBranch((h) => (h === c.branch ? null : h))}
+                      onMouseLeave={() =>
+                        setHoverBranch((h) => (h === c.branch ? null : h))
+                      }
                       title={c.title}
                       className={cn(
                         "group w-full max-w-full min-w-0 flex items-start gap-1.5 pl-1.5 pr-1 py-1 rounded-md border text-left cursor-pointer transition-all",
@@ -369,7 +404,11 @@ export function MemoryTimelineCalendar({
                     >
                       <span
                         className="shrink-0 w-1.5 h-1.5 rounded-full mt-[4px]"
-                        style={{ background: memoryIds?.has(c.id) ? DOT_MEMORY : DOT_PLAIN }}
+                        style={{
+                          background: memoryIds?.has(c.id)
+                            ? DOT_MEMORY
+                            : DOT_PLAIN,
+                        }}
                       />
                       <span className="min-w-0 flex-1">
                         <span className="block text-[10px] leading-snug text-[var(--text-secondary)] line-clamp-2 break-words">
@@ -390,9 +429,19 @@ export function MemoryTimelineCalendar({
 
       {/* ── Curved connectors (branch → cards) ── */}
       {paths.length > 0 && (
-        <svg className="absolute inset-0 pointer-events-none z-20" width="100%" height="100%">
+        <svg
+          className="absolute inset-0 pointer-events-none z-20"
+          width="100%"
+          height="100%"
+        >
           {paths.map((d, i) => (
-            <path key={i} d={d} fill="none" stroke={CONNECTOR} strokeWidth={1.5} />
+            <path
+              key={i}
+              d={d}
+              fill="none"
+              stroke={CONNECTOR}
+              strokeWidth={1.5}
+            />
           ))}
         </svg>
       )}

--- a/src/features/memory/components/memory-timeline-panel.tsx
+++ b/src/features/memory/components/memory-timeline-panel.tsx
@@ -36,7 +36,11 @@ export function MemoryTimelinePanel({
   if (!open) return null;
   return (
     <>
-      <div className="absolute inset-0 z-20 bg-black/10 animate-fade-in" onClick={onClose} aria-hidden />
+      <div
+        className="absolute inset-0 z-20 bg-black/10 animate-fade-in"
+        onClick={onClose}
+        aria-hidden
+      />
       <aside
         className={cn(
           "absolute right-0 top-0 bottom-0 z-30 w-[330px] flex flex-col",
@@ -46,8 +50,12 @@ export function MemoryTimelinePanel({
       >
         <div className="flex items-start gap-2 px-3 h-[40px] shrink-0 border-b border-[var(--border-default)]">
           <div className="flex-1 min-w-0 pt-1">
-            <div className="text-[11px] font-medium text-[var(--text-primary)] truncate">{title}</div>
-            <div className="text-[9px] text-[var(--text-tertiary)] truncate">{subtitle}</div>
+            <div className="text-[11px] font-medium text-[var(--text-primary)] truncate">
+              {title}
+            </div>
+            <div className="text-[9px] text-[var(--text-tertiary)] truncate">
+              {subtitle}
+            </div>
           </div>
           <button
             onClick={onClose}
@@ -79,7 +87,9 @@ export function MemoryTimelinePanel({
                   ) : (
                     <ClaudeIcon className="size-3 shrink-0 opacity-70" />
                   )}
-                  <span className="text-[11px] text-[var(--text-primary)] truncate flex-1">{it.title}</span>
+                  <span className="text-[11px] text-[var(--text-primary)] truncate flex-1">
+                    {it.title}
+                  </span>
                   {it.score !== undefined && (
                     <span className="text-[9px] text-[var(--text-tertiary)] tabular-nums">
                       {Math.round(it.score * 100)}%
@@ -89,7 +99,11 @@ export function MemoryTimelinePanel({
                 <div className="flex items-center gap-1.5 text-[9px] text-[var(--text-tertiary)]">
                   <span className="truncate flex-1">{it.note}</span>
                   {it.ts_ms > 0 && (
-                    <span className="shrink-0">{timeAgo(new Date(it.ts_ms).toISOString(), { suffix: true })}</span>
+                    <span className="shrink-0">
+                      {timeAgo(new Date(it.ts_ms).toISOString(), {
+                        suffix: true,
+                      })}
+                    </span>
                   )}
                 </div>
               </button>

--- a/src/features/memory/components/memory-timeline-view.tsx
+++ b/src/features/memory/components/memory-timeline-view.tsx
@@ -61,25 +61,40 @@ function buildChain(t: MemoryTimeline) {
 }
 type Chain = ReturnType<typeof buildChain>;
 
-function affectingItems(selectedId: string, chain: Chain, t: MemoryTimeline): PanelItem[] {
+function affectingItems(
+  selectedId: string,
+  chain: Chain,
+  t: MemoryTimeline,
+): PanelItem[] {
   const notes = new Map<string, string>();
-  const add = (mid: string, note: string) => { if (!notes.has(mid)) notes.set(mid, note); };
+  const add = (mid: string, note: string) => {
+    if (!notes.has(mid)) notes.set(mid, note);
+  };
   if (selectedId.startsWith("commit:")) {
     const sha = selectedId.slice(7);
     for (const sid of chain.commitToSessions.get(sha) ?? [])
-      for (const mid of chain.sessionToMems.get(sid) ?? []) add(mid, `fed a run → ${sha.slice(0, 7)}`);
+      for (const mid of chain.sessionToMems.get(sid) ?? [])
+        add(mid, `fed a run → ${sha.slice(0, 7)}`);
   } else if (selectedId.startsWith("session:")) {
-    for (const mid of chain.sessionToMems.get(selectedId.slice(8)) ?? []) add(mid, "fed this run");
+    for (const mid of chain.sessionToMems.get(selectedId.slice(8)) ?? [])
+      add(mid, "fed this run");
   } else if (selectedId.startsWith("branch:")) {
     const br = selectedId.slice(7);
     for (const s of t.sessions)
       if (s.branch === br)
-        for (const mid of chain.sessionToMems.get(s.id) ?? []) add(mid, `fed a run on ${br}`);
+        for (const mid of chain.sessionToMems.get(s.id) ?? [])
+          add(mid, `fed a run on ${br}`);
   }
   return [...notes.entries()]
     .map(([mid, note]) => {
       const m = chain.memById.get(mid) as TimelineMemory;
-      return { id: mid, title: m.title, source: m.source, note, ts_ms: m.ts_ms };
+      return {
+        id: mid,
+        title: m.title,
+        source: m.source,
+        note,
+        ts_ms: m.ts_ms,
+      };
     })
     .sort((a, b) => b.ts_ms - a.ts_ms);
 }
@@ -89,7 +104,8 @@ export function MemoryTimelineView() {
   const isRepo = useGitStore.use.isRepo();
   const timeline = useMemoryStore.use.timeline();
   const loading = useMemoryStore.use.timelineLoading();
-  const { ensureProject, loadTimeline, navigateToMemory } = useMemoryStore.use.actions();
+  const { ensureProject, loadTimeline, navigateToMemory } =
+    useMemoryStore.use.actions();
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
@@ -106,17 +122,22 @@ export function MemoryTimelineView() {
     if (projectPath && isRepo) void loadTimeline(projectPath);
   }, [projectPath, isRepo, ensureProject, loadTimeline]);
 
-  const chain = useMemo(() => (timeline ? buildChain(timeline) : null), [timeline]);
+  const chain = useMemo(
+    () => (timeline ? buildChain(timeline) : null),
+    [timeline],
+  );
 
   // Card ids (commit/session) that have memory feeding into them via the chain.
   const memoryIds = useMemo(() => {
     if (!timeline || !chain) return null;
     const s = new Set<string>();
     for (const ses of timeline.sessions)
-      if ((chain.sessionToMems.get(ses.id)?.length ?? 0) > 0) s.add(`session:${ses.id}`);
+      if ((chain.sessionToMems.get(ses.id)?.length ?? 0) > 0)
+        s.add(`session:${ses.id}`);
     for (const c of timeline.commits) {
       const sids = chain.commitToSessions.get(c.sha) ?? [];
-      if (sids.some((sid) => (chain.sessionToMems.get(sid)?.length ?? 0) > 0)) s.add(`commit:${c.sha}`);
+      if (sids.some((sid) => (chain.sessionToMems.get(sid)?.length ?? 0) > 0))
+        s.add(`commit:${c.sha}`);
     }
     return s;
   }, [timeline, chain]);
@@ -128,7 +149,11 @@ export function MemoryTimelineView() {
         const s = timeline?.sessions.find((x) => x.id === id.slice(8));
         if (s) {
           const sub =
-            s.agent === "codex" ? "codex" : s.agent === "cersei" ? "cersei" : "claude";
+            s.agent === "codex"
+              ? "codex"
+              : s.agent === "cersei"
+                ? "cersei"
+                : "claude";
           navigateToMemory(sub, s.id);
         }
         return;
@@ -165,12 +190,21 @@ export function MemoryTimelineView() {
             note = `impacts ${sha.slice(0, 7)} on ${chain.commitBySha.get(sha)?.branch ?? "?"}`;
           } else note = "linked to a run";
         }
-        items.push({ id: h.id, title: m.title, source: m.source, note, ts_ms: m.ts_ms, score: h.score });
+        items.push({
+          id: h.id,
+          title: m.title,
+          source: m.source,
+          note,
+          ts_ms: m.ts_ms,
+          score: h.score,
+        });
       }
       setHighlightIds(hi);
       setSearchItems(items);
       if (items.length === 0)
-        setSearchError("No indexed memory matched. Build the Graph tab first if results look empty.");
+        setSearchError(
+          "No indexed memory matched. Build the Graph tab first if results look empty.",
+        );
     } catch (e) {
       const msg = String(e);
       setSearchError(
@@ -198,23 +232,38 @@ export function MemoryTimelineView() {
     return (
       <Centered>
         <div className="text-center max-w-[320px] px-6 space-y-2">
-          <GitBranch size={22} className="text-[var(--text-tertiary)] mx-auto" />
-          <p className="text-[12px] text-[var(--text-secondary)]">Timeline needs a git repo</p>
+          <GitBranch
+            size={22}
+            className="text-[var(--text-tertiary)] mx-auto"
+          />
+          <p className="text-[12px] text-[var(--text-secondary)]">
+            Timeline needs a git repo
+          </p>
           <p className="text-[11px] text-[var(--text-tertiary)] leading-relaxed">
-            Initialize git to map agent sessions and memory onto branch lanes over time.
+            Initialize git to map agent sessions and memory onto branch lanes
+            over time.
           </p>
         </div>
       </Centered>
     );
   }
   if (loading && !timeline) {
-    return <Centered><Loader2 size={18} className="animate-spin text-[var(--text-tertiary)]" /></Centered>;
+    return (
+      <Centered>
+        <Loader2
+          size={18}
+          className="animate-spin text-[var(--text-tertiary)]"
+        />
+      </Centered>
+    );
   }
   if (!timeline || !chain) {
     return (
       <Centered>
         <div className="text-center space-y-2">
-          <p className="text-[12px] text-[var(--text-tertiary)]">Couldn't build the timeline.</p>
+          <p className="text-[12px] text-[var(--text-tertiary)]">
+            Couldn't build the timeline.
+          </p>
           <button
             onClick={() => projectPath && void loadTimeline(projectPath, true)}
             className="inline-flex items-center gap-1.5 h-7 px-3 rounded-md border border-[var(--border-default)] text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
@@ -234,19 +283,24 @@ export function MemoryTimelineView() {
     : selectedId
       ? affectingItems(selectedId, chain, timeline)
       : [];
-  const panelTitle = searchMode ? `Impact of “${query.trim()}”` : selectionTitle(selectedId, timeline);
+  const panelTitle = searchMode
+    ? `Impact of “${query.trim()}”`
+    : selectionTitle(selectedId, timeline);
   const panelSubtitle = searchMode
-    ? searchError ?? `${searchItems!.length} memories · ${highlightIds?.size ?? 0} git targets`
+    ? (searchError ??
+      `${searchItems!.length} memories · ${highlightIds?.size ?? 0} git targets`)
     : "memory affecting this, newest first";
 
   return (
     <div className="h-full flex flex-col bg-[var(--bg-base)]">
       {/* Header */}
       <div className="flex items-center gap-3 px-3 h-[32px] shrink-0 border-b border-[var(--border-default)] text-[10px] text-[var(--text-tertiary)]">
-        <span className="text-[11px] font-medium text-[var(--text-secondary)]">Timeline</span>
+        <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+          Timeline
+        </span>
         <span className="tabular-nums">
-          {timeline.branches.length} branches · {timeline.commits.length} commits ·{" "}
-          {timeline.sessions.length} sessions
+          {timeline.branches.length} branches · {timeline.commits.length}{" "}
+          commits · {timeline.sessions.length} sessions
         </span>
         <div className="flex-1" />
         {/* Day-range segmented toggle (auto via breakpoint, user-overridable). */}
@@ -305,7 +359,10 @@ export function MemoryTimelineView() {
         {/* Floating semantic search pill — overlaid on the chart, no box. */}
         <div className="absolute bottom-5 left-1/2 -translate-x-1/2 z-10 w-[min(620px,calc(100%-40px))]">
           <div className="flex items-center gap-2.5 h-11 rounded-full bg-[#141414]/95 backdrop-blur-2xl shadow-[0_10px_40px_rgba(0,0,0,0.6)] border border-white/[0.12] px-4">
-            <Search size={15} className="text-[var(--text-tertiary)] shrink-0" />
+            <Search
+              size={15}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
             <input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
@@ -318,7 +375,11 @@ export function MemoryTimelineView() {
               className="flex-1 min-w-0 bg-transparent outline-none text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]"
             />
             {(query || searchMode) && !searching && (
-              <button onClick={clearSearch} className="text-[var(--text-tertiary)] hover:text-[var(--text-primary)] shrink-0" title="Clear">
+              <button
+                onClick={clearSearch}
+                className="text-[var(--text-tertiary)] hover:text-[var(--text-primary)] shrink-0"
+                title="Clear"
+              >
                 <X size={15} />
               </button>
             )}
@@ -328,7 +389,11 @@ export function MemoryTimelineView() {
               className="flex items-center justify-center w-7 h-7 rounded-full bg-[var(--accent-primary)] text-[var(--bg-base)] shrink-0 disabled:opacity-30 hover:opacity-90 transition-opacity cursor-pointer"
               title="Search memory impact"
             >
-              {searching ? <Loader2 size={14} className="animate-spin" /> : <ArrowUp size={15} />}
+              {searching ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <ArrowUp size={15} />
+              )}
             </button>
           </div>
         </div>
@@ -353,5 +418,9 @@ function selectionTitle(selectedId: string | null, t: MemoryTimeline): string {
 }
 
 function Centered({ children }: { children: React.ReactNode }) {
-  return <div className="h-full flex items-center justify-center text-[var(--text-tertiary)] text-[12px]">{children}</div>;
+  return (
+    <div className="h-full flex items-center justify-center text-[var(--text-tertiary)] text-[12px]">
+      {children}
+    </div>
+  );
 }

--- a/src/features/memory/components/memory-tree-view.tsx
+++ b/src/features/memory/components/memory-tree-view.tsx
@@ -58,11 +58,17 @@ function wrapLabel(text: string, maxChars: number, maxLines = 2): string[] {
   }
   if (lines.length < maxLines && cur) lines.push(cur);
   // Hard-clamp each line; ellipsise the last if we dropped content.
-  const out = lines.slice(0, maxLines).map((l) => (l.length > maxChars ? l.slice(0, maxChars - 1) : l));
+  const out = lines
+    .slice(0, maxLines)
+    .map((l) => (l.length > maxChars ? l.slice(0, maxChars - 1) : l));
   const shown = out.join(" ");
   if (shown.length < clean.length && out.length) {
     const i = out.length - 1;
-    out[i] = (out[i].length > maxChars - 1 ? out[i].slice(0, maxChars - 1) : out[i]).trimEnd() + "…";
+    out[i] =
+      (out[i].length > maxChars - 1
+        ? out[i].slice(0, maxChars - 1)
+        : out[i]
+      ).trimEnd() + "…";
   }
   return out;
 }
@@ -80,7 +86,10 @@ export function MemoryTreeView({
     [projectPath],
   );
 
-  const tree = useMemo(() => buildMemoryTree(graph, rootLabel), [graph, rootLabel]);
+  const tree = useMemo(
+    () => buildMemoryTree(graph, rootLabel),
+    [graph, rootLabel],
+  );
 
   // parentId for every node — drives the ancestor decision-path highlight.
   const parentOf = useMemo(() => {
@@ -137,7 +146,12 @@ export function MemoryTreeView({
   const [transform, setTransform] = useState({ x: 28, y: 24, k: 1 });
   const wrapRef = useRef<HTMLDivElement>(null);
   const userMoved = useRef(false);
-  const panning = useRef<{ x: number; y: number; tx: number; ty: number } | null>(null);
+  const panning = useRef<{
+    x: number;
+    y: number;
+    tx: number;
+    ty: number;
+  } | null>(null);
 
   useEffect(() => {
     userMoved.current = false;
@@ -167,7 +181,10 @@ export function MemoryTreeView({
       const lx = e.clientX - rect.left;
       const ly = e.clientY - rect.top;
       setTransform((t) => {
-        const k = Math.min(MAX_K, Math.max(MIN_K, t.k * Math.exp(-e.deltaY * ZOOM_STEP)));
+        const k = Math.min(
+          MAX_K,
+          Math.max(MIN_K, t.k * Math.exp(-e.deltaY * ZOOM_STEP)),
+        );
         const wx = (lx - t.x) / t.k;
         const wy = (ly - t.y) / t.k;
         return { x: lx - wx * k, y: ly - wy * k, k };
@@ -180,7 +197,12 @@ export function MemoryTreeView({
   const dragMoved = useRef(false);
   const onPointerDown = (e: React.PointerEvent) => {
     dragMoved.current = false;
-    panning.current = { x: e.clientX, y: e.clientY, tx: transform.x, ty: transform.y };
+    panning.current = {
+      x: e.clientX,
+      y: e.clientY,
+      tx: transform.x,
+      ty: transform.y,
+    };
     (e.target as Element).setPointerCapture?.(e.pointerId);
   };
   const onPointerMove = (e: React.PointerEvent) => {
@@ -190,7 +212,11 @@ export function MemoryTreeView({
       dragMoved.current = true;
       userMoved.current = true;
     }
-    setTransform((t) => ({ ...t, x: p.tx + (e.clientX - p.x), y: p.ty + (e.clientY - p.y) }));
+    setTransform((t) => ({
+      ...t,
+      x: p.tx + (e.clientX - p.x),
+      y: p.ty + (e.clientY - p.y),
+    }));
   };
   const onPointerUp = () => {
     panning.current = null;
@@ -202,12 +228,16 @@ export function MemoryTreeView({
   };
 
   const hasMatches = matchedIds.size > 0;
-  const visibleSet = useMemo(() => new Set(layout.visible.map((v) => v.id)), [layout.visible]);
+  const visibleSet = useMemo(
+    () => new Set(layout.visible.map((v) => v.id)),
+    [layout.visible],
+  );
 
   /** Dim factor for a node id given current path/search/time state. */
   const dimmed = (t: TreeNode): boolean => {
     if (pathIds) return !pathIds.has(t.id);
-    if (cutoffMs != null && t.node && t.node.timestampMs > cutoffMs) return true;
+    if (cutoffMs != null && t.node && t.node.timestampMs > cutoffMs)
+      return true;
     if (hasMatches && t.node) return !matchedIds.has(t.id);
     return false;
   };
@@ -223,7 +253,9 @@ export function MemoryTreeView({
       onClick={onBackgroundClick}
     >
       <svg width="100%" height="100%" className="block select-none">
-        <g transform={`translate(${transform.x} ${transform.y}) scale(${transform.k})`}>
+        <g
+          transform={`translate(${transform.x} ${transform.y}) scale(${transform.k})`}
+        >
           {/* Connectors: parent card right edge → child card left edge. */}
           {layout.visible.map((t) => {
             if (collapsed.has(t.id)) return null;
@@ -231,7 +263,8 @@ export function MemoryTreeView({
             return t.children.map((c) => {
               if (!visibleSet.has(c.id)) return null;
               const cp = layout.positions.get(c.id)!;
-              const onPath = !!pathIds && pathIds.has(t.id) && pathIds.has(c.id);
+              const onPath =
+                !!pathIds && pathIds.has(t.id) && pathIds.has(c.id);
               const dim = dimmed(c) && !onPath;
               return (
                 <path
@@ -285,9 +318,19 @@ export function MemoryTreeView({
                       toggle(t.id);
                     }}
                   >
-                    <rect x={-6} y={-8} width={16} height={16} fill="transparent" />
+                    <rect
+                      x={-6}
+                      y={-8}
+                      width={16}
+                      height={16}
+                      fill="transparent"
+                    />
                     <path
-                      d={collapsed.has(t.id) ? "M0 -4 L5 0 L0 4 Z" : "M-4 -1.5 L4 -1.5 L0 3.5 Z"}
+                      d={
+                        collapsed.has(t.id)
+                          ? "M0 -4 L5 0 L0 4 Z"
+                          : "M-4 -1.5 L4 -1.5 L0 3.5 Z"
+                      }
                       fill={lit ? HL : "var(--text-tertiary)"}
                     />
                   </g>
@@ -295,7 +338,9 @@ export function MemoryTreeView({
                 {(() => {
                   const fontSize = isRoot ? 11 : isCat ? 10.5 : 10;
                   const textX = isRoot ? 10 : 20;
-                  const maxChars = Math.floor((CARD_W - textX - 9) / (fontSize * 0.54));
+                  const maxChars = Math.floor(
+                    (CARD_W - textX - 9) / (fontSize * 0.54),
+                  );
                   const suffix =
                     collapsed.has(t.id) && t.children.length > 0
                       ? `  (${t.children.length})`
@@ -303,7 +348,9 @@ export function MemoryTreeView({
                   const lines = wrapLabel(t.label + suffix, maxChars, 3);
                   const lineH = fontSize + 2.5;
                   const top = CARD_H / 2 - ((lines.length - 1) * lineH) / 2;
-                  const textColor = lit ? "var(--text-primary)" : "var(--text-secondary)";
+                  const textColor = lit
+                    ? "var(--text-primary)"
+                    : "var(--text-secondary)";
                   return (
                     <>
                       <rect
@@ -339,7 +386,12 @@ export function MemoryTreeView({
                         fill={textColor}
                       >
                         {lines.map((ln, i) => (
-                          <tspan key={i} x={textX} y={top + i * lineH} dominantBaseline="middle">
+                          <tspan
+                            key={i}
+                            x={textX}
+                            y={top + i * lineH}
+                            dominantBaseline="middle"
+                          >
                             {ln}
                           </tspan>
                         ))}

--- a/src/features/memory/components/provider-pickers.tsx
+++ b/src/features/memory/components/provider-pickers.tsx
@@ -34,7 +34,13 @@ function loadModelIds(provider: string): Promise<string[]> {
   return p;
 }
 
-function PickerDropdown({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) {
+function PickerDropdown({
+  trigger,
+  children,
+}: {
+  trigger: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
@@ -75,10 +81,18 @@ function ModelCombo({
   }, [models, q]);
 
   return (
-    <Popover.Root open={open} onOpenChange={(o) => { setOpen(o); if (!o) setQ(""); }}>
+    <Popover.Root
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setQ("");
+      }}
+    >
       <Popover.Trigger asChild>
         <button className="flex min-w-0 items-center gap-1.5 h-[26px] rounded-full border border-border-default bg-bg-elevated px-2 text-[10px] font-medium text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors outline-none cursor-pointer">
-          {loading && <Loader2 size={11} className="animate-spin text-text-tertiary" />}
+          {loading && (
+            <Loader2 size={11} className="animate-spin text-text-tertiary" />
+          )}
           <span className="max-w-[160px] truncate font-mono">
             {value || (loading ? "Loading…" : "Select model")}
           </span>
@@ -112,11 +126,16 @@ function ModelCombo({
               filtered.map((id) => (
                 <button
                   key={id}
-                  onClick={() => { onSelect(id); setOpen(false); }}
+                  onClick={() => {
+                    onSelect(id);
+                    setOpen(false);
+                  }}
                   className="flex w-full items-center gap-2 px-2.5 h-[26px] text-left text-[11px] font-mono text-text-secondary hover:bg-bg-hover hover:text-text-primary cursor-pointer outline-none"
                 >
                   <span className="flex-1 truncate">{id}</span>
-                  {id === value && <Check size={11} className="text-text-primary" />}
+                  {id === value && (
+                    <Check size={11} className="text-text-primary" />
+                  )}
                 </button>
               ))
             )}
@@ -177,7 +196,9 @@ export function ProviderModelSelector({
           <>
             {provider && <ProviderLogo id={provider} size={13} />}
             <span className="max-w-[100px] truncate">
-              {provider ? providerById(provider)?.name ?? provider : "Provider"}
+              {provider
+                ? (providerById(provider)?.name ?? provider)
+                : "Provider"}
             </span>
             <ChevronDown size={11} className="text-text-tertiary" />
           </>
@@ -191,11 +212,18 @@ export function ProviderModelSelector({
           >
             <ProviderLogo id={p.id} size={14} />
             <span className="flex-1 truncate">{p.name}</span>
-            {p.id === provider && <Check size={12} className="text-text-primary" />}
+            {p.id === provider && (
+              <Check size={12} className="text-text-primary" />
+            )}
           </DropdownMenu.Item>
         ))}
       </PickerDropdown>
-      <ModelCombo models={models} value={model} loading={loading} onSelect={onModel} />
+      <ModelCombo
+        models={models}
+        value={model}
+        loading={loading}
+        onSelect={onModel}
+      />
     </>
   );
 }

--- a/src/features/memory/components/shared-memory-view.tsx
+++ b/src/features/memory/components/shared-memory-view.tsx
@@ -63,10 +63,22 @@ function agentMeta(agent: string): {
 } {
   const a = agent.toLowerCase();
   if (a.includes("codex"))
-    return { Icon: CodexIcon, tint: "var(--agent-codex-chip-bg)", label: "Codex" };
+    return {
+      Icon: CodexIcon,
+      tint: "var(--agent-codex-chip-bg)",
+      label: "Codex",
+    };
   if (a.includes("claude"))
-    return { Icon: ClaudeIcon, tint: "var(--agent-claude-chip-bg)", label: "Claude" };
-  return { Icon: null, tint: "var(--bg-elevated)", label: agent.split(/[-_]/)[0] || agent };
+    return {
+      Icon: ClaudeIcon,
+      tint: "var(--agent-claude-chip-bg)",
+      label: "Claude",
+    };
+  return {
+    Icon: null,
+    tint: "var(--bg-elevated)",
+    label: agent.split(/[-_]/)[0] || agent,
+  };
 }
 
 const str = (v: unknown): string => (v == null ? "" : String(v));
@@ -114,7 +126,10 @@ export function SharedMemoryView({ projectPath, className }: Props) {
   const [agentFilter, setAgentFilter] = useState<string>("");
   const [kindFilter, setKindFilter] = useState<string>("");
 
-  const plans = useMemo(() => events.filter((e) => e.kind === "plan_set"), [events]);
+  const plans = useMemo(
+    () => events.filter((e) => e.kind === "plan_set"),
+    [events],
+  );
 
   // Filter options derived from the data actually present.
   const agentOptions = useMemo(
@@ -136,10 +151,16 @@ export function SharedMemoryView({ projectPath, className }: Props) {
       eventDetail(e).toLowerCase().includes(q));
 
   const eventRows = useMemo(
-    () => events.filter((e) => baseMatch(e) && (!kindFilter || e.kind === kindFilter)),
+    () =>
+      events.filter(
+        (e) => baseMatch(e) && (!kindFilter || e.kind === kindFilter),
+      ),
     [events, q, agentFilter, kindFilter],
   );
-  const planRows = useMemo(() => plans.filter(baseMatch), [plans, q, agentFilter]);
+  const planRows = useMemo(
+    () => plans.filter(baseMatch),
+    [plans, q, agentFilter],
+  );
 
   return (
     <div className={cn("h-full flex flex-col bg-[var(--bg-base)]", className)}>
@@ -265,13 +286,25 @@ function EventRow({
         onClick={onToggle}
         className={cn(
           "w-full flex items-center h-[40px] px-3 text-left transition-colors cursor-pointer",
-          expanded ? "bg-[var(--bg-elevated)]/50" : "hover:bg-[var(--bg-hover)]",
+          expanded
+            ? "bg-[var(--bg-elevated)]/50"
+            : "hover:bg-[var(--bg-hover)]",
         )}
       >
-        <span className={cn(EVENT_COL.seq, "font-mono text-[10px] tabular-nums text-[var(--text-ghost)]")}>
+        <span
+          className={cn(
+            EVENT_COL.seq,
+            "font-mono text-[10px] tabular-nums text-[var(--text-ghost)]",
+          )}
+        >
           {e.seq}
         </span>
-        <span className={cn(EVENT_COL.time, "text-[10px] text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            EVENT_COL.time,
+            "text-[10px] text-[var(--text-tertiary)]",
+          )}
+        >
           {eventTime(e.ts)}
         </span>
         <span className={EVENT_COL.agent}>
@@ -282,10 +315,17 @@ function EventRow({
         </span>
         <span className={cn(EVENT_COL.detail, "min-w-0 pr-3")}>
           <span className="block truncate text-[12px] text-[var(--text-secondary)]">
-            {eventDetail(e) || <span className="text-[var(--text-ghost)]">—</span>}
+            {eventDetail(e) || (
+              <span className="text-[var(--text-ghost)]">—</span>
+            )}
           </span>
         </span>
-        <span className={cn(EVENT_COL.chevron, "flex items-center justify-end text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            EVENT_COL.chevron,
+            "flex items-center justify-end text-[var(--text-tertiary)]",
+          )}
+        >
           {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
         </span>
       </button>
@@ -369,13 +409,25 @@ function PlanRow({
         onClick={onToggle}
         className={cn(
           "w-full flex items-center h-[40px] px-3 text-left transition-colors cursor-pointer",
-          expanded ? "bg-[var(--bg-elevated)]/50" : "hover:bg-[var(--bg-hover)]",
+          expanded
+            ? "bg-[var(--bg-elevated)]/50"
+            : "hover:bg-[var(--bg-hover)]",
         )}
       >
-        <span className={cn(PLAN_COL.seq, "font-mono text-[10px] tabular-nums text-[var(--text-ghost)]")}>
+        <span
+          className={cn(
+            PLAN_COL.seq,
+            "font-mono text-[10px] tabular-nums text-[var(--text-ghost)]",
+          )}
+        >
           {e.seq}
         </span>
-        <span className={cn(PLAN_COL.time, "text-[10px] text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            PLAN_COL.time,
+            "text-[10px] text-[var(--text-tertiary)]",
+          )}
+        >
           {eventTime(e.ts)}
         </span>
         <span className={PLAN_COL.agent}>
@@ -389,7 +441,12 @@ function PlanRow({
             {firstLine || <span className="text-[var(--text-ghost)]">—</span>}
           </span>
         </span>
-        <span className={cn(PLAN_COL.chevron, "flex items-center justify-end text-[var(--text-tertiary)]")}>
+        <span
+          className={cn(
+            PLAN_COL.chevron,
+            "flex items-center justify-end text-[var(--text-tertiary)]",
+          )}
+        >
           {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
         </span>
       </button>
@@ -456,7 +513,9 @@ function SegBtn({
       <span className={active ? "opacity-100" : "opacity-60"}>{icon}</span>
       {label}
       {count > 0 && (
-        <span className="text-[9px] tabular-nums text-[var(--text-ghost)]">{count}</span>
+        <span className="text-[9px] tabular-nums text-[var(--text-ghost)]">
+          {count}
+        </span>
       )}
     </button>
   );
@@ -482,7 +541,8 @@ function FilterMenu({
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
@@ -514,7 +574,10 @@ function FilterMenu({
         <span className="max-w-[120px] truncate">{display}</span>
         <ChevronDown
           size={10}
-          className={cn("shrink-0 opacity-50 transition-transform", open && "rotate-180")}
+          className={cn(
+            "shrink-0 opacity-50 transition-transform",
+            open && "rotate-180",
+          )}
         />
       </button>
       {open && (
@@ -564,7 +627,9 @@ function FilterOption({
       )}
     >
       <span className="min-w-0 flex-1 truncate">{label}</span>
-      {active && <Check size={11} className="shrink-0 text-[var(--accent-primary)]" />}
+      {active && (
+        <Check size={11} className="shrink-0 text-[var(--accent-primary)]" />
+      )}
     </button>
   );
 }
@@ -637,7 +702,9 @@ function MetaChip({
 }) {
   return (
     <span className="inline-flex items-center gap-1.5">
-      <span className="text-[9px] uppercase tracking-wider text-[var(--text-ghost)]">{label}</span>
+      <span className="text-[9px] uppercase tracking-wider text-[var(--text-ghost)]">
+        {label}
+      </span>
       <span
         className={cn(
           "text-[11px] text-[var(--text-secondary)]",

--- a/src/features/memory/lib/codebase-index-api.ts
+++ b/src/features/memory/lib/codebase-index-api.ts
@@ -25,14 +25,24 @@ export interface CodebaseIndexProgress {
 
 export const codebaseIndex = {
   status(projectPath: string): Promise<CodebaseIndexStatus> {
-    return invoke<CodebaseIndexStatus>("codebase_index_status", { projectPath });
+    return invoke<CodebaseIndexStatus>("codebase_index_status", {
+      projectPath,
+    });
   },
-  build(projectPath: string, opts: CodebaseBuildOpts): Promise<CodebaseIndexStatus> {
-    return invoke<CodebaseIndexStatus>("codebase_index_build", { projectPath, opts });
+  build(
+    projectPath: string,
+    opts: CodebaseBuildOpts,
+  ): Promise<CodebaseIndexStatus> {
+    return invoke<CodebaseIndexStatus>("codebase_index_build", {
+      projectPath,
+      opts,
+    });
   },
 };
 
 export const listenCodebaseIndexProgress = (
   handler: (p: CodebaseIndexProgress) => void,
 ): Promise<UnlistenFn> =>
-  listen<CodebaseIndexProgress>("atlas:codebase-index:progress", (e) => handler(e.payload));
+  listen<CodebaseIndexProgress>("atlas:codebase-index:progress", (e) =>
+    handler(e.payload),
+  );

--- a/src/features/memory/lib/memory-chat-api.ts
+++ b/src/features/memory/lib/memory-chat-api.ts
@@ -87,14 +87,16 @@ export const memoryChat = {
     invoke<void>("memory_chat_send", { streamId, projectPath, messages }),
   retrieve: (projectPath: string, query: string) =>
     invoke<RetrieveResult>("memory_chat_retrieve", { projectPath, query }),
-  cancel: (streamId: string) => invoke<void>("memory_chat_cancel", { streamId }),
+  cancel: (streamId: string) =>
+    invoke<void>("memory_chat_cancel", { streamId }),
 
   sessionsList: () => invoke<SessionMeta[]>("memory_chat_sessions_list"),
   sessionGet: (id: string) =>
     invoke<MemoryChatSessionWire>("memory_chat_session_get", { id }),
   sessionSave: (session: MemoryChatSessionWire) =>
     invoke<void>("memory_chat_session_save", { session }),
-  sessionDelete: (id: string) => invoke<void>("memory_chat_session_delete", { id }),
+  sessionDelete: (id: string) =>
+    invoke<void>("memory_chat_session_delete", { id }),
 };
 
 export const listenMemoryChat = (
@@ -105,9 +107,13 @@ export const listenMemoryChat = (
 export const listenChatModelProgress = (
   handler: (p: DownloadProgress) => void,
 ): Promise<UnlistenFn> =>
-  listen<DownloadProgress>("atlas:memory-chat-model:progress", (e) => handler(e.payload));
+  listen<DownloadProgress>("atlas:memory-chat-model:progress", (e) =>
+    handler(e.payload),
+  );
 
 export const listenChatModelDone = (
   handler: (d: DownloadDone) => void,
 ): Promise<UnlistenFn> =>
-  listen<DownloadDone>("atlas:memory-chat-model:done", (e) => handler(e.payload));
+  listen<DownloadDone>("atlas:memory-chat-model:done", (e) =>
+    handler(e.payload),
+  );

--- a/src/features/memory/lib/memory-graph-api.ts
+++ b/src/features/memory/lib/memory-graph-api.ts
@@ -33,9 +33,12 @@ export const memoryGraph = {
   embedStatus: () => invoke<EmbedStatus>("memory_embed_status"),
   embedDownload: () => invoke<void>("memory_embed_download"),
   buildIndex: (projectPath: string) =>
-    invoke<MemoryGraphData & { dim: number; doc_count: number }>("memory_index_build", {
-      projectPath,
-    }),
+    invoke<MemoryGraphData & { dim: number; doc_count: number }>(
+      "memory_index_build",
+      {
+        projectPath,
+      },
+    ),
   query: (projectPath: string, query: string, topK = 12) =>
     invoke<QueryHit[]>("memory_index_query", { projectPath, query, topK }),
 };
@@ -43,7 +46,9 @@ export const memoryGraph = {
 export const listenMemoryEmbedProgress = (
   handler: (p: DownloadProgress) => void,
 ): Promise<UnlistenFn> =>
-  listen<DownloadProgress>("atlas:memory-embed:progress", (e) => handler(e.payload));
+  listen<DownloadProgress>("atlas:memory-embed:progress", (e) =>
+    handler(e.payload),
+  );
 
 export const listenMemoryEmbedDone = (
   handler: (p: DownloadDone) => void,

--- a/src/features/memory/lib/memory-tree.ts
+++ b/src/features/memory/lib/memory-tree.ts
@@ -7,7 +7,10 @@
 // memory that references them (so an agent's decision/reasoning chains read as
 // nested branches). Pure functions — no DOM, no deps.
 
-import type { MemoryGraphData, MemoryNode } from "../components/memory-graph-canvas";
+import type {
+  MemoryGraphData,
+  MemoryNode,
+} from "../components/memory-graph-canvas";
 
 export interface TreeNode {
   /** Stable id. Memory nodes use the memory id; synthetic nodes use `root` /
@@ -45,7 +48,10 @@ const CATEGORY_LABEL: Record<string, string> = {
 };
 
 function categoryLabel(kind: string): string {
-  return CATEGORY_LABEL[kind] ?? (kind ? kind[0].toUpperCase() + kind.slice(1) : "Other");
+  return (
+    CATEGORY_LABEL[kind] ??
+    (kind ? kind[0].toUpperCase() + kind.slice(1) : "Other")
+  );
 }
 
 function categoryRank(kind: string): number {
@@ -59,7 +65,10 @@ function categoryRank(kind: string): number {
  * parent is always older ⇒ acyclic); memories with no such link hang under
  * their category branch. Similarity edges are ignored for nesting.
  */
-export function buildMemoryTree(graph: MemoryGraphData, rootLabel: string): TreeNode {
+export function buildMemoryTree(
+  graph: MemoryGraphData,
+  rootLabel: string,
+): TreeNode {
   const byId = new Map<string, MemoryNode>();
   for (const n of graph.nodes) byId.set(n.id, n);
 
@@ -113,7 +122,13 @@ export function buildMemoryTree(graph: MemoryGraphData, rootLabel: string): Tree
   const ensureCategory = (kind: string): TreeNode => {
     let c = categories.get(kind);
     if (!c) {
-      c = { id: `cat:${kind}`, label: categoryLabel(kind), kind, depth: 1, children: [] };
+      c = {
+        id: `cat:${kind}`,
+        label: categoryLabel(kind),
+        kind,
+        depth: 1,
+        children: [],
+      };
       categories.set(kind, c);
     }
     return c;
@@ -133,7 +148,9 @@ export function buildMemoryTree(graph: MemoryGraphData, rootLabel: string): Tree
     kind: "root",
     depth: 0,
     children: Array.from(categories.values()).sort(
-      (a, b) => categoryRank(a.kind) - categoryRank(b.kind) || a.label.localeCompare(b.label),
+      (a, b) =>
+        categoryRank(a.kind) - categoryRank(b.kind) ||
+        a.label.localeCompare(b.label),
     ),
   };
 
@@ -141,7 +158,9 @@ export function buildMemoryTree(graph: MemoryGraphData, rootLabel: string): Tree
   const sortRec = (t: TreeNode, depth: number) => {
     t.depth = depth;
     if (t.node) {
-      t.children.sort((a, b) => (b.node?.timestampMs ?? 0) - (a.node?.timestampMs ?? 0));
+      t.children.sort(
+        (a, b) => (b.node?.timestampMs ?? 0) - (a.node?.timestampMs ?? 0),
+      );
     }
     for (const c of t.children) sortRec(c, depth + 1);
   };
@@ -170,7 +189,10 @@ export const CARD_H = 54;
  * internal nodes centre on their visible children's span. Collapsed subtrees
  * contribute one row (the collapsed node) and are not descended into.
  */
-export function layoutTree(root: TreeNode, collapsed: ReadonlySet<string>): TreeLayout {
+export function layoutTree(
+  root: TreeNode,
+  collapsed: ReadonlySet<string>,
+): TreeLayout {
   const positions = new Map<string, { x: number; y: number }>();
   const visible: TreeNode[] = [];
   let row = 0;

--- a/src/features/memory/stores/memory-chat-store.ts
+++ b/src/features/memory/stores/memory-chat-store.ts
@@ -79,7 +79,11 @@ interface MemoryChatState {
     downloadModel: () => Promise<void>;
     loadModel: () => Promise<void>;
     loadList: () => Promise<void>;
-    newSession: (init?: { mode?: ChatMode; provider?: string; model?: string }) => string;
+    newSession: (init?: {
+      mode?: ChatMode;
+      provider?: string;
+      model?: string;
+    }) => string;
     selectSession: (id: string) => Promise<void>;
     deleteSession: (id: string) => Promise<void>;
     setMode: (id: string, mode: ChatMode) => void;
@@ -88,7 +92,10 @@ interface MemoryChatState {
     send: (id: string, text: string, projectPath: string) => Promise<void>;
     stop: (id: string) => void;
     loadCodebaseStatus: (projectPath: string, force?: boolean) => Promise<void>;
-    buildCodebaseIndex: (projectPath: string, opts: CodebaseBuildOpts) => Promise<void>;
+    buildCodebaseIndex: (
+      projectPath: string,
+      opts: CodebaseBuildOpts,
+    ) => Promise<void>;
   };
 }
 
@@ -175,7 +182,9 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
 
     downloadModel: async () => {
       set({ modelPhase: "downloading", modelProgress: null, modelError: null });
-      const unProg = await listenChatModelProgress((p) => set({ modelProgress: p }));
+      const unProg = await listenChatModelProgress((p) =>
+        set({ modelProgress: p }),
+      );
       const unDone = await listenChatModelDone((d) => {
         unProg();
         unDone();
@@ -184,7 +193,10 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
           set({ modelProgress: null });
           void get().actions.loadModel();
         } else {
-          set({ modelPhase: "download-failed", modelError: d.error ?? "Download failed" });
+          set({
+            modelPhase: "download-failed",
+            modelError: d.error ?? "Download failed",
+          });
         }
       });
       try {
@@ -229,7 +241,10 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
         updatedAt: now(),
         loaded: true,
       };
-      set((st) => ({ sessions: { ...st.sessions, [id]: session }, activeId: id }));
+      set((st) => ({
+        sessions: { ...st.sessions, [id]: session },
+        activeId: id,
+      }));
       return id;
     },
 
@@ -289,7 +304,9 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
         const s = st.sessions[id];
         if (!s) return {};
         // Reset model on provider change so the selector reloads the right list.
-        return { sessions: { ...st.sessions, [id]: { ...s, provider, model: "" } } };
+        return {
+          sessions: { ...st.sessions, [id]: { ...s, provider, model: "" } },
+        };
       }),
     setModel: (id, model) =>
       set((st) => {
@@ -303,7 +320,8 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
       const trimmed = text.trim();
       if (!session || !trimmed || get().streaming[id]) return;
       if (session.mode === "local" && get().modelPhase !== "ready") return;
-      if (session.mode === "provider" && (!session.provider || !session.model)) return;
+      if (session.mode === "provider" && (!session.provider || !session.model))
+        return;
 
       const priorMessages = session.messages;
       const userMsg = makeMessage("user", trimmed);
@@ -325,28 +343,53 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
       if (session.mode === "provider") {
         // Retrieve in Rust → augmented prompt; generate via the BYOK provider.
         try {
-          const { prompt, sources } = await memoryChat.retrieve(projectPath, trimmed);
-          set((st) => ({ sourcesByMsg: { ...st.sourcesByMsg, [assistantMsg.id]: sources } }));
-          const wire = priorMessages.map((m) => ({ role: m.role, content: m.content }));
+          const { prompt, sources } = await memoryChat.retrieve(
+            projectPath,
+            trimmed,
+          );
+          set((st) => ({
+            sourcesByMsg: { ...st.sourcesByMsg, [assistantMsg.id]: sources },
+          }));
+          const wire = priorMessages.map((m) => ({
+            role: m.role,
+            content: m.content,
+          }));
           wire.push({ role: "user", content: prompt });
-          await providerChat.stream(streamId, session.provider, session.model, wire);
+          await providerChat.stream(
+            streamId,
+            session.provider,
+            session.model,
+            wire,
+          );
         } catch (e) {
-          onEvent(set, get, { stream_id: streamId, kind: "error", message: String(e) });
+          onEvent(set, get, {
+            stream_id: streamId,
+            kind: "error",
+            message: String(e),
+          });
         }
         return;
       }
 
       // Local mode: Rust does retrieval + on-device generation.
-      const wire = messages.slice(0, -1).map((m) => ({ role: m.role, content: m.content }));
+      const wire = messages
+        .slice(0, -1)
+        .map((m) => ({ role: m.role, content: m.content }));
       try {
         await memoryChat.send(streamId, projectPath, wire);
       } catch (e) {
-        onEvent(set, get, { stream_id: streamId, kind: "error", message: String(e) });
+        onEvent(set, get, {
+          stream_id: streamId,
+          kind: "error",
+          message: String(e),
+        });
       }
     },
 
     stop: (id) => {
-      const streamId = Object.entries(get().streamToSession).find(([, sid]) => sid === id)?.[0];
+      const streamId = Object.entries(get().streamToSession).find(
+        ([, sid]) => sid === id,
+      )?.[0];
       if (streamId) void memoryChat.cancel(streamId);
     },
 
@@ -363,7 +406,9 @@ const useMemoryChatStoreBase = create<MemoryChatState>()((set, get) => ({
     buildCodebaseIndex: async (projectPath, opts) => {
       if (get().codebaseBuilding) return;
       set({ codebaseBuilding: true, codebaseProgress: null });
-      const un = await listenCodebaseIndexProgress((p) => set({ codebaseProgress: p }));
+      const un = await listenCodebaseIndexProgress((p) =>
+        set({ codebaseProgress: p }),
+      );
       try {
         const status = await codebaseIndex.build(projectPath, opts);
         set({ codebaseStatus: status });

--- a/src/features/memory/stores/memory-graph-store.ts
+++ b/src/features/memory/stores/memory-graph-store.ts
@@ -167,7 +167,12 @@ export const useMemoryGraphStore = createSelectors(
 
       setQuery: (q) => set({ query: q }),
       clearQuery: () =>
-        set({ query: "", results: [], matchedIds: new Set(), selectedId: null }),
+        set({
+          query: "",
+          results: [],
+          matchedIds: new Set(),
+          selectedId: null,
+        }),
       select: (id) => set({ selectedId: id }),
     },
   })),

--- a/src/features/memory/stores/memory-store.ts
+++ b/src/features/memory/stores/memory-store.ts
@@ -3,7 +3,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { createSelectors } from "@/lib/create-selectors";
 import type { AgentMemory, MemorySubTab } from "../lib/memory-types";
 import { memoryPolicy, type Policy } from "../lib/memory-policy-api";
-import { memoryTimeline, type MemoryTimeline } from "../lib/memory-timeline-api";
+import {
+  memoryTimeline,
+  type MemoryTimeline,
+} from "../lib/memory-timeline-api";
 
 /**
  * Module-level cache for the Memory module. The Memory tab isn't persistent —
@@ -113,8 +116,14 @@ export const useMemoryStore = createSelectors(
         if (!force && s.project === projectPath && s.agentMemory) return; // cache hit
         set({ agentMemoryLoading: true });
         try {
-          const data = await invoke<AgentMemory>("agent_memory_read", { projectPath });
-          set({ agentMemory: data, agentMemoryLoading: false, project: projectPath });
+          const data = await invoke<AgentMemory>("agent_memory_read", {
+            projectPath,
+          });
+          set({
+            agentMemory: data,
+            agentMemoryLoading: false,
+            project: projectPath,
+          });
         } catch {
           set({ agentMemory: null, agentMemoryLoading: false });
         }
@@ -122,7 +131,12 @@ export const useMemoryStore = createSelectors(
 
       loadPolicies: async (projectPath, force = false) => {
         const s = get();
-        if (!force && s.project === projectPath && s.policies && s.policyPhase === "ready") {
+        if (
+          !force &&
+          s.project === projectPath &&
+          s.policies &&
+          s.policyPhase === "ready"
+        ) {
           return; // cache hit — no re-index
         }
         set({ policyPhase: "loading", policyError: null });
@@ -175,15 +189,19 @@ export const useMemoryStore = createSelectors(
           set({ timelineLoading: false });
           if (!hadData) set({ timeline: null });
         } finally {
-          if (get().timelineRefreshing === projectPath) set({ timelineRefreshing: null });
+          if (get().timelineRefreshing === projectPath)
+            set({ timelineRefreshing: null });
         }
       },
 
-      setPolicyPhase: (phase, error = null) => set({ policyPhase: phase, policyError: error }),
+      setPolicyPhase: (phase, error = null) =>
+        set({ policyPhase: phase, policyError: error }),
       setPolicies: (rows) => set({ policies: rows, policyPhase: "ready" }),
       updatePolicyValue: (id, value) =>
         set((st) => ({
-          policies: st.policies?.map((p) => (p.id === id ? { ...p, value } : p)) ?? null,
+          policies:
+            st.policies?.map((p) => (p.id === id ? { ...p, value } : p)) ??
+            null,
         })),
     },
   })),

--- a/src/features/memory/stores/shared-memory-store.ts
+++ b/src/features/memory/stores/shared-memory-store.ts
@@ -98,7 +98,12 @@ export const useSharedMemoryStore = createSelectors(
         if (!projectPath) return;
         await sharedMemory.clear(projectPath);
         if (get().projectPath !== projectPath) return;
-        set({ state: EMPTY_STATE, events: [], queryResults: [], queryText: "" });
+        set({
+          state: EMPTY_STATE,
+          events: [],
+          queryResults: [],
+          queryText: "",
+        });
       },
     },
   })),

--- a/src/features/mentions/components/mention-picker.tsx
+++ b/src/features/mentions/components/mention-picker.tsx
@@ -127,481 +127,494 @@ const RECENT_LIMIT = 5;
 
 // ── Picker component ────────────────────────────────────────────────────────
 
-export const MentionPicker = forwardRef<MentionPickerHandle, MentionPickerProps>(
-  function MentionPicker(
-    {
-      open,
-      query,
-      anchor,
-      projectPath,
-      agentId,
-      onSelect,
-      onClose,
-      excludeIds,
-      hostSelectors,
-      initialScope,
-    },
-    ref
-  ) {
-    const recentFiles = useRecentFilesStore.use.items();
-    // Workspace mentions are scoped to the active org (see `searchWorkspaces`).
-    // Subscribe so switching orgs re-runs the search and the list reflects the
-    // new org's projects even while the picker stays mounted.
-    const activeOrganisationId = useOrgStore.use.activeOrganisationId();
-    const [scope, setScope] = useState<MentionKind | null>(initialScope ?? null);
-    /** When scope === "past_message" and no `pastSession` is locked, the
-     *  picker shows a sessions list (level 1). Once `pastSession` is set,
-     *  it shows messages inside that session (level 2). */
-    const [pastSession, setPastSession] = useState<PastSessionRef | null>(null);
-    const [pastSessions, setPastSessions] = useState<PastSessionRef[]>([]);
-    const [results, setResults] = useState<MentionData[]>([]);
-    const [active, setActive] = useState(0);
-    /** True until the backend FileIndex finishes its initial walk for the
-     *  active workspace. With multiple workspaces the first `@`/`~` in a
-     *  freshly-switched project can land before its index is built — without
-     *  this we'd flash a misleading "No matches" instead of a loading hint. */
-    const [indexing, setIndexing] = useState(false);
-    /** Bumped when the backend reports the index changed, to re-run the
-     *  in-flight search once the walk completes. */
-    const [indexNonce, setIndexNonce] = useState(0);
+export const MentionPicker = forwardRef<
+  MentionPickerHandle,
+  MentionPickerProps
+>(function MentionPicker(
+  {
+    open,
+    query,
+    anchor,
+    projectPath,
+    agentId,
+    onSelect,
+    onClose,
+    excludeIds,
+    hostSelectors,
+    initialScope,
+  },
+  ref,
+) {
+  const recentFiles = useRecentFilesStore.use.items();
+  // Workspace mentions are scoped to the active org (see `searchWorkspaces`).
+  // Subscribe so switching orgs re-runs the search and the list reflects the
+  // new org's projects even while the picker stays mounted.
+  const activeOrganisationId = useOrgStore.use.activeOrganisationId();
+  const [scope, setScope] = useState<MentionKind | null>(initialScope ?? null);
+  /** When scope === "past_message" and no `pastSession` is locked, the
+   *  picker shows a sessions list (level 1). Once `pastSession` is set,
+   *  it shows messages inside that session (level 2). */
+  const [pastSession, setPastSession] = useState<PastSessionRef | null>(null);
+  const [pastSessions, setPastSessions] = useState<PastSessionRef[]>([]);
+  const [results, setResults] = useState<MentionData[]>([]);
+  const [active, setActive] = useState(0);
+  /** True until the backend FileIndex finishes its initial walk for the
+   *  active workspace. With multiple workspaces the first `@`/`~` in a
+   *  freshly-switched project can land before its index is built — without
+   *  this we'd flash a misleading "No matches" instead of a loading hint. */
+  const [indexing, setIndexing] = useState(false);
+  /** Bumped when the backend reports the index changed, to re-run the
+   *  in-flight search once the walk completes. */
+  const [indexNonce, setIndexNonce] = useState(0);
 
-    // Reset transient state when the popover (re-)opens.
-    // When `initialScope` is set, lock to that scope — the picker
-    // then renders as if the user had drilled into that category.
-    useEffect(() => {
-      if (open) {
-        setScope(initialScope ?? null);
-        setPastSession(null);
-        setActive(0);
-      } else {
-        setResults([]);
-        setPastSessions([]);
-      }
-    }, [open, initialScope]);
-
-    // Run providers on every (query, scope, pastSession, projectPath)
-    // change. Each provider gets its own AbortSignal so stale results
-    // from a prior query get dropped before they hit setState. The
-    // past-message scope has its own two-level path:
-    //   - no pastSession: load the session list once per scope-entry
-    //   - pastSession set: search messages inside that session
-    useEffect(() => {
-      if (!open) return;
-      const controller = new AbortController();
-      const ctx: MentionContext = { projectPath, agentId };
-
-      // Empty query + no scope renders "Recent files + Browse
-      // categories" — the picker ignores `results` entirely in that
-      // state. Short-circuit so we don't pay any IPC.
-      if (!query.trim() && !scope) {
-        setResults([]);
-        setPastSessions([]);
-        return () => controller.abort();
-      }
-
-      // No debounce — the Rust side reads everything from cached
-      // state now (file index, folder list, git refs, knowledge,
-      // symbols are all in `MentionCacheState` / `FileIndexState`),
-      // so each invoke is sub-millisecond. Firing on every keystroke
-      // keeps the picker truly live; the AbortController drops the
-      // result of any in-flight invoke if a newer keystroke beat it
-      // back, so stale results never paint.
-      const applyExcludes = (items: MentionData[]) => {
-        if (!excludeIds || excludeIds.size === 0) return items;
-        return items.filter((m) => !excludeIds.has(`${m.kind}:${m.id}`));
-      };
-      if (scope === "past_message" && !pastSession) {
-        void listPastSessions(ctx).then((sessions) => {
-          if (controller.signal.aborted) return;
-          const q = query.trim().toLowerCase();
-          const filtered = q
-            ? sessions.filter((s) => s.title.toLowerCase().includes(q))
-            : sessions;
-          setPastSessions(filtered.slice(0, 30));
-          setResults([]);
-        });
-      } else if (scope === "past_message" && pastSession) {
-        void listMessagesInPastSession(pastSession, query, controller.signal).then(
-          (msgs) => {
-            if (controller.signal.aborted) return;
-            setResults(applyExcludes(msgs));
-            setPastSessions([]);
-          }
-        );
-      } else {
-        void searchMentions(query, scope, ctx).then((r) => {
-          if (controller.signal.aborted) return;
-          setResults(applyExcludes(r));
-          setPastSessions([]);
-        });
-      }
-
-      return () => controller.abort();
-    }, [open, query, scope, pastSession, projectPath, agentId, excludeIds, indexNonce, activeOrganisationId]);
-
-    // Reset the keyboard cursor to the top ONLY when the user changes what
-    // they're looking at (query/scope/session) — NOT when results merely
-    // refresh in the background (e.g. the index-build `indexNonce` bump), which
-    // would otherwise snap the highlight back to the first item mid-navigation.
-    useEffect(() => {
+  // Reset transient state when the popover (re-)opens.
+  // When `initialScope` is set, lock to that scope — the picker
+  // then renders as if the user had drilled into that category.
+  useEffect(() => {
+    if (open) {
+      setScope(initialScope ?? null);
+      setPastSession(null);
       setActive(0);
-    }, [query, scope, pastSession]);
+    } else {
+      setResults([]);
+      setPastSessions([]);
+    }
+  }, [open, initialScope]);
 
-    // Detect whether the active workspace's file index is still building, for
-    // the file-dependent scopes (blended / file / folder). Drives the
-    // "Indexing files…" hint so the first `@` in a freshly-opened workspace
-    // shows a loading state instead of "No matches". `ensureFileIndex` returns
-    // null on the already-confirmed fast path (→ not indexing).
-    useEffect(() => {
-      if (!open || !projectPath) {
-        setIndexing(false);
-        return;
-      }
-      if (scope !== null && scope !== "file" && scope !== "folder") {
-        setIndexing(false);
-        return;
-      }
-      let cancelled = false;
-      void ensureFileIndex(projectPath).then((status) => {
-        if (cancelled) return;
-        setIndexing(status ? !status.indexed : false);
+  // Run providers on every (query, scope, pastSession, projectPath)
+  // change. Each provider gets its own AbortSignal so stale results
+  // from a prior query get dropped before they hit setState. The
+  // past-message scope has its own two-level path:
+  //   - no pastSession: load the session list once per scope-entry
+  //   - pastSession set: search messages inside that session
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    const ctx: MentionContext = { projectPath, agentId };
+
+    // Empty query + no scope renders "Recent files + Browse
+    // categories" — the picker ignores `results` entirely in that
+    // state. Short-circuit so we don't pay any IPC.
+    if (!query.trim() && !scope) {
+      setResults([]);
+      setPastSessions([]);
+      return () => controller.abort();
+    }
+
+    // No debounce — the Rust side reads everything from cached
+    // state now (file index, folder list, git refs, knowledge,
+    // symbols are all in `MentionCacheState` / `FileIndexState`),
+    // so each invoke is sub-millisecond. Firing on every keystroke
+    // keeps the picker truly live; the AbortController drops the
+    // result of any in-flight invoke if a newer keystroke beat it
+    // back, so stale results never paint.
+    const applyExcludes = (items: MentionData[]) => {
+      if (!excludeIds || excludeIds.size === 0) return items;
+      return items.filter((m) => !excludeIds.has(`${m.kind}:${m.id}`));
+    };
+    if (scope === "past_message" && !pastSession) {
+      void listPastSessions(ctx).then((sessions) => {
+        if (controller.signal.aborted) return;
+        const q = query.trim().toLowerCase();
+        const filtered = q
+          ? sessions.filter((s) => s.title.toLowerCase().includes(q))
+          : sessions;
+        setPastSessions(filtered.slice(0, 30));
+        setResults([]);
       });
-      return () => {
-        cancelled = true;
-      };
-    }, [open, projectPath, scope]);
-
-    // Flip the loading hint off and re-run the search the moment the backend
-    // reports the walk completed (fired by `fileindex_open_project` on initial
-    // walk and by the fs-watch debouncer thereafter).
-    useEffect(() => {
-      if (!open) return;
-      let cancelled = false;
-      let unlisten: (() => void) | null = null;
-      void listen("atlas:fileindex:updated", () => {
-        if (cancelled) return;
-        setIndexing(false);
-        setIndexNonce((n) => n + 1);
-      }).then((un) => {
-        if (cancelled) un();
-        else unlisten = un;
+    } else if (scope === "past_message" && pastSession) {
+      void listMessagesInPastSession(
+        pastSession,
+        query,
+        controller.signal,
+      ).then((msgs) => {
+        if (controller.signal.aborted) return;
+        setResults(applyExcludes(msgs));
+        setPastSessions([]);
       });
-      return () => {
-        cancelled = true;
-        unlisten?.();
-      };
-    }, [open]);
+    } else {
+      void searchMentions(query, scope, ctx).then((r) => {
+        if (controller.signal.aborted) return;
+        setResults(applyExcludes(r));
+        setPastSessions([]);
+      });
+    }
 
-    // Re-run the search when skills/packs change on disk (install, projection,
-    // adopt, …) so a freshly installed skill/component shows up without the
-    // user reopening the picker. Mirrors the file-index refresh above.
-    useEffect(() => {
-      if (!open) return;
-      const onChanged = () => setIndexNonce((n) => n + 1);
-      window.addEventListener(SKILLS_CHANGED_EVENT, onChanged);
-      return () => window.removeEventListener(SKILLS_CHANGED_EVENT, onChanged);
-    }, [open]);
+    return () => controller.abort();
+  }, [
+    open,
+    query,
+    scope,
+    pastSession,
+    projectPath,
+    agentId,
+    excludeIds,
+    indexNonce,
+    activeOrganisationId,
+  ]);
 
-    // Build the renderable row list. Order:
-    //   no scope + empty query → Recents (header) → files → Categories header → categories
-    //   no scope + query       → blended results sorted by rank
-    //   scope locked           → header showing scope → results in that scope
-    const rows = useMemo<Row[]>(() => {
-      const out: Row[] = [];
-      if (scope === "past_message" && !pastSession) {
-        out.push({ type: "header", label: "Past Messages · pick a session" });
-        if (pastSessions.length === 0) {
-          // No matches; header alone — the empty-state block below handles
-          // copy when there's nothing else to show.
-          return out;
-        }
-        for (const s of pastSessions) {
-          out.push({ type: "session", session: s });
-        }
+  // Reset the keyboard cursor to the top ONLY when the user changes what
+  // they're looking at (query/scope/session) — NOT when results merely
+  // refresh in the background (e.g. the index-build `indexNonce` bump), which
+  // would otherwise snap the highlight back to the first item mid-navigation.
+  useEffect(() => {
+    setActive(0);
+  }, [query, scope, pastSession]);
+
+  // Detect whether the active workspace's file index is still building, for
+  // the file-dependent scopes (blended / file / folder). Drives the
+  // "Indexing files…" hint so the first `@` in a freshly-opened workspace
+  // shows a loading state instead of "No matches". `ensureFileIndex` returns
+  // null on the already-confirmed fast path (→ not indexing).
+  useEffect(() => {
+    if (!open || !projectPath) {
+      setIndexing(false);
+      return;
+    }
+    if (scope !== null && scope !== "file" && scope !== "folder") {
+      setIndexing(false);
+      return;
+    }
+    let cancelled = false;
+    void ensureFileIndex(projectPath).then((status) => {
+      if (cancelled) return;
+      setIndexing(status ? !status.indexed : false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, projectPath, scope]);
+
+  // Flip the loading hint off and re-run the search the moment the backend
+  // reports the walk completed (fired by `fileindex_open_project` on initial
+  // walk and by the fs-watch debouncer thereafter).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    void listen("atlas:fileindex:updated", () => {
+      if (cancelled) return;
+      setIndexing(false);
+      setIndexNonce((n) => n + 1);
+    }).then((un) => {
+      if (cancelled) un();
+      else unlisten = un;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [open]);
+
+  // Re-run the search when skills/packs change on disk (install, projection,
+  // adopt, …) so a freshly installed skill/component shows up without the
+  // user reopening the picker. Mirrors the file-index refresh above.
+  useEffect(() => {
+    if (!open) return;
+    const onChanged = () => setIndexNonce((n) => n + 1);
+    window.addEventListener(SKILLS_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(SKILLS_CHANGED_EVENT, onChanged);
+  }, [open]);
+
+  // Build the renderable row list. Order:
+  //   no scope + empty query → Recents (header) → files → Categories header → categories
+  //   no scope + query       → blended results sorted by rank
+  //   scope locked           → header showing scope → results in that scope
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = [];
+    if (scope === "past_message" && !pastSession) {
+      out.push({ type: "header", label: "Past Messages · pick a session" });
+      if (pastSessions.length === 0) {
+        // No matches; header alone — the empty-state block below handles
+        // copy when there's nothing else to show.
         return out;
       }
-      if (scope === "past_message" && pastSession) {
-        out.push({
-          type: "header",
-          label: `↶ ${pastSession.title}`,
-        });
-        for (const m of results) {
-          out.push({ type: "mention", mention: m });
-        }
-        return out;
+      for (const s of pastSessions) {
+        out.push({ type: "session", session: s });
       }
-      if (scope) {
-        // Group results under per-kind sub-headers. Homogeneous scopes collapse
-        // to a single header (unchanged); the `#` rail (skills + pack components)
-        // splits into Skills / Commands / Agents / Rules.
-        const groupOf = (m: MentionData): { key: string; label: string } => {
-          // Skills can be installed globally or per-workspace — segment them so
-          // the user sees which scope a skill came from.
-          if (m.kind === "skill") {
-            const ws = m.scope === "project";
-            return {
-              key: `skill:${m.scope}`,
-              label: ws ? "Workspace Skills" : "Global Skills",
-            };
-          }
-          if (m.kind === "component") {
-            const label =
-              m.componentKind === "command"
-                ? "Commands"
-                : m.componentKind === "agent"
-                  ? "Agents"
-                  : "Rules";
-            return { key: `component:${m.componentKind}`, label };
-          }
-          return { key: m.kind, label: categoryForKind(m.kind).label };
-        };
-        let lastKey: string | null = null;
-        for (const m of results) {
-          const g = groupOf(m);
-          if (g.key !== lastKey) {
-            out.push({ type: "header", label: g.label });
-            lastKey = g.key;
-          }
-          out.push({ type: "mention", mention: m });
-        }
-        // Keep the scope header visible even with zero results (empty-state copy
-        // renders below it).
-        if (out.length === 0) {
-          out.push({ type: "header", label: categoryForKind(scope).label });
-        }
-        return out;
-      }
-      if (!query.trim()) {
-        // The recents mirror is a single global store reflecting the ACTIVE
-        // workspace; right after a workspace switch there's an async window
-        // where it still holds the previous project's files. Filter to THIS
-        // picker's project so a recent from another project can never surface.
-        const recents = recentFiles
-          .filter(
-            (r) =>
-              !projectPath ||
-              r.absPath === projectPath ||
-              r.absPath.startsWith(projectPath + "/"),
-          )
-          .slice(0, RECENT_LIMIT);
-        if (recents.length > 0) {
-          out.push({ type: "header", label: "Recent files" });
-          for (const r of recents) {
-            out.push({
-              type: "mention",
-              mention: recentToMention(r),
-              recentLabel: dirOf(r.rel),
-            });
-          }
-        }
-        out.push({ type: "header", label: "Browse" });
-        for (const cat of MENTION_CATEGORIES) {
-          out.push({ type: "category", cat });
-        }
-        return out;
-      }
-      // Blended: results are already ranked by Rust (nucleo), capped
-      // top-N. JS just renders in the order Rust returned them — no
-      // second scoring pass.
+      return out;
+    }
+    if (scope === "past_message" && pastSession) {
+      out.push({
+        type: "header",
+        label: `↶ ${pastSession.title}`,
+      });
       for (const m of results) {
         out.push({ type: "mention", mention: m });
       }
       return out;
-    }, [scope, query, results, recentFiles, projectPath]);
-
-    // Compute the navigable rows (skip headers). `active` is an index into
-    // *navigable* rows, not the full list; the renderer maps it back.
-    const navIndices = useMemo(() => {
-      const idxs: number[] = [];
-      for (let i = 0; i < rows.length; i++) {
-        if (rows[i].type !== "header") idxs.push(i);
-      }
-      return idxs;
-    }, [rows]);
-
-    useEffect(() => {
-      if (active >= navIndices.length) setActive(0);
-    }, [active, navIndices.length]);
-
-    const activeRowIdx = navIndices[active];
-    const activeRow: Row | undefined = activeRowIdx === undefined ? undefined : rows[activeRowIdx];
-
-    const onSelectRef = useRef(onSelect);
-    onSelectRef.current = onSelect;
-    const onCloseRef = useRef(onClose);
-    onCloseRef.current = onClose;
-
-    useImperativeHandle(
-      ref,
-      (): MentionPickerHandle => ({
-        moveDown: () => {
-          if (navIndices.length === 0) return;
-          setActive((a) => (a + 1) % navIndices.length);
-        },
-        moveUp: () => {
-          if (navIndices.length === 0) return;
-          setActive((a) => (a - 1 + navIndices.length) % navIndices.length);
-        },
-        commit: () => {
-          if (!activeRow) return false;
-          if (activeRow.type === "category") {
-            setScope(activeRow.cat.kind);
-            setActive(0);
-            return true;
-          }
-          if (activeRow.type === "session") {
-            setPastSession(activeRow.session);
-            setActive(0);
-            return true;
-          }
-          if (activeRow.type === "mention") {
-            onSelectRef.current(activeRow.mention);
-            return true;
-          }
-          return false;
-        },
-        goBack: () => {
-          if (pastSession) {
-            setPastSession(null);
-            setActive(0);
-            return true;
-          }
-          // When a scope was locked from the outside (initialScope),
-          // there's no "above" level to drop to — let the parent close.
-          if (scope && !initialScope) {
-            setScope(null);
-            setActive(0);
-            return true;
-          }
-          return false;
-        },
-      }),
-      [activeRow, navIndices.length, pastSession, scope, initialScope]
-    );
-
-    // Dismiss on click outside the picker AND outside the host editor.
-    // Defaults cover the chat composer (.atlas-chat-cm-host); other
-    // surfaces (Tiptap, future composers) pass their own selectors via
-    // `hostSelectors` so a click inside their editable doesn't dismiss.
-    const hostSelectorsRef = useRef(hostSelectors);
-    hostSelectorsRef.current = hostSelectors;
-    useEffect(() => {
-      if (!open) return;
-      const handler = (e: MouseEvent) => {
-        const target = e.target as HTMLElement | null;
-        if (!target) return;
-        if (target.closest(".atlas-chat-cm-host")) return;
-        if (target.closest(".atlas-mention-picker")) return;
-        const extras = hostSelectorsRef.current;
-        if (extras) {
-          for (const sel of extras) {
-            if (target.closest(sel)) return;
-          }
+    }
+    if (scope) {
+      // Group results under per-kind sub-headers. Homogeneous scopes collapse
+      // to a single header (unchanged); the `#` rail (skills + pack components)
+      // splits into Skills / Commands / Agents / Rules.
+      const groupOf = (m: MentionData): { key: string; label: string } => {
+        // Skills can be installed globally or per-workspace — segment them so
+        // the user sees which scope a skill came from.
+        if (m.kind === "skill") {
+          const ws = m.scope === "project";
+          return {
+            key: `skill:${m.scope}`,
+            label: ws ? "Workspace Skills" : "Global Skills",
+          };
         }
-        onCloseRef.current();
+        if (m.kind === "component") {
+          const label =
+            m.componentKind === "command"
+              ? "Commands"
+              : m.componentKind === "agent"
+                ? "Agents"
+                : "Rules";
+          return { key: `component:${m.componentKind}`, label };
+        }
+        return { key: m.kind, label: categoryForKind(m.kind).label };
       };
-      // Mousedown so we beat click handlers inside the editor.
-      window.addEventListener("mousedown", handler);
-      return () => window.removeEventListener("mousedown", handler);
-    }, [open]);
+      let lastKey: string | null = null;
+      for (const m of results) {
+        const g = groupOf(m);
+        if (g.key !== lastKey) {
+          out.push({ type: "header", label: g.label });
+          lastKey = g.key;
+        }
+        out.push({ type: "mention", mention: m });
+      }
+      // Keep the scope header visible even with zero results (empty-state copy
+      // renders below it).
+      if (out.length === 0) {
+        out.push({ type: "header", label: categoryForKind(scope).label });
+      }
+      return out;
+    }
+    if (!query.trim()) {
+      // The recents mirror is a single global store reflecting the ACTIVE
+      // workspace; right after a workspace switch there's an async window
+      // where it still holds the previous project's files. Filter to THIS
+      // picker's project so a recent from another project can never surface.
+      const recents = recentFiles
+        .filter(
+          (r) =>
+            !projectPath ||
+            r.absPath === projectPath ||
+            r.absPath.startsWith(projectPath + "/"),
+        )
+        .slice(0, RECENT_LIMIT);
+      if (recents.length > 0) {
+        out.push({ type: "header", label: "Recent files" });
+        for (const r of recents) {
+          out.push({
+            type: "mention",
+            mention: recentToMention(r),
+            recentLabel: dirOf(r.rel),
+          });
+        }
+      }
+      out.push({ type: "header", label: "Browse" });
+      for (const cat of MENTION_CATEGORIES) {
+        out.push({ type: "category", cat });
+      }
+      return out;
+    }
+    // Blended: results are already ranked by Rust (nucleo), capped
+    // top-N. JS just renders in the order Rust returned them — no
+    // second scoring pass.
+    for (const m of results) {
+      out.push({ type: "mention", mention: m });
+    }
+    return out;
+  }, [scope, query, results, recentFiles, projectPath]);
 
-    if (!open || !anchor) return null;
+  // Compute the navigable rows (skip headers). `active` is an index into
+  // *navigable* rows, not the full list; the renderer maps it back.
+  const navIndices = useMemo(() => {
+    const idxs: number[] = [];
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i].type !== "header") idxs.push(i);
+    }
+    return idxs;
+  }, [rows]);
 
-    // Position: prefer below the caret so it doesn't cover lines above
-    // the cursor (the common case for mid-page editors like the
-    // knowledge note editor). Fall back to above when there isn't
-    // enough room below — that's the chat composer's case since it
-    // sits flush at the bottom of the viewport.
-    //
-    // Coords come from `view.coordsAtPos` which is viewport-relative,
-    // so `position: fixed` lines up cleanly regardless of sidebars or
-    // resizable panels in between.
-    const PICKER_WIDTH = 420;
-    const PICKER_MAX_HEIGHT = 360;
-    const GAP = 6;
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const left = Math.max(8, Math.min(anchor.x, vw - PICKER_WIDTH - 8));
-    // anchor.y is the caret's TOP. We need the line's height so the
-    // popup sits just under the active line — we don't have it here,
-    // so use a sensible default (matches the chat composer's caret).
-    const LINE_HEIGHT = 20;
-    const caretBottom = anchor.y + LINE_HEIGHT;
-    const roomBelow = vh - caretBottom - 8;
-    const placeBelow = roomBelow >= PICKER_MAX_HEIGHT;
-    const positionStyle: React.CSSProperties = placeBelow
-      ? { top: Math.max(8, caretBottom + GAP) }
-      : { bottom: Math.max(8, vh - anchor.y + GAP) };
+  useEffect(() => {
+    if (active >= navIndices.length) setActive(0);
+  }, [active, navIndices.length]);
 
-    return createPortal(
-      <div
-        className={cn(
-          "atlas-mention-picker",
-          "rounded-lg overflow-hidden",
-          "bg-bg-secondary border border-border-default",
-          "shadow-[0_8px_24px_rgba(0,0,0,0.5)]",
-          "flex flex-col"
-        )}
-        // Keep mouse interactions from blurring CM:
-        onMouseDown={(e) => e.preventDefault()}
-        style={{
-          position: "fixed",
-          left,
-          ...positionStyle,
-          width: PICKER_WIDTH,
-          maxHeight: PICKER_MAX_HEIGHT,
-          zIndex: 9999,
-        }}
-      >
-            {rows.length === 0 ||
-            (rows.length === 1 && rows[0].type === "header") ? (
-              <div className="flex-1 px-3 py-6 text-center text-[11px] text-text-tertiary leading-snug">
-                {indexing &&
-                (scope === null || scope === "file" || scope === "folder") ? (
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="size-1.5 rounded-full bg-text-tertiary animate-pulse" />
-                    Indexing files…
-                  </span>
-                ) : (
-                  emptyStateCopy({
-                    scope,
-                    pastSession: pastSession !== null,
-                    query: query.trim(),
-                    hasProject: projectPath !== null,
-                  })
-                )}
-              </div>
-            ) : (
-              <VirtualizedRows
-                rows={rows}
-                activeRowIdx={activeRowIdx}
-                navIndices={navIndices}
-                setActive={setActive}
-                setScope={setScope}
-                setPastSession={setPastSession}
-                onSelect={onSelectRef}
-              />
-            )}
-            <div className="border-t border-border-default px-3 h-[26px] flex items-center justify-between shrink-0">
-              <span className="text-[9px] text-text-tertiary uppercase tracking-wider">
-                {scope
-                  ? `Scope: ${categoryForKind(scope).label}`
-                  : query
-                    ? "Filtered"
-                    : "Top: recents · then categories"}
-              </span>
-              <span className="flex items-center gap-1.5 text-[9px] text-text-tertiary">
-                <Kbd>↑↓</Kbd>
-                <Kbd>↵</Kbd>
-                <span>select</span>
-                <Kbd>esc</Kbd>
-              </span>
-            </div>
-      </div>,
-      document.body
-    );
-  }
-);
+  const activeRowIdx = navIndices[active];
+  const activeRow: Row | undefined =
+    activeRowIdx === undefined ? undefined : rows[activeRowIdx];
+
+  const onSelectRef = useRef(onSelect);
+  onSelectRef.current = onSelect;
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useImperativeHandle(
+    ref,
+    (): MentionPickerHandle => ({
+      moveDown: () => {
+        if (navIndices.length === 0) return;
+        setActive((a) => (a + 1) % navIndices.length);
+      },
+      moveUp: () => {
+        if (navIndices.length === 0) return;
+        setActive((a) => (a - 1 + navIndices.length) % navIndices.length);
+      },
+      commit: () => {
+        if (!activeRow) return false;
+        if (activeRow.type === "category") {
+          setScope(activeRow.cat.kind);
+          setActive(0);
+          return true;
+        }
+        if (activeRow.type === "session") {
+          setPastSession(activeRow.session);
+          setActive(0);
+          return true;
+        }
+        if (activeRow.type === "mention") {
+          onSelectRef.current(activeRow.mention);
+          return true;
+        }
+        return false;
+      },
+      goBack: () => {
+        if (pastSession) {
+          setPastSession(null);
+          setActive(0);
+          return true;
+        }
+        // When a scope was locked from the outside (initialScope),
+        // there's no "above" level to drop to — let the parent close.
+        if (scope && !initialScope) {
+          setScope(null);
+          setActive(0);
+          return true;
+        }
+        return false;
+      },
+    }),
+    [activeRow, navIndices.length, pastSession, scope, initialScope],
+  );
+
+  // Dismiss on click outside the picker AND outside the host editor.
+  // Defaults cover the chat composer (.atlas-chat-cm-host); other
+  // surfaces (Tiptap, future composers) pass their own selectors via
+  // `hostSelectors` so a click inside their editable doesn't dismiss.
+  const hostSelectorsRef = useRef(hostSelectors);
+  hostSelectorsRef.current = hostSelectors;
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest(".atlas-chat-cm-host")) return;
+      if (target.closest(".atlas-mention-picker")) return;
+      const extras = hostSelectorsRef.current;
+      if (extras) {
+        for (const sel of extras) {
+          if (target.closest(sel)) return;
+        }
+      }
+      onCloseRef.current();
+    };
+    // Mousedown so we beat click handlers inside the editor.
+    window.addEventListener("mousedown", handler);
+    return () => window.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (!open || !anchor) return null;
+
+  // Position: prefer below the caret so it doesn't cover lines above
+  // the cursor (the common case for mid-page editors like the
+  // knowledge note editor). Fall back to above when there isn't
+  // enough room below — that's the chat composer's case since it
+  // sits flush at the bottom of the viewport.
+  //
+  // Coords come from `view.coordsAtPos` which is viewport-relative,
+  // so `position: fixed` lines up cleanly regardless of sidebars or
+  // resizable panels in between.
+  const PICKER_WIDTH = 420;
+  const PICKER_MAX_HEIGHT = 360;
+  const GAP = 6;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const left = Math.max(8, Math.min(anchor.x, vw - PICKER_WIDTH - 8));
+  // anchor.y is the caret's TOP. We need the line's height so the
+  // popup sits just under the active line — we don't have it here,
+  // so use a sensible default (matches the chat composer's caret).
+  const LINE_HEIGHT = 20;
+  const caretBottom = anchor.y + LINE_HEIGHT;
+  const roomBelow = vh - caretBottom - 8;
+  const placeBelow = roomBelow >= PICKER_MAX_HEIGHT;
+  const positionStyle: React.CSSProperties = placeBelow
+    ? { top: Math.max(8, caretBottom + GAP) }
+    : { bottom: Math.max(8, vh - anchor.y + GAP) };
+
+  return createPortal(
+    <div
+      className={cn(
+        "atlas-mention-picker",
+        "rounded-lg overflow-hidden",
+        "bg-bg-secondary border border-border-default",
+        "shadow-[0_8px_24px_rgba(0,0,0,0.5)]",
+        "flex flex-col",
+      )}
+      // Keep mouse interactions from blurring CM:
+      onMouseDown={(e) => e.preventDefault()}
+      style={{
+        position: "fixed",
+        left,
+        ...positionStyle,
+        width: PICKER_WIDTH,
+        maxHeight: PICKER_MAX_HEIGHT,
+        zIndex: 9999,
+      }}
+    >
+      {rows.length === 0 || (rows.length === 1 && rows[0].type === "header") ? (
+        <div className="flex-1 px-3 py-6 text-center text-[11px] text-text-tertiary leading-snug">
+          {indexing &&
+          (scope === null || scope === "file" || scope === "folder") ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="size-1.5 rounded-full bg-text-tertiary animate-pulse" />
+              Indexing files…
+            </span>
+          ) : (
+            emptyStateCopy({
+              scope,
+              pastSession: pastSession !== null,
+              query: query.trim(),
+              hasProject: projectPath !== null,
+            })
+          )}
+        </div>
+      ) : (
+        <VirtualizedRows
+          rows={rows}
+          activeRowIdx={activeRowIdx}
+          navIndices={navIndices}
+          setActive={setActive}
+          setScope={setScope}
+          setPastSession={setPastSession}
+          onSelect={onSelectRef}
+        />
+      )}
+      <div className="border-t border-border-default px-3 h-[26px] flex items-center justify-between shrink-0">
+        <span className="text-[9px] text-text-tertiary uppercase tracking-wider">
+          {scope
+            ? `Scope: ${categoryForKind(scope).label}`
+            : query
+              ? "Filtered"
+              : "Top: recents · then categories"}
+        </span>
+        <span className="flex items-center gap-1.5 text-[9px] text-text-tertiary">
+          <Kbd>↑↓</Kbd>
+          <Kbd>↵</Kbd>
+          <span>select</span>
+          <Kbd>esc</Kbd>
+        </span>
+      </div>
+    </div>,
+    document.body,
+  );
+});
 
 // ── Virtualized row list ────────────────────────────────────────────────────
 //
@@ -700,7 +713,7 @@ function VirtualizedRows({
                   "text-left px-3 flex items-center gap-2 text-[11.5px]",
                   isActive
                     ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]",
                 )}
               >
                 <span className="opacity-75 w-4 flex items-center justify-center">
@@ -728,7 +741,7 @@ function VirtualizedRows({
                   "text-left px-3 flex items-center gap-2 text-[11.5px]",
                   isActive
                     ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]",
                 )}
                 title={row.session.filePath}
               >
@@ -761,7 +774,7 @@ function VirtualizedRows({
                 "text-left px-3 flex items-center gap-2 text-[11.5px]",
                 isActive
                   ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
-                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]",
               )}
               title={mentionTitle(m)}
             >
@@ -823,18 +836,30 @@ function mentionGlyph(m: MentionData) {
 function CategoryIcon({ kind }: { kind: MentionKind }) {
   const size = 11;
   switch (kind) {
-    case "file":         return <FileText size={size} />;
-    case "folder":       return <Folder size={size} />;
-    case "symbol":       return <Hash size={size} />;
-    case "knowledge":    return <BookOpen size={size} />;
-    case "skill":        return <Zap size={size} />;
-    case "component":    return <Zap size={size} />;
-    case "repo":         return <FolderGit2 size={size} />;
-    case "workspace":    return <Boxes size={size} />;
-    case "paper":        return <Newspaper size={size} />;
-    case "branch":       return <GitBranch size={size} />;
-    case "past_message": return <MessageSquare size={size} />;
-    case "past_session": return <MessageSquare size={size} />;
+    case "file":
+      return <FileText size={size} />;
+    case "folder":
+      return <Folder size={size} />;
+    case "symbol":
+      return <Hash size={size} />;
+    case "knowledge":
+      return <BookOpen size={size} />;
+    case "skill":
+      return <Zap size={size} />;
+    case "component":
+      return <Zap size={size} />;
+    case "repo":
+      return <FolderGit2 size={size} />;
+    case "workspace":
+      return <Boxes size={size} />;
+    case "paper":
+      return <Newspaper size={size} />;
+    case "branch":
+      return <GitBranch size={size} />;
+    case "past_message":
+      return <MessageSquare size={size} />;
+    case "past_session":
+      return <MessageSquare size={size} />;
   }
 }
 
@@ -856,16 +881,30 @@ function secondaryLabel(m: MentionData): string {
     case "file":
     case "folder":
       return dirOf(m.displayName);
-    case "symbol":       return `${m.symbolKind} · ${shortPath(m.filePath)}`;
-    case "knowledge":    return m.folder ? `${m.folder} · ${m.source}` : m.source;
-    case "skill":        return m.scope === "project" ? `${m.description} · project` : m.description;
-    case "component":    return `${m.componentKind} · pack: ${m.pack}`;
-    case "repo":         return m.hasReadme ? "cloned · README" : "cloned";
-    case "workspace":    return m.orgName ? `${m.orgName} · ${shortPath(m.absPath)}` : shortPath(m.absPath);
-    case "paper":        return m.authors[0] ?? "";
-    case "branch":       return m.refKind + (m.isCurrent ? " · HEAD" : "");
-    case "past_message": return m.sessionTitle;
-    case "past_session": return "session transcript";
+    case "symbol":
+      return `${m.symbolKind} · ${shortPath(m.filePath)}`;
+    case "knowledge":
+      return m.folder ? `${m.folder} · ${m.source}` : m.source;
+    case "skill":
+      return m.scope === "project"
+        ? `${m.description} · project`
+        : m.description;
+    case "component":
+      return `${m.componentKind} · pack: ${m.pack}`;
+    case "repo":
+      return m.hasReadme ? "cloned · README" : "cloned";
+    case "workspace":
+      return m.orgName
+        ? `${m.orgName} · ${shortPath(m.absPath)}`
+        : shortPath(m.absPath);
+    case "paper":
+      return m.authors[0] ?? "";
+    case "branch":
+      return m.refKind + (m.isCurrent ? " · HEAD" : "");
+    case "past_message":
+      return m.sessionTitle;
+    case "past_session":
+      return "session transcript";
   }
 }
 
@@ -897,7 +936,9 @@ function emptyStateCopy(args: {
       : "No user messages in this session.";
   }
   if (args.scope) {
-    const label = MENTION_CATEGORIES.find((c) => c.kind === args.scope)?.label ?? args.scope;
+    const label =
+      MENTION_CATEGORIES.find((c) => c.kind === args.scope)?.label ??
+      args.scope;
     return args.query
       ? `No ${label.toLowerCase()} matching "${args.query}".`
       : `No ${label.toLowerCase()} indexed yet.`;
@@ -909,17 +950,29 @@ function emptyStateCopy(args: {
 
 function mentionTitle(m: MentionData): string {
   switch (m.kind) {
-    case "file":         return m.absPath;
-    case "folder":       return m.absPath;
-    case "symbol":       return `${m.filePath}:${m.line}`;
-    case "knowledge":    return m.filePath;
-    case "skill":        return m.description || m.filePath;
-    case "component":    return m.description || m.filePath;
-    case "repo":         return m.absPath;
-    case "workspace":    return m.absPath;
-    case "paper":        return m.metadataPath;
-    case "branch":       return `${m.refKind} ${m.id} (${m.sha.slice(0, 7)})`;
-    case "past_message": return m.content;
-    case "past_session": return m.sessionTitle;
+    case "file":
+      return m.absPath;
+    case "folder":
+      return m.absPath;
+    case "symbol":
+      return `${m.filePath}:${m.line}`;
+    case "knowledge":
+      return m.filePath;
+    case "skill":
+      return m.description || m.filePath;
+    case "component":
+      return m.description || m.filePath;
+    case "repo":
+      return m.absPath;
+    case "workspace":
+      return m.absPath;
+    case "paper":
+      return m.metadataPath;
+    case "branch":
+      return `${m.refKind} ${m.id} (${m.sha.slice(0, 7)})`;
+    case "past_message":
+      return m.content;
+    case "past_session":
+      return m.sessionTitle;
   }
 }

--- a/src/features/mission-control/components/dashboard/chart-card.tsx
+++ b/src/features/mission-control/components/dashboard/chart-card.tsx
@@ -28,14 +28,20 @@ export function ChartCard({
     >
       <div className="flex items-center justify-between px-3.5 pt-3 pb-1 shrink-0">
         <div className="min-w-0">
-          <div className="text-[12px] font-medium text-[var(--text-primary)] truncate">{title}</div>
+          <div className="text-[12px] font-medium text-[var(--text-primary)] truncate">
+            {title}
+          </div>
           {subtitle && (
-            <div className="text-[10px] text-[var(--text-tertiary)] truncate">{subtitle}</div>
+            <div className="text-[10px] text-[var(--text-tertiary)] truncate">
+              {subtitle}
+            </div>
           )}
         </div>
         {right}
       </div>
-      <div className={cn("flex-1 min-h-0 px-2 pb-2", bodyClassName)}>{children}</div>
+      <div className={cn("flex-1 min-h-0 px-2 pb-2", bodyClassName)}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/features/mission-control/components/dashboard/chart-tooltip.tsx
+++ b/src/features/mission-control/components/dashboard/chart-tooltip.tsx
@@ -22,7 +22,9 @@ export function ChartTooltip({ active, payload, label }: TipProps) {
   return (
     <div className="rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] px-2.5 py-2 shadow-lg text-[11px] min-w-[150px]">
       {label != null && (
-        <div className="text-[10px] text-[var(--text-tertiary)] mb-1 font-mono">{String(label)}</div>
+        <div className="text-[10px] text-[var(--text-tertiary)] mb-1 font-mono">
+          {String(label)}
+        </div>
       )}
       {rows.slice(0, 8).map((p) => (
         <div key={String(p.dataKey)} className="flex items-center gap-2">
@@ -30,7 +32,9 @@ export function ChartTooltip({ active, payload, label }: TipProps) {
             className="h-1.5 w-1.5 rounded-full shrink-0"
             style={{ backgroundColor: (p.color as string) ?? p.fill }}
           />
-          <span className="flex-1 min-w-0 truncate text-[var(--text-secondary)]">{p.name}</span>
+          <span className="flex-1 min-w-0 truncate text-[var(--text-secondary)]">
+            {p.name}
+          </span>
           <span className="font-mono tabular-nums text-[var(--text-primary)]">
             {fmtTokens(Number(p.value) || 0)}
           </span>
@@ -39,7 +43,9 @@ export function ChartTooltip({ active, payload, label }: TipProps) {
       {rows.length > 1 && (
         <div className="mt-1 pt-1 border-t border-[var(--border-subtle)] flex items-center justify-between">
           <span className="text-[var(--text-tertiary)]">Total</span>
-          <span className="font-mono tabular-nums text-[var(--text-primary)]">{fmtTokens(total)}</span>
+          <span className="font-mono tabular-nums text-[var(--text-primary)]">
+            {fmtTokens(total)}
+          </span>
         </div>
       )}
     </div>

--- a/src/features/mission-control/components/dashboard/consumption-pie.tsx
+++ b/src/features/mission-control/components/dashboard/consumption-pie.tsx
@@ -15,7 +15,9 @@ export function ConsumptionPie({ data }: { data: MissionControlUsage }) {
     <ChartCard title="Consumption" subtitle="Token share by project">
       <div className="h-[240px] flex items-center gap-2">
         {shares.length === 0 ? (
-          <div className="flex-1 text-center text-[11px] text-[var(--text-tertiary)]">No data.</div>
+          <div className="flex-1 text-center text-[11px] text-[var(--text-tertiary)]">
+            No data.
+          </div>
         ) : (
           <>
             <div className="relative h-full w-[160px] shrink-0">
@@ -49,12 +51,17 @@ export function ConsumptionPie({ data }: { data: MissionControlUsage }) {
             </div>
             <div className="flex-1 min-w-0 overflow-y-auto max-h-full space-y-1 pr-1">
               {shares.slice(0, 10).map((s, i) => (
-                <div key={s.path} className="flex items-center gap-2 text-[11px]">
+                <div
+                  key={s.path}
+                  className="flex items-center gap-2 text-[11px]"
+                >
                   <span
                     className="h-1.5 w-1.5 rounded-full shrink-0"
                     style={{ backgroundColor: projectColor(i) }}
                   />
-                  <span className="flex-1 min-w-0 truncate text-[var(--text-secondary)]">{s.name}</span>
+                  <span className="flex-1 min-w-0 truncate text-[var(--text-secondary)]">
+                    {s.name}
+                  </span>
                   <span className="font-mono tabular-nums text-[var(--text-tertiary)]">
                     {total > 0 ? Math.round((s.value / total) * 100) : 0}%
                   </span>
@@ -74,7 +81,11 @@ function PieTip({
   total,
 }: {
   active?: boolean;
-  payload?: Array<{ name?: string; value?: number; payload?: { name: string } }>;
+  payload?: Array<{
+    name?: string;
+    value?: number;
+    payload?: { name: string };
+  }>;
   total: number;
 }) {
   if (!active || !payload || payload.length === 0) return null;
@@ -82,7 +93,9 @@ function PieTip({
   const v = Number(p.value) || 0;
   return (
     <div className="rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] px-2.5 py-1.5 text-[11px]">
-      <div className="text-[var(--text-secondary)]">{p.payload?.name ?? p.name}</div>
+      <div className="text-[var(--text-secondary)]">
+        {p.payload?.name ?? p.name}
+      </div>
       <div className="font-mono text-[var(--text-primary)]">
         {fmtTokens(v)} · {total > 0 ? Math.round((v / total) * 100) : 0}%
       </div>

--- a/src/features/mission-control/components/dashboard/dashboard-header.tsx
+++ b/src/features/mission-control/components/dashboard/dashboard-header.tsx
@@ -1,5 +1,12 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Download, FileText, Image as ImageIcon, FileType2, RefreshCw, ChevronDown } from "lucide-react";
+import {
+  Download,
+  FileText,
+  Image as ImageIcon,
+  FileType2,
+  RefreshCw,
+  ChevronDown,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AtlasIcon } from "@/components/atlas-icon";
 import type { TimeRange } from "../../types";
@@ -22,7 +29,9 @@ export function DashboardHeader({
   return (
     <div className="flex items-center gap-2 px-3 h-[32px] shrink-0 border-b border-[var(--border-default)]">
       <AtlasIcon size={14} className="rounded-[3px]" />
-      <span className="text-[12px] font-semibold text-[var(--text-primary)]">Console</span>
+      <span className="text-[12px] font-semibold text-[var(--text-primary)]">
+        Console
+      </span>
       <div className="flex-1" />
 
       {/* Time range segmented control */}
@@ -57,7 +66,8 @@ export function DashboardHeader({
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
           <button className="flex items-center gap-1.5 h-[26px] px-2.5 rounded-md border border-[var(--border-default)] text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors outline-none">
-            <Download size={12} /> Export <ChevronDown size={11} className="text-[var(--text-tertiary)]" />
+            <Download size={12} /> Export{" "}
+            <ChevronDown size={11} className="text-[var(--text-tertiary)]" />
           </button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Portal>
@@ -66,9 +76,21 @@ export function DashboardHeader({
             sideOffset={4}
             className="z-[var(--z-max)] min-w-[170px] rounded-lg border border-[var(--border-default)] bg-[#000] py-1.5 shadow-xl text-[12px] text-[var(--text-secondary)]"
           >
-            <Item icon={<FileType2 size={13} />} label="PDF report" onSelect={() => onExport("pdf")} />
-            <Item icon={<ImageIcon size={13} />} label="JPEG image" onSelect={() => onExport("jpeg")} />
-            <Item icon={<FileText size={13} />} label="Markdown report" onSelect={() => onExport("markdown")} />
+            <Item
+              icon={<FileType2 size={13} />}
+              label="PDF report"
+              onSelect={() => onExport("pdf")}
+            />
+            <Item
+              icon={<ImageIcon size={13} />}
+              label="JPEG image"
+              onSelect={() => onExport("jpeg")}
+            />
+            <Item
+              icon={<FileText size={13} />}
+              label="Markdown report"
+              onSelect={() => onExport("markdown")}
+            />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
@@ -76,7 +98,15 @@ export function DashboardHeader({
   );
 }
 
-function Item({ icon, label, onSelect }: { icon: React.ReactNode; label: string; onSelect: () => void }) {
+function Item({
+  icon,
+  label,
+  onSelect,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onSelect: () => void;
+}) {
   return (
     <DropdownMenu.Item
       onSelect={onSelect}

--- a/src/features/mission-control/components/dashboard/gantt-timeline.tsx
+++ b/src/features/mission-control/components/dashboard/gantt-timeline.tsx
@@ -54,7 +54,10 @@ export function GanttTimeline({ data }: { data: MissionControlUsage }) {
       for (const [date, tokens] of r.days) {
         const ms = Date.parse(`${date}T12:00:00`);
         if (Number.isNaN(ms)) continue;
-        const idx = Math.min(BUCKETS - 1, Math.max(0, Math.floor((ms - min) / bucketMs)));
+        const idx = Math.min(
+          BUCKETS - 1,
+          Math.max(0, Math.floor((ms - min) / bucketMs)),
+        );
         arr[idx] += tokens;
       }
       for (const v of arr) maxCell = Math.max(maxCell, v);
@@ -65,7 +68,10 @@ export function GanttTimeline({ data }: { data: MissionControlUsage }) {
 
   if (rows.length === 0) {
     return (
-      <ChartCard title="Project timeline" subtitle="Activity + token volume over time">
+      <ChartCard
+        title="Project timeline"
+        subtitle="Activity + token volume over time"
+      >
         <div className="h-[120px] flex items-center justify-center text-[11px] text-[var(--text-tertiary)]">
           No project activity.
         </div>
@@ -84,7 +90,10 @@ export function GanttTimeline({ data }: { data: MissionControlUsage }) {
       <div className="px-1.5 pb-1 space-y-1.5">
         {rows.map((r, ri) => (
           <div key={r.path} className="flex items-center gap-2">
-            <div className="w-[120px] shrink-0 truncate text-[11px] text-[var(--text-secondary)]" title={r.name}>
+            <div
+              className="w-[120px] shrink-0 truncate text-[11px] text-[var(--text-secondary)]"
+              title={r.name}
+            >
               {r.name}
             </div>
             <div className="relative flex-1 h-5 rounded bg-[var(--bg-base)] overflow-hidden">

--- a/src/features/mission-control/components/dashboard/logs-table.tsx
+++ b/src/features/mission-control/components/dashboard/logs-table.tsx
@@ -10,7 +10,20 @@ const ROW_H = 30;
 const PAGE_SIZE = 100;
 /** Cap entries loaded into memory across all projects (most-recent-first). */
 const LOAD_CAP = 5000;
-const SOURCES = ["all", "atlas", "agent", "chat", "git", "knowledge", "github", "project", "system", "editor", "research", "canvas"] as const;
+const SOURCES = [
+  "all",
+  "atlas",
+  "agent",
+  "chat",
+  "git",
+  "knowledge",
+  "github",
+  "project",
+  "system",
+  "editor",
+  "research",
+  "canvas",
+] as const;
 
 function parseJsonl(raw: string): LogEntry[] {
   return raw
@@ -79,9 +92,15 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return all.filter((e) => {
-      if (projectFilter !== "all" && e.projectPath !== projectFilter) return false;
+      if (projectFilter !== "all" && e.projectPath !== projectFilter)
+        return false;
       if (sourceFilter !== "all" && e.source !== sourceFilter) return false;
-      if (q && !(`${e.summary} ${e.kind} ${e.source} ${e.projectName ?? ""}`.toLowerCase().includes(q)))
+      if (
+        q &&
+        !`${e.summary} ${e.kind} ${e.source} ${e.projectName ?? ""}`
+          .toLowerCase()
+          .includes(q)
+      )
         return false;
       return true;
     });
@@ -93,7 +112,11 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
   const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const clampedPage = Math.min(page, pageCount - 1);
   const rows = useMemo(
-    () => filtered.slice(clampedPage * PAGE_SIZE, clampedPage * PAGE_SIZE + PAGE_SIZE),
+    () =>
+      filtered.slice(
+        clampedPage * PAGE_SIZE,
+        clampedPage * PAGE_SIZE + PAGE_SIZE,
+      ),
     [filtered, clampedPage],
   );
 
@@ -110,8 +133,12 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
     <div className="h-full flex flex-col rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] overflow-hidden">
       {/* Toolbar */}
       <div className="flex items-center gap-2 px-2.5 h-[38px] shrink-0 border-b border-[var(--border-default)]">
-        <span className="text-[12px] font-medium text-[var(--text-primary)] mr-1">Activity log</span>
-        <span className="text-[10px] text-[var(--text-tertiary)]">{filtered.length}</span>
+        <span className="text-[12px] font-medium text-[var(--text-primary)] mr-1">
+          Activity log
+        </span>
+        <span className="text-[10px] text-[var(--text-tertiary)]">
+          {filtered.length}
+        </span>
         <div className="flex-1" />
         <div className="flex items-center gap-1.5 h-[26px] rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] px-2 w-[180px]">
           <Search size={11} className="text-[var(--text-tertiary)] shrink-0" />
@@ -122,12 +149,21 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
             className="flex-1 bg-transparent outline-none text-[11px] text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)]"
           />
         </div>
-        <Select value={sourceFilter} onChange={setSourceFilter} options={SOURCES as unknown as string[]} />
+        <Select
+          value={sourceFilter}
+          onChange={setSourceFilter}
+          options={SOURCES as unknown as string[]}
+        />
         <Select
           value={projectFilter}
           onChange={setProjectFilter}
           options={["all", ...projects.map((p) => p.projectPath)]}
-          labels={{ all: "All projects", ...Object.fromEntries(projects.map((p) => [p.projectPath, p.projectName])) }}
+          labels={{
+            all: "All projects",
+            ...Object.fromEntries(
+              projects.map((p) => [p.projectPath, p.projectName]),
+            ),
+          }}
         />
       </div>
 
@@ -143,16 +179,27 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
       {/* Body */}
       <div ref={parentRef} className="flex-1 min-h-0 overflow-auto">
         {rows.length === 0 ? (
-          <div className="px-3 py-4 text-[11px] text-[var(--text-tertiary)]">No log entries.</div>
+          <div className="px-3 py-4 text-[11px] text-[var(--text-tertiary)]">
+            No log entries.
+          </div>
         ) : (
-          <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+          <div
+            style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          >
             {virtualizer.getVirtualItems().map((v) => {
               const e = rows[v.index];
               if (!e) return null;
               return (
                 <div
                   key={e.id}
-                  style={{ position: "absolute", top: 0, left: 0, width: "100%", height: ROW_H, transform: `translateY(${v.start}px)` }}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: ROW_H,
+                    transform: `translateY(${v.start}px)`,
+                  }}
                   className="flex items-center px-3 text-[11px] border-b border-[var(--border-subtle)] hover:bg-[var(--bg-hover)]"
                 >
                   <span className="w-[120px] shrink-0 font-mono text-[10px] text-[var(--text-tertiary)]">
@@ -160,7 +207,9 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
                   </span>
                   <span
                     className="w-[80px] shrink-0 truncate"
-                    style={{ color: SOURCE_COLOR[e.source] ?? "var(--text-secondary)" }}
+                    style={{
+                      color: SOURCE_COLOR[e.source] ?? "var(--text-secondary)",
+                    }}
                   >
                     {e.source}
                   </span>
@@ -170,7 +219,10 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
                   <span className="w-[140px] shrink-0 truncate font-mono text-[var(--text-tertiary)]">
                     {e.kind}
                   </span>
-                  <span className="flex-1 min-w-0 truncate text-[var(--text-secondary)]" title={e.summary}>
+                  <span
+                    className="flex-1 min-w-0 truncate text-[var(--text-secondary)]"
+                    title={e.summary}
+                  >
                     {e.summary}
                   </span>
                 </div>
@@ -184,7 +236,8 @@ export function LogsTable({ projects }: { projects: ProjectMetrics[] }) {
       {filtered.length > PAGE_SIZE && (
         <div className="flex items-center justify-between px-3 h-[30px] shrink-0 border-t border-[var(--border-default)] text-[10px] text-[var(--text-tertiary)]">
           <span className="font-mono tabular-nums">
-            {clampedPage * PAGE_SIZE + 1}–{Math.min(filtered.length, (clampedPage + 1) * PAGE_SIZE)} of{" "}
+            {clampedPage * PAGE_SIZE + 1}–
+            {Math.min(filtered.length, (clampedPage + 1) * PAGE_SIZE)} of{" "}
             {filtered.length}
           </span>
           <div className="flex items-center gap-1">

--- a/src/features/mission-control/components/dashboard/mission-control-dashboard.tsx
+++ b/src/features/mission-control/components/dashboard/mission-control-dashboard.tsx
@@ -19,7 +19,9 @@ export function MissionControlDashboard() {
   const error = useMissionControlStore.use.error();
   const { setRange, refresh } = useMissionControlStore.use.actions();
   // Re-fetch when the set of workspaces changes.
-  const wsSig = useWorkspaceStore((s) => s.workspaces.map((w) => w.path).join("|"));
+  const wsSig = useWorkspaceStore((s) =>
+    s.workspaces.map((w) => w.path).join("|"),
+  );
 
   // Node captured for image/PDF export (cards + charts + gantt).
   const captureRef = useRef<HTMLDivElement>(null);
@@ -57,10 +59,14 @@ export function MissionControlDashboard() {
 
       <div className="flex-1 min-h-0 overflow-y-auto">
         {!data && loading && (
-          <div className="p-6 text-[12px] text-[var(--text-tertiary)]">Loading metrics…</div>
+          <div className="p-6 text-[12px] text-[var(--text-tertiary)]">
+            Loading metrics…
+          </div>
         )}
         {error && (
-          <div className="p-6 text-[12px] text-[var(--status-error)]">Failed to load: {error}</div>
+          <div className="p-6 text-[12px] text-[var(--status-error)]">
+            Failed to load: {error}
+          </div>
         )}
         {data && (
           <div className="p-4 space-y-4">

--- a/src/features/mission-control/components/dashboard/stat-card.tsx
+++ b/src/features/mission-control/components/dashboard/stat-card.tsx
@@ -23,7 +23,10 @@ export function StatCard({
     >
       <div className="flex items-center gap-1.5">
         {accent && (
-          <span className="h-1.5 w-1.5 rounded-full shrink-0" style={{ backgroundColor: accent }} />
+          <span
+            className="h-1.5 w-1.5 rounded-full shrink-0"
+            style={{ backgroundColor: accent }}
+          />
         )}
         <span className="text-[9px] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">
           {label}
@@ -32,7 +35,11 @@ export function StatCard({
       <span className="text-[20px] font-mono tabular-nums text-[var(--text-primary)] leading-none">
         {value}
       </span>
-      {sub && <span className="text-[10px] text-[var(--text-tertiary)] font-mono">{sub}</span>}
+      {sub && (
+        <span className="text-[10px] text-[var(--text-tertiary)] font-mono">
+          {sub}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/features/mission-control/components/dashboard/usage-area-chart.tsx
+++ b/src/features/mission-control/components/dashboard/usage-area-chart.tsx
@@ -23,9 +23,15 @@ export function UsageAreaChart({
   data: MissionControlUsage;
   rangeDays: number | null;
 }) {
-  const paths = useMemo(() => data.projects.map((p) => p.projectPath), [data.projects]);
+  const paths = useMemo(
+    () => data.projects.map((p) => p.projectPath),
+    [data.projects],
+  );
   const nameByPath = useMemo(
-    () => Object.fromEntries(data.projects.map((p) => [p.projectPath, p.projectName])),
+    () =>
+      Object.fromEntries(
+        data.projects.map((p) => [p.projectPath, p.projectName]),
+      ),
     [data.projects],
   );
   const colors = useMemo(() => projectColorMap(paths), [paths]);
@@ -35,22 +41,43 @@ export function UsageAreaChart({
   );
 
   return (
-    <ChartCard title="Token usage over time" subtitle="Combined tokens per day, stacked by project">
+    <ChartCard
+      title="Token usage over time"
+      subtitle="Combined tokens per day, stacked by project"
+    >
       <div className="h-[240px]">
         {rows.length === 0 ? (
           <Empty />
         ) : (
           <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={rows} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
+            <AreaChart
+              data={rows}
+              margin={{ top: 8, right: 8, left: 4, bottom: 0 }}
+            >
               <defs>
                 {paths.map((p) => (
-                  <linearGradient key={p} id={`area-${gid(p)}`} x1="0" y1="0" x2="0" y2="1">
+                  <linearGradient
+                    key={p}
+                    id={`area-${gid(p)}`}
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
                     <stop offset="0%" stopColor={colors[p]} stopOpacity={0.5} />
-                    <stop offset="100%" stopColor={colors[p]} stopOpacity={0.03} />
+                    <stop
+                      offset="100%"
+                      stopColor={colors[p]}
+                      stopOpacity={0.03}
+                    />
                   </linearGradient>
                 ))}
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke={CHART.grid} vertical={false} />
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={CHART.grid}
+                vertical={false}
+              />
               <XAxis
                 dataKey="date"
                 tick={{ fill: CHART.axis, fontSize: CHART.tickFont }}
@@ -66,7 +93,10 @@ export function UsageAreaChart({
                 width={44}
                 tickFormatter={(v: number) => fmtTokens(v)}
               />
-              <Tooltip content={<ChartTooltip />} cursor={{ stroke: CHART.grid }} />
+              <Tooltip
+                content={<ChartTooltip />}
+                cursor={{ stroke: CHART.grid }}
+              />
               {paths.map((p) => (
                 <Area
                   key={p}

--- a/src/features/mission-control/components/dashboard/usage-bar-chart.tsx
+++ b/src/features/mission-control/components/dashboard/usage-bar-chart.tsx
@@ -26,7 +26,10 @@ export function UsageBarChart({ data }: { data: MissionControlUsage }) {
           Review: p.review.inputTokens + p.review.outputTokens,
         }))
         .filter((r) => r.Claude + r.Codex + r.Review > 0)
-        .sort((a, b) => b.Claude + b.Codex + b.Review - (a.Claude + a.Codex + a.Review))
+        .sort(
+          (a, b) =>
+            b.Claude + b.Codex + b.Review - (a.Claude + a.Codex + a.Review),
+        )
         .slice(0, 12),
     [data.projects],
   );
@@ -40,15 +43,24 @@ export function UsageBarChart({ data }: { data: MissionControlUsage }) {
           </div>
         ) : (
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={rows} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke={CHART.grid} vertical={false} />
+            <BarChart
+              data={rows}
+              margin={{ top: 8, right: 8, left: 4, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={CHART.grid}
+                vertical={false}
+              />
               <XAxis
                 dataKey="name"
                 tick={{ fill: CHART.axis, fontSize: CHART.tickFont }}
                 tickLine={false}
                 axisLine={{ stroke: CHART.grid }}
                 interval={0}
-                tickFormatter={(s: string) => (s.length > 10 ? `${s.slice(0, 9)}…` : s)}
+                tickFormatter={(s: string) =>
+                  s.length > 10 ? `${s.slice(0, 9)}…` : s
+                }
               />
               <YAxis
                 tick={{ fill: CHART.axis, fontSize: CHART.tickFont }}
@@ -57,10 +69,29 @@ export function UsageBarChart({ data }: { data: MissionControlUsage }) {
                 width={44}
                 tickFormatter={(v: number) => fmtTokens(v)}
               />
-              <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(255,255,255,0.03)" }} />
-              <Bar dataKey="Claude" stackId="a" fill={AGENT_COLOR.claude} isAnimationActive={false} />
-              <Bar dataKey="Codex" stackId="a" fill={AGENT_COLOR.codex} isAnimationActive={false} />
-              <Bar dataKey="Review" stackId="a" fill={AGENT_COLOR.review} radius={[2, 2, 0, 0]} isAnimationActive={false} />
+              <Tooltip
+                content={<ChartTooltip />}
+                cursor={{ fill: "rgba(255,255,255,0.03)" }}
+              />
+              <Bar
+                dataKey="Claude"
+                stackId="a"
+                fill={AGENT_COLOR.claude}
+                isAnimationActive={false}
+              />
+              <Bar
+                dataKey="Codex"
+                stackId="a"
+                fill={AGENT_COLOR.codex}
+                isAnimationActive={false}
+              />
+              <Bar
+                dataKey="Review"
+                stackId="a"
+                fill={AGENT_COLOR.review}
+                radius={[2, 2, 0, 0]}
+                isAnimationActive={false}
+              />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/src/features/mission-control/lib/export.ts
+++ b/src/features/mission-control/lib/export.ts
@@ -8,7 +8,10 @@ async function htmlToImage() {
 }
 
 /** Capture a DOM node to a PNG/JPEG data URL on the AMOLED background. */
-async function capture(node: HTMLElement, kind: "png" | "jpeg"): Promise<string> {
+async function capture(
+  node: HTMLElement,
+  kind: "png" | "jpeg",
+): Promise<string> {
   // Fonts must be ready or text renders as fallback in the capture.
   if (document.fonts?.ready) await document.fonts.ready;
   const { toPng, toJpeg } = await htmlToImage();
@@ -16,9 +19,12 @@ async function capture(node: HTMLElement, kind: "png" | "jpeg"): Promise<string>
     backgroundColor: "#000000",
     pixelRatio: 2,
     // Skip anything explicitly marked non-exportable (e.g. interactive controls).
-    filter: (el: HTMLElement) => !(el.dataset && el.dataset.noexport === "true"),
+    filter: (el: HTMLElement) =>
+      !(el.dataset && el.dataset.noexport === "true"),
   };
-  return kind === "png" ? toPng(node, opts) : toJpeg(node, { ...opts, quality: 0.95 });
+  return kind === "png"
+    ? toPng(node, opts)
+    : toJpeg(node, { ...opts, quality: 0.95 });
 }
 
 function dataUrlToBytes(dataUrl: string): number[] {
@@ -29,7 +35,10 @@ function dataUrlToBytes(dataUrl: string): number[] {
   return out;
 }
 
-async function pickSave(defaultName: string, ext: string): Promise<string | null> {
+async function pickSave(
+  defaultName: string,
+  ext: string,
+): Promise<string | null> {
   const { save } = await import("@tauri-apps/plugin-dialog");
   const chosen = await save({
     defaultPath: defaultName,
@@ -45,7 +54,10 @@ export async function exportJpeg(node: HTMLElement): Promise<void> {
   const dataUrl = await capture(node, "jpeg");
   const target = await pickSave(`atlas-console-${stamp()}.jpg`, "jpg");
   if (!target) return;
-  await invoke("mission_control_write_file", { targetPath: target, bytes: dataUrlToBytes(dataUrl) });
+  await invoke("mission_control_write_file", {
+    targetPath: target,
+    bytes: dataUrlToBytes(dataUrl),
+  });
 }
 
 /** Export the dashboard node as a multi-page PDF (image-per-page slices). */
@@ -92,7 +104,10 @@ export async function exportMarkdown(data: MissionControlUsage): Promise<void> {
   const md = buildMarkdown(data);
   const target = await pickSave(`atlas-console-${stamp()}.md`, "md");
   if (!target) return;
-  await invoke("mission_control_export_markdown", { targetPath: target, markdown: md });
+  await invoke("mission_control_export_markdown", {
+    targetPath: target,
+    markdown: md,
+  });
 }
 
 function buildMarkdown(data: MissionControlUsage): string {
@@ -100,26 +115,42 @@ function buildMarkdown(data: MissionControlUsage): string {
   const lines: string[] = [];
   lines.push(`# Atlas — Console Report`);
   lines.push("");
-  lines.push(`_Generated ${new Date(data.generatedAt).toLocaleString()} · ${data.projects.length} projects_`);
+  lines.push(
+    `_Generated ${new Date(data.generatedAt).toLocaleString()} · ${data.projects.length} projects_`,
+  );
   lines.push("");
   lines.push(`## Totals`);
   lines.push("");
   lines.push(`| Metric | Value |`);
   lines.push(`| --- | --- |`);
   lines.push(`| Total tokens | ${fmtTokens(t.totalTokens)} |`);
-  lines.push(`| Claude input / output | ${fmtTokens(t.claudeInput)} / ${fmtTokens(t.claudeOutput)} |`);
+  lines.push(
+    `| Claude input / output | ${fmtTokens(t.claudeInput)} / ${fmtTokens(t.claudeOutput)} |`,
+  );
   lines.push(`| Claude cache | ${fmtTokens(t.claudeCache)} |`);
-  lines.push(`| Requests / sessions | ${fmtTokens(t.claudeRequests)} / ${t.claudeSessions} |`);
-  lines.push(`| Codex tokens | ${fmtTokens(t.codexTokens)} (${t.codexSessions} threads) |`);
-  lines.push(`| Review tokens / runs | ${fmtTokens(t.reviewInput + t.reviewOutput)} / ${t.reviewRuns} |`);
-  lines.push(`| BYOK tokens / calls | ${fmtTokens(t.byokInput + t.byokOutput)} / ${t.byokRequests} |`);
+  lines.push(
+    `| Requests / sessions | ${fmtTokens(t.claudeRequests)} / ${t.claudeSessions} |`,
+  );
+  lines.push(
+    `| Codex tokens | ${fmtTokens(t.codexTokens)} (${t.codexSessions} threads) |`,
+  );
+  lines.push(
+    `| Review tokens / runs | ${fmtTokens(t.reviewInput + t.reviewOutput)} / ${t.reviewRuns} |`,
+  );
+  lines.push(
+    `| BYOK tokens / calls | ${fmtTokens(t.byokInput + t.byokOutput)} / ${t.byokRequests} |`,
+  );
   lines.push(`| Total cost | ${fmtCost(t.totalCostUsd)} |`);
   lines.push("");
   lines.push(`## Per project`);
   lines.push("");
-  lines.push(`| Project | Claude (in/out) | Cost | Requests | Codex | Review |`);
+  lines.push(
+    `| Project | Claude (in/out) | Cost | Requests | Codex | Review |`,
+  );
   lines.push(`| --- | --- | --- | --- | --- | --- |`);
-  for (const p of [...data.projects].sort((a, b) => b.totalTokens - a.totalTokens)) {
+  for (const p of [...data.projects].sort(
+    (a, b) => b.totalTokens - a.totalTokens,
+  )) {
     lines.push(
       `| ${p.projectName} | ${fmtTokens(p.claude.inputTokens)} / ${fmtTokens(p.claude.outputTokens)} | ${fmtCost(p.claude.costUsd)} | ${fmtTokens(p.claude.requests)} | ${fmtTokens(p.codex.tokens)} | ${fmtTokens(p.review.inputTokens + p.review.outputTokens)} |`,
     );

--- a/src/features/mission-control/lib/series.ts
+++ b/src/features/mission-control/lib/series.ts
@@ -6,7 +6,10 @@ export function bucketTokens(d: DailyBucket): number {
 }
 
 /** Filter the daily series to the last `rangeDays` (null = all time). */
-export function filterDaily(daily: DailyBucket[], rangeDays: number | null): DailyBucket[] {
+export function filterDaily(
+  daily: DailyBucket[],
+  rangeDays: number | null,
+): DailyBucket[] {
   if (rangeDays == null) return daily;
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - rangeDays);
@@ -43,7 +46,11 @@ export function consumptionShares(
   data: MissionControlUsage,
 ): Array<{ name: string; path: string; value: number }> {
   return data.projects
-    .map((p) => ({ name: p.projectName, path: p.projectPath, value: p.totalTokens }))
+    .map((p) => ({
+      name: p.projectName,
+      path: p.projectPath,
+      value: p.totalTokens,
+    }))
     .filter((s) => s.value > 0)
     .sort((a, b) => b.value - a.value);
 }

--- a/src/features/mission-control/stores/mission-control-store.ts
+++ b/src/features/mission-control/stores/mission-control-store.ts
@@ -35,9 +35,12 @@ export const useMissionControlStore = createSelectors(
           const projectPaths = useWorkspaceStore
             .getState()
             .workspaces.map((w) => w.path);
-          const data = await invoke<MissionControlUsage>("mission_control_usage", {
-            projectPaths,
-          });
+          const data = await invoke<MissionControlUsage>(
+            "mission_control_usage",
+            {
+              projectPaths,
+            },
+          );
           set({ data, loading: false });
         } catch (e) {
           set({ error: String(e), loading: false });

--- a/src/features/model-chat/components/model-chat-panel.tsx
+++ b/src/features/model-chat/components/model-chat-panel.tsx
@@ -28,7 +28,10 @@ import { Kbd, KbdGroup } from "@/ui/kbd";
 import { MessageItem } from "@/features/chat/components/message-item";
 import { ChatSearchPalette } from "@/features/chat/components/chat-search-palette";
 import { usePaneFind } from "@/features/chat/lib/use-pane-find";
-import { ChatInput, type ChatInputHandle } from "@/features/chat/components/chat-input";
+import {
+  ChatInput,
+  type ChatInputHandle,
+} from "@/features/chat/components/chat-input";
 import {
   MentionPicker,
   type MentionPickerHandle,
@@ -38,7 +41,10 @@ import type { MentionData } from "@/features/chat/lib/mentions";
 import { ModelChatSidebar } from "./model-chat-sidebar";
 import { ModelChatLinksPanel } from "./model-chat-links-panel";
 import { ProviderLogo } from "@/components/provider-logo";
-import { CHAT_PROVIDERS, providerById } from "@/features/settings/lib/providers";
+import {
+  CHAT_PROVIDERS,
+  providerById,
+} from "@/features/settings/lib/providers";
 import { useByokStore } from "@/features/settings/stores/byok-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
@@ -93,7 +99,9 @@ function mcRecordHeight(id: string, h: number) {
   mcHeights.set(id, h);
 }
 function mcAverageHeight(): number {
-  return mcHeightCount > 0 ? Math.round(mcHeightSum / mcHeightCount) : MC_DEFAULT_ROW;
+  return mcHeightCount > 0
+    ? Math.round(mcHeightSum / mcHeightCount)
+    : MC_DEFAULT_ROW;
 }
 
 // `tabId` is the center-panel tab id — used to scope the Cmd+F finder to this
@@ -120,7 +128,9 @@ export function ModelChatPanel({ tabId }: { tabId?: string } = {}) {
     return <EmptyState hasOtherKeys={Object.keys(keys).length > 0} />;
   }
 
-  return <ChatSurface tabId={tabId} configuredIds={configured.map((p) => p.id)} />;
+  return (
+    <ChatSurface tabId={tabId} configuredIds={configured.map((p) => p.id)} />
+  );
 }
 
 function ChatSurface({
@@ -201,7 +211,9 @@ function Conversation({
     measureElement:
       typeof window !== "undefined" && !navigator.userAgent.includes("Firefox")
         ? (el) => {
-            const h = Math.round(el?.getBoundingClientRect().height ?? mcAverageHeight());
+            const h = Math.round(
+              el?.getBoundingClientRect().height ?? mcAverageHeight(),
+            );
             const id = el?.getAttribute("data-message-id");
             if (id) mcRecordHeight(id, h);
             return h;
@@ -292,7 +304,10 @@ function Conversation({
       </div>
 
       {/* Messages */}
-      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto [overflow-anchor:none]">
+      <div
+        ref={scrollRef}
+        className="flex-1 min-h-0 overflow-y-auto [overflow-anchor:none]"
+      >
         {messages.length === 0 ? (
           <div className="grid h-full place-items-center px-6">
             <div className="max-w-[420px] text-center">
@@ -300,8 +315,8 @@ function Conversation({
                 {providerById(session.provider)?.name ?? "Chat"}
               </p>
               <p className="mt-1 text-[12px] text-text-tertiary">
-                Ask anything. Responses stream directly from the model using your
-                stored key.
+                Ask anything. Responses stream directly from the model using
+                your stored key.
               </p>
             </div>
           </div>
@@ -415,7 +430,9 @@ function Composer({
       const { open } = await import("@tauri-apps/plugin-dialog");
       const sel = await open({
         multiple: true,
-        filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "gif"] }],
+        filters: [
+          { name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "gif"] },
+        ],
       });
       const paths = Array.isArray(sel) ? sel : sel ? [sel] : [];
       const next: ComposerAttachment[] = [];
@@ -427,7 +444,9 @@ function Composer({
       }
       if (next.length) setAttachments((a) => [...a, ...next]);
     } catch (e) {
-      toast.error(`Couldn't attach image: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Couldn't attach image: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   };
 
@@ -542,10 +561,16 @@ function Composer({
                 key={i}
                 className="group relative h-12 w-12 overflow-hidden rounded-md border border-border-default"
               >
-                <img src={a.dataUrl} alt="" className="h-full w-full object-cover" />
+                <img
+                  src={a.dataUrl}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
                 <button
                   type="button"
-                  onClick={() => setAttachments((arr) => arr.filter((_, j) => j !== i))}
+                  onClick={() =>
+                    setAttachments((arr) => arr.filter((_, j) => j !== i))
+                  }
                   className="absolute right-0.5 top-0.5 grid h-4 w-4 place-items-center rounded bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity"
                   title="Remove"
                 >
@@ -599,8 +624,12 @@ function Composer({
                     className="flex items-center gap-2 px-2.5 h-[28px] text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary cursor-pointer outline-none"
                   >
                     <ProviderLogo id={id} size={14} />
-                    <span className="flex-1 truncate">{providerById(id)?.name ?? id}</span>
-                    {id === provider && <Check size={12} className="text-text-primary" />}
+                    <span className="flex-1 truncate">
+                      {providerById(id)?.name ?? id}
+                    </span>
+                    {id === provider && (
+                      <Check size={12} className="text-text-primary" />
+                    )}
                   </DropdownMenu.Item>
                 ))}
               </PickerDropdown>
@@ -716,7 +745,9 @@ function ModelCombo({
     >
       <Popover.Trigger asChild>
         <button className="flex min-w-0 items-center gap-1.5 h-[26px] rounded-full border border-border-default bg-bg-elevated px-2 text-[10px] font-medium text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors outline-none cursor-pointer">
-          {loading && <Loader2 size={11} className="animate-spin text-text-tertiary" />}
+          {loading && (
+            <Loader2 size={11} className="animate-spin text-text-tertiary" />
+          )}
           <span className="max-w-[200px] truncate font-mono">
             {value || (loading ? "Loading…" : "Select model")}
           </span>
@@ -757,7 +788,9 @@ function ModelCombo({
                   className="flex w-full items-center gap-2 px-2.5 h-[26px] text-left text-[11px] font-mono text-text-secondary hover:bg-bg-hover hover:text-text-primary cursor-pointer outline-none"
                 >
                   <span className="flex-1 truncate">{id}</span>
-                  {id === value && <Check size={11} className="text-text-primary" />}
+                  {id === value && (
+                    <Check size={11} className="text-text-primary" />
+                  )}
                 </button>
               ))
             )}
@@ -788,16 +821,18 @@ function MessageAttachments({ messageId }: { messageId: string }) {
 
 function EmptyState({ hasOtherKeys }: { hasOtherKeys: boolean }) {
   const openSettings = () => {
-    void import("@/features/layout/stores/layout-store").then(({ useLayoutStore }) => {
-      useLayoutStore.getState().actions.addTab({
-        id: "settings",
-        type: "settings",
-        title: "Settings",
-        closable: true,
-        dirty: false,
-        data: { section: "providers" },
-      });
-    });
+    void import("@/features/layout/stores/layout-store").then(
+      ({ useLayoutStore }) => {
+        useLayoutStore.getState().actions.addTab({
+          id: "settings",
+          type: "settings",
+          title: "Settings",
+          closable: true,
+          dirty: false,
+          data: { section: "providers" },
+        });
+      },
+    );
   };
   return (
     <div className="grid h-full place-items-center bg-bg-base p-6">
@@ -806,7 +841,9 @@ function EmptyState({ hasOtherKeys }: { hasOtherKeys: boolean }) {
           <KeyRound size={20} className="text-text-tertiary" />
         </div>
         <p className="mt-3 text-[13px] font-medium text-text-primary">
-          {hasOtherKeys ? "No chat-capable provider yet" : "No provider keys yet"}
+          {hasOtherKeys
+            ? "No chat-capable provider yet"
+            : "No provider keys yet"}
         </p>
         <p className="mt-1 text-[11px] text-text-tertiary">
           {hasOtherKeys

--- a/src/features/model-chat/components/model-chat-sidebar.tsx
+++ b/src/features/model-chat/components/model-chat-sidebar.tsx
@@ -1,5 +1,11 @@
 import { useMemo, useState } from "react";
-import { Plus, Search, Trash2, PanelLeftClose, MessageSquare } from "lucide-react";
+import {
+  Plus,
+  Search,
+  Trash2,
+  PanelLeftClose,
+  MessageSquare,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "@/lib/time-ago";
 import { ProviderLogo, hasProviderLogo } from "@/components/provider-logo";
@@ -71,7 +77,10 @@ export function ModelChatSidebar({ onNew }: { onNew: () => void }) {
                 <div className="flex items-start gap-1.5">
                   <span className="shrink-0 inline-flex h-[15px] items-center justify-center">
                     {streaming[m.id] ? (
-                      <AtlasLoader size={8} className="text-[var(--accent-primary)]" />
+                      <AtlasLoader
+                        size={8}
+                        className="text-[var(--accent-primary)]"
+                      />
                     ) : m.provider && hasProviderLogo(m.provider) ? (
                       <ProviderLogo id={m.provider} size={13} />
                     ) : (

--- a/src/features/model-chat/lib/model-capabilities.ts
+++ b/src/features/model-chat/lib/model-capabilities.ts
@@ -18,7 +18,9 @@ export function modelSupportsVision(provider: string, model: string): boolean {
         /claude-(opus|sonnet|haiku)-[4-9]/.test(m)
       );
     case "openai":
-      return /gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-4-vision|chatgpt-4o|o1|o3|o4/.test(m);
+      return /gpt-4o|gpt-4\.1|gpt-4-turbo|gpt-4-vision|chatgpt-4o|o1|o3|o4/.test(
+        m,
+      );
     default:
       // Open-weight + gateway providers: match common vision model markers.
       return /vision|-vl\b|vl-|pixtral|llava|internvl|qwen2?-vl|llama-3\.2|maverick|scout/.test(

--- a/src/features/model-chat/lib/model-chat-api.ts
+++ b/src/features/model-chat/lib/model-chat-api.ts
@@ -41,14 +41,24 @@ export interface WireMsg {
 /** Streaming events from Rust (Rig), tagged by `stream_id`. */
 export type ModelChatEvent =
   | { stream_id: string; kind: "text_delta"; delta: string }
-  | { stream_id: string; kind: "usage"; input_tokens: number; output_tokens: number }
+  | {
+      stream_id: string;
+      kind: "usage";
+      input_tokens: number;
+      output_tokens: number;
+    }
   | { stream_id: string; kind: "done" }
   | { stream_id: string; kind: "error"; message: string };
 
 export const modelchat = {
   models: (provider: string) =>
     invoke<{ id: string }[]>("modelchat_models", { provider }),
-  stream: (streamId: string, provider: string, model: string, messages: WireMsg[]) =>
+  stream: (
+    streamId: string,
+    provider: string,
+    model: string,
+    messages: WireMsg[],
+  ) =>
     invoke<void>("modelchat_stream", { streamId, provider, model, messages }),
   cancel: (streamId: string) => invoke<void>("modelchat_cancel", { streamId }),
 
@@ -57,7 +67,8 @@ export const modelchat = {
     invoke<ModelChatSessionWire>("modelchat_session_get", { id }),
   sessionSave: (session: ModelChatSessionWire) =>
     invoke<void>("modelchat_session_save", { session }),
-  sessionDelete: (id: string) => invoke<void>("modelchat_session_delete", { id }),
+  sessionDelete: (id: string) =>
+    invoke<void>("modelchat_session_delete", { id }),
 };
 
 export const listenModelChat = (

--- a/src/features/model-chat/stores/model-chat-store.ts
+++ b/src/features/model-chat/stores/model-chat-store.ts
@@ -61,7 +61,11 @@ interface ModelChatState {
     deleteSession: (id: string) => Promise<void>;
     setProvider: (id: string, provider: string) => void;
     setModel: (id: string, model: string) => void;
-    send: (id: string, text: string, attachments?: ComposerAttachment[]) => Promise<void>;
+    send: (
+      id: string,
+      text: string,
+      attachments?: ComposerAttachment[],
+    ) => Promise<void>;
     stop: (id: string) => void;
   };
 }
@@ -212,7 +216,12 @@ export const useModelChatStore = createSelectors(
         setModel: (id, model) =>
           set((st) =>
             st.sessions[id]
-              ? { sessions: { ...st.sessions, [id]: { ...st.sessions[id], model } } }
+              ? {
+                  sessions: {
+                    ...st.sessions,
+                    [id]: { ...st.sessions[id], model },
+                  },
+                }
               : st,
           ),
 
@@ -245,7 +254,10 @@ export const useModelChatStore = createSelectors(
             streaming: { ...st.streaming, [id]: true },
             streamToSession: { ...st.streamToSession, [streamId]: id },
             attachmentsByMsg: attachments?.length
-              ? { ...st.attachmentsByMsg, [userMsg.id]: attachments.map((a) => a.dataUrl) }
+              ? {
+                  ...st.attachmentsByMsg,
+                  [userMsg.id]: attachments.map((a) => a.dataUrl),
+                }
               : st.attachmentsByMsg,
           }));
 
@@ -262,7 +274,12 @@ export const useModelChatStore = createSelectors(
           }));
 
           try {
-            await modelchat.stream(streamId, session.provider, session.model, wire);
+            await modelchat.stream(
+              streamId,
+              session.provider,
+              session.model,
+              wire,
+            );
           } catch (e) {
             // The promise resolves at stream end; a reject here is a hard
             // failure (the `error` event handles in-stream errors).
@@ -299,9 +316,14 @@ export const useModelChatStore = createSelectors(
           const msgs = s.messages.slice();
           const last = msgs[msgs.length - 1];
           if (last && last.role === "assistant") {
-            msgs[msgs.length - 1] = { ...last, content: last.content + e.delta };
+            msgs[msgs.length - 1] = {
+              ...last,
+              content: last.content + e.delta,
+            };
           }
-          return { sessions: { ...st.sessions, [id]: { ...s, messages: msgs } } };
+          return {
+            sessions: { ...st.sessions, [id]: { ...s, messages: msgs } },
+          };
         });
         return;
       }
@@ -311,14 +333,20 @@ export const useModelChatStore = createSelectors(
         if (s) {
           useUsageStore
             .getState()
-            .actions.trackUsage(s.provider, s.model, e.input_tokens, e.output_tokens);
+            .actions.trackUsage(
+              s.provider,
+              s.model,
+              e.input_tokens,
+              e.output_tokens,
+            );
         }
         return;
       }
 
       if (e.kind === "error") {
         const s = getFn().sessions[id];
-        const name = providerById(s?.provider ?? "")?.name ?? s?.provider ?? "Chat";
+        const name =
+          providerById(s?.provider ?? "")?.name ?? s?.provider ?? "Chat";
         toast.error(`${s?.provider ?? "chat"}: ${e.message}`);
         notify().add({
           kind: "chat-error",
@@ -334,7 +362,8 @@ export const useModelChatStore = createSelectors(
 
       if (e.kind === "done") {
         const s = getFn().sessions[id];
-        const name = providerById(s?.provider ?? "")?.name ?? s?.provider ?? "Chat";
+        const name =
+          providerById(s?.provider ?? "")?.name ?? s?.provider ?? "Chat";
         const last = s?.messages[s.messages.length - 1];
         const snippet = (last?.role === "assistant" ? last.content : "").trim();
         if (snippet) {

--- a/src/features/monitor/components/usage-bar.tsx
+++ b/src/features/monitor/components/usage-bar.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { BarChart3, Zap, Clock } from "lucide-react";
 import { useUsageStore } from "../stores/usage-store";
 import { useChatStore } from "@/features/chat/stores/chat-store";
@@ -41,7 +45,7 @@ export function UsageBar() {
         acpSessionId: sess.acpSessionId,
         status: sess.status,
       };
-    })
+    }),
   );
   const acpSessionId = chatSession?.acpSessionId ?? null;
   const isStreaming = chatSession?.status === "running";
@@ -75,7 +79,7 @@ export function UsageBar() {
       (e) => {
         if (e.payload.cwd !== cwd) return;
         queryClient.invalidateQueries({ queryKey });
-      }
+      },
     );
     return () => {
       unlistenPromise.then((u) => u());
@@ -119,7 +123,11 @@ export function UsageBar() {
     requestCountFallback,
   ]);
 
-  const totalTokens = display.inputTokens + display.outputTokens + display.cacheCreation + display.cacheRead;
+  const totalTokens =
+    display.inputTokens +
+    display.outputTokens +
+    display.cacheCreation +
+    display.cacheRead;
   const elapsed = Math.floor((Date.now() - sessionStart) / 60000);
 
   return (
@@ -137,7 +145,9 @@ export function UsageBar() {
         {display.model && (
           <>
             <span>·</span>
-            <span className="truncate max-w-[120px]" title={display.model}>{display.model}</span>
+            <span className="truncate max-w-[120px]" title={display.model}>
+              {display.model}
+            </span>
           </>
         )}
       </button>
@@ -150,31 +160,53 @@ export function UsageBar() {
         >
           <div className="flex items-center gap-1.5 text-[11px] font-semibold text-text-secondary">
             <BarChart3 size={12} />
-            {display.source === "claude" ? "Claude Code Session" : "Session Usage"}
+            {display.source === "claude"
+              ? "Claude Code Session"
+              : "Session Usage"}
           </div>
 
           <div className="grid grid-cols-2 gap-2">
-            <UsageStat label="Input" value={display.inputTokens.toLocaleString()} />
-            <UsageStat label="Output" value={display.outputTokens.toLocaleString()} />
+            <UsageStat
+              label="Input"
+              value={display.inputTokens.toLocaleString()}
+            />
+            <UsageStat
+              label="Output"
+              value={display.outputTokens.toLocaleString()}
+            />
             {display.source === "claude" && (
               <>
-                <UsageStat label="Cache write" value={display.cacheCreation.toLocaleString()} />
-                <UsageStat label="Cache read" value={display.cacheRead.toLocaleString()} />
+                <UsageStat
+                  label="Cache write"
+                  value={display.cacheCreation.toLocaleString()}
+                />
+                <UsageStat
+                  label="Cache read"
+                  value={display.cacheRead.toLocaleString()}
+                />
               </>
             )}
             <UsageStat label="Requests" value={String(display.requestCount)} />
-            <UsageStat label="Cost" value={`$${display.totalCost.toFixed(4)}`} />
+            <UsageStat
+              label="Cost"
+              value={`$${display.totalCost.toFixed(4)}`}
+            />
           </div>
 
           {display.model && (
-            <div className="text-[9px] font-mono text-text-tertiary truncate" title={display.model}>
+            <div
+              className="text-[9px] font-mono text-text-tertiary truncate"
+              title={display.model}
+            >
               model: {display.model}
             </div>
           )}
 
           <div className="flex items-center gap-1 text-[9px] text-text-tertiary pt-1 border-t border-border-subtle">
             <Clock size={9} />
-            {display.source === "claude" ? "Live from .jsonl" : `Session: ${elapsed}m`}
+            {display.source === "claude"
+              ? "Live from .jsonl"
+              : `Session: ${elapsed}m`}
           </div>
         </div>
       )}
@@ -186,7 +218,9 @@ function UsageStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded border border-border-default bg-bg-primary px-2 py-1">
       <div className="text-[11px] font-mono text-text-primary">{value}</div>
-      <div className="text-[8px] text-text-tertiary uppercase tracking-wide">{label}</div>
+      <div className="text-[8px] text-text-tertiary uppercase tracking-wide">
+        {label}
+      </div>
     </div>
   );
 }

--- a/src/features/monitor/components/usage-modal.tsx
+++ b/src/features/monitor/components/usage-modal.tsx
@@ -62,7 +62,10 @@ export function UsageModal({
               </thead>
               <tbody>
                 {sessions.map((s) => (
-                  <tr key={s.session_id} className="border-b border-border-subtle hover:bg-bg-hover">
+                  <tr
+                    key={s.session_id}
+                    className="border-b border-border-subtle hover:bg-bg-hover"
+                  >
                     <Td className="text-left max-w-0">
                       <span className="block truncate text-text-secondary">
                         {s.preview || s.session_id.slice(0, 8)}
@@ -71,16 +74,24 @@ export function UsageModal({
                     <Td className="text-left text-text-tertiary truncate">
                       {(s.model ?? "—").replace(/^claude-/, "")}
                     </Td>
-                    <Td className="text-right font-mono tabular-nums">{fmtTokens(s.input_tokens)}</Td>
-                    <Td className="text-right font-mono tabular-nums">{fmtTokens(s.output_tokens)}</Td>
+                    <Td className="text-right font-mono tabular-nums">
+                      {fmtTokens(s.input_tokens)}
+                    </Td>
+                    <Td className="text-right font-mono tabular-nums">
+                      {fmtTokens(s.output_tokens)}
+                    </Td>
                     <Td className="text-right font-mono tabular-nums">
                       {fmtTokens(s.cache_creation_tokens + s.cache_read_tokens)}
                     </Td>
-                    <Td className="text-right font-mono tabular-nums">{s.request_count}</Td>
+                    <Td className="text-right font-mono tabular-nums">
+                      {s.request_count}
+                    </Td>
                     <Td className="text-right font-mono tabular-nums text-text-primary">
                       {fmtCost(s.total_cost_usd)}
                     </Td>
-                    <Td className="text-right text-text-tertiary">{fmtDate(s.last_modified)}</Td>
+                    <Td className="text-right text-text-tertiary">
+                      {fmtDate(s.last_modified)}
+                    </Td>
                   </tr>
                 ))}
               </tbody>
@@ -92,13 +103,34 @@ export function UsageModal({
   );
 }
 
-function Th({ className, children }: { className?: string; children: React.ReactNode }) {
+function Th({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
   return (
-    <th className={cn("px-3 py-1.5 font-medium uppercase tracking-wider text-[9px]", className)}>
+    <th
+      className={cn(
+        "px-3 py-1.5 font-medium uppercase tracking-wider text-[9px]",
+        className,
+      )}
+    >
       {children}
     </th>
   );
 }
-function Td({ className, children }: { className?: string; children: React.ReactNode }) {
-  return <td className={cn("px-3 py-1.5 text-text-secondary", className)}>{children}</td>;
+function Td({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <td className={cn("px-3 py-1.5 text-text-secondary", className)}>
+      {children}
+    </td>
+  );
 }

--- a/src/features/monitor/components/usage-panel.tsx
+++ b/src/features/monitor/components/usage-panel.tsx
@@ -20,12 +20,23 @@ const OTHERS_COLOR = "var(--text-ghost)";
 const TOKEN_TYPES = [
   { key: "input_tokens", label: "Input", color: "var(--text-primary)" },
   { key: "output_tokens", label: "Output", color: "var(--text-secondary)" },
-  { key: "cache_creation_tokens", label: "Cache write", color: "var(--status-info)" },
-  { key: "cache_read_tokens", label: "Cache read", color: "var(--text-tertiary)" },
+  {
+    key: "cache_creation_tokens",
+    label: "Cache write",
+    color: "var(--status-info)",
+  },
+  {
+    key: "cache_read_tokens",
+    label: "Cache read",
+    color: "var(--text-tertiary)",
+  },
 ] as const;
 
 const sessionTokens = (s: SessionUsage) =>
-  s.input_tokens + s.output_tokens + s.cache_creation_tokens + s.cache_read_tokens;
+  s.input_tokens +
+  s.output_tokens +
+  s.cache_creation_tokens +
+  s.cache_read_tokens;
 
 export function UsagePanel() {
   const cwd = useProjectStore((s) => s.currentProject?.path ?? null);
@@ -56,7 +67,8 @@ export function UsagePanel() {
 
   const { totals, sessions } = data;
   const useCost = totals.total_cost_usd > 0;
-  const metric = (s: SessionUsage) => (useCost ? s.total_cost_usd : sessionTokens(s));
+  const metric = (s: SessionUsage) =>
+    useCost ? s.total_cost_usd : sessionTokens(s);
 
   // Donut: top 5 sessions + "others".
   const top = sessions.slice(0, 5);
@@ -66,10 +78,14 @@ export function UsagePanel() {
     value: metric(s),
     color: SESSION_COLORS[i] ?? OTHERS_COLOR,
   }));
-  if (restMetric > 0) segments.push({ label: "others", value: restMetric, color: OTHERS_COLOR });
+  if (restMetric > 0)
+    segments.push({ label: "others", value: restMetric, color: OTHERS_COLOR });
 
   const totalTokens =
-    totals.input_tokens + totals.output_tokens + totals.cache_creation_tokens + totals.cache_read_tokens;
+    totals.input_tokens +
+    totals.output_tokens +
+    totals.cache_creation_tokens +
+    totals.cache_read_tokens;
 
   return (
     <div className="h-full overflow-y-auto hide-scrollbar px-3 py-3 space-y-4">
@@ -96,17 +112,26 @@ export function UsagePanel() {
       <div className="space-y-1.5">
         <div className="flex h-2 w-full overflow-hidden rounded-full bg-[var(--border-default)]">
           {TOKEN_TYPES.map((t) => {
-            const pct = totalTokens > 0 ? (totals[t.key] / totalTokens) * 100 : 0;
+            const pct =
+              totalTokens > 0 ? (totals[t.key] / totalTokens) * 100 : 0;
             return pct > 0 ? (
-              <div key={t.key} style={{ width: `${pct}%`, background: t.color }} />
+              <div
+                key={t.key}
+                style={{ width: `${pct}%`, background: t.color }}
+              />
             ) : null;
           })}
         </div>
         <div className="grid grid-cols-2 gap-x-3 gap-y-1">
           {TOKEN_TYPES.map((t) => (
             <div key={t.key} className="flex items-center gap-1.5 min-w-0">
-              <span className="w-2 h-2 rounded-full shrink-0" style={{ background: t.color }} />
-              <span className="text-[10px] text-text-tertiary truncate flex-1 min-w-0">{t.label}</span>
+              <span
+                className="w-2 h-2 rounded-full shrink-0"
+                style={{ background: t.color }}
+              />
+              <span className="text-[10px] text-text-tertiary truncate flex-1 min-w-0">
+                {t.label}
+              </span>
               <span className="text-[10px] font-mono tabular-nums text-text-secondary shrink-0">
                 {fmtTokens(totals[t.key])}
               </span>
@@ -163,8 +188,12 @@ export function UsagePanel() {
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-border-default bg-bg-secondary px-2 py-1.5 flex flex-col gap-0.5 min-w-0">
-      <span className="text-[9px] text-text-tertiary uppercase tracking-wider truncate">{label}</span>
-      <span className="text-[12px] font-mono tabular-nums text-text-primary truncate">{value}</span>
+      <span className="text-[9px] text-text-tertiary uppercase tracking-wider truncate">
+        {label}
+      </span>
+      <span className="text-[12px] font-mono tabular-nums text-text-primary truncate">
+        {value}
+      </span>
     </div>
   );
 }

--- a/src/features/monitor/lib/usage-format.ts
+++ b/src/features/monitor/lib/usage-format.ts
@@ -11,5 +11,8 @@ export function fmtCost(n: number): string {
 
 export function fmtDate(ms: number | null): string {
   if (!ms) return "—";
-  return new Date(ms).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/src/features/monitor/stores/usage-report-store.ts
+++ b/src/features/monitor/stores/usage-report-store.ts
@@ -1,5 +1,8 @@
 import { create } from "zustand";
-import { getProjectUsage, type ProjectUsage } from "@/features/chat/lib/claude-api";
+import {
+  getProjectUsage,
+  type ProjectUsage,
+} from "@/features/chat/lib/claude-api";
 
 /**
  * Cached project-usage report, keyed by workspace cwd. The panel renders

--- a/src/features/monitor/stores/usage-store.ts
+++ b/src/features/monitor/stores/usage-store.ts
@@ -16,7 +16,12 @@ interface UsageState {
     timestamp: number;
   }>;
   actions: {
-    trackUsage: (provider: string, model: string, inputTokens: number, outputTokens: number) => void;
+    trackUsage: (
+      provider: string,
+      model: string,
+      inputTokens: number,
+      outputTokens: number,
+    ) => void;
     reset: () => void;
   };
 }
@@ -28,7 +33,7 @@ const COST_TABLE: Record<string, [number, number]> = {
   "claude-haiku-4-5-20251001": [0.8, 4],
   "gpt-4o": [2.5, 10],
   "gpt-4o-mini": [0.15, 0.6],
-  "o3": [10, 40],
+  o3: [10, 40],
   "gemini-2.5-pro-preview-06-05": [1.25, 10],
   "gemini-2.5-flash-preview-05-20": [0.15, 0.6],
   // BYOK model-chat — common direct-API models.
@@ -42,13 +47,19 @@ const COST_TABLE: Record<string, [number, number]> = {
   "deepseek-reasoner": [0.55, 2.19],
   "grok-4": [3, 15],
   "llama-3.3-70b-versatile": [0.59, 0.79],
-  "sonar": [1, 1],
+  sonar: [1, 1],
   "sonar-pro": [3, 15],
 };
 
-function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
+function estimateCost(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
   const rates = COST_TABLE[model] ?? [1, 3]; // fallback
-  return (inputTokens / 1_000_000) * rates[0] + (outputTokens / 1_000_000) * rates[1];
+  return (
+    (inputTokens / 1_000_000) * rates[0] + (outputTokens / 1_000_000) * rates[1]
+  );
 }
 
 export const useUsageStore = createSelectors(
@@ -69,7 +80,14 @@ export const useUsageStore = createSelectors(
           requestCount: s.requestCount + 1,
           history: [
             ...s.history,
-            { provider, model, inputTokens, outputTokens, cost, timestamp: Date.now() },
+            {
+              provider,
+              model,
+              inputTokens,
+              outputTokens,
+              cost,
+              timestamp: Date.now(),
+            },
           ].slice(-500),
         }));
       },
@@ -83,5 +101,5 @@ export const useUsageStore = createSelectors(
           history: [],
         }),
     },
-  }))
+  })),
 );

--- a/src/features/node-setup/components/node-setup-banner.tsx
+++ b/src/features/node-setup/components/node-setup-banner.tsx
@@ -56,7 +56,10 @@ export function NodeSetupBanner() {
       : "Installing Node…";
   return (
     <StatusPill>
-      <Loader2 size={11} className="animate-spin text-[var(--accent-primary)]" />
+      <Loader2
+        size={11}
+        className="animate-spin text-[var(--accent-primary)]"
+      />
       <span>{label}</span>
     </StatusPill>
   );

--- a/src/features/node-setup/lib/node-setup-api.ts
+++ b/src/features/node-setup/lib/node-setup-api.ts
@@ -36,7 +36,9 @@ export const nodeSetup = {
 export const listenNodeInstallProgress = (
   handler: (p: NodeInstallProgress) => void,
 ): Promise<UnlistenFn> =>
-  listen<NodeInstallProgress>("atlas:node-install:progress", (e) => handler(e.payload));
+  listen<NodeInstallProgress>("atlas:node-install:progress", (e) =>
+    handler(e.payload),
+  );
 
 export const listenNodeInstallDone = (
   handler: (p: NodeInstallDone) => void,

--- a/src/features/node-setup/stores/node-setup-store.ts
+++ b/src/features/node-setup/stores/node-setup-store.ts
@@ -116,7 +116,8 @@ export const useNodeSetupStore = createSelectors(
       const progressUnlisten = await listenNodeInstallProgress((p) => {
         set((s) => {
           const next = [...s.installLog, p.line];
-          if (next.length > LOG_LINE_CAP) next.splice(0, next.length - LOG_LINE_CAP);
+          if (next.length > LOG_LINE_CAP)
+            next.splice(0, next.length - LOG_LINE_CAP);
           return { installLog: next };
         });
       });
@@ -135,7 +136,10 @@ export const useNodeSetupStore = createSelectors(
           // cached/failed agent spawns and re-run ACP discovery.
           resetAgent();
           void useClaudeSetupStore.getState().actions.refreshStatus();
-          setTimeout(() => set({ phase: "ok", reason: null }), SUCCESS_FLASH_MS);
+          setTimeout(
+            () => set({ phase: "ok", reason: null }),
+            SUCCESS_FLASH_MS,
+          );
         } else {
           logEvent({
             source: "atlas",
@@ -146,7 +150,8 @@ export const useNodeSetupStore = createSelectors(
           });
           set({
             phase: "failed",
-            installError: p.error ?? "Node install failed. See the log for details.",
+            installError:
+              p.error ?? "Node install failed. See the log for details.",
           });
         }
       });

--- a/src/features/notifications/components/notification-panel.tsx
+++ b/src/features/notifications/components/notification-panel.tsx
@@ -1,11 +1,5 @@
 import { useMemo } from "react";
-import {
-  Bell,
-  Shield,
-  AlertTriangle,
-  X,
-  Sparkles,
-} from "lucide-react";
+import { Bell, Shield, AlertTriangle, X, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "@/lib/time-ago";
 import { AtlasIcon } from "@/components/atlas-icon";
@@ -20,7 +14,8 @@ import {
 function dayBucket(iso: string): string {
   const d = new Date(iso);
   const now = new Date();
-  const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const startOf = (x: Date) =>
+    new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
   const days = Math.round((startOf(now) - startOf(d)) / 86_400_000);
   if (days <= 0) return "Today";
   if (days === 1) return "Yesterday";
@@ -88,9 +83,15 @@ export function NotificationPanel() {
             <div className="grid h-full place-items-center px-6">
               <div className="text-center">
                 <div className="mx-auto grid h-11 w-11 place-items-center rounded-2xl border border-border-subtle bg-white/[0.03]">
-                  <Bell size={18} className="text-text-tertiary" strokeWidth={1.5} />
+                  <Bell
+                    size={18}
+                    className="text-text-tertiary"
+                    strokeWidth={1.5}
+                  />
                 </div>
-                <p className="mt-3 text-[12px] text-text-tertiary">No notifications</p>
+                <p className="mt-3 text-[12px] text-text-tertiary">
+                  No notifications
+                </p>
               </div>
             </div>
           ) : (
@@ -177,12 +178,20 @@ function NotificationIcon({ n }: { n: AppNotification }) {
   if (n.kind === "permission")
     return <Shield size={15} className="text-accent" strokeWidth={1.5} />;
   if (n.kind === "agent-failed" || n.kind === "chat-error")
-    return <AlertTriangle size={15} className="text-[var(--status-error)]" strokeWidth={1.5} />;
+    return (
+      <AlertTriangle
+        size={15}
+        className="text-[var(--status-error)]"
+        strokeWidth={1.5}
+      />
+    );
   if (n.kind === "chat-done" && n.provider)
     return <ProviderLogo id={n.provider} size={16} />;
   if (n.source === "agent")
     return <AtlasIcon size={16} className="rounded-[5px]" />;
-  return <Sparkles size={15} className="text-text-secondary" strokeWidth={1.5} />;
+  return (
+    <Sparkles size={15} className="text-text-secondary" strokeWidth={1.5} />
+  );
 }
 
 /** Best-effort: bring the originating chat into view. */

--- a/src/features/notifications/stores/notifications-store.ts
+++ b/src/features/notifications/stores/notifications-store.ts
@@ -30,7 +30,10 @@ export interface AppNotification {
 }
 
 /** Input for `add` — id/timestamp/read are filled in. */
-export type NewNotification = Omit<AppNotification, "id" | "timestamp" | "read">;
+export type NewNotification = Omit<
+  AppNotification,
+  "id" | "timestamp" | "read"
+>;
 
 const MAX_ITEMS = 100;
 
@@ -74,7 +77,9 @@ export const useNotificationsStore = createSelectors(
         set((s) => ({ items: s.items.filter((i) => i.id !== id) })),
       clearAll: () => set({ items: [] }),
       markAllRead: () =>
-        set((s) => ({ items: s.items.map((i) => (i.read ? i : { ...i, read: true })) })),
+        set((s) => ({
+          items: s.items.map((i) => (i.read ? i : { ...i, read: true })),
+        })),
       open: () =>
         set((s) => ({
           panelOpen: true,

--- a/src/features/organisations/components/create-org-dialog.tsx
+++ b/src/features/organisations/components/create-org-dialog.tsx
@@ -149,7 +149,9 @@ export function CreateOrgDialog({
       await switchOrg(id); // land the user in the org they just made
     } catch (e) {
       // Rust hands back a user-facing string (duplicate handle, offline, …).
-      toast.error(typeof e === "string" ? e : "Couldn't create the organisation.");
+      toast.error(
+        typeof e === "string" ? e : "Couldn't create the organisation.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -248,7 +250,9 @@ export function CreateOrgDialog({
                 <p
                   className={cn(
                     "mt-1 h-[13px] text-[10px] leading-[13px]",
-                    slug.kind === "taken" ? "text-error" : "text-[var(--text-tertiary)]",
+                    slug.kind === "taken"
+                      ? "text-error"
+                      : "text-[var(--text-tertiary)]",
                   )}
                 >
                   {slug.kind === "taken"

--- a/src/features/organisations/components/members-modal.tsx
+++ b/src/features/organisations/components/members-modal.tsx
@@ -131,7 +131,8 @@ export function MembersModal({
   const invalidInvites = pendingInvites.filter((e) => !isEmail(e));
 
   const submitInvite = async () => {
-    if (!orgId || pendingInvites.length === 0 || invalidInvites.length > 0) return;
+    if (!orgId || pendingInvites.length === 0 || invalidInvites.length > 0)
+      return;
     setInviting(true);
     // Sequential, not Promise.all: every /api/auth/* path shares one
     // 100-req/60s budget, and a partial failure should still leave the invites
@@ -178,9 +179,7 @@ export function MembersModal({
           className="fixed top-8.5 left-4 right-4 bottom-6 rounded-xl border border-[var(--border-default)] bg-[var(--bg-sidebar)] overflow-hidden flex flex-col shadow-[var(--shadow-overlay)] focus:outline-none"
           style={{ zIndex: "var(--z-modal)" as unknown as number }}
         >
-          <Dialog.Title className="sr-only">
-            Members of {org.name}
-          </Dialog.Title>
+          <Dialog.Title className="sr-only">Members of {org.name}</Dialog.Title>
 
           {/* Header — mirrors the git-graph fullscreen bar. */}
           <div className="flex items-center justify-between px-3 h-[32px] shrink-0 border-b border-border-subtle">
@@ -335,7 +334,9 @@ export function MembersModal({
                           snapshot.status === "signed-in" &&
                           snapshot.user?.id === m.userId
                         }
-                        onRole={(role) => orgId && void setRole(orgId, m.id, role)}
+                        onRole={(role) =>
+                          orgId && void setRole(orgId, m.id, role)
+                        }
                         onRemove={() => orgId && void remove(orgId, m)}
                       />
                     ))
@@ -401,7 +402,9 @@ function MemberRow({
             <span className="block truncate text-[12px] text-text-primary">
               {member.name || member.email}
               {isSelf && (
-                <span className="ml-1.5 text-[10px] text-text-tertiary">You</span>
+                <span className="ml-1.5 text-[10px] text-text-tertiary">
+                  You
+                </span>
               )}
             </span>
             {member.name && (
@@ -491,16 +494,28 @@ function InviteRow({
   return (
     <div className="border-b border-border-subtle">
       <div className="w-full flex items-center h-[40px] px-3 text-left transition-colors hover:bg-bg-hover">
-        <span className={cn(COL.person, "min-w-0 truncate text-[12px] text-text-primary")}>
+        <span
+          className={cn(
+            COL.person,
+            "min-w-0 truncate text-[12px] text-text-primary",
+          )}
+        >
           {invite.email}
         </span>
         <span className={cn(COL.role, "text-[11px] text-text-secondary")}>
           {invite.role ? ROLE_LABELS[invite.role] : "—"}
         </span>
-        <span className={cn(COL.joined, "text-[10px] text-text-tertiary capitalize")}>
+        <span
+          className={cn(
+            COL.joined,
+            "text-[10px] text-text-tertiary capitalize",
+          )}
+        >
           {invite.status}
         </span>
-        <span className={cn(COL.actions, "flex items-center justify-end gap-0.5")}>
+        <span
+          className={cn(COL.actions, "flex items-center justify-end gap-0.5")}
+        >
           {invite.acceptUrl && (
             <button
               onClick={() =>

--- a/src/features/organisations/components/org-switcher.tsx
+++ b/src/features/organisations/components/org-switcher.tsx
@@ -44,7 +44,11 @@ function OrgAvatar({ org, size = 20 }: { org: Organisation; size?: number }) {
       }}
     >
       {org.logo ? (
-        <img src={org.logo} alt="" className="h-full w-full rounded-[5px] object-cover" />
+        <img
+          src={org.logo}
+          alt=""
+          className="h-full w-full rounded-[5px] object-cover"
+        />
       ) : (
         initials(org.name)
       )}
@@ -90,9 +94,13 @@ export function OrgSwitcher() {
     org: Organisation,
   ): { ok: true } | { ok: false; reason: string } => {
     if (!(org.syncEnabled && org.remoteId)) return { ok: true };
-    if (!signedIn) return { ok: false, reason: "Sign in to open this synced organisation" };
+    if (!signedIn)
+      return { ok: false, reason: "Sign in to open this synced organisation" };
     if (myOrgIds && !myOrgIds.has(org.remoteId)) {
-      return { ok: false, reason: "This account isn't a member of this organisation" };
+      return {
+        ok: false,
+        reason: "This account isn't a member of this organisation",
+      };
     }
     return { ok: true };
   };
@@ -114,7 +122,8 @@ export function OrgSwitcher() {
   const [membersOpen, setMembersOpen] = useState(false);
 
   const active =
-    organisations.find((o) => o.id === activeOrganisationId) ?? organisations[0];
+    organisations.find((o) => o.id === activeOrganisationId) ??
+    organisations[0];
   /** Members are a SERVER surface, so this needs both halves: an org that
    *  actually exists server-side, AND a live credential to talk to it with.
    *  Signing out does not un-sync an org — you stay in it, and every member
@@ -169,7 +178,10 @@ export function OrgSwitcher() {
           >
             <OrgAvatar org={active} size={16} />
             <span className="text-left truncate">{active.name}</span>
-            <ChevronsUpDown size={12} className="text-[var(--text-tertiary)] shrink-0" />
+            <ChevronsUpDown
+              size={12}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
           </button>
         </DropdownMenu.Trigger>
 
@@ -206,7 +218,10 @@ export function OrgSwitcher() {
                   }}
                   className="flex items-center justify-center h-5 w-5 rounded-full border border-[var(--border-default)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] outline-none transition-colors shrink-0 cursor-pointer disabled:opacity-50"
                 >
-                  <RefreshCw size={10} className={refreshing ? "animate-spin" : ""} />
+                  <RefreshCw
+                    size={10}
+                    className={refreshing ? "animate-spin" : ""}
+                  />
                 </button>
               )}
             </div>
@@ -256,7 +271,9 @@ export function OrgSwitcher() {
                     )}
                   >
                     <OrgAvatar org={org} size={18} />
-                    <span className="flex-1 text-left truncate">{org.name}</span>
+                    <span className="flex-1 text-left truncate">
+                      {org.name}
+                    </span>
                     {/* A locked org offers no row actions — you can't manage an
                         org this account has no access to. */}
                     {/* Rename (pencil) — appears on hover; doesn't switch/close. */}
@@ -290,10 +307,16 @@ export function OrgSwitcher() {
                       </button>
                     )}
                     {!access.ok ? (
-                      <Lock size={11} className="text-[var(--text-tertiary)] shrink-0" />
+                      <Lock
+                        size={11}
+                        className="text-[var(--text-tertiary)] shrink-0"
+                      />
                     ) : (
                       isActive && (
-                        <Check size={13} className="text-[var(--text-secondary)] shrink-0" />
+                        <Check
+                          size={13}
+                          className="text-[var(--text-secondary)] shrink-0"
+                        />
                       )
                     )}
                   </DropdownMenu.Item>
@@ -312,7 +335,10 @@ export function OrgSwitcher() {
               }}
               className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] outline-none hover:bg-[var(--bg-active)] hover:text-[var(--text-primary)] cursor-pointer shrink-0"
             >
-              <Plus size={13} className="text-[var(--text-tertiary)] shrink-0" />
+              <Plus
+                size={13}
+                className="text-[var(--text-tertiary)] shrink-0"
+              />
               <span className="flex-1 text-left">Create organisation…</span>
             </DropdownMenu.Item>
 
@@ -326,8 +352,13 @@ export function OrgSwitcher() {
                 }}
                 className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] outline-none hover:bg-[var(--bg-active)] hover:text-[var(--text-primary)] cursor-pointer shrink-0"
               >
-                <Users size={13} className="text-[var(--text-tertiary)] shrink-0" />
-                <span className="flex-1 text-left">Invite &amp; Manage members</span>
+                <Users
+                  size={13}
+                  className="text-[var(--text-tertiary)] shrink-0"
+                />
+                <span className="flex-1 text-left">
+                  Invite &amp; Manage members
+                </span>
               </DropdownMenu.Item>
             ) : (
               <div
@@ -339,7 +370,9 @@ export function OrgSwitcher() {
                 className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] text-[var(--text-secondary)] opacity-40 cursor-not-allowed select-none shrink-0"
               >
                 <Users size={13} className="shrink-0" />
-                <span className="flex-1 text-left">Invite &amp; Manage members</span>
+                <span className="flex-1 text-left">
+                  Invite &amp; Manage members
+                </span>
               </div>
             )}
 
@@ -353,7 +386,10 @@ export function OrgSwitcher() {
                 title="Syncing…"
                 className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] text-[var(--text-secondary)] select-none"
               >
-                <Loader2 size={13} className="shrink-0 animate-spin text-[var(--text-tertiary)]" />
+                <Loader2
+                  size={13}
+                  className="shrink-0 animate-spin text-[var(--text-tertiary)]"
+                />
                 <span className="flex-1 text-left truncate">
                   Syncing {active.name}…
                 </span>
@@ -363,11 +399,17 @@ export function OrgSwitcher() {
                 title="This organisation is synced with your Atlas account"
                 className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] text-[var(--text-secondary)] select-none"
               >
-                <Cloud size={13} className="shrink-0 text-[var(--text-tertiary)]" />
+                <Cloud
+                  size={13}
+                  className="shrink-0 text-[var(--text-tertiary)]"
+                />
                 <span className="flex-1 text-left truncate">
                   {active.name} is synced
                 </span>
-                <Check size={12} className="shrink-0 text-[var(--text-secondary)]" />
+                <Check
+                  size={12}
+                  className="shrink-0 text-[var(--text-secondary)]"
+                />
               </div>
             ) : (
               <DropdownMenu.Item
@@ -458,7 +500,12 @@ function DeleteOrgDialog({
             This permanently removes the organisation
             {projectCount > 0 && (
               <>
-                {" "}and its <span className="text-[var(--text-primary)]">{projectCount} project{projectCount === 1 ? "" : "s"}</span> (plus their chats)
+                {" "}
+                and its{" "}
+                <span className="text-[var(--text-primary)]">
+                  {projectCount} project{projectCount === 1 ? "" : "s"}
+                </span>{" "}
+                (plus their chats)
               </>
             )}{" "}
             from Atlas. Your actual project files on disk are not touched. This

--- a/src/features/organisations/lib/org-switch.ts
+++ b/src/features/organisations/lib/org-switch.ts
@@ -43,15 +43,17 @@ export async function switchOrg(id: string): Promise<void> {
   try {
     const wsActions = useWorkspaceStore.getState().actions;
     const projectActions = useProjectStore.getState().actions;
-    const outgoingActiveWs =
-      useWorkspaceStore.getState().activeWorkspaceId;
+    const outgoingActiveWs = useWorkspaceStore.getState().activeWorkspaceId;
     const outgoingPath =
       useProjectStore.getState().currentProject?.path ?? null;
 
     // 1) Remember the outgoing org's active workspace so switching back
     //    restores the user where they left off.
     if (activeOrganisationId) {
-      orgActions.setActiveWorkspaceForOrg(activeOrganisationId, outgoingActiveWs);
+      orgActions.setActiveWorkspaceForOrg(
+        activeOrganisationId,
+        outgoingActiveWs,
+      );
     }
 
     // 2) Flush the active workspace's unsaved state (KB buffer, editor tabs)
@@ -130,7 +132,10 @@ export async function deleteOrgAndData(id: string): Promise<boolean> {
   // anyway"). A non-admin who stays a member on the server may see it return on
   // the next sync; that is the accepted tradeoff. Only signed-in, only if the
   // org was ever linked.
-  if (target?.remoteId && useAuthStore.getState().snapshot.status === "signed-in") {
+  if (
+    target?.remoteId &&
+    useAuthStore.getState().snapshot.status === "signed-in"
+  ) {
     try {
       await auth.deleteOrg(target.remoteId);
     } catch (e) {

--- a/src/features/organisations/stores/members-store.ts
+++ b/src/features/organisations/stores/members-store.ts
@@ -71,7 +71,10 @@ export const useMembersStore = createSelectors(
     const roster = (orgId: string): OrgRoster => get().byOrg[orgId] ?? EMPTY;
     const patch = (orgId: string, next: Partial<OrgRoster>) =>
       set((s) => ({
-        byOrg: { ...s.byOrg, [orgId]: { ...(s.byOrg[orgId] ?? EMPTY), ...next } },
+        byOrg: {
+          ...s.byOrg,
+          [orgId]: { ...(s.byOrg[orgId] ?? EMPTY), ...next },
+        },
       }));
 
     return {
@@ -81,7 +84,8 @@ export const useMembersStore = createSelectors(
           if (!orgId) return;
           const current = roster(orgId);
           const fresh =
-            current.loadedAt !== null && Date.now() - current.loadedAt < FRESH_MS;
+            current.loadedAt !== null &&
+            Date.now() - current.loadedAt < FRESH_MS;
           if (!opts?.force && (fresh || inFlight.has(orgId))) return;
           if (inFlight.has(orgId)) return;
 
@@ -120,7 +124,9 @@ export const useMembersStore = createSelectors(
         setRole: async (orgId, memberId, role) => {
           const before = roster(orgId).members;
           patch(orgId, {
-            members: before.map((m) => (m.id === memberId ? { ...m, role } : m)),
+            members: before.map((m) =>
+              m.id === memberId ? { ...m, role } : m,
+            ),
           });
           try {
             await auth.updateMemberRole(orgId, memberId, role);
@@ -155,7 +161,9 @@ export const useMembersStore = createSelectors(
             });
             return invitation;
           } catch (e) {
-            toast.error(typeof e === "string" ? e : "Couldn't send that invite.");
+            toast.error(
+              typeof e === "string" ? e : "Couldn't send that invite.",
+            );
             return null;
           }
         },

--- a/src/features/organisations/stores/org-store.ts
+++ b/src/features/organisations/stores/org-store.ts
@@ -23,7 +23,9 @@ function nameTaken(
   exceptId?: string,
 ): boolean {
   const norm = name.trim().toLowerCase();
-  return orgs.some((o) => o.id !== exceptId && o.name.trim().toLowerCase() === norm);
+  return orgs.some(
+    (o) => o.id !== exceptId && o.name.trim().toLowerCase() === norm,
+  );
 }
 
 /**
@@ -139,7 +141,10 @@ interface OrgState {
      *  (the caller must reassign/close those first). Returns whether removed. */
     deleteOrg: (id: string) => boolean;
     /** Record the per-org last-active workspace (restore target on switch). */
-    setActiveWorkspaceForOrg: (orgId: string, workspaceId: string | null) => void;
+    setActiveWorkspaceForOrg: (
+      orgId: string,
+      workspaceId: string | null,
+    ) => void;
     /** Low-level setter used by the org-switch orchestration + overlay gate. */
     setSwitching: (v: boolean) => void;
     /** Set the active org id (authoritative swap; called by org-switch). */
@@ -410,7 +415,9 @@ export const useOrgStore = createSelectors(
             payload: { orgId: id, remoteId },
           });
         } catch (e) {
-          toast.error(typeof e === "string" ? e : "Couldn't sync organisation.");
+          toast.error(
+            typeof e === "string" ? e : "Couldn't sync organisation.",
+          );
         }
       },
 

--- a/src/features/pdf/components/annotation-layer.tsx
+++ b/src/features/pdf/components/annotation-layer.tsx
@@ -1,4 +1,8 @@
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Trash2 } from "lucide-react";
 import {
   usePdfAnnotationStore,
@@ -31,12 +35,18 @@ const MIN_HIGHLIGHT = 0.005; // ignore stray taps
  * tool is "none" the layer is click-through so PDF text selection/links work;
  * note pins stay interactive regardless so notes can always be read/edited.
  */
-export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayerProps) {
+export function AnnotationLayer({
+  pdfPath,
+  page,
+  pageW,
+  pageH,
+}: AnnotationLayerProps) {
   const tool = usePdfAnnotationStore.use.tool();
   const color = usePdfAnnotationStore.use.color();
   const selectedId = usePdfAnnotationStore.use.selectedId();
   const byPath = usePdfAnnotationStore.use.byPath();
-  const { add, remove, select, updateNoteText } = usePdfAnnotationStore.use.actions();
+  const { add, remove, select, updateNoteText } =
+    usePdfAnnotationStore.use.actions();
 
   const annotations = (byPath[pdfPath] ?? []).filter((a) => a.page === page);
   const [draft, setDraft] = useState<Draft | null>(null);
@@ -69,7 +79,11 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
       return;
     }
     if (tool === "highlight") {
-      setDraft({ kind: "highlight", start: p, rect: { x: p.x, y: p.y, w: 0, h: 0 } });
+      setDraft({
+        kind: "highlight",
+        start: p,
+        rect: { x: p.x, y: p.y, w: 0, h: 0 },
+      });
     } else if (tool === "pencil") {
       setDraft({ kind: "pencil", start: p, points: [p] });
     }
@@ -95,7 +109,12 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
 
   const onPointerUp = () => {
     if (!draft) return;
-    if (draft.kind === "highlight" && draft.rect && draft.rect.w > MIN_HIGHLIGHT && draft.rect.h > MIN_HIGHLIGHT) {
+    if (
+      draft.kind === "highlight" &&
+      draft.rect &&
+      draft.rect.w > MIN_HIGHLIGHT &&
+      draft.rect.h > MIN_HIGHLIGHT
+    ) {
       add(pdfPath, {
         id: newAnnotationId(),
         kind: "highlight",
@@ -104,7 +123,11 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
         rect: draft.rect,
         createdAt: new Date().toISOString(),
       });
-    } else if (draft.kind === "pencil" && draft.points && draft.points.length > 1) {
+    } else if (
+      draft.kind === "pencil" &&
+      draft.points &&
+      draft.points.length > 1
+    ) {
       add(pdfPath, {
         id: newAnnotationId(),
         kind: "pencil",
@@ -121,7 +144,9 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
     if (tool === "erase") remove(pdfPath, a.id);
   };
 
-  const notes = annotations.filter((a): a is Extract<PdfAnnotation, { kind: "note" }> => a.kind === "note");
+  const notes = annotations.filter(
+    (a): a is Extract<PdfAnnotation, { kind: "note" }> => a.kind === "note",
+  );
   const selectedNote = notes.find((n) => n.id === selectedId);
 
   return (
@@ -140,7 +165,12 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
         className="absolute inset-0"
         style={{
           pointerEvents: tool === "none" ? "none" : "auto",
-          cursor: tool === "pencil" ? "crosshair" : tool === "erase" ? "not-allowed" : "default",
+          cursor:
+            tool === "pencil"
+              ? "crosshair"
+              : tool === "erase"
+                ? "not-allowed"
+                : "default",
           touchAction: "none",
         }}
         onPointerDown={onPointerDown}
@@ -167,7 +197,9 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
             return (
               <polyline
                 key={a.id}
-                points={a.points.map((p) => `${p.x * pageW},${p.y * pageH}`).join(" ")}
+                points={a.points
+                  .map((p) => `${p.x * pageW},${p.y * pageH}`)
+                  .join(" ")}
                 fill="none"
                 stroke={a.color}
                 strokeWidth={2}
@@ -194,7 +226,9 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
         )}
         {draft?.kind === "pencil" && draft.points && (
           <polyline
-            points={draft.points.map((p) => `${p.x * pageW},${p.y * pageH}`).join(" ")}
+            points={draft.points
+              .map((p) => `${p.x * pageW},${p.y * pageH}`)
+              .join(" ")}
             fill="none"
             stroke={color}
             strokeWidth={2}
@@ -209,7 +243,9 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
         <button
           key={n.id}
           type="button"
-          onClick={() => (tool === "erase" ? remove(pdfPath, n.id) : select(n.id))}
+          onClick={() =>
+            tool === "erase" ? remove(pdfPath, n.id) : select(n.id)
+          }
           className="absolute flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-black/20 text-[10px] font-bold text-black/70 shadow-sm"
           style={{
             left: n.x * pageW,
@@ -236,7 +272,9 @@ export function AnnotationLayer({ pdfPath, page, pageW, pageH }: AnnotationLayer
           <textarea
             autoFocus
             value={selectedNote.text}
-            onChange={(e) => updateNoteText(pdfPath, selectedNote.id, e.target.value)}
+            onChange={(e) =>
+              updateNoteText(pdfPath, selectedNote.id, e.target.value)
+            }
             placeholder="Write a note…"
             className="h-20 w-full resize-none rounded-sm border border-border-default bg-bg-base p-1.5 text-[12px] text-text-primary outline-none placeholder:text-text-tertiary"
           />

--- a/src/features/pdf/components/pdf-toolbar.tsx
+++ b/src/features/pdf/components/pdf-toolbar.tsx
@@ -1,4 +1,12 @@
-import { MousePointer2, Highlighter, Pencil, StickyNote, Eraser, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  MousePointer2,
+  Highlighter,
+  Pencil,
+  StickyNote,
+  Eraser,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   usePdfAnnotationStore,
@@ -22,7 +30,13 @@ const TOOLS: Array<{ tool: PdfTool; icon: typeof Pencil; label: string }> = [
   { tool: "erase", icon: Eraser, label: "Erase" },
 ];
 
-export function PdfToolbar({ fileName, zoom, dirty, onZoomIn, onZoomOut }: PdfToolbarProps) {
+export function PdfToolbar({
+  fileName,
+  zoom,
+  dirty,
+  onZoomIn,
+  onZoomOut,
+}: PdfToolbarProps) {
   const tool = usePdfAnnotationStore.use.tool();
   const color = usePdfAnnotationStore.use.color();
   const { setTool, setColor } = usePdfAnnotationStore.use.actions();
@@ -41,7 +55,7 @@ export function PdfToolbar({ fileName, zoom, dirty, onZoomIn, onZoomOut }: PdfTo
               "flex h-6 w-6 items-center justify-center rounded transition-colors",
               tool === t
                 ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
-                : "text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                : "text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]",
             )}
           >
             <Icon size={13} />
@@ -61,14 +75,19 @@ export function PdfToolbar({ fileName, zoom, dirty, onZoomIn, onZoomOut }: PdfTo
             title={c}
             className={cn(
               "h-3.5 w-3.5 rounded-full border transition-transform",
-              color === c ? "border-[var(--text-primary)] scale-110" : "border-black/20"
+              color === c
+                ? "border-[var(--text-primary)] scale-110"
+                : "border-black/20",
             )}
             style={{ background: c }}
           />
         ))}
       </div>
 
-      <div className="mx-1 flex flex-1 items-center justify-center gap-1.5 truncate text-[11px] font-mono text-[var(--text-tertiary)]" title={fileName}>
+      <div
+        className="mx-1 flex flex-1 items-center justify-center gap-1.5 truncate text-[11px] font-mono text-[var(--text-tertiary)]"
+        title={fileName}
+      >
         {/* Unsaved-changes dot — Cmd+S bakes annotations into the PDF file. */}
         {dirty && (
           <span
@@ -81,13 +100,23 @@ export function PdfToolbar({ fileName, zoom, dirty, onZoomIn, onZoomOut }: PdfTo
 
       {/* Zoom */}
       <div className="flex items-center gap-0.5">
-        <button type="button" onClick={onZoomOut} title="Zoom out" className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]">
+        <button
+          type="button"
+          onClick={onZoomOut}
+          title="Zoom out"
+          className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        >
           <ZoomOut size={13} />
         </button>
         <span className="w-9 text-center text-[10px] font-mono text-[var(--text-tertiary)]">
           {Math.round(zoom * 100)}%
         </span>
-        <button type="button" onClick={onZoomIn} title="Zoom in" className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]">
+        <button
+          type="button"
+          onClick={onZoomIn}
+          title="Zoom in"
+          className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+        >
           <ZoomIn size={13} />
         </button>
       </div>

--- a/src/features/pdf/components/pdf-viewer.tsx
+++ b/src/features/pdf/components/pdf-viewer.tsx
@@ -70,7 +70,10 @@ export function PdfViewer({ filePath, tabId }: PdfViewerProps) {
 
   // react-pdf wants a stable object; hand it a copy of the raw bytes (pdfjs
   // transfers the buffer to its worker, which would detach our `fileData`).
-  const pdfFile = useMemo(() => (fileData ? { data: fileData.slice() } : null), [fileData]);
+  const pdfFile = useMemo(
+    () => (fileData ? { data: fileData.slice() } : null),
+    [fileData],
+  );
 
   const pageWidth = useMemo(() => {
     const fit = Math.max(320, containerWidth - PAGE_PADDING);
@@ -112,20 +115,36 @@ export function PdfViewer({ filePath, tabId }: PdfViewerProps) {
         onZoomOut={() => setZoom((z) => Math.max(0.5, z - 0.2))}
       />
 
-      <div ref={scrollRef} className="flex flex-1 justify-center overflow-auto bg-[var(--bg-canvas)] p-8">
+      <div
+        ref={scrollRef}
+        className="flex flex-1 justify-center overflow-auto bg-[var(--bg-canvas)] p-8"
+      >
         {error ? (
-          <div className="mt-20 text-[12px] text-[var(--status-error)]">{error}</div>
+          <div className="mt-20 text-[12px] text-[var(--status-error)]">
+            {error}
+          </div>
         ) : pdfFile ? (
           <Document
             file={pdfFile}
             onLoadSuccess={(pdf) => setNumPages(pdf.numPages)}
-            onLoadError={(e) => setError(e.message || "Failed to load PDF document.")}
+            onLoadError={(e) =>
+              setError(e.message || "Failed to load PDF document.")
+            }
             loading={<PdfSpinner label="Loading PDF" />}
-            error={<div className="mt-20 text-[12px] text-[var(--status-error)]">Failed to load PDF document.</div>}
+            error={
+              <div className="mt-20 text-[12px] text-[var(--status-error)]">
+                Failed to load PDF document.
+              </div>
+            }
             className="flex flex-col items-center gap-4"
           >
             {Array.from({ length: numPages }, (_, i) => (
-              <PdfPage key={i} pdfPath={filePath} pageNumber={i + 1} width={pageWidth} />
+              <PdfPage
+                key={i}
+                pdfPath={filePath}
+                pageNumber={i + 1}
+                width={pageWidth}
+              />
             ))}
           </Document>
         ) : (
@@ -138,23 +157,48 @@ export function PdfViewer({ filePath, tabId }: PdfViewerProps) {
 
 /** One rendered page + its annotation overlay. Measures its own rendered size
  *  so the overlay (normalized coords) maps to exact pixels. */
-function PdfPage({ pdfPath, pageNumber, width }: { pdfPath: string; pageNumber: number; width: number }) {
+function PdfPage({
+  pdfPath,
+  pageNumber,
+  width,
+}: {
+  pdfPath: string;
+  pageNumber: number;
+  width: number;
+}) {
   const ref = useRef<HTMLDivElement>(null);
   const { width: w, height: h } = useElementSize(ref);
   return (
-    <div ref={ref} className="relative bg-white shadow-lg" data-page-number={pageNumber}>
+    <div
+      ref={ref}
+      className="relative bg-white shadow-lg"
+      data-page-number={pageNumber}
+    >
       <Page
         pageNumber={pageNumber}
         width={width}
         renderTextLayer
         renderAnnotationLayer
         loading={
-          <div className="flex items-center justify-center bg-white" style={{ width, height: width * 1.29 }}>
-            <Loader2 size={16} className="animate-spin text-[var(--text-tertiary)]" />
+          <div
+            className="flex items-center justify-center bg-white"
+            style={{ width, height: width * 1.29 }}
+          >
+            <Loader2
+              size={16}
+              className="animate-spin text-[var(--text-tertiary)]"
+            />
           </div>
         }
       />
-      {w > 0 && h > 0 && <AnnotationLayer pdfPath={pdfPath} page={pageNumber} pageW={w} pageH={h} />}
+      {w > 0 && h > 0 && (
+        <AnnotationLayer
+          pdfPath={pdfPath}
+          page={pageNumber}
+          pageW={w}
+          pageH={h}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/pdf/hooks/use-element-size.ts
+++ b/src/features/pdf/hooks/use-element-size.ts
@@ -12,7 +12,8 @@ export function useElementSize(ref: RefObject<HTMLElement | null>): {
     if (!el) return;
     const ro = new ResizeObserver((entries) => {
       const r = entries[0]?.contentRect;
-      if (r) setSize({ width: Math.round(r.width), height: Math.round(r.height) });
+      if (r)
+        setSize({ width: Math.round(r.width), height: Math.round(r.height) });
     });
     ro.observe(el);
     return () => ro.disconnect();

--- a/src/features/pdf/stores/pdf-annotation-store.ts
+++ b/src/features/pdf/stores/pdf-annotation-store.ts
@@ -128,7 +128,9 @@ export const usePdfAnnotationStore = createSelectors(
         },
         remove: (pdfPath, id) => {
           set((s) => {
-            s.byPath[pdfPath] = (s.byPath[pdfPath] ?? []).filter((a) => a.id !== id);
+            s.byPath[pdfPath] = (s.byPath[pdfPath] ?? []).filter(
+              (a) => a.id !== id,
+            );
             s.dirty[pdfPath] = true;
             if (s.selectedId === id) s.selectedId = null;
           });
@@ -155,7 +157,11 @@ export const usePdfAnnotationStore = createSelectors(
           if (!projectPath) return;
           const annotations = get().byPath[pdfPath] ?? [];
           try {
-            await invoke("pdf_annotations_save", { projectPath, pdfPath, annotations });
+            await invoke("pdf_annotations_save", {
+              projectPath,
+              pdfPath,
+              annotations,
+            });
             set((s) => {
               s.dirty[pdfPath] = false;
             });
@@ -164,8 +170,8 @@ export const usePdfAnnotationStore = createSelectors(
           }
         },
       },
-    }))
-  )
+    })),
+  ),
 );
 
 export function newAnnotationId(): string {

--- a/src/features/pomodoro/components/active-timer.tsx
+++ b/src/features/pomodoro/components/active-timer.tsx
@@ -74,8 +74,16 @@ export function ActiveTimer() {
               No session running
             </div>
             <div className="inline-flex items-stretch rounded-md overflow-hidden bg-bg-elevated border border-border-default text-text-primary mt-3 divide-x divide-border-default shadow-[0_2px_8px_rgba(0,0,0,0.35)]">
-              <GroupedActionBtn icon={Zap} label="Quick start" onClick={quickStart} />
-              <GroupedActionBtn icon={Download} label="Export" onClick={handleExport} />
+              <GroupedActionBtn
+                icon={Zap}
+                label="Quick start"
+                onClick={quickStart}
+              />
+              <GroupedActionBtn
+                icon={Download}
+                label="Export"
+                onClick={handleExport}
+              />
               <GroupedActionBtn
                 icon={Trash2}
                 label="Clear all"
@@ -135,7 +143,9 @@ export function ActiveTimer() {
       </div>
 
       <div className="px-5 pb-4">
-        <div className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider mb-2">Cycles</div>
+        <div className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+          Cycles
+        </div>
         <div className="flex gap-1.5">
           {Array.from({ length: cyclesPlanned }, (_, i) => {
             const done = i < cycleIdx;
@@ -158,7 +168,9 @@ export function ActiveTimer() {
       </div>
 
       <div className="px-5 pb-4">
-        <div className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider mb-2">Preset</div>
+        <div className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+          Preset
+        </div>
         <div className="flex flex-wrap gap-1.5">
           {PRESETS.filter((p) => p.id !== "custom").map((p) => {
             const active = p.id === presetId;
@@ -184,7 +196,9 @@ export function ActiveTimer() {
 
       {today && (
         <div className="px-5 pb-5 mt-auto">
-          <div className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider mb-2">Today</div>
+          <div className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider mb-2">
+            Today
+          </div>
           <div className="grid grid-cols-2 gap-2">
             <Stat label="Focus" value={fmtDur(today.focusMin)} />
             <Stat label="Sessions" value={String(today.sessions)} />

--- a/src/features/pomodoro/components/day-card.tsx
+++ b/src/features/pomodoro/components/day-card.tsx
@@ -21,9 +21,7 @@ export function DayCard({ day, active, onClick }: Props) {
       onClick={onClick}
       className={cn(
         "w-full flex items-stretch gap-3 px-4 py-3 text-left border-b border-border-subtle outline-none transition-colors cursor-pointer",
-        active
-          ? "bg-bg-elevated"
-          : "hover:bg-bg-hover",
+        active ? "bg-bg-elevated" : "hover:bg-bg-hover",
       )}
     >
       <div className="w-12 shrink-0 flex flex-col items-start justify-center leading-none">
@@ -40,7 +38,9 @@ export function DayCard({ day, active, onClick }: Props) {
         <div className="flex items-center gap-2 text-[11px] text-text-tertiary">
           <span>{fmtDur(day.focusMin)}</span>
           <span className="text-text-tertiary/50">·</span>
-          <span>{day.sessions} session{day.sessions === 1 ? "" : "s"}</span>
+          <span>
+            {day.sessions} session{day.sessions === 1 ? "" : "s"}
+          </span>
         </div>
         {day.sessions === 0 && (
           <p className="text-[11px] text-text-secondary leading-snug line-clamp-2">
@@ -50,7 +50,10 @@ export function DayCard({ day, active, onClick }: Props) {
       </div>
       <ChevronRight
         size={12}
-        className={cn("self-center shrink-0", active ? "text-text-primary" : "text-text-tertiary/60")}
+        className={cn(
+          "self-center shrink-0",
+          active ? "text-text-primary" : "text-text-tertiary/60",
+        )}
       />
     </button>
   );

--- a/src/features/pomodoro/components/day-rail.tsx
+++ b/src/features/pomodoro/components/day-rail.tsx
@@ -13,7 +13,8 @@ export function DayRail() {
   const [activeTag, setActiveTag] = useState<string | null>(null);
 
   const filtered = days.filter((d) => {
-    if (q && !(d.summary ?? "").toLowerCase().includes(q.toLowerCase())) return false;
+    if (q && !(d.summary ?? "").toLowerCase().includes(q.toLowerCase()))
+      return false;
     return true;
   });
 

--- a/src/features/pomodoro/components/day-timeline.tsx
+++ b/src/features/pomodoro/components/day-timeline.tsx
@@ -15,11 +15,14 @@ interface Props {
 }
 
 export function DayTimeline({ day, blocks, nowMin, onNewSession }: Props) {
-  const dateStr = new Date(day.date + "T00:00:00").toLocaleDateString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
+  const dateStr = new Date(day.date + "T00:00:00").toLocaleDateString(
+    undefined,
+    {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    },
+  );
 
   // Auto-fit the hour gutter to the work-hours range, expanding to cover
   // any block or the current time outside it.
@@ -35,7 +38,10 @@ export function DayTimeline({ day, blocks, nowMin, onNewSession }: Props) {
   }
   startHour = Math.max(0, startHour);
   endHour = Math.min(24, endHour);
-  const hours = Array.from({ length: endHour - startHour + 1 }, (_, i) => startHour + i);
+  const hours = Array.from(
+    { length: endHour - startHour + 1 },
+    (_, i) => startHour + i,
+  );
   const totalHeight = (endHour - startHour) * HOUR_PX;
 
   const minToY = (m: number) => ((m - startHour * 60) / 60) * HOUR_PX;
@@ -54,7 +60,9 @@ export function DayTimeline({ day, blocks, nowMin, onNewSession }: Props) {
           <div className="flex items-center gap-2 text-[11px] text-text-tertiary whitespace-nowrap mt-2">
             <span>{fmtDur(day.focusMin)} focus</span>
             <span className="text-text-tertiary/50">·</span>
-            <span>{day.sessions} session{day.sessions === 1 ? "" : "s"}</span>
+            <span>
+              {day.sessions} session{day.sessions === 1 ? "" : "s"}
+            </span>
             {day.distractions > 0 && (
               <>
                 <span className="text-text-tertiary/50">·</span>
@@ -76,7 +84,10 @@ export function DayTimeline({ day, blocks, nowMin, onNewSession }: Props) {
         className="relative px-6 py-4"
         style={{ minHeight: totalHeight + 32 }}
       >
-        <div className="relative" style={{ height: totalHeight, marginLeft: 56 }}>
+        <div
+          className="relative"
+          style={{ height: totalHeight, marginLeft: 56 }}
+        >
           {hours.slice(0, -1).map((h, i) => (
             <div
               key={h}
@@ -209,7 +220,8 @@ function TimelineBlock({
         </div>
         {isFocus && (block.distractions ?? 0) > 0 && (
           <div className="text-[10px] text-text-tertiary">
-            {block.distractions} distraction{block.distractions === 1 ? "" : "s"}
+            {block.distractions} distraction
+            {block.distractions === 1 ? "" : "s"}
           </div>
         )}
       </div>

--- a/src/features/pomodoro/components/new-session-sheet.tsx
+++ b/src/features/pomodoro/components/new-session-sheet.tsx
@@ -107,7 +107,11 @@ export function NewSessionSheet() {
                 </Field>
                 <Field
                   label="Tags"
-                  hint={tags.length ? `${tags.length} selected` : "categorize this session"}
+                  hint={
+                    tags.length
+                      ? `${tags.length} selected`
+                      : "categorize this session"
+                  }
                 >
                   <TagInput value={tags} onChange={setTags} known={knownTags} />
                 </Field>
@@ -139,8 +143,12 @@ export function NewSessionSheet() {
                               : "border-border-default hover:bg-bg-hover",
                           )}
                         >
-                          <div className="text-[13px] font-medium text-text-primary">{p.label}</div>
-                          <div className="text-[11px] text-text-tertiary mt-0.5">{p.sub}</div>
+                          <div className="text-[13px] font-medium text-text-primary">
+                            {p.label}
+                          </div>
+                          <div className="text-[11px] text-text-tertiary mt-0.5">
+                            {p.sub}
+                          </div>
                         </button>
                       );
                     })}
@@ -154,7 +162,9 @@ export function NewSessionSheet() {
                         min={5}
                         max={180}
                         value={customFocus}
-                        onChange={(e) => setCustomFocus(parseInt(e.target.value || "0"))}
+                        onChange={(e) =>
+                          setCustomFocus(parseInt(e.target.value || "0"))
+                        }
                         className="w-full h-9 px-3 bg-bg-input border border-border-default rounded text-[13px] text-text-primary outline-none focus:border-border-focus tabular-nums"
                       />
                     </Field>
@@ -164,7 +174,9 @@ export function NewSessionSheet() {
                         min={1}
                         max={60}
                         value={customBreak}
-                        onChange={(e) => setCustomBreak(parseInt(e.target.value || "0"))}
+                        onChange={(e) =>
+                          setCustomBreak(parseInt(e.target.value || "0"))
+                        }
                         className="w-full h-9 px-3 bg-bg-input border border-border-default rounded text-[13px] text-text-primary outline-none focus:border-border-focus tabular-nums"
                       />
                     </Field>
@@ -172,7 +184,11 @@ export function NewSessionSheet() {
                 )}
                 <Field label="Cycles" hint={`≈ ${fmtDur(totalMin)} total`}>
                   <div className="flex items-center gap-2.5">
-                    <StepperBtn onClick={() => setCycles((c) => Math.max(1, c - 1))}>−</StepperBtn>
+                    <StepperBtn
+                      onClick={() => setCycles((c) => Math.max(1, c - 1))}
+                    >
+                      −
+                    </StepperBtn>
                     <div className="flex gap-1 flex-1">
                       {Array.from({ length: 8 }, (_, i) => {
                         const filled = i < cycles;
@@ -188,7 +204,11 @@ export function NewSessionSheet() {
                         );
                       })}
                     </div>
-                    <StepperBtn onClick={() => setCycles((c) => Math.min(8, c + 1))}>+</StepperBtn>
+                    <StepperBtn
+                      onClick={() => setCycles((c) => Math.min(8, c + 1))}
+                    >
+                      +
+                    </StepperBtn>
                     <span className="text-[13px] font-semibold text-text-primary min-w-[18px] text-right tabular-nums">
                       {cycles}
                     </span>
@@ -239,7 +259,9 @@ export function NewSessionSheet() {
                         <div
                           key={i}
                           className="flex gap-0.5"
-                          style={{ flex: `${focusMin + (i < cycles - 1 ? breakMin : 0)} 1 0` }}
+                          style={{
+                            flex: `${focusMin + (i < cycles - 1 ? breakMin : 0)} 1 0`,
+                          }}
                         >
                           <div
                             className="bg-text-primary rounded-sm flex items-center justify-center text-[10px] text-bg-primary font-semibold tabular-nums"
@@ -322,7 +344,9 @@ function Stepper({ step }: { step: number }) {
             >
               {l}
             </span>
-            {i < labels.length - 1 && <div className="w-6 h-px bg-border-default mx-1" />}
+            {i < labels.length - 1 && (
+              <div className="w-6 h-px bg-border-default mx-1" />
+            )}
           </div>
         );
       })}
@@ -345,7 +369,9 @@ function Field({
         <span className="text-[10px] font-semibold text-text-tertiary uppercase tracking-wider">
           {label}
         </span>
-        {hint && <span className="text-[11px] text-text-tertiary/70">{hint}</span>}
+        {hint && (
+          <span className="text-[11px] text-text-tertiary/70">{hint}</span>
+        )}
       </div>
       {children}
     </label>

--- a/src/features/pomodoro/components/tag-input.tsx
+++ b/src/features/pomodoro/components/tag-input.tsx
@@ -15,7 +15,12 @@ interface Props {
  * chips followed by an inline "+ Add" affordance. Suggestions for
  * existing (known) tags not yet selected appear below.
  */
-export function TagInput({ value, onChange, known, placeholder = "tag name" }: Props) {
+export function TagInput({
+  value,
+  onChange,
+  known,
+  placeholder = "tag name",
+}: Props) {
   const [adding, setAdding] = useState(false);
   const [draft, setDraft] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/features/pomodoro/lib/format.ts
+++ b/src/features/pomodoro/lib/format.ts
@@ -1,4 +1,5 @@
-export const padZ = (n: number) => String(Math.max(0, Math.floor(n))).padStart(2, "0");
+export const padZ = (n: number) =>
+  String(Math.max(0, Math.floor(n))).padStart(2, "0");
 
 export function fmtHM(mins: number): string {
   const m = Math.max(0, Math.floor(mins));

--- a/src/features/pomodoro/lib/presets.ts
+++ b/src/features/pomodoro/lib/presets.ts
@@ -11,8 +11,20 @@ export interface Preset {
 export const PRESETS: Preset[] = [
   { id: "25-5", label: "Classic", sub: "25 / 5", focusMin: 25, breakMin: 5 },
   { id: "50-10", label: "Deep", sub: "50 / 10", focusMin: 50, breakMin: 10 },
-  { id: "90-15", label: "Ultradian", sub: "90 / 15", focusMin: 90, breakMin: 15 },
-  { id: "custom", label: "Custom", sub: "pick your own", focusMin: 25, breakMin: 5 },
+  {
+    id: "90-15",
+    label: "Ultradian",
+    sub: "90 / 15",
+    focusMin: 90,
+    breakMin: 15,
+  },
+  {
+    id: "custom",
+    label: "Custom",
+    sub: "pick your own",
+    focusMin: 25,
+    breakMin: 5,
+  },
 ];
 
 export function presetById(id: PresetId): Preset {

--- a/src/features/pomodoro/stores/pomodoro-store.ts
+++ b/src/features/pomodoro/stores/pomodoro-store.ts
@@ -178,7 +178,9 @@ export const usePomodoroStore = createSelectors(
                 });
                 fireNotification(
                   "Back to focus",
-                  s.currentTask ? `Resuming: ${s.currentTask}` : "Cycle starting.",
+                  s.currentTask
+                    ? `Resuming: ${s.currentTask}`
+                    : "Cycle starting.",
                 );
               }
             }
@@ -306,7 +308,10 @@ export const usePomodoroStore = createSelectors(
                 ? normalized
                 : [{ ...emptyToday(), today: true }, ...normalized];
               s.activeDayIdx = 0;
-              s.blocks = (file?.blocks ?? []).map((b) => ({ ...b, current: false }));
+              s.blocks = (file?.blocks ?? []).map((b) => ({
+                ...b,
+                current: false,
+              }));
               s.knownTags = file?.knownTags ?? [];
               s.hydrated = true;
               s.hydratedFor = projectPath;
@@ -376,7 +381,11 @@ let lastSig = "";
 export function attachPersistence(projectPath: string) {
   return usePomodoroStore.subscribe((s) => {
     if (!s.hydrated) return;
-    const file: PomodoroFile = { days: s.days, blocks: s.blocks, knownTags: s.knownTags };
+    const file: PomodoroFile = {
+      days: s.days,
+      blocks: s.blocks,
+      knownTags: s.knownTags,
+    };
     const sig = JSON.stringify(file);
     if (sig === lastSig) return;
     lastSig = sig;

--- a/src/features/project/components/welcome-screen.tsx
+++ b/src/features/project/components/welcome-screen.tsx
@@ -1,10 +1,5 @@
 import { useProjectStore } from "../stores/project-store";
-import {
-  FolderOpen,
-  Clock,
-  X,
-  Folder,
-} from "lucide-react";
+import { FolderOpen, Clock, X, Folder } from "lucide-react";
 import { AtlasIcon } from "@/components/atlas-icon";
 
 export function WelcomeScreen() {
@@ -42,9 +37,16 @@ export function WelcomeScreen() {
           onClick={handleOpenFolder}
           className="w-full flex items-center gap-2.5 px-3 py-2 rounded-md border border-[var(--border-default)] bg-[var(--bg-secondary)] hover:bg-[var(--bg-hover)] hover:border-[var(--border-strong)] transition-colors text-left group"
         >
-          <FolderOpen size={14} className="text-[var(--accent-primary)] shrink-0" />
-          <span className="text-[12px] font-medium text-[var(--text-primary)]">Open Folder</span>
-          <span className="text-[10px] text-[var(--text-tertiary)] ml-auto font-mono">⌘O</span>
+          <FolderOpen
+            size={14}
+            className="text-[var(--accent-primary)] shrink-0"
+          />
+          <span className="text-[12px] font-medium text-[var(--text-primary)]">
+            Open Folder
+          </span>
+          <span className="text-[10px] text-[var(--text-tertiary)] ml-auto font-mono">
+            ⌘O
+          </span>
         </button>
 
         {/* Recent projects */}
@@ -93,11 +95,14 @@ export function WelcomeScreen() {
         {/* Hint */}
         <div className="text-center">
           <span className="text-[10px] text-[var(--text-tertiary)]">
-            Press <kbd className="px-1 py-0.5 rounded bg-[var(--bg-elevated)] border border-[var(--border-default)] text-[9px] font-mono">⌘K</kbd> for command palette
+            Press{" "}
+            <kbd className="px-1 py-0.5 rounded bg-[var(--bg-elevated)] border border-[var(--border-default)] text-[9px] font-mono">
+              ⌘K
+            </kbd>{" "}
+            for command palette
           </span>
         </div>
       </div>
     </div>
   );
 }
-

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -144,7 +144,10 @@ interface ProjectState {
     clearRecents: () => void;
     updateSettings: (partial: Partial<AppSettings>) => void;
     /** One-shot hydration from Rust. Called once on app boot. */
-    hydrate: (payload: AppStateWire, opts?: { skipActiveSwitch?: boolean }) => void;
+    hydrate: (
+      payload: AppStateWire,
+      opts?: { skipActiveSwitch?: boolean },
+    ) => void;
   };
 }
 
@@ -188,8 +191,8 @@ export async function flushAppStateSave(): Promise<void> {
     clearTimeout(saveTimer);
     saveTimer = null;
   }
-  await invoke("save_app_state", { payload: buildAppStatePayload() }).catch((e) =>
-    console.warn("flushAppStateSave failed:", e),
+  await invoke("save_app_state", { payload: buildAppStatePayload() }).catch(
+    (e) => console.warn("flushAppStateSave failed:", e),
   );
 }
 
@@ -246,13 +249,28 @@ function maybeEnsureAtlasGitignore(path: string, settings: AppSettings): void {
  */
 export async function loadProjectStores(path: string): Promise<void> {
   await Promise.all([
-    useExplorerStore.getState().actions.openFolder(path).catch((e) => console.error("Explorer failed:", e)),
-    useGitStore.getState().actions.loadStatus(path).catch((e) => console.error("Git failed:", e)),
-    useSessionStore.getState().actions.loadSession(path).catch((e) => console.error("Session load failed:", e)),
+    useExplorerStore
+      .getState()
+      .actions.openFolder(path)
+      .catch((e) => console.error("Explorer failed:", e)),
+    useGitStore
+      .getState()
+      .actions.loadStatus(path)
+      .catch((e) => console.error("Git failed:", e)),
+    useSessionStore
+      .getState()
+      .actions.loadSession(path)
+      .catch((e) => console.error("Session load failed:", e)),
     // Only the KB META bind is on the critical path — it's cheap and the @-/~
     // mention picker needs it for page-header titles + emoji from `_meta.json`.
-    useKnowledgeMetaStore.getState().actions.bind(path).catch((e) => console.error("Knowledge bind failed:", e)),
-    useLayoutStore.getState().actions.loadEditorState(path).catch((e) => console.error("Editor state load failed:", e)),
+    useKnowledgeMetaStore
+      .getState()
+      .actions.bind(path)
+      .catch((e) => console.error("Knowledge bind failed:", e)),
+    useLayoutStore
+      .getState()
+      .actions.loadEditorState(path)
+      .catch((e) => console.error("Editor state load failed:", e)),
   ]);
 
   // Load the full KB entries OFF the switch critical path. This is the single
@@ -263,7 +281,9 @@ export async function loadProjectStores(path: string): Promise<void> {
   // while still warming the @-/~ mention cache shortly after open. Fire-and-
   // forget; a stale project is harmless (entries are keyed by path).
   const warmEntries = () => {
-    void useKnowledgeStore.getState().actions.loadEntries(path)
+    void useKnowledgeStore
+      .getState()
+      .actions.loadEntries(path)
       .catch((e) => console.error("Knowledge entries load failed:", e));
   };
   if (typeof requestIdleCallback === "function") {
@@ -347,10 +367,15 @@ export const useProjectStore = createSelectors(
           void useExplorerStore.getState().actions.refresh();
         }
         if (partial.uiScale !== undefined) applyUiScale(partial.uiScale);
-        if (partial.codeEditorTheme !== undefined) applyEditorTheme(partial.codeEditorTheme);
-        if (partial.atlasTheme !== undefined) applyAtlasTheme(partial.atlasTheme);
+        if (partial.codeEditorTheme !== undefined)
+          applyEditorTheme(partial.codeEditorTheme);
+        if (partial.atlasTheme !== undefined)
+          applyAtlasTheme(partial.atlasTheme);
       },
-      hydrate: (payload: AppStateWire, opts?: { skipActiveSwitch?: boolean }) => {
+      hydrate: (
+        payload: AppStateWire,
+        opts?: { skipActiveSwitch?: boolean },
+      ) => {
         // Merge with defaults so older state.json files (written before a new
         // setting existed) get the modern default rather than `undefined`.
         const settings: AppSettings = {

--- a/src/features/project/stores/session-store.ts
+++ b/src/features/project/stores/session-store.ts
@@ -62,7 +62,9 @@ export const useSessionStore = createSelectors(
       setLastResearchSource: (source) =>
         set((s) => ({ session: { ...s.session, lastResearchSource: source } })),
       setLastResearchResults: (results) =>
-        set((s) => ({ session: { ...s.session, lastResearchResults: results } })),
+        set((s) => ({
+          session: { ...s.session, lastResearchResults: results },
+        })),
       setLastTrendingPapers: (papers) =>
         set((s) => ({ session: { ...s.session, lastTrendingPapers: papers } })),
       setLastOpenedFiles: (files) =>
@@ -75,12 +77,18 @@ export const useSessionStore = createSelectors(
         set((s) => ({
           session: {
             ...s.session,
-            searchHistory: [query, ...s.session.searchHistory.filter((q) => q !== query)].slice(0, 20),
+            searchHistory: [
+              query,
+              ...s.session.searchHistory.filter((q) => q !== query),
+            ].slice(0, 20),
           },
         })),
       removeSearchHistory: (query) =>
         set((s) => ({
-          session: { ...s.session, searchHistory: s.session.searchHistory.filter((q) => q !== query) },
+          session: {
+            ...s.session,
+            searchHistory: s.session.searchHistory.filter((q) => q !== query),
+          },
         })),
       clearSearchHistory: () =>
         set((s) => ({ session: { ...s.session, searchHistory: [] } })),
@@ -109,5 +117,5 @@ export const useSessionStore = createSelectors(
         }
       },
     },
-  }))
+  })),
 );

--- a/src/features/research/components/research-panel.tsx
+++ b/src/features/research/components/research-panel.tsx
@@ -2,10 +2,16 @@ import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-function invokeWithTimeout<T>(cmd: string, args?: Record<string, unknown>, ms = 15000): Promise<T> {
+function invokeWithTimeout<T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+  ms = 15000,
+): Promise<T> {
   return Promise.race([
     invoke<T>(cmd, args),
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`${cmd} timed out`)), ms)),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${cmd} timed out`)), ms),
+    ),
   ]);
 }
 import { cn } from "@/lib/utils";
@@ -45,7 +51,10 @@ export function ResearchPanel() {
 
   const [query, setQuery] = useState("");
   const [source, setSource] = useState<SearchSource>("arxiv");
-  const [activeQuery, setActiveQuery] = useState<{ q: string; src: SearchSource } | null>(null);
+  const [activeQuery, setActiveQuery] = useState<{
+    q: string;
+    src: SearchSource;
+  } | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [downloadingIds, setDownloadingIds] = useState<Set<string>>(new Set());
   const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
@@ -63,8 +72,14 @@ export function ResearchPanel() {
     queryKey: ["research", "search", activeQuery?.src, activeQuery?.q],
     queryFn: () => {
       if (!activeQuery) return [];
-      const command = activeQuery.src === "semantic-scholar" ? "search_semantic_scholar" : "search_arxiv";
-      return invokeWithTimeout<ArxivPaper[]>(command, { query: activeQuery.q, maxResults: 15 });
+      const command =
+        activeQuery.src === "semantic-scholar"
+          ? "search_semantic_scholar"
+          : "search_arxiv";
+      return invokeWithTimeout<ArxivPaper[]>(command, {
+        query: activeQuery.q,
+        maxResults: 15,
+      });
     },
     enabled: !!activeQuery,
     staleTime: 5 * 60 * 1000,
@@ -86,7 +101,11 @@ export function ResearchPanel() {
         paperTitle: paper.title,
       });
     } catch {}
-    setDownloadingIds((s) => { const n = new Set(s); n.delete(paper.id); return n; });
+    setDownloadingIds((s) => {
+      const n = new Set(s);
+      n.delete(paper.id);
+      return n;
+    });
   };
 
   const handleSaveToKnowledge = async (paper: ArxivPaper) => {
@@ -112,7 +131,8 @@ export function ResearchPanel() {
         summary: paper.title.slice(0, 120),
         payload: { id: paper.id, link: paper.link, authors: paper.authors },
       });
-      const { useKnowledgeStore } = await import("@/features/knowledge/stores/knowledge-store");
+      const { useKnowledgeStore } =
+        await import("@/features/knowledge/stores/knowledge-store");
       useKnowledgeStore.getState().actions.loadEntries(currentProject.path);
       setSavedIds((s) => new Set(s).add(paper.id));
     } catch {}
@@ -132,8 +152,16 @@ export function ResearchPanel() {
       {/* Search bar */}
       <div className="px-3 py-2 border-b border-border-subtle bg-bg-primary shrink-0 space-y-1.5">
         <div className="flex items-center gap-1">
-          <SourceButton label="arXiv" active={source === "arxiv"} onClick={() => setSource("arxiv")} />
-          <SourceButton label="Semantic Scholar" active={source === "semantic-scholar"} onClick={() => setSource("semantic-scholar")} />
+          <SourceButton
+            label="arXiv"
+            active={source === "arxiv"}
+            onClick={() => setSource("arxiv")}
+          />
+          <SourceButton
+            label="Semantic Scholar"
+            active={source === "semantic-scholar"}
+            onClick={() => setSource("semantic-scholar")}
+          />
         </div>
         <div className="flex gap-1.5">
           <div className="flex-1 flex items-center gap-2 h-7 rounded border border-border-default bg-bg-secondary px-2 focus-within:ring-1 focus-within:ring-border-focus">
@@ -142,7 +170,11 @@ export function ResearchPanel() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-              placeholder={source === "arxiv" ? "Search arXiv papers..." : "Search Semantic Scholar..."}
+              placeholder={
+                source === "arxiv"
+                  ? "Search arXiv papers..."
+                  : "Search Semantic Scholar..."
+              }
               className="flex-1 bg-transparent outline-none text-[11px] text-text-primary placeholder:text-text-tertiary"
             />
           </div>
@@ -153,10 +185,14 @@ export function ResearchPanel() {
               "h-7 px-3 rounded text-[10px] font-medium transition-colors",
               query.trim() && !search.isFetching
                 ? "bg-accent text-text-inverse hover:bg-accent-hover"
-                : "bg-bg-elevated text-text-tertiary"
+                : "bg-bg-elevated text-text-tertiary",
             )}
           >
-            {search.isFetching ? <Loader2 size={11} className="animate-spin" /> : "Search"}
+            {search.isFetching ? (
+              <Loader2 size={11} className="animate-spin" />
+            ) : (
+              "Search"
+            )}
           </button>
         </div>
       </div>
@@ -171,10 +207,18 @@ export function ResearchPanel() {
                 Trending in AI & Math
               </span>
               <button
-                onClick={() => queryClient.invalidateQueries({ queryKey: ["research", "trending"] })}
+                onClick={() =>
+                  queryClient.invalidateQueries({
+                    queryKey: ["research", "trending"],
+                  })
+                }
                 className="ml-auto text-[9px] text-text-tertiary hover:text-text-secondary"
               >
-                {trending.isFetching ? <Loader2 size={9} className="animate-spin" /> : "Refresh"}
+                {trending.isFetching ? (
+                  <Loader2 size={9} className="animate-spin" />
+                ) : (
+                  "Refresh"
+                )}
               </button>
             </div>
             {trending.isFetching && !trending.data && (
@@ -184,7 +228,13 @@ export function ResearchPanel() {
             )}
             {trending.error && (
               <div className="px-4 py-6 text-[11px] text-text-tertiary text-center">
-                Failed to load trending papers. <button onClick={() => trending.refetch()} className="text-accent underline">Retry</button>
+                Failed to load trending papers.{" "}
+                <button
+                  onClick={() => trending.refetch()}
+                  className="text-accent underline"
+                >
+                  Retry
+                </button>
               </div>
             )}
             {trending.data?.map((paper) => (
@@ -192,7 +242,9 @@ export function ResearchPanel() {
                 key={paper.id}
                 paper={paper}
                 expanded={expandedId === paper.id}
-                onToggle={() => setExpandedId(expandedId === paper.id ? null : paper.id)}
+                onToggle={() =>
+                  setExpandedId(expandedId === paper.id ? null : paper.id)
+                }
                 onOpenBrowser={openInBrowser}
                 onDownload={() => handleDownloadPdf(paper)}
                 onSaveToKnowledge={() => handleSaveToKnowledge(paper)}
@@ -206,7 +258,13 @@ export function ResearchPanel() {
 
         {search.error && (
           <div className="px-4 py-6 text-[11px] text-text-tertiary text-center">
-            Search failed. <button onClick={() => search.refetch()} className="text-accent underline">Retry</button>
+            Search failed.{" "}
+            <button
+              onClick={() => search.refetch()}
+              className="text-accent underline"
+            >
+              Retry
+            </button>
           </div>
         )}
 
@@ -215,7 +273,9 @@ export function ResearchPanel() {
             key={paper.id}
             paper={paper}
             expanded={expandedId === paper.id}
-            onToggle={() => setExpandedId(expandedId === paper.id ? null : paper.id)}
+            onToggle={() =>
+              setExpandedId(expandedId === paper.id ? null : paper.id)
+            }
             onOpenBrowser={openInBrowser}
             onDownload={() => handleDownloadPdf(paper)}
             onSaveToKnowledge={() => handleSaveToKnowledge(paper)}
@@ -287,7 +347,7 @@ function PaperCard({
             size={12}
             className={cn(
               "text-text-tertiary shrink-0 transition-transform mt-1",
-              expanded && "rotate-180"
+              expanded && "rotate-180",
             )}
           />
         </div>
@@ -315,7 +375,13 @@ function PaperCard({
             {hasProject && paper.pdf_url && (
               <ActionButton
                 onClick={onDownload}
-                icon={downloading ? <Loader2 size={10} className="animate-spin" /> : <Download size={10} />}
+                icon={
+                  downloading ? (
+                    <Loader2 size={10} className="animate-spin" />
+                  ) : (
+                    <Download size={10} />
+                  )
+                }
                 label={downloading ? "Downloading..." : "Download PDF"}
                 accent
               />
@@ -358,7 +424,7 @@ function ActionButton({
         accent
           ? "bg-accent-muted text-accent hover:bg-accent/20"
           : "bg-bg-elevated border border-border-default text-text-secondary hover:text-text-primary hover:bg-bg-hover",
-        disabled && "opacity-50 cursor-default"
+        disabled && "opacity-50 cursor-default",
       )}
     >
       {icon}
@@ -383,7 +449,7 @@ function SourceButton({
         "px-2 py-0.5 rounded text-[9px] font-medium transition-colors",
         active
           ? "bg-accent text-text-inverse"
-          : "bg-bg-elevated text-text-tertiary border border-border-default hover:text-text-secondary hover:bg-bg-hover"
+          : "bg-bg-elevated text-text-tertiary border border-border-default hover:text-text-secondary hover:bg-bg-hover",
       )}
     >
       {label}

--- a/src/features/review-agents/components/mermaid-block.tsx
+++ b/src/features/review-agents/components/mermaid-block.tsx
@@ -10,7 +10,9 @@ let lastPaletteKey = "";
 
 /** Read one CSS custom property off the document root, with a fallback. */
 function cssVar(name: string, fallback: string): string {
-  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
   return v || fallback;
 }
 
@@ -28,7 +30,15 @@ async function getMermaid() {
   const border = cssVar("--border-strong", "#3d3d3d");
   const line = cssVar("--text-tertiary", "#777777");
 
-  const paletteKey = [bg, raised, elevated, textPrimary, textSecondary, border, line].join("|");
+  const paletteKey = [
+    bg,
+    raised,
+    elevated,
+    textPrimary,
+    textSecondary,
+    border,
+    line,
+  ].join("|");
   if (paletteKey !== lastPaletteKey) {
     lastPaletteKey = paletteKey;
     mermaid.initialize({
@@ -59,12 +69,19 @@ async function getMermaid() {
 function sanitize(src: string): string {
   let s = src.trim();
   // Ensure a diagram header.
-  if (!/^(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|mindmap|gantt)/.test(s)) {
+  if (
+    !/^(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|mindmap|gantt)/.test(
+      s,
+    )
+  ) {
     s = `flowchart TD\n${s}`;
   }
   // `subgraph "Title"` → `subgraph s_n["Title"]` (a subgraph needs an id).
   let sg = 0;
-  s = s.replace(/subgraph\s+"([^"]+)"/g, (_m, title) => `subgraph sg${sg++}["${title}"]`);
+  s = s.replace(
+    /subgraph\s+"([^"]+)"/g,
+    (_m, title) => `subgraph sg${sg++}["${title}"]`,
+  );
   // Old-style labeled edge `A -- text --> B` → pipe form with a quoted label
   // (handles labels with leading dashes / specials that break the `--` form).
   s = s.replace(
@@ -136,7 +153,9 @@ export function MermaidBlock({ code }: { code: string }) {
     // under <body> (e.g. from an earlier failed render). Successful diagrams are
     // injected inside this component, never appended to the body.
     document
-      .querySelectorAll('body > [id^="atlas-mermaid-"], body > [id^="datlas-mermaid-"]')
+      .querySelectorAll(
+        'body > [id^="atlas-mermaid-"], body > [id^="datlas-mermaid-"]',
+      )
       .forEach((n) => n.remove());
 
     (async () => {
@@ -169,7 +188,11 @@ export function MermaidBlock({ code }: { code: string }) {
     );
   }
   if (!svg) {
-    return <div className="p-3 text-[11px] text-text-tertiary">Rendering diagram…</div>;
+    return (
+      <div className="p-3 text-[11px] text-text-tertiary">
+        Rendering diagram…
+      </div>
+    );
   }
   return (
     <div

--- a/src/features/review-agents/components/review-agents-panel.tsx
+++ b/src/features/review-agents/components/review-agents-panel.tsx
@@ -91,7 +91,13 @@ export function ReviewAgentsPanel() {
         prev.some((c) => c.hash === sha)
           ? prev
           : [
-              { hash: sha, short_hash: sha.slice(0, 7), message: "(selected commit)", author: "", date: "" },
+              {
+                hash: sha,
+                short_hash: sha.slice(0, 7),
+                message: "(selected commit)",
+                author: "",
+                date: "",
+              },
               ...prev,
             ],
       );
@@ -164,11 +170,14 @@ export function ReviewAgentsPanel() {
 
   const onOpenIssue = (relativeFile: string) => {
     if (!projectPath) return;
-    const full = relativeFile.startsWith("/") ? relativeFile : `${projectPath}/${relativeFile}`;
+    const full = relativeFile.startsWith("/")
+      ? relativeFile
+      : `${projectPath}/${relativeFile}`;
     openFile(full);
   };
 
-  const onShareFile = (file: FileVerdict) => sendToAgentChat(fileToMarkdown(file));
+  const onShareFile = (file: FileVerdict) =>
+    sendToAgentChat(fileToMarkdown(file));
 
   const canRun =
     !!projectPath &&
@@ -227,7 +236,10 @@ export function ReviewAgentsPanel() {
         {providersLoaded && providers.length === 0 ? (
           <div className="flex items-start gap-1.5 text-text-tertiary rounded border border-border-default bg-bg-selected/20 p-2">
             <KeyRound size={12} className="mt-0.5 shrink-0" />
-            <span>No API keys configured. Add one in Settings → API keys to run reviews.</span>
+            <span>
+              No API keys configured. Add one in Settings → API keys to run
+              reviews.
+            </span>
           </div>
         ) : (
           <div className="flex gap-1.5">
@@ -287,10 +299,15 @@ export function ReviewAgentsPanel() {
             onOpenIssue={onOpenIssue}
             projectPath={projectPath}
             onShareFile={onShareFile}
-            onBack={records.length > 0 ? () => actions.selectRecord(null) : undefined}
+            onBack={
+              records.length > 0 ? () => actions.selectRecord(null) : undefined
+            }
           />
         ) : (
-          <RecordList records={records} onPick={(r) => actions.selectRecord(r)} />
+          <RecordList
+            records={records}
+            onPick={(r) => actions.selectRecord(r)}
+          />
         )}
       </div>
     </div>
@@ -317,7 +334,9 @@ function LiveProgress({
     <div className="p-2 flex flex-col gap-2 animate-fade-in">
       <div className="flex items-center gap-1.5 text-text-tertiary">
         <Loader2 size={12} className="animate-spin" />
-        {synthesisText ? "Synthesizing report…" : `Reviewing files… (${done}/${total})`}
+        {synthesisText
+          ? "Synthesizing report…"
+          : `Reviewing files… (${done}/${total})`}
       </div>
 
       {pending.map((p) => (
@@ -379,7 +398,9 @@ function RecordView({
             <ChevronLeft size={12} /> Back
           </button>
         )}
-        <span className="truncate text-[10px] text-text-tertiary">{record.title}</span>
+        <span className="truncate text-[10px] text-text-tertiary">
+          {record.title}
+        </span>
         <button
           onClick={() => sendToAgentChat(reportToMarkdown(record))}
           className="ml-auto flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer shrink-0"
@@ -422,7 +443,9 @@ function RecordList({
           </div>
           <div className="mt-0.5 flex items-center gap-2 text-[10px] text-text-tertiary">
             <span>{r.model}</span>
-            {typeof r.report?.score === "number" && <span>· {r.report.score}/100</span>}
+            {typeof r.report?.score === "number" && (
+              <span>· {r.report.score}/100</span>
+            )}
             <span>· {r.report?.files.length ?? 0} files</span>
             <span className="ml-auto">{relativeTime(r.createdAt)}</span>
           </div>

--- a/src/features/review-agents/components/verdict-cards.tsx
+++ b/src/features/review-agents/components/verdict-cards.tsx
@@ -26,7 +26,12 @@ interface Props {
 
 /** Render a full review report: badges, architecture diagram, overview, and a
  *  per-file accordion. */
-export function ReportView({ report, onOpenIssue, projectPath, onShareFile }: Props) {
+export function ReportView({
+  report,
+  onOpenIssue,
+  projectPath,
+  onShareFile,
+}: Props) {
   const hasSecurity =
     report.security_concerns &&
     report.security_concerns.trim().toLowerCase() !== "no";
@@ -36,10 +41,17 @@ export function ReportView({ report, onOpenIssue, projectPath, onShareFile }: Pr
       {/* Badges */}
       <div className="flex flex-wrap gap-1.5">
         {typeof report.score === "number" && (
-          <Badge label="Score" value={`${report.score}/100`} tone={scoreTone(report.score)} />
+          <Badge
+            label="Score"
+            value={`${report.score}/100`}
+            tone={scoreTone(report.score)}
+          />
         )}
         {typeof report.estimated_effort_to_review === "number" && (
-          <Badge label="Effort" value={`${report.estimated_effort_to_review}/5`} />
+          <Badge
+            label="Effort"
+            value={`${report.estimated_effort_to_review}/5`}
+          />
         )}
         <Badge
           label="Tests"
@@ -99,7 +111,8 @@ export function ReportView({ report, onOpenIssue, projectPath, onShareFile }: Pr
           <div>
             <div className="text-text-secondary">
               {report.not_reviewed.length} file
-              {report.not_reviewed.length > 1 ? "s" : ""} not individually reviewed
+              {report.not_reviewed.length > 1 ? "s" : ""} not individually
+              reviewed
             </div>
             <div className="mt-0.5 font-mono text-[10px] break-all">
               {report.not_reviewed.join(", ")}
@@ -132,7 +145,10 @@ export function FileCard({
   const stash = async () => {
     if (!projectPath) return;
     try {
-      await invoke("git_stash_paths", { path: projectPath, paths: [file.path] });
+      await invoke("git_stash_paths", {
+        path: projectPath,
+        paths: [file.path],
+      });
       toast.success(`Stashed ${name}`);
     } catch (e) {
       toast.error(String(e));
@@ -156,12 +172,17 @@ export function FileCard({
       >
         <ChevronRight
           size={12}
-          className={cn("text-text-tertiary shrink-0 transition-transform", open && "rotate-90")}
+          className={cn(
+            "text-text-tertiary shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
         />
         <RiskDot risk={file.risk} />
         <span className="flex-1 min-w-0 truncate">
           <span className="text-text-primary">{name}</span>
-          {dir && <span className="text-text-tertiary text-[10px]"> {dir}</span>}
+          {dir && (
+            <span className="text-text-tertiary text-[10px]"> {dir}</span>
+          )}
         </span>
         {file.key_issues.length > 0 && (
           <span className="shrink-0 text-[10px] text-amber-400/90 flex items-center gap-0.5">
@@ -172,7 +193,9 @@ export function FileCard({
       {open && (
         <div className="px-2.5 pb-2.5 pt-0.5 flex flex-col gap-1.5">
           {file.summary && (
-            <div className="text-text-secondary leading-relaxed">{file.summary}</div>
+            <div className="text-text-secondary leading-relaxed">
+              {file.summary}
+            </div>
           )}
           {file.key_issues.map((issue, i) => (
             <button
@@ -185,7 +208,9 @@ export function FileCard({
             >
               <div className="flex items-center gap-1.5">
                 <AlertTriangle size={11} className="text-amber-400 shrink-0" />
-                <span className="font-medium text-text-primary">{issue.issue_header}</span>
+                <span className="font-medium text-text-primary">
+                  {issue.issue_header}
+                </span>
                 {typeof issue.start_line === "number" && (
                   <span className="ml-auto font-mono text-[10px] text-text-tertiary">
                     :{issue.start_line}
@@ -204,12 +229,24 @@ export function FileCard({
           {/* Per-file actions */}
           <div className="flex items-center gap-1 pt-1">
             {onShare && file.key_issues.length > 0 && (
-              <ActionBtn icon={<LinkIcon size={11} />} label="Share" onClick={() => onShare(file)} />
+              <ActionBtn
+                icon={<LinkIcon size={11} />}
+                label="Share"
+                onClick={() => onShare(file)}
+              />
             )}
             {projectPath && (
               <>
-                <ActionBtn icon={<Archive size={11} />} label="Stash" onClick={stash} />
-                <ActionBtn icon={<EyeOff size={11} />} label="Ignore" onClick={ignore} />
+                <ActionBtn
+                  icon={<Archive size={11} />}
+                  label="Stash"
+                  onClick={stash}
+                />
+                <ActionBtn
+                  icon={<EyeOff size={11} />}
+                  label="Ignore"
+                  onClick={ignore}
+                />
               </>
             )}
           </div>
@@ -259,7 +296,10 @@ function Section({
       >
         <ChevronRight
           size={12}
-          className={cn("text-text-tertiary shrink-0 transition-transform", open && "rotate-90")}
+          className={cn(
+            "text-text-tertiary shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
         />
         {icon}
         <span className="font-medium">{title}</span>
@@ -276,7 +316,12 @@ function RiskDot({ risk }: { risk: string }) {
       : risk === "medium"
         ? "bg-[var(--status-warning)]"
         : "bg-text-tertiary";
-  return <span className={cn("size-1.5 rounded-full shrink-0", tone)} title={`risk: ${risk}`} />;
+  return (
+    <span
+      className={cn("size-1.5 rounded-full shrink-0", tone)}
+      title={`risk: ${risk}`}
+    />
+  );
 }
 
 function Badge({
@@ -292,9 +337,12 @@ function Badge({
     <span
       className={cn(
         "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 border text-[10.5px]",
-        tone === "good" && "border-[var(--status-success)]/50 bg-[var(--bg-elevated)] text-text-secondary",
-        tone === "warn" && "border-[var(--status-warning)]/40 bg-[var(--status-warning)]/10 text-[var(--status-warning)]",
-        tone === "neutral" && "border-border-default bg-[var(--bg-elevated)] text-text-secondary",
+        tone === "good" &&
+          "border-[var(--status-success)]/50 bg-[var(--bg-elevated)] text-text-secondary",
+        tone === "warn" &&
+          "border-[var(--status-warning)]/40 bg-[var(--status-warning)]/10 text-[var(--status-warning)]",
+        tone === "neutral" &&
+          "border-border-default bg-[var(--bg-elevated)] text-text-secondary",
       )}
     >
       <span className="text-text-tertiary">{label}</span>

--- a/src/features/review-agents/lib/model-catalog.ts
+++ b/src/features/review-agents/lib/model-catalog.ts
@@ -19,15 +19,15 @@ const PREFERRED: Record<string, string[]> = {
     "claude-sonnet-4-5",
   ],
   openai: ["gpt-5.1", "gpt-5", "o4-mini", "gpt-4.1", "gpt-4o"],
-  google: [
-    "gemini-3.1-pro-preview",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-  ],
+  google: ["gemini-3.1-pro-preview", "gemini-2.5-pro", "gemini-2.5-flash"],
   xai: ["grok-4", "grok-code-fast-1", "grok-3"],
   deepseek: ["deepseek-reasoner", "deepseek-chat"],
   mistral: ["mistral-large-latest", "codestral-latest"],
-  groq: ["moonshotai/kimi-k2-instruct", "qwen-3-coder-480b", "llama-3.3-70b-versatile"],
+  groq: [
+    "moonshotai/kimi-k2-instruct",
+    "qwen-3-coder-480b",
+    "llama-3.3-70b-versatile",
+  ],
   together: [
     "Qwen/Qwen3-Coder-480B-A35B-Instruct",
     "deepseek-ai/DeepSeek-V3",
@@ -127,7 +127,10 @@ export function isPreferredModel(provider: string, id: string): boolean {
 }
 
 /** The default model to select for a provider given its curated list. */
-export function defaultModelFor(provider: string, curated: string[]): string | null {
+export function defaultModelFor(
+  provider: string,
+  curated: string[],
+): string | null {
   const preferred = PREFERRED[provider] ?? [];
   // Prefer the first available preferred model, else the first curated one.
   const firstPreferred = preferred.find((id) => curated.includes(id));

--- a/src/features/review-agents/lib/review-api.ts
+++ b/src/features/review-agents/lib/review-api.ts
@@ -99,12 +99,16 @@ export const listenReview = (
 /** Serialize a single file's verdict to markdown for sharing with the agent. */
 export function fileToMarkdown(file: FileVerdict): string {
   const lines: string[] = [];
-  lines.push(`Please review and address the following in \`${file.path}\` (risk: ${file.risk}):`);
+  lines.push(
+    `Please review and address the following in \`${file.path}\` (risk: ${file.risk}):`,
+  );
   lines.push("");
   if (file.summary) lines.push(file.summary, "");
   for (const i of file.key_issues) {
     const at = typeof i.start_line === "number" ? `:${i.start_line}` : "";
-    lines.push(`- **${i.issue_header}** (\`${i.relevant_file}${at}\`) — ${i.issue_content}`);
+    lines.push(
+      `- **${i.issue_header}** (\`${i.relevant_file}${at}\`) — ${i.issue_content}`,
+    );
   }
   return lines.join("\n");
 }
@@ -122,11 +126,21 @@ export function reportToMarkdown(record: ReviewRecord): string {
     meta.push(`**Effort:** ${r.estimated_effort_to_review}/5`);
   meta.push(`**Tests:** ${r.relevant_tests}`);
   if (meta.length) lines.push(meta.join(" · "), "");
-  if (r.security_concerns && r.security_concerns.trim().toLowerCase() !== "no") {
+  if (
+    r.security_concerns &&
+    r.security_concerns.trim().toLowerCase() !== "no"
+  ) {
     lines.push(`**Security:** ${r.security_concerns}`, "");
   }
   if (r.architecture_mermaid.trim()) {
-    lines.push("## Architecture", "", "```mermaid", r.architecture_mermaid.trim(), "```", "");
+    lines.push(
+      "## Architecture",
+      "",
+      "```mermaid",
+      r.architecture_mermaid.trim(),
+      "```",
+      "",
+    );
   }
   if (r.files.length) {
     lines.push("## Files", "");
@@ -135,13 +149,17 @@ export function reportToMarkdown(record: ReviewRecord): string {
       if (f.summary) lines.push(f.summary);
       for (const i of f.key_issues) {
         const at = typeof i.start_line === "number" ? `:${i.start_line}` : "";
-        lines.push(`- **${i.issue_header}** (\`${i.relevant_file}${at}\`) — ${i.issue_content}`);
+        lines.push(
+          `- **${i.issue_header}** (\`${i.relevant_file}${at}\`) — ${i.issue_content}`,
+        );
       }
       lines.push("");
     }
   }
   if (r.not_reviewed.length) {
-    lines.push(`_Not individually reviewed (${r.not_reviewed.length}): ${r.not_reviewed.join(", ")}_`);
+    lines.push(
+      `_Not individually reviewed (${r.not_reviewed.length}): ${r.not_reviewed.join(", ")}_`,
+    );
   }
   return lines.join("\n");
 }

--- a/src/features/review-agents/stores/review-store.ts
+++ b/src/features/review-agents/stores/review-store.ts
@@ -45,7 +45,10 @@ interface ReviewState {
   /** Fatal error that aborted the run. */
   streamError: string | null;
   /** A source preset requested from elsewhere (Source Control). */
-  pendingSource: { mode: "working" | "staged" | "commit" | "branch"; sha?: string } | null;
+  pendingSource: {
+    mode: "working" | "staged" | "commit" | "branch";
+    sha?: string;
+  } | null;
   actions: {
     init: (project: string) => Promise<void>;
     refreshRecords: (project: string) => Promise<void>;
@@ -58,7 +61,10 @@ interface ReviewState {
     start: (project: string) => Promise<void>;
     cancel: () => void;
     selectRecord: (record: ReviewRecord | null) => void;
-    requestReview: (mode: "working" | "staged" | "commit" | "branch", sha?: string) => void;
+    requestReview: (
+      mode: "working" | "staged" | "commit" | "branch",
+      sha?: string,
+    ) => void;
     consumePending: () => void;
   };
 }
@@ -110,7 +116,9 @@ export const useReviewStore = createSelectors(
                 break;
               case "file_done":
                 set((s) => ({
-                  pendingFiles: s.pendingFiles.filter((p) => p !== e.verdict.path),
+                  pendingFiles: s.pendingFiles.filter(
+                    (p) => p !== e.verdict.path,
+                  ),
                   liveFiles: [
                     ...s.liveFiles.filter((f) => f.path !== e.verdict.path),
                     e.verdict,
@@ -130,7 +138,10 @@ export const useReviewStore = createSelectors(
                   liveFiles: [],
                   pendingFiles: [],
                   selectedRecord: e.record,
-                  records: [e.record, ...s.records.filter((r) => r.id !== e.record.id)],
+                  records: [
+                    e.record,
+                    ...s.records.filter((r) => r.id !== e.record.id),
+                  ],
                 }));
                 break;
               case "error":
@@ -147,7 +158,8 @@ export const useReviewStore = createSelectors(
         set({ providers, providersLoaded: true });
 
         const saved = localStorage.getItem(LS_PROVIDER);
-        const provider = saved && providers.includes(saved) ? saved : providers[0] ?? null;
+        const provider =
+          saved && providers.includes(saved) ? saved : (providers[0] ?? null);
         if (provider) {
           await get().actions.setProvider(provider);
         }
@@ -173,7 +185,8 @@ export const useReviewStore = createSelectors(
         const { selectedProvider } = get();
         if (!selectedProvider) {
           // Nothing selected yet (or was cleared) — pick the first available.
-          if (providers.length > 0) await get().actions.setProvider(providers[0]);
+          if (providers.length > 0)
+            await get().actions.setProvider(providers[0]);
         } else if (!providers.includes(selectedProvider)) {
           // The selected provider's key was removed — switch or clear.
           if (providers.length > 0) {
@@ -196,8 +209,11 @@ export const useReviewStore = createSelectors(
         const models = curateModels(provider, liveIds);
         const saved = localStorage.getItem(lsModelKey(provider));
         const selectedModel =
-          saved && models.includes(saved) ? saved : defaultModelFor(provider, models);
-        if (selectedModel) localStorage.setItem(lsModelKey(provider), selectedModel);
+          saved && models.includes(saved)
+            ? saved
+            : defaultModelFor(provider, models);
+        if (selectedModel)
+          localStorage.setItem(lsModelKey(provider), selectedModel);
         set({ models, selectedModel, loadingModels: false });
       },
 
@@ -224,7 +240,13 @@ export const useReviewStore = createSelectors(
           selectedRecord: null,
         });
         try {
-          await review.start(id, project, selectedProvider, selectedModel, source);
+          await review.start(
+            id,
+            project,
+            selectedProvider,
+            selectedModel,
+            source,
+          );
         } catch (err) {
           if (get().activeId === id && get().streaming) {
             set({ streaming: false, streamError: String(err) });
@@ -240,7 +262,8 @@ export const useReviewStore = createSelectors(
         }
       },
 
-      selectRecord: (record) => set({ selectedRecord: record, streamError: null }),
+      selectRecord: (record) =>
+        set({ selectedRecord: record, streamError: null }),
 
       requestReview: (mode, sha) => set({ pendingSource: { mode, sha } }),
 

--- a/src/features/settings/components/atlas-themes-settings.tsx
+++ b/src/features/settings/components/atlas-themes-settings.tsx
@@ -108,7 +108,10 @@ function CodeLine({
   tokens: Array<{ w: string; c: string }>;
 }) {
   return (
-    <div className="flex h-1.5 items-center gap-1" style={{ paddingLeft: indent * 8 }}>
+    <div
+      className="flex h-1.5 items-center gap-1"
+      style={{ paddingLeft: indent * 8 }}
+    >
       {tokens.map((tk, i) => (
         <span
           key={i}
@@ -140,37 +143,75 @@ function ThemePreview({ theme }: { theme: AtlasTheme }) {
       {/* Activity rail */}
       <div
         className="flex w-5 shrink-0 flex-col items-center gap-2 py-2"
-        style={{ background: s.panel, borderRight: `1px solid ${s.borderSubtle}` }}
+        style={{
+          background: s.panel,
+          borderRight: `1px solid ${s.borderSubtle}`,
+        }}
       >
-        <span className="h-2 w-2 rounded-[3px]" style={{ background: s.accent }} />
-        <span className="h-2 w-2 rounded-[3px]" style={{ background: s.textTertiary }} />
-        <span className="h-2 w-2 rounded-[3px]" style={{ background: s.textGhost }} />
-        <span className="h-2 w-2 rounded-[3px]" style={{ background: s.textGhost }} />
+        <span
+          className="h-2 w-2 rounded-[3px]"
+          style={{ background: s.accent }}
+        />
+        <span
+          className="h-2 w-2 rounded-[3px]"
+          style={{ background: s.textTertiary }}
+        />
+        <span
+          className="h-2 w-2 rounded-[3px]"
+          style={{ background: s.textGhost }}
+        />
+        <span
+          className="h-2 w-2 rounded-[3px]"
+          style={{ background: s.textGhost }}
+        />
       </div>
 
       {/* Pane 1 — file tree */}
       <div
         className="flex w-[26%] shrink-0 flex-col gap-2 p-2"
-        style={{ background: s.panel, borderRight: `1px solid ${s.borderSubtle}` }}
+        style={{
+          background: s.panel,
+          borderRight: `1px solid ${s.borderSubtle}`,
+        }}
       >
-        <span className="h-1.5 w-1/2 rounded-full" style={{ background: s.textTertiary }} />
-        <span className="h-1.5 w-4/5 rounded-full" style={{ background: s.textSecondary }} />
+        <span
+          className="h-1.5 w-1/2 rounded-full"
+          style={{ background: s.textTertiary }}
+        />
+        <span
+          className="h-1.5 w-4/5 rounded-full"
+          style={{ background: s.textSecondary }}
+        />
         <span
           className="-mx-1 h-3 rounded px-1"
-          style={{ background: `color-mix(in srgb, ${s.accent} 16%, transparent)` }}
+          style={{
+            background: `color-mix(in srgb, ${s.accent} 16%, transparent)`,
+          }}
         >
           <span
             className="mt-[5px] block h-1.5 w-3/5 rounded-full"
             style={{ background: s.accent }}
           />
         </span>
-        <span className="h-1.5 w-2/3 rounded-full" style={{ background: s.textTertiary }} />
-        <span className="h-1.5 w-1/2 rounded-full" style={{ background: s.textTertiary }} />
-        <span className="h-1.5 w-3/4 rounded-full" style={{ background: s.textGhost }} />
+        <span
+          className="h-1.5 w-2/3 rounded-full"
+          style={{ background: s.textTertiary }}
+        />
+        <span
+          className="h-1.5 w-1/2 rounded-full"
+          style={{ background: s.textTertiary }}
+        />
+        <span
+          className="h-1.5 w-3/4 rounded-full"
+          style={{ background: s.textGhost }}
+        />
       </div>
 
       {/* Pane 2 — editor with syntax-highlighted dummy code */}
-      <div className="flex min-w-0 flex-1 flex-col" style={{ background: s.base }}>
+      <div
+        className="flex min-w-0 flex-1 flex-col"
+        style={{ background: s.base }}
+      >
         {/* Tab strip */}
         <div
           className="flex items-center gap-1 px-2 py-1.5"
@@ -178,44 +219,106 @@ function ThemePreview({ theme }: { theme: AtlasTheme }) {
         >
           <span
             className="h-2.5 w-10 rounded-t"
-            style={{ background: s.tabActive, borderTop: `1px solid ${s.accent}` }}
+            style={{
+              background: s.tabActive,
+              borderTop: `1px solid ${s.accent}`,
+            }}
           />
-          <span className="h-2.5 w-8 rounded-t" style={{ background: s.panel }} />
+          <span
+            className="h-2.5 w-8 rounded-t"
+            style={{ background: s.panel }}
+          />
         </div>
         {/* Code body */}
         <div className="flex flex-1 flex-col gap-[7px] p-2.5">
-          <CodeLine tokens={[{ w: "22%", c: mut }, { w: "34%", c: mut }]} />
-          <CodeLine tokens={[{ w: "18%", c: kw }, { w: "28%", c: id }, { w: "10%", c: punc }]} />
-          <CodeLine indent={1} tokens={[{ w: "26%", c: id }, { w: "14%", c: punc }, { w: "30%", c: kw }]} />
-          <CodeLine indent={2} tokens={[{ w: "16%", c: kw }, { w: "40%", c: id }]} />
-          <CodeLine indent={2} tokens={[{ w: "30%", c: id }, { w: "12%", c: punc }, { w: "22%", c: mut }]} />
+          <CodeLine
+            tokens={[
+              { w: "22%", c: mut },
+              { w: "34%", c: mut },
+            ]}
+          />
+          <CodeLine
+            tokens={[
+              { w: "18%", c: kw },
+              { w: "28%", c: id },
+              { w: "10%", c: punc },
+            ]}
+          />
+          <CodeLine
+            indent={1}
+            tokens={[
+              { w: "26%", c: id },
+              { w: "14%", c: punc },
+              { w: "30%", c: kw },
+            ]}
+          />
+          <CodeLine
+            indent={2}
+            tokens={[
+              { w: "16%", c: kw },
+              { w: "40%", c: id },
+            ]}
+          />
+          <CodeLine
+            indent={2}
+            tokens={[
+              { w: "30%", c: id },
+              { w: "12%", c: punc },
+              { w: "22%", c: mut },
+            ]}
+          />
           <CodeLine indent={1} tokens={[{ w: "12%", c: punc }]} />
-          <CodeLine tokens={[{ w: "20%", c: kw }, { w: "24%", c: id }]} />
+          <CodeLine
+            tokens={[
+              { w: "20%", c: kw },
+              { w: "24%", c: id },
+            ]}
+          />
         </div>
       </div>
 
       {/* Pane 3 — chat / assistant */}
       <div
         className="flex w-[24%] shrink-0 flex-col gap-2 p-2"
-        style={{ background: s.panel, borderLeft: `1px solid ${s.borderSubtle}` }}
+        style={{
+          background: s.panel,
+          borderLeft: `1px solid ${s.borderSubtle}`,
+        }}
       >
         <div
           className="flex flex-col gap-1 rounded p-1.5"
           style={{ background: s.elevated }}
         >
-          <span className="h-1.5 w-full rounded-full" style={{ background: s.textTertiary }} />
-          <span className="h-1.5 w-3/4 rounded-full" style={{ background: s.textTertiary }} />
+          <span
+            className="h-1.5 w-full rounded-full"
+            style={{ background: s.textTertiary }}
+          />
+          <span
+            className="h-1.5 w-3/4 rounded-full"
+            style={{ background: s.textTertiary }}
+          />
         </div>
         <div
           className="ml-auto flex w-4/5 flex-col gap-1 rounded p-1.5"
-          style={{ background: `color-mix(in srgb, ${s.accent} 18%, transparent)` }}
+          style={{
+            background: `color-mix(in srgb, ${s.accent} 18%, transparent)`,
+          }}
         >
-          <span className="h-1.5 w-full rounded-full" style={{ background: s.accent }} />
-          <span className="h-1.5 w-2/3 rounded-full" style={{ background: s.accent }} />
+          <span
+            className="h-1.5 w-full rounded-full"
+            style={{ background: s.accent }}
+          />
+          <span
+            className="h-1.5 w-2/3 rounded-full"
+            style={{ background: s.accent }}
+          />
         </div>
         <span
           className="mt-auto h-4 w-full rounded"
-          style={{ background: s.input, border: `1px solid ${s.borderDefault}` }}
+          style={{
+            background: s.input,
+            border: `1px solid ${s.borderDefault}`,
+          }}
         />
       </div>
     </div>

--- a/src/features/settings/components/code-editor-theme-thumbnail.tsx
+++ b/src/features/settings/components/code-editor-theme-thumbnail.tsx
@@ -6,7 +6,11 @@ import type { EditorColorTheme } from "@/features/editor/themes/types";
  * theme shares one background; only syntax varies). Mirrors the visual-preview
  * approach of the Layouts picker's LayoutThumbnail.
  */
-export function CodeEditorThemeThumbnail({ theme }: { theme: EditorColorTheme }) {
+export function CodeEditorThemeThumbnail({
+  theme,
+}: {
+  theme: EditorColorTheme;
+}) {
   const c = theme.colors;
   return (
     <div
@@ -17,7 +21,9 @@ export function CodeEditorThemeThumbnail({ theme }: { theme: EditorColorTheme })
         className="h-full w-full px-2.5 py-2 font-mono leading-[1.6]"
         style={{ fontSize: "9px", color: c.fg }}
       >
-        <div style={{ color: c.comment, fontStyle: "italic" }}>// {theme.name} syntax preview</div>
+        <div style={{ color: c.comment, fontStyle: "italic" }}>
+          // {theme.name} syntax preview
+        </div>
         <div>
           <span style={{ color: c.keyword, fontStyle: "italic" }}>import</span>{" "}
           <span style={{ color: c.operator }}>{"{"}</span>{" "}
@@ -31,7 +37,9 @@ export function CodeEditorThemeThumbnail({ theme }: { theme: EditorColorTheme })
         </div>
         <div>
           <span style={{ color: c.keyword, fontStyle: "italic" }}>export</span>{" "}
-          <span style={{ color: c.keyword, fontStyle: "italic" }}>function</span>{" "}
+          <span style={{ color: c.keyword, fontStyle: "italic" }}>
+            function
+          </span>{" "}
           <span style={{ color: c.func }}>render</span>
           <span style={{ color: c.operator }}>(</span>
           <span style={{ color: c.variable }}>node</span>

--- a/src/features/settings/components/marketplace/installed-skills.tsx
+++ b/src/features/settings/components/marketplace/installed-skills.tsx
@@ -100,10 +100,12 @@ export function InstalledSkills({
 
   const seed = installedCache.get(cacheKeyFor(scope, effectiveProject));
   const [view, setView] = useState<ReconcileView | null>(seed?.view ?? null);
-  const [packList, setPackList] = useState<InstalledPack[]>(seed?.packList ?? []);
-  const [packProjected, setPackProjected] = useState<Record<string, Set<string>>>(
-    seed?.packProjected ?? {},
+  const [packList, setPackList] = useState<InstalledPack[]>(
+    seed?.packList ?? [],
   );
+  const [packProjected, setPackProjected] = useState<
+    Record<string, Set<string>>
+  >(seed?.packProjected ?? {});
   const [target, setTarget] = useState<ModalTarget>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -135,13 +137,21 @@ export function InstalledSkills({
     setPackList(pl);
     const entries = await Promise.all(
       pl.map(async (p) => {
-        const views = await packsApi.projections(scope, p.pack.name, effectiveProject);
+        const views = await packsApi.projections(
+          scope,
+          p.pack.name,
+          effectiveProject,
+        );
         return [p.pack.name, new Set(views.map((x) => x.tool))] as const;
       }),
     );
     const projected = Object.fromEntries(entries);
     setPackProjected(projected);
-    installedCache.set(key, { view: v, packList: pl, packProjected: projected });
+    installedCache.set(key, {
+      view: v,
+      packList: pl,
+      packProjected: projected,
+    });
   }, [scope, effectiveProject, projectMissing]);
 
   useEffect(() => {
@@ -162,7 +172,8 @@ export function InstalledSkills({
   // unit). Packs that ship NO skills (commands/agents/rules only) still appear
   // as their own rows so they don't vanish.
   const skills = useMemo(
-    () => [...(view?.skills ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+    () =>
+      [...(view?.skills ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
     [view],
   );
   const packsNoSkills = useMemo(
@@ -188,8 +199,16 @@ export function InstalledSkills({
       setError(null);
       try {
         if (on)
-          await packsApi.project(scope, packName, toolId, null, false, effectiveProject);
-        else await packsApi.unproject(scope, packName, toolId, effectiveProject);
+          await packsApi.project(
+            scope,
+            packName,
+            toolId,
+            null,
+            false,
+            effectiveProject,
+          );
+        else
+          await packsApi.unproject(scope, packName, toolId, effectiveProject);
         await refresh();
       } catch (e) {
         setError(String(e));
@@ -214,7 +233,14 @@ export function InstalledSkills({
       try {
         if (status === "synced")
           await skillsApi.unproject(scope, name, toolId, effectiveProject);
-        else await skillsApi.project(scope, name, toolId, status === "drifted", effectiveProject);
+        else
+          await skillsApi.project(
+            scope,
+            name,
+            toolId,
+            status === "drifted",
+            effectiveProject,
+          );
         await refresh();
       } catch (e) {
         setError(String(e));
@@ -333,21 +359,44 @@ export function InstalledSkills({
                     onClick={() => setTarget({ kind: "pack", pack: p })}
                     className="flex w-full items-center h-[40px] border-b border-border-subtle px-3 text-left transition-colors hover:bg-bg-hover"
                   >
-                    <span className={cn(COL.name, "flex items-center gap-2 min-w-0")}>
-                      <Package size={13} className="shrink-0 text-text-tertiary" />
+                    <span
+                      className={cn(
+                        COL.name,
+                        "flex items-center gap-2 min-w-0",
+                      )}
+                    >
+                      <Package
+                        size={13}
+                        className="shrink-0 text-text-tertiary"
+                      />
                       <span className="truncate text-[12px] text-text-primary">
                         {p.pack.name}
                       </span>
                     </span>
-                    <span className={cn(COL.origin, "truncate font-mono text-[10px] text-text-tertiary")}>
+                    <span
+                      className={cn(
+                        COL.origin,
+                        "truncate font-mono text-[10px] text-text-tertiary",
+                      )}
+                    >
                       {p.source}
                     </span>
-                    <span className={cn(COL.tools, "truncate text-[10px] text-text-tertiary")}>
+                    <span
+                      className={cn(
+                        COL.tools,
+                        "truncate text-[10px] text-text-tertiary",
+                      )}
+                    >
                       {proj.size > 0
                         ? `${proj.size} tool${proj.size > 1 ? "s" : ""}`
                         : kindCounts(p.pack.components) || "—"}
                     </span>
-                    <span className={cn(COL.chevron, "flex justify-end text-text-tertiary")}>
+                    <span
+                      className={cn(
+                        COL.chevron,
+                        "flex justify-end text-text-tertiary",
+                      )}
+                    >
                       <ChevronRight size={14} />
                     </span>
                   </button>
@@ -386,13 +435,28 @@ export function InstalledSkills({
                         </span>
                       )}
                     </span>
-                    <span className={cn(COL.origin, "truncate text-[11px] text-text-tertiary")}>
+                    <span
+                      className={cn(
+                        COL.origin,
+                        "truncate text-[11px] text-text-tertiary",
+                      )}
+                    >
                       {origin}
                     </span>
-                    <span className={cn(COL.tools, "text-[11px] text-text-secondary tabular-nums")}>
+                    <span
+                      className={cn(
+                        COL.tools,
+                        "text-[11px] text-text-secondary tabular-nums",
+                      )}
+                    >
                       {onCount > 0 ? `${onCount} on` : "off"}
                     </span>
-                    <span className={cn(COL.chevron, "flex justify-end text-text-tertiary")}>
+                    <span
+                      className={cn(
+                        COL.chevron,
+                        "flex justify-end text-text-tertiary",
+                      )}
+                    >
                       <ChevronRight size={14} />
                     </span>
                   </button>
@@ -409,7 +473,9 @@ export function InstalledSkills({
       {target?.kind === "pack" && (
         <PackManageModal
           pack={packByName.get(target.pack.pack.name) ?? target.pack}
-          packSkills={(view?.skills ?? []).filter((s) => s.pack === target.pack.pack.name)}
+          packSkills={(view?.skills ?? []).filter(
+            (s) => s.pack === target.pack.pack.name,
+          )}
           tools={tools}
           projected={mergeOptimistic(
             packProjected[target.pack.pack.name] ?? new Set<string>(),
@@ -419,7 +485,9 @@ export function InstalledSkills({
           busy={busy}
           scope={scope}
           effectiveProject={effectiveProject}
-          onToggle={(toolId, on) => void togglePackTool(target.pack.pack.name, toolId, on)}
+          onToggle={(toolId, on) =>
+            void togglePackTool(target.pack.pack.name, toolId, on)
+          }
           onUpdated={() => void refresh()}
           onUninstall={() => void uninstallPack(target.pack.pack.name)}
           onClose={() => {
@@ -439,7 +507,9 @@ export function InstalledSkills({
           detectedFor={detectedFor}
           busy={busy}
           optimistic={optimistic}
-          onToggle={(toolId, status) => void toggleSkillTool(target.skill.name, toolId, status)}
+          onToggle={(toolId, status) =>
+            void toggleSkillTool(target.skill.name, toolId, status)
+          }
           onOpen={() => void openSkill(target.skill.name)}
           onPromote={() => void promoteSkill(target.skill.name)}
           onUninstall={() => void uninstallSkill(target.skill.name)}
@@ -512,13 +582,20 @@ function ToolToggles({
         const readOnly = status === "pack" || status === "conflict";
         return (
           <div key={t.id} className="flex items-center justify-between">
-            <span className="text-[12px] text-text-secondary">{t.displayName}</span>
+            <span className="text-[12px] text-text-secondary">
+              {t.displayName}
+            </span>
             {!detected ? (
-              <span className="text-[10px] text-text-ghost" title="Tool not detected in this scope">
+              <span
+                className="text-[10px] text-text-ghost"
+                title="Tool not detected in this scope"
+              >
                 n/a
               </span>
             ) : readOnly ? (
-              <span className="text-[10px] text-text-tertiary capitalize">{status}</span>
+              <span className="text-[10px] text-text-tertiary capitalize">
+                {status}
+              </span>
             ) : (
               <OnOff
                 on={on}
@@ -598,7 +675,11 @@ function PackManageModal({
               projectedTools={projected}
               onDone={onUpdated}
             />
-            <ModalAction icon={Copy} label="Copy as markdown" onClick={copyMarkdown} />
+            <ModalAction
+              icon={Copy}
+              label="Copy as markdown"
+              onClick={copyMarkdown}
+            />
             <ModalAction
               icon={Github}
               label="View on GitHub"
@@ -616,7 +697,10 @@ function PackManageModal({
       }
     >
       <SkillDescriptions
-        skills={packSkills.map((s) => ({ name: s.name, description: s.description }))}
+        skills={packSkills.map((s) => ({
+          name: s.name,
+          description: s.description,
+        }))}
         fallback="This pack ships no skills (commands / agents / rules only)."
       />
     </SkillModalShell>
@@ -673,7 +757,11 @@ function SkillManageModal({
             onClick={(t, status) => onToggle(t.id, status)}
           />
           <div className="flex flex-col gap-2 border-t border-border-default pt-3">
-            <ModalAction icon={ExternalLink} label="Open in editor" onClick={onOpen} />
+            <ModalAction
+              icon={ExternalLink}
+              label="Open in editor"
+              onClick={onOpen}
+            />
             {scope === "project" && (
               <ModalAction
                 icon={ArrowUpCircle}
@@ -693,7 +781,9 @@ function SkillManageModal({
         </div>
       }
     >
-      <SkillDescriptions skills={[{ name: skill.name, description: skill.description }]} />
+      <SkillDescriptions
+        skills={[{ name: skill.name, description: skill.description }]}
+      />
     </SkillModalShell>
   );
 }
@@ -731,10 +821,22 @@ function PackUpdate({
   const apply = async () => {
     setState("updating");
     try {
-      const res = await packsApi.install(scope, source, false, effectiveProject);
+      const res = await packsApi.install(
+        scope,
+        source,
+        false,
+        effectiveProject,
+      );
       if (res.state === "updated") {
         for (const toolId of projectedTools)
-          await packsApi.project(scope, name, toolId, null, true, effectiveProject);
+          await packsApi.project(
+            scope,
+            name,
+            toolId,
+            null,
+            true,
+            effectiveProject,
+          );
       }
       onDone();
       setState("uptodate");
@@ -747,12 +849,27 @@ function PackUpdate({
   const base =
     "flex w-full items-center gap-2 rounded-md border border-border-default px-2.5 py-2 text-[12px] font-medium text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary";
   if (state === "checking")
-    return <span className={base}><Loader2 size={13} className="animate-spin" /> Checking…</span>;
+    return (
+      <span className={base}>
+        <Loader2 size={13} className="animate-spin" /> Checking…
+      </span>
+    );
   if (state === "updating")
-    return <span className={base}><Loader2 size={13} className="animate-spin" /> Updating…</span>;
-  if (state === "uptodate")
-    return <span className={base}>Up to date</span>;
+    return (
+      <span className={base}>
+        <Loader2 size={13} className="animate-spin" /> Updating…
+      </span>
+    );
+  if (state === "uptodate") return <span className={base}>Up to date</span>;
   if (state === "available")
-    return <button onClick={apply} className={base}><ArrowUpCircle size={13} /> Update available</button>;
-  return <button onClick={check} className={base}><RefreshCw size={13} /> Check for update</button>;
+    return (
+      <button onClick={apply} className={base}>
+        <ArrowUpCircle size={13} /> Update available
+      </button>
+    );
+  return (
+    <button onClick={check} className={base}>
+      <RefreshCw size={13} /> Check for update
+    </button>
+  );
 }

--- a/src/features/settings/components/marketplace/skill-modal.tsx
+++ b/src/features/settings/components/marketplace/skill-modal.tsx
@@ -105,7 +105,9 @@ export function SkillDescriptions({
     <div className="flex flex-col gap-3.5">
       {skills.map((s) => (
         <div key={s.name}>
-          <div className="text-[12px] font-medium text-text-primary">{s.name}</div>
+          <div className="text-[12px] font-medium text-text-primary">
+            {s.name}
+          </div>
           {s.description && (
             <div className="mt-0.5 text-[12px] leading-relaxed text-text-tertiary">
               {s.description}

--- a/src/features/settings/components/marketplace/skills-marketplace.tsx
+++ b/src/features/settings/components/marketplace/skills-marketplace.tsx
@@ -17,7 +17,16 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { Boxes, Check, Copy, Download, Github, Loader2, Search, X } from "lucide-react";
+import {
+  Boxes,
+  Check,
+  Copy,
+  Download,
+  Github,
+  Loader2,
+  Search,
+  X,
+} from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
 
@@ -25,11 +34,7 @@ import { cn } from "@/lib/utils";
 import { packs as packsApi } from "@/features/packs/lib/packs-api";
 import { skills as skillsApi } from "@/features/skills/lib/skills-api";
 import { SKILLS_CHANGED_EVENT } from "@/features/skills/lib/skills-events";
-import {
-  SkillModalShell,
-  SkillDescriptions,
-  ModalAction,
-} from "./skill-modal";
+import { SkillModalShell, SkillDescriptions, ModalAction } from "./skill-modal";
 import type {
   ComponentKind,
   Pack,
@@ -37,7 +42,14 @@ import type {
   Scope,
 } from "@/features/packs/lib/types";
 
-const POPULAR_SEEDS = ["agent", "react", "design", "review", "database", "python"];
+const POPULAR_SEEDS = [
+  "agent",
+  "react",
+  "design",
+  "review",
+  "database",
+  "python",
+];
 const POPULAR_LS_KEY = "atlas:skills:popular:v1";
 
 // Cache the first popular fetch so re-entering Discover (or restarting the app)
@@ -69,7 +81,12 @@ async function runInstall(
   notifyInstalling();
   try {
     // Install just THIS skill (not the whole repo) — the registry is skill-level.
-    await packsApi.installSkill(scope, hit.source, hit.skillId || hit.name, projectPath);
+    await packsApi.installSkill(
+      scope,
+      hit.source,
+      hit.skillId || hit.name,
+      projectPath,
+    );
   } catch (e) {
     toast.error(`Couldn't install ${hit.name}: ${String(e)}`);
   } finally {
@@ -132,7 +149,9 @@ export function SkillsMarketplace({
 
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<PackSearchHit[]>([]);
-  const [popular, setPopular] = useState<PackSearchHit[]>(() => loadPopularCache() ?? []);
+  const [popular, setPopular] = useState<PackSearchHit[]>(
+    () => loadPopularCache() ?? [],
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Re-render whenever the module-level install registry changes.
@@ -147,7 +166,9 @@ export function SkillsMarketplace({
   // The set of installed skill NAMES (each registry hit is one skill; `skillId`
   // is its name). We check installed-state per skill, NOT per source repo — a
   // repo holds many skills, so "is the repo installed" wrongly marks all of them.
-  const [installedSkills, setInstalledSkills] = useState<Set<string>>(new Set());
+  const [installedSkills, setInstalledSkills] = useState<Set<string>>(
+    new Set(),
+  );
 
   const refreshInstalled = useCallback(async () => {
     try {
@@ -245,7 +266,9 @@ export function SkillsMarketplace({
           spellCheck={false}
           className="min-w-0 flex-1 bg-transparent text-[11px] text-text-primary outline-none placeholder:text-text-tertiary"
         />
-        {loading && <Loader2 size={11} className="animate-spin text-text-tertiary" />}
+        {loading && (
+          <Loader2 size={11} className="animate-spin text-text-tertiary" />
+        )}
         {query && (
           <button
             type="button"
@@ -269,7 +292,9 @@ export function SkillsMarketplace({
           {/* sticky header */}
           <div className="sticky top-0 z-10 flex items-center h-[28px] border-b border-border-default bg-bg-base px-3 text-[10px] uppercase tracking-wider text-text-tertiary">
             <span className={cn(COL.rank, "text-right pr-2")}>#</span>
-            <span className={COL.skill}>{query.trim() ? "Results" : "Popular"}</span>
+            <span className={COL.skill}>
+              {query.trim() ? "Results" : "Popular"}
+            </span>
             <span className={COL.source}>Source</span>
             <span className={cn(COL.installs, "text-right")}>Installs</span>
             <span className={COL.action} />
@@ -306,7 +331,12 @@ export function SkillsMarketplace({
                   >
                     {i + 1}
                   </span>
-                  <span className={cn(COL.skill, "truncate text-[12px] text-text-primary")}>
+                  <span
+                    className={cn(
+                      COL.skill,
+                      "truncate text-[12px] text-text-primary",
+                    )}
+                  >
                     {hit.name}
                   </span>
                   <span
@@ -377,7 +407,11 @@ function InstallButton({
       onClick={onClick}
       className="inline-flex items-center gap-1.5 rounded-md border border-border-default px-2.5 py-1 text-[11px] font-medium text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary disabled:opacity-50"
     >
-      {installing ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
+      {installing ? (
+        <Loader2 size={12} className="animate-spin" />
+      ) : (
+        <Download size={12} />
+      )}
       Install
     </button>
   );
@@ -400,7 +434,7 @@ function SkillDetailModal({
 }) {
   // Seed synchronously from cache so a re-opened modal paints instantly.
   const [preview, setPreview] = useState<Pack | null>(
-    hit ? previewCache.get(hit.source) ?? null : null,
+    hit ? (previewCache.get(hit.source) ?? null) : null,
   );
   const [loading, setLoading] = useState(false);
 
@@ -445,7 +479,11 @@ function SkillDetailModal({
   }, [preview]);
 
   const modalSkills = useMemo(
-    () => skillComponents.map((c) => ({ name: c.name, description: c.description })),
+    () =>
+      skillComponents.map((c) => ({
+        name: c.name,
+        description: c.description,
+      })),
     [skillComponents],
   );
 
@@ -454,7 +492,8 @@ function SkillDetailModal({
   const copyMarkdown = () => {
     if (!hit) return;
     const lines = [`# ${hit.name}`, ""];
-    if (preview?.manifest?.description) lines.push(preview.manifest.description, "");
+    if (preview?.manifest?.description)
+      lines.push(preview.manifest.description, "");
     for (const c of skillComponents) {
       lines.push(`## ${c.name}`);
       if (c.description) lines.push("", c.description);
@@ -469,7 +508,11 @@ function SkillDetailModal({
       open={!!hit}
       onClose={onClose}
       title={hit?.name ?? ""}
-      subtitle={hit ? `${hit.source} · ${hit.installs.toLocaleString()} installs` : undefined}
+      subtitle={
+        hit
+          ? `${hit.source} · ${hit.installs.toLocaleString()} installs`
+          : undefined
+      }
       actions={
         <div className="flex flex-col gap-2">
           <ModalAction
@@ -480,7 +523,11 @@ function SkillDetailModal({
             disabled={installed}
             onClick={onInstall}
           />
-          <ModalAction icon={Copy} label="Copy as markdown" onClick={copyMarkdown} />
+          <ModalAction
+            icon={Copy}
+            label="Copy as markdown"
+            onClick={copyMarkdown}
+          />
           {hit && (
             <ModalAction
               icon={Github}

--- a/src/features/settings/components/models-manager.tsx
+++ b/src/features/settings/components/models-manager.tsx
@@ -37,7 +37,9 @@ export function ModelsManager() {
 
   const [kind, setKind] = useState<ModelKind>("embedding");
   const [query, setQuery] = useState("");
-  const [confirm, setConfirm] = useState<{ id: string; name: string } | null>(null);
+  const [confirm, setConfirm] = useState<{ id: string; name: string } | null>(
+    null,
+  );
 
   useEffect(() => {
     void actions.init();
@@ -56,7 +58,9 @@ export function ModelsManager() {
     try {
       await actions.download(m.id);
     } catch (e) {
-      toast.error(`Download failed: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Download failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   };
 
@@ -106,12 +110,25 @@ export function ModelsManager() {
       {/* Toolbar */}
       <div className="shrink-0 border-b border-border-default px-4 py-2.5 flex items-center gap-2">
         <div className="flex items-center rounded-md border border-border-default overflow-hidden">
-          <KindTab active={kind === "embedding"} onClick={() => setKind("embedding")} icon={Boxes} label="Embedding" />
-          <KindTab active={kind === "llm"} onClick={() => setKind("llm")} icon={Cpu} label="Language" />
+          <KindTab
+            active={kind === "embedding"}
+            onClick={() => setKind("embedding")}
+            icon={Boxes}
+            label="Embedding"
+          />
+          <KindTab
+            active={kind === "llm"}
+            onClick={() => setKind("llm")}
+            icon={Cpu}
+            label="Language"
+          />
         </div>
 
         <div className="relative ml-auto w-[240px]">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-tertiary" />
+          <Search
+            size={13}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-tertiary"
+          />
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -128,7 +145,9 @@ export function ModelsManager() {
       {/* Table */}
       <div className="flex-1 min-h-0 overflow-auto">
         {!loaded ? (
-          <div className="p-8 text-center text-[11px] text-text-tertiary">Loading models…</div>
+          <div className="p-8 text-center text-[11px] text-text-tertiary">
+            Loading models…
+          </div>
         ) : (
           <div className="min-w-[560px]">
             {/* header */}
@@ -149,17 +168,27 @@ export function ModelsManager() {
                 >
                   <div className={COL.name}>
                     <div className="flex items-center gap-1.5">
-                      <span className="text-[12px] font-medium text-text-primary">{m.name}</span>
+                      <span className="text-[12px] font-medium text-text-primary">
+                        {m.name}
+                      </span>
                       {m.selected && (
                         <span className="text-[9px] uppercase tracking-wide text-[var(--bg-base)] bg-accent rounded px-1 py-px">
                           In use
                         </span>
                       )}
                     </div>
-                    <div className="text-[10px] text-text-tertiary mt-0.5 truncate">{m.description}</div>
+                    <div className="text-[10px] text-text-tertiary mt-0.5 truncate">
+                      {m.description}
+                    </div>
                   </div>
-                  <div className={cn(COL.size, "text-[11px] text-text-secondary")}>{fmtSize(m.sizeMb)}</div>
-                  <div className={cn(COL.dim, "text-[11px] text-text-secondary")}>
+                  <div
+                    className={cn(COL.size, "text-[11px] text-text-secondary")}
+                  >
+                    {fmtSize(m.sizeMb)}
+                  </div>
+                  <div
+                    className={cn(COL.dim, "text-[11px] text-text-secondary")}
+                  >
                     {m.dim ?? "—"}
                   </div>
                   <div className={COL.status}>
@@ -167,7 +196,8 @@ export function ModelsManager() {
                       <ProgressBar dl={dl} />
                     ) : m.downloaded ? (
                       <span className="inline-flex items-center gap-1 text-[10px] text-text-secondary">
-                        <Check size={12} className="text-text-secondary" /> Downloaded
+                        <Check size={12} className="text-text-secondary" />{" "}
+                        Downloaded
                       </span>
                     ) : (
                       <button
@@ -179,7 +209,12 @@ export function ModelsManager() {
                       </button>
                     )}
                   </div>
-                  <div className={cn(COL.use, "flex items-center justify-end gap-1")}>
+                  <div
+                    className={cn(
+                      COL.use,
+                      "flex items-center justify-end gap-1",
+                    )}
+                  >
                     {m.downloaded && !m.selected && (
                       <button
                         type="button"
@@ -187,7 +222,11 @@ export function ModelsManager() {
                         onClick={() => void doUse(m)}
                         className="h-6 rounded-md px-2 text-[10px] font-medium border border-border-default bg-bg-elevated text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-50"
                       >
-                        {busy ? <Loader2 size={11} className="animate-spin" /> : "Use"}
+                        {busy ? (
+                          <Loader2 size={11} className="animate-spin" />
+                        ) : (
+                          "Use"
+                        )}
                       </button>
                     )}
                     {m.downloaded && !m.selected && (
@@ -237,7 +276,9 @@ function KindTab({
       onClick={onClick}
       className={cn(
         "inline-flex items-center gap-1.5 h-7 px-2.5 text-[11px] font-medium transition-colors cursor-pointer",
-        active ? "bg-bg-selected text-text-primary" : "text-text-secondary hover:bg-bg-hover",
+        active
+          ? "bg-bg-selected text-text-primary"
+          : "text-text-secondary hover:bg-bg-hover",
       )}
     >
       {Icon && <Icon size={12} />}
@@ -246,11 +287,17 @@ function KindTab({
   );
 }
 
-function ProgressBar({ dl }: { dl: { fileIndex: number; fileCount: number; received: number; total: number } }) {
+function ProgressBar({
+  dl,
+}: {
+  dl: { fileIndex: number; fileCount: number; received: number; total: number };
+}) {
   const pct = Math.min(
     100,
     Math.round(
-      ((dl.fileIndex + (dl.total ? dl.received / dl.total : 0)) / Math.max(1, dl.fileCount)) * 100,
+      ((dl.fileIndex + (dl.total ? dl.received / dl.total : 0)) /
+        Math.max(1, dl.fileCount)) *
+        100,
     ),
   );
   return (
@@ -261,7 +308,9 @@ function ProgressBar({ dl }: { dl: { fileIndex: number; fileCount: number; recei
           style={{ width: `${pct}%` }}
         />
       </div>
-      <span className="text-[10px] tabular-nums text-text-tertiary">{pct}%</span>
+      <span className="text-[10px] tabular-nums text-text-tertiary">
+        {pct}%
+      </span>
     </div>
   );
 }
@@ -276,19 +325,28 @@ function ConfirmReindex({
   onConfirm: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onCancel}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onCancel}
+    >
       <div
         className="w-[380px] rounded-lg border border-border-default bg-bg-primary p-4 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start gap-2.5">
-          <AlertTriangle size={16} className="text-[var(--status-warning)] shrink-0 mt-0.5" />
+          <AlertTriangle
+            size={16}
+            className="text-[var(--status-warning)] shrink-0 mt-0.5"
+          />
           <div>
-            <p className="text-[13px] font-semibold text-text-primary">Switch embedding model?</p>
+            <p className="text-[13px] font-semibold text-text-primary">
+              Switch embedding model?
+            </p>
             <p className="text-[11px] text-text-secondary mt-1 leading-relaxed">
-              Using <span className="text-text-primary">{name}</span> re-embeds your memory in a new
-              vector space. Atlas will wipe this project's memory index and rebuild it in the
-              background. Your notes and files are untouched.
+              Using <span className="text-text-primary">{name}</span> re-embeds
+              your memory in a new vector space. Atlas will wipe this project's
+              memory index and rebuild it in the background. Your notes and
+              files are untouched.
             </p>
           </div>
         </div>

--- a/src/features/settings/components/providers-settings.tsx
+++ b/src/features/settings/components/providers-settings.tsx
@@ -104,18 +104,21 @@ export function ProvidersSettings() {
     return list;
   }, [category, query, sortKey, configuredOnly, keys]);
 
-  const tabs: Array<{ id: ProviderCategory | "All"; label: string; count: number }> =
-    useMemo(
-      () => [
-        { id: "All", label: "All", count: PROVIDERS.length },
-        ...PROVIDER_CATEGORIES.map((c) => ({
-          id: c,
-          label: c,
-          count: PROVIDERS.filter((p) => p.category === c).length,
-        })),
-      ],
-      [],
-    );
+  const tabs: Array<{
+    id: ProviderCategory | "All";
+    label: string;
+    count: number;
+  }> = useMemo(
+    () => [
+      { id: "All", label: "All", count: PROVIDERS.length },
+      ...PROVIDER_CATEGORIES.map((c) => ({
+        id: c,
+        label: c,
+        count: PROVIDERS.filter((p) => p.category === c).length,
+      })),
+    ],
+    [],
+  );
 
   return (
     <div className="h-full flex flex-col bg-bg-base">
@@ -177,7 +180,9 @@ export function ProvidersSettings() {
                 className="flex items-center gap-2 px-3 h-[26px] text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary cursor-pointer outline-none"
               >
                 <span className="inline-flex w-3.5 justify-center">
-                  {configuredOnly && <Check size={11} className="text-text-primary" />}
+                  {configuredOnly && (
+                    <Check size={11} className="text-text-primary" />
+                  )}
                 </span>
                 Configured only
               </DropdownMenu.CheckboxItem>
@@ -194,7 +199,9 @@ export function ProvidersSettings() {
                   className="flex items-center justify-between gap-2 px-3 h-[26px] text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary cursor-pointer outline-none"
                 >
                   {SORT_LABELS[k]}
-                  {sortKey === k && <Check size={11} className="text-text-primary" />}
+                  {sortKey === k && (
+                    <Check size={11} className="text-text-primary" />
+                  )}
                 </DropdownMenu.Item>
               ))}
             </DropdownMenu.Content>
@@ -279,7 +286,12 @@ function ProviderTableRow({
           {provider.env}
         </span>
         {/* Category */}
-        <span className={cn(COL.category, "truncate text-[11px] text-text-secondary")}>
+        <span
+          className={cn(
+            COL.category,
+            "truncate text-[11px] text-text-secondary",
+          )}
+        >
           {provider.category}
         </span>
         {/* Key */}
@@ -309,7 +321,12 @@ function ProviderTableRow({
           )}
         </span>
         {/* Chevron */}
-        <span className={cn(COL.chevron, "flex items-center justify-end text-text-tertiary")}>
+        <span
+          className={cn(
+            COL.chevron,
+            "flex items-center justify-end text-text-tertiary",
+          )}
+        >
           {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
       </button>
@@ -417,4 +434,3 @@ function ProviderEditor({
     </div>
   );
 }
-

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -73,8 +73,12 @@ const SECTIONS: Array<{
 
 const NAV_COLLAPSED_KEY = "atlas:settings:navCollapsed";
 
-export function SettingsPanel({ initialSection }: { initialSection?: string } = {}) {
-  const [activeSection, setActiveSection] = useState(initialSection ?? "general");
+export function SettingsPanel({
+  initialSection,
+}: { initialSection?: string } = {}) {
+  const [activeSection, setActiveSection] = useState(
+    initialSection ?? "general",
+  );
 
   // Honor cross-component "open Settings → <section>" requests (e.g. the
   // sidebar's Skills button), whether this panel is fresh or already mounted.
@@ -206,11 +210,14 @@ function GeneralSettings() {
   // Model pricing (models.dev) — manual refresh + count for the picker.
   const pricingPrices = useModelPricingStore.use.prices();
   const pricingLoading = useModelPricingStore.use.loading();
-  const { load: loadPricing, refresh: refreshPricing } = useModelPricingStore.use.actions();
+  const { load: loadPricing, refresh: refreshPricing } =
+    useModelPricingStore.use.actions();
   useEffect(() => {
     void loadPricing();
   }, [loadPricing]);
-  const pricedModelCount = Object.keys(pricingPrices).filter((k) => k.includes("/")).length;
+  const pricedModelCount = Object.keys(pricingPrices).filter((k) =>
+    k.includes("/"),
+  ).length;
   const updatePricing = async () => {
     await refreshPricing();
     const n = Object.keys(useModelPricingStore.getState().prices).filter((k) =>
@@ -238,7 +245,9 @@ function GeneralSettings() {
       setCli(next);
       toast.success("Installed atlas tools");
     } catch (e) {
-      toast.error(`Install failed: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Install failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
     } finally {
       setInstalling(false);
     }
@@ -263,9 +272,7 @@ function GeneralSettings() {
       >
         <Toggle
           checked={settings.autoAddAtlasGitignore}
-          onChange={(next) =>
-            updateSettings({ autoAddAtlasGitignore: next })
-          }
+          onChange={(next) => updateSettings({ autoAddAtlasGitignore: next })}
         />
       </SettingRow>
       <SettingRow
@@ -362,7 +369,11 @@ function GeneralSettings() {
             "disabled:opacity-50 disabled:cursor-not-allowed",
           )}
         >
-          {installing ? "Installing…" : cli?.installed ? "Reinstall" : "Install"}
+          {installing
+            ? "Installing…"
+            : cli?.installed
+              ? "Reinstall"
+              : "Install"}
         </button>
       </SettingRow>
       <SettingRow
@@ -399,7 +410,8 @@ function AppearanceSettings() {
   const [tab, setTab] = useState<AppearanceTab>("accent");
 
   const scalePct = Math.round(settings.uiScale * 100);
-  const setScale = (next: number) => updateSettings({ uiScale: clampScale(next) });
+  const setScale = (next: number) =>
+    updateSettings({ uiScale: clampScale(next) });
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -415,7 +427,10 @@ function AppearanceSettings() {
         ))}
 
         {/* Interface zoom — right-aligned control (like Skills' scope control). */}
-        <div className="ml-auto flex items-center gap-1 pr-0.5" title="Interface zoom (⌘+ / ⌘- / ⌘0)">
+        <div
+          className="ml-auto flex items-center gap-1 pr-0.5"
+          title="Interface zoom (⌘+ / ⌘- / ⌘0)"
+        >
           <button
             type="button"
             aria-label="Zoom out"
@@ -454,7 +469,11 @@ function AppearanceSettings() {
       </div>
 
       <div className="min-h-0 flex-1">
-        {tab === "theme" ? <CodeEditorThemesSettings /> : <AtlasThemesSettings />}
+        {tab === "theme" ? (
+          <CodeEditorThemesSettings />
+        ) : (
+          <AtlasThemesSettings />
+        )}
       </div>
     </div>
   );
@@ -505,10 +524,14 @@ function UpdatesSettings() {
       // When an update exists, the background download starts and the store
       // reflects it below; only surface the "up to date" case here.
       if (!status.available) {
-        toast.success(`You're on the latest version (${status.currentVersion}).`);
+        toast.success(
+          `You're on the latest version (${status.currentVersion}).`,
+        );
       }
     } catch (e) {
-      toast.error(`Update check failed: ${e instanceof Error ? e.message : String(e)}`);
+      toast.error(
+        `Update check failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
     } finally {
       setChecking(false);
     }
@@ -534,7 +557,9 @@ function UpdatesSettings() {
     </button>
   ) : downloading ? (
     <span className="text-[11px] text-text-tertiary tabular-nums">
-      {progress != null ? `Downloading ${Math.round(progress * 100)}%` : "Preparing…"}
+      {progress != null
+        ? `Downloading ${Math.round(progress * 100)}%`
+        : "Preparing…"}
     </span>
   ) : (
     <button
@@ -553,7 +578,10 @@ function UpdatesSettings() {
 
   return (
     <div className="space-y-6">
-      <SectionTitle title="Updates" subtitle="How Atlas keeps itself up to date" />
+      <SectionTitle
+        title="Updates"
+        subtitle="How Atlas keeps itself up to date"
+      />
       <SettingRow
         label="Automatic updates"
         description="Check for a newer version in the background and download it automatically. Updates are Apple-signed and notarized; Atlas verifies the signature before installing. Turn off to never check or download."
@@ -564,7 +592,11 @@ function UpdatesSettings() {
         />
       </SettingRow>
       <SettingRow
-        label={ready ? `Update ready${version ? ` (${version})` : ""}` : "Check for updates"}
+        label={
+          ready
+            ? `Update ready${version ? ` (${version})` : ""}`
+            : "Check for updates"
+        }
         description={
           ready
             ? "A new version has been downloaded and verified. Restart now, or it'll be applied automatically the next time you quit Atlas."
@@ -660,10 +692,12 @@ function KeybindingsSettings() {
                 key={b.action}
                 className={cn(
                   "flex items-center justify-between px-3 h-[32px]",
-                  i > 0 && "border-t border-border-subtle"
+                  i > 0 && "border-t border-border-subtle",
                 )}
               >
-                <span className="text-[11px] text-text-secondary">{b.action}</span>
+                <span className="text-[11px] text-text-secondary">
+                  {b.action}
+                </span>
                 <KbdCombo combo={b.keys} />
               </div>
             ))}
@@ -720,18 +754,28 @@ function AboutSettings() {
           <AtlasIcon size={40} className="rounded-xl" />
           <div>
             <p className="text-sm font-semibold text-text-primary">Atlas</p>
-            <p className="text-[10px] text-text-tertiary">v0.2.4 — The second brain IDE</p>
+            <p className="text-[10px] text-text-tertiary">
+              v0.2.4 — The second brain IDE
+            </p>
           </div>
         </div>
         <p className="text-[11px] text-text-secondary leading-relaxed pt-2">
-          Built with Tauri, React, and Rust. An everything app for agentic development — from code analysis to task management, research, and AI orchestration.
+          Built with Tauri, React, and Rust. An everything app for agentic
+          development — from code analysis to task management, research, and AI
+          orchestration.
         </p>
       </div>
     </div>
   );
 }
 
-function SectionTitle({ title, subtitle }: { title: string; subtitle: string }) {
+function SectionTitle({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) {
   return (
     <div>
       <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
@@ -740,7 +784,15 @@ function SectionTitle({ title, subtitle }: { title: string; subtitle: string }) 
   );
 }
 
-function SettingRow({ label, description, children }: { label: string; description: string; children: React.ReactNode }) {
+function SettingRow({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
@@ -793,9 +845,7 @@ function Toggle({
         "relative inline-flex h-5 w-9 shrink-0 items-center",
         "rounded-full border-2 border-transparent transition-colors",
         disabled ? "opacity-40 cursor-not-allowed" : "cursor-pointer",
-        value
-          ? "bg-[var(--accent-primary)]"
-          : "bg-[var(--bg-elevated)]"
+        value ? "bg-[var(--accent-primary)]" : "bg-[var(--bg-elevated)]",
       )}
     >
       <span
@@ -804,10 +854,9 @@ function Toggle({
           "transition-transform duration-150",
           value
             ? "translate-x-4 bg-[var(--bg-base)]"
-            : "translate-x-0 bg-white"
+            : "translate-x-0 bg-white",
         )}
       />
     </button>
   );
 }
-

--- a/src/features/settings/components/skills-and-packs.tsx
+++ b/src/features/settings/components/skills-and-packs.tsx
@@ -35,7 +35,9 @@ export function SkillsAndPacks() {
       <div className="flex h-[29px] shrink-0 items-center gap-1 border-b border-border-default px-2">
         <div className="flex items-center gap-1.5 px-1.5">
           <AtlasIcon size={13} />
-          <span className="text-[12px] font-semibold text-text-primary">Skills</span>
+          <span className="text-[12px] font-semibold text-text-primary">
+            Skills
+          </span>
         </div>
         <span className="mx-1 h-3.5 w-px bg-border-default" />
         {TABS.map((t) => (
@@ -56,7 +58,9 @@ export function SkillsAndPacks() {
                 key={s}
                 active={scope === s}
                 disabled={disabled}
-                title={disabled ? "Open a project to use project scope" : undefined}
+                title={
+                  disabled ? "Open a project to use project scope" : undefined
+                }
                 onClick={() => setScope(s)}
                 label={s}
               />

--- a/src/features/settings/lib/models-api.ts
+++ b/src/features/settings/lib/models-api.ts
@@ -58,10 +58,16 @@ export const models = {
   reindex: (cwd: string) => invoke<void>("force_reindex", { cwd }),
 };
 
-export const listenModelProgress = (cb: (p: DownloadProgress) => void): Promise<UnlistenFn> =>
-  listen<DownloadProgress>("atlas:model-download:progress", (e) => cb(e.payload));
+export const listenModelProgress = (
+  cb: (p: DownloadProgress) => void,
+): Promise<UnlistenFn> =>
+  listen<DownloadProgress>("atlas:model-download:progress", (e) =>
+    cb(e.payload),
+  );
 
-export const listenModelDone = (cb: (d: DownloadDone) => void): Promise<UnlistenFn> =>
+export const listenModelDone = (
+  cb: (d: DownloadDone) => void,
+): Promise<UnlistenFn> =>
   listen<DownloadDone>("atlas:model-download:done", (e) => cb(e.payload));
 
 /** Fires whenever the catalog's on-disk / selection state changes. */

--- a/src/features/settings/lib/providers.ts
+++ b/src/features/settings/lib/providers.ts
@@ -183,8 +183,7 @@ export const PROVIDERS: ProviderDef[] = [
     name: "Azure OpenAI",
     env: "AZURE_API_KEY",
     category: "Gateway",
-    docsUrl:
-      "https://learn.microsoft.com/azure/ai-services/openai/quickstart",
+    docsUrl: "https://learn.microsoft.com/azure/ai-services/openai/quickstart",
   },
 
   // ── Embeddings & audio ───────────────────────────────────────────

--- a/src/features/settings/stores/model-pricing-store.ts
+++ b/src/features/settings/stores/model-pricing-store.ts
@@ -37,10 +37,14 @@ const base = create<ModelPricingState>((set, get) => ({
       // Rust side reloads the cache here automatically.
       if (!listenerBound) {
         listenerBound = true;
-        void listen("atlas:models-pricing-updated", () => void get().actions.load());
+        void listen(
+          "atlas:models-pricing-updated",
+          () => void get().actions.load(),
+        );
       }
       try {
-        const prices = await invoke<Record<string, ModelPrice>>("models_pricing_get");
+        const prices =
+          await invoke<Record<string, ModelPrice>>("models_pricing_get");
         set({ prices, loaded: true });
       } catch {
         set({ loaded: true });
@@ -50,7 +54,8 @@ const base = create<ModelPricingState>((set, get) => ({
       set({ loading: true });
       try {
         await invoke("models_pricing_refresh");
-        const prices = await invoke<Record<string, ModelPrice>>("models_pricing_get");
+        const prices =
+          await invoke<Record<string, ModelPrice>>("models_pricing_get");
         set({ prices, loaded: true });
       } catch {
         // best-effort — keep whatever's cached
@@ -75,6 +80,7 @@ export function priceFor(
 /** Compact display: `$3 / $15` (input / output per 1M tokens). */
 export function formatPrice(p: ModelPrice | null, loading: boolean): string {
   if (loading || !p) return "---";
-  const fmt = (n: number) => (Number.isInteger(n) ? `$${n}` : `$${n.toFixed(2)}`);
+  const fmt = (n: number) =>
+    Number.isInteger(n) ? `$${n}` : `$${n.toFixed(2)}`;
   return `${fmt(p.input)} / ${fmt(p.output)}`;
 }

--- a/src/features/settings/stores/models-store.ts
+++ b/src/features/settings/stores/models-store.ts
@@ -64,7 +64,9 @@ export const useModelsStore = createSelectors(
             void get().actions.refresh();
           }),
         );
-        unlistens.push(await listenModelsChanged(() => void get().actions.refresh()));
+        unlistens.push(
+          await listenModelsChanged(() => void get().actions.refresh()),
+        );
       },
 
       refresh: async () => {
@@ -83,7 +85,14 @@ export const useModelsStore = createSelectors(
         set((s) => ({
           downloading: {
             ...s.downloading,
-            [id]: { id, file: "", fileIndex: 0, fileCount: 1, received: 0, total: 0 },
+            [id]: {
+              id,
+              file: "",
+              fileIndex: 0,
+              fileCount: 1,
+              received: 0,
+              total: 0,
+            },
           },
         }));
         try {

--- a/src/features/skills/lib/skills-api.ts
+++ b/src/features/skills/lib/skills-api.ts
@@ -147,7 +147,9 @@ export const skills = {
 
   /** Promote a project skill to the global library + re-project at global scope. */
   promote: (name: string, projectPath: string) =>
-    afterSkillMutation(invoke<SkillMeta>("skills_promote", { name, projectPath })),
+    afterSkillMutation(
+      invoke<SkillMeta>("skills_promote", { name, projectPath }),
+    ),
 
   /** Freeze every Atlas symlink projection into a real copy (uninstall safety). */
   freeze: (scope: Scope, projectPath?: string | null) =>

--- a/src/features/terminal/components/block-terminal.tsx
+++ b/src/features/terminal/components/block-terminal.tsx
@@ -1,13 +1,30 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { Loader2, CheckCircle2, XCircle, ChevronRight, Folder, Copy, RotateCw, ChevronDown, ChevronUp, Search, X, GitBranch, Lock } from "lucide-react";
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  ChevronRight,
+  Folder,
+  Copy,
+  RotateCw,
+  ChevronDown,
+  ChevronUp,
+  Search,
+  X,
+  GitBranch,
+  Lock,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { openFileOrReveal } from "@/lib/open-file";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { resolveTerminalFont } from "../utils/resolve-font";
-import { resolveTerminalOutput, type AnsiSegment } from "../lib/ansi-to-segments";
+import {
+  resolveTerminalOutput,
+  type AnsiSegment,
+} from "../lib/ansi-to-segments";
 import { splitLinks, normalizeUrl } from "../lib/linkify-paths";
 import { createTerminalKeymap } from "../lib/terminal-keymap";
 import { createPathLinkProvider } from "../lib/path-link-provider";
@@ -61,9 +78,13 @@ function renderHL(text: string, query: string): ReactNode {
     }
     if (idx > i) nodes.push(text.slice(i, idx));
     nodes.push(
-      <mark key={k++} data-term-match className="rounded-[2px] bg-[var(--status-warning)]/40 text-inherit">
+      <mark
+        key={k++}
+        data-term-match
+        className="rounded-[2px] bg-[var(--status-warning)]/40 text-inherit"
+      >
         {text.slice(idx, idx + q.length)}
-      </mark>
+      </mark>,
     );
     i = idx + q.length;
   }
@@ -88,11 +109,22 @@ const XTERM_THEME = {
   // hiding the selected glyphs (opaque #303030 read as nearly invisible).
   selectionBackground: "rgba(97,175,239,0.35)",
   selectionInactiveBackground: "rgba(255,255,255,0.16)",
-  black: "#1a1a1a", red: "#e06c75", green: "#98c379", yellow: "#e5c07b",
-  blue: "#61afef", magenta: "#c678dd", cyan: "#56b6c2", white: "#cccccc",
-  brightBlack: "#5c6370", brightRed: "#e06c75", brightGreen: "#98c379",
-  brightYellow: "#e5c07b", brightBlue: "#61afef", brightMagenta: "#c678dd",
-  brightCyan: "#56b6c2", brightWhite: "#ffffff",
+  black: "#1a1a1a",
+  red: "#e06c75",
+  green: "#98c379",
+  yellow: "#e5c07b",
+  blue: "#61afef",
+  magenta: "#c678dd",
+  cyan: "#56b6c2",
+  white: "#cccccc",
+  brightBlack: "#5c6370",
+  brightRed: "#e06c75",
+  brightGreen: "#98c379",
+  brightYellow: "#e5c07b",
+  brightBlue: "#61afef",
+  brightMagenta: "#c678dd",
+  brightCyan: "#56b6c2",
+  brightWhite: "#ffffff",
 };
 
 /**
@@ -104,7 +136,11 @@ const XTERM_THEME = {
  * The React command input sends lines to the shell; when an alt-screen app is
  * running, keystrokes go to xterm instead.
  */
-export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalProps) {
+export function BlockTerminal({
+  isActive,
+  onFocus,
+  terminalKey,
+}: BlockTerminalProps) {
   const [blocks, setBlocks] = useState<TerminalBlock[]>([]);
   const [altScreen, setAltScreen] = useState(false);
   const [cwd, setCwd] = useState<string>("");
@@ -124,7 +160,9 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
 
   useEffect(() => {
     void invoke<string | null>("terminal_zsh_dir")
-      .then((d) => { zshDirRef.current = d; })
+      .then((d) => {
+        zshDirRef.current = d;
+      })
       .catch(() => {});
   }, []);
 
@@ -197,7 +235,11 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
         /* keep defaults */
       }
 
-      const id = await invoke<string>("terminal_create", { cols, rows, cwd: initialCwd });
+      const id = await invoke<string>("terminal_create", {
+        cols,
+        rows,
+        cwd: initialCwd,
+      });
       if (disposed) {
         void invoke("terminal_close", { id }).catch(() => {});
         return;
@@ -223,13 +265,18 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
         if (mod && key === "c") {
           if (term.hasSelection()) {
             e.preventDefault();
-            void navigator.clipboard.writeText(term.getSelection()).catch(() => {});
+            void navigator.clipboard
+              .writeText(term.getSelection())
+              .catch(() => {});
           }
           return false;
         }
         if (mod && key === "v") {
           e.preventDefault();
-          void navigator.clipboard.readText().then((t) => t && term.paste(t)).catch(() => {});
+          void navigator.clipboard
+            .readText()
+            .then((t) => t && term.paste(t))
+            .catch(() => {});
           return false;
         }
         if (e.metaKey && key === "a") {
@@ -252,12 +299,15 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
         }
       });
 
-      unOut = await listen<{ id: string; data: number[] }>("terminal-output", (e) => {
-        if (e.payload.id !== id || disposed) return;
-        const bytes = new Uint8Array(e.payload.data);
-        term.write(bytes); // interactive surface
-        parser.push(decoderRef.current.decode(bytes, { stream: true })); // blocks
-      });
+      unOut = await listen<{ id: string; data: number[] }>(
+        "terminal-output",
+        (e) => {
+          if (e.payload.id !== id || disposed) return;
+          const bytes = new Uint8Array(e.payload.data);
+          term.write(bytes); // interactive surface
+          parser.push(decoderRef.current.decode(bytes, { stream: true })); // blocks
+        },
+      );
       unExit = await listen<{ id: string }>("terminal-exit", () => {});
     })();
 
@@ -266,7 +316,8 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
       safeUnlisten(unOut);
       safeUnlisten(unExit);
       xtermRef.current?.dispose();
-      if (ptyRef.current) void invoke("terminal_close", { id: ptyRef.current }).catch(() => {});
+      if (ptyRef.current)
+        void invoke("terminal_close", { id: ptyRef.current }).catch(() => {});
     };
   }, []);
 
@@ -284,7 +335,12 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
       } catch {
         return;
       }
-      if (id) void invoke("terminal_resize", { id, cols: t.cols, rows: t.rows }).catch(() => {});
+      if (id)
+        void invoke("terminal_resize", {
+          id,
+          cols: t.cols,
+          rows: t.rows,
+        }).catch(() => {});
     });
     ro.observe(host);
     return () => ro.disconnect();
@@ -347,7 +403,12 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
           if (cancelled) return;
           setGit(
             s.is_repo
-              ? { branch: s.branch, ahead: s.ahead, behind: s.behind, dirty: s.files.length > 0 }
+              ? {
+                  branch: s.branch,
+                  ahead: s.ahead,
+                  behind: s.behind,
+                  dirty: s.files.length > 0,
+                }
               : null,
           );
         })
@@ -434,7 +495,8 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
   }, [search.query, blocks]);
 
   const navMatch = useCallback((dir: 1 | -1) => {
-    const els = scrollRef.current?.querySelectorAll<HTMLElement>("[data-term-match]");
+    const els =
+      scrollRef.current?.querySelectorAll<HTMLElement>("[data-term-match]");
     if (!els || !els.length) return;
     matchIdxRef.current = (matchIdxRef.current + dir + els.length) % els.length;
     els.forEach((el) => el.classList.remove("term-match-active"));
@@ -449,7 +511,11 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
   }, []);
 
   return (
-    <div data-block-terminal className="relative flex h-full w-full flex-col bg-[var(--bg-base)]" onClick={onFocus}>
+    <div
+      data-block-terminal
+      className="relative flex h-full w-full flex-col bg-[var(--bg-base)]"
+      onClick={onFocus}
+    >
       {/* Interactive surface — overlays the block list while an alt-screen app runs. */}
       <div
         ref={xtermHostRef}
@@ -467,7 +533,9 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
           <input
             ref={searchInputRef}
             value={search.query}
-            onChange={(e) => setSearch((s) => ({ ...s, query: e.target.value }))}
+            onChange={(e) =>
+              setSearch((s) => ({ ...s, query: e.target.value }))
+            }
             onKeyDown={(e) => {
               if (e.key === "Escape") closeSearch();
               else if (e.key === "Enter") navMatch(e.shiftKey ? -1 : 1);
@@ -478,13 +546,25 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
           <span className="w-10 shrink-0 text-right text-[10px] tabular-nums text-[var(--text-tertiary)]">
             {matchCount}
           </span>
-          <button type="button" onClick={() => navMatch(-1)} className="rounded p-0.5 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]">
+          <button
+            type="button"
+            onClick={() => navMatch(-1)}
+            className="rounded p-0.5 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
             <ChevronUp size={13} />
           </button>
-          <button type="button" onClick={() => navMatch(1)} className="rounded p-0.5 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]">
+          <button
+            type="button"
+            onClick={() => navMatch(1)}
+            className="rounded p-0.5 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
             <ChevronDown size={13} />
           </button>
-          <button type="button" onClick={closeSearch} className="rounded p-0.5 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]">
+          <button
+            type="button"
+            onClick={closeSearch}
+            className="rounded p-0.5 text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+          >
             <X size={13} />
           </button>
         </div>
@@ -497,7 +577,13 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
         style={{ visibility: altScreen ? "hidden" : "visible" }}
       >
         {blocks.map((b) => (
-          <BlockCard key={b.id} block={b} onRerun={runCommand} onPassword={writePassword} query={search.query} />
+          <BlockCard
+            key={b.id}
+            block={b}
+            onRerun={runCommand}
+            onPassword={writePassword}
+            query={search.query}
+          />
         ))}
       </div>
 
@@ -507,9 +593,15 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
       {!altScreen && (
         <div className="flex min-h-[28px] items-center gap-2 border-t border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-[5px]">
           {busy ? (
-            <Loader2 size={13} className="shrink-0 animate-spin text-[var(--accent-primary)]" />
+            <Loader2
+              size={13}
+              className="shrink-0 animate-spin text-[var(--accent-primary)]"
+            />
           ) : (
-            <ChevronRight size={13} className="shrink-0 text-[var(--accent-primary)]" />
+            <ChevronRight
+              size={13}
+              className="shrink-0 text-[var(--accent-primary)]"
+            />
           )}
           <CommandInput
             ref={commandInputRef}
@@ -573,12 +665,22 @@ function StatusBadge({ cwd, git }: { cwd: string; git: TermGit | null }) {
       {git && (
         <>
           <span className="h-3 w-px bg-[var(--border-default)]" />
-          <span className="flex items-center gap-1" title={`On branch ${git.branch}`}>
+          <span
+            className="flex items-center gap-1"
+            title={`On branch ${git.branch}`}
+          >
             <GitBranch size={9} />
             {git.branch || "(detached)"}
             {git.ahead > 0 && <span>↑{git.ahead}</span>}
             {git.behind > 0 && <span>↓{git.behind}</span>}
-            {git.dirty && <span className="text-[var(--status-warning)]" title="Uncommitted changes">●</span>}
+            {git.dirty && (
+              <span
+                className="text-[var(--status-warning)]"
+                title="Uncommitted changes"
+              >
+                ●
+              </span>
+            )}
           </span>
         </>
       )}
@@ -613,7 +715,9 @@ function BlockCard({
   const hasHeader = block.command !== "";
 
   const duration =
-    !block.running && block.endedAt ? formatDuration(block.endedAt - block.startedAt) : null;
+    !block.running && block.endedAt
+      ? formatDuration(block.endedAt - block.startedAt)
+      : null;
 
   const copyOutput = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -628,11 +732,20 @@ function BlockCard({
       {hasHeader && (
         <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-2.5 h-[28px] text-[12px]">
           {block.running ? (
-            <Loader2 size={12} className="shrink-0 animate-spin text-[var(--accent-primary)]" />
+            <Loader2
+              size={12}
+              className="shrink-0 animate-spin text-[var(--accent-primary)]"
+            />
           ) : block.exitCode && block.exitCode !== 0 ? (
-            <XCircle size={12} className="shrink-0 text-[var(--status-error)]" />
+            <XCircle
+              size={12}
+              className="shrink-0 text-[var(--status-error)]"
+            />
           ) : (
-            <CheckCircle2 size={12} className="shrink-0 text-[var(--status-success)]" />
+            <CheckCircle2
+              size={12}
+              className="shrink-0 text-[var(--status-success)]"
+            />
           )}
           <button
             type="button"
@@ -655,11 +768,25 @@ function BlockCard({
           <div className="ml-auto flex items-center gap-2 text-[10px] text-[var(--text-tertiary)]">
             {/* Hover actions */}
             <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-              <BlockAction title={copied ? "Copied" : "Copy output"} onClick={copyOutput} icon={Copy} />
-              <BlockAction title="Rerun" onClick={(e) => { e.stopPropagation(); onRerun(block.command); }} icon={RotateCw} />
+              <BlockAction
+                title={copied ? "Copied" : "Copy output"}
+                onClick={copyOutput}
+                icon={Copy}
+              />
+              <BlockAction
+                title="Rerun"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRerun(block.command);
+                }}
+                icon={RotateCw}
+              />
               <BlockAction
                 title={collapsed ? "Expand" : "Collapse"}
-                onClick={(e) => { e.stopPropagation(); setCollapsed((c) => !c); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setCollapsed((c) => !c);
+                }}
                 icon={ChevronDown}
                 rotated={collapsed}
               />
@@ -671,15 +798,20 @@ function BlockCard({
               </span>
             )}
             {duration && <span>{duration}</span>}
-            {!block.running && block.exitCode != null && block.exitCode !== 0 && (
-              <span className="text-[var(--status-error)]">exit {block.exitCode}</span>
-            )}
+            {!block.running &&
+              block.exitCode != null &&
+              block.exitCode !== 0 && (
+                <span className="text-[var(--status-error)]">
+                  exit {block.exitCode}
+                </span>
+              )}
           </div>
         </div>
       )}
       {!collapsed && (clipped || block.truncated) && (
         <div className="px-3 pt-2 text-[10px] italic text-[var(--text-tertiary)]">
-          earlier output hidden — showing the latest {Math.round(RENDER_CAP / 1024)} KB (Copy gets more)
+          earlier output hidden — showing the latest{" "}
+          {Math.round(RENDER_CAP / 1024)} KB (Copy gets more)
         </div>
       )}
       {!collapsed && segments.length > 0 && (
@@ -710,12 +842,23 @@ function BlockAction({
       title={title}
       className="flex h-5 w-5 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
     >
-      <Icon size={11} className={cn("transition-transform", rotated && "-rotate-90")} />
+      <Icon
+        size={11}
+        className={cn("transition-transform", rotated && "-rotate-90")}
+      />
     </button>
   );
 }
 
-function BlockOutput({ segments, cwd, query }: { segments: AnsiSegment[]; cwd: string; query: string }) {
+function BlockOutput({
+  segments,
+  cwd,
+  query,
+}: {
+  segments: AnsiSegment[];
+  cwd: string;
+  query: string;
+}) {
   const openPath = useCallback(
     (raw: string) => {
       // Resolve to an absolute path, then open in Atlas if it's a kind we can
@@ -726,7 +869,7 @@ function BlockOutput({ segments, cwd, query }: { segments: AnsiSegment[]; cwd: s
         })
         .catch(() => {});
     },
-    [cwd]
+    [cwd],
   );
   const openLink = useCallback((raw: string) => {
     void import("@tauri-apps/plugin-opener")
@@ -766,8 +909,8 @@ function BlockOutput({ segments, cwd, query }: { segments: AnsiSegment[]; cwd: s
             <span key={`${i}-${j}`} style={s.style}>
               {renderHL(p.text, query)}
             </span>
-          )
-        )
+          ),
+        ),
       )}
     </pre>
   );

--- a/src/features/terminal/components/command-input.tsx
+++ b/src/features/terminal/components/command-input.tsx
@@ -10,7 +10,11 @@ import {
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { CommandSuggestions, type Suggestion } from "./command-suggestions";
-import { parseToken, applyCompletion, type TokenInfo } from "../lib/command-completion";
+import {
+  parseToken,
+  applyCompletion,
+  type TokenInfo,
+} from "../lib/command-completion";
 
 export interface CommandInputHandle {
   focus: () => void;
@@ -66,12 +70,18 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
     const [open, setOpen] = useState(false);
     const [activeIndex, setActiveIndex] = useState(0);
     const cmdListRef = useRef<string[] | null>(null); // $PATH commands, fetched once
-    const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+      undefined,
+    );
     const cycleRef = useRef<CycleState | null>(null);
     const cwdRef = useRef(cwd);
     cwdRef.current = cwd;
 
-    useImperativeHandle(ref, () => ({ focus: () => taRef.current?.focus() }), []);
+    useImperativeHandle(
+      ref,
+      () => ({ focus: () => taRef.current?.focus() }),
+      [],
+    );
 
     // Auto-grow the textarea with its content (multi-line via Shift+Enter).
     const resize = useCallback(() => {
@@ -151,11 +161,17 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
         }
         if (info.token.length < 1) return [];
         try {
-          const res = await invoke<RawPathCompletion[]>("terminal_path_complete", {
-            cwd: cwdRef.current ?? "~",
-            token: info.token,
-          });
-          return res.map((e) => ({ name: e.name, kind: e.is_dir ? "dir" : "file" }));
+          const res = await invoke<RawPathCompletion[]>(
+            "terminal_path_complete",
+            {
+              cwd: cwdRef.current ?? "~",
+              token: info.token,
+            },
+          );
+          return res.map((e) => ({
+            name: e.name,
+            kind: e.is_dir ? "dir" : "file",
+          }));
         } catch {
           return [];
         }
@@ -193,7 +209,9 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
       const repl =
         c.info.kind === "command"
           ? m.name
-          : c.info.dirPart + m.name.replace(/ /g, "\\ ") + (m.kind === "dir" ? "/" : "");
+          : c.info.dirPart +
+            m.name.replace(/ /g, "\\ ") +
+            (m.kind === "dir" ? "/" : "");
       const v = ta.value;
       const next = v.slice(0, c.info.start) + repl + v.slice(c.replacedEnd);
       c.replacedEnd = c.info.start + repl.length;
@@ -233,7 +251,8 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
         const ta = taRef.current;
         if (!ta) return;
         const c = cycleRef.current;
-        const info = c?.info ?? parseToken(ta.value, ta.selectionStart ?? ta.value.length);
+        const info =
+          c?.info ?? parseToken(ta.value, ta.selectionStart ?? ta.value.length);
         if (!info) return closeSuggest();
         finalize(info, c?.replacedEnd ?? info.caret, s);
       },
@@ -252,7 +271,12 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
         if (items.length === 0) return closeSuggest();
         if (items.length === 1) return finalize(info, info.caret, items[0]);
         const index = dir > 0 ? 0 : items.length - 1;
-        cycleRef.current = { info, matches: items, index, replacedEnd: info.caret };
+        cycleRef.current = {
+          info,
+          matches: items,
+          index,
+          replacedEnd: info.caret,
+        };
         setSuggestions(items);
         setOpen(true);
         applyCycle();
@@ -280,7 +304,11 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
       // interactive prompts (create-next-app, etc.) work. Navigation keys are
       // forwarded raw to the PTY; typed text is sent as a line on Enter.
       if (busy && writeRaw) {
-        if (e.key === "c" && e.ctrlKey && ta.selectionStart === ta.selectionEnd) {
+        if (
+          e.key === "c" &&
+          e.ctrlKey &&
+          ta.selectionStart === ta.selectionEnd
+        ) {
           e.preventDefault();
           onInterrupt();
           return;
@@ -363,7 +391,9 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
         e.preventDefault();
         closeSuggest();
         histIdxRef.current =
-          histIdxRef.current < 0 ? h.length - 1 : Math.max(0, histIdxRef.current - 1);
+          histIdxRef.current < 0
+            ? h.length - 1
+            : Math.max(0, histIdxRef.current - 1);
         setText(h[histIdxRef.current]);
         return;
       }
@@ -401,9 +431,13 @@ export const CommandInput = forwardRef<CommandInputHandle, CommandInputProps>(
           spellCheck={false}
           autoCapitalize="off"
           autoCorrect="off"
-          placeholder={busy ? "Type a response, then press Enter…" : "Run a command…"}
+          placeholder={
+            busy ? "Type a response, then press Enter…" : "Run a command…"
+          }
           className="flex-1 resize-none overflow-hidden border-none bg-transparent p-0 text-[13px] leading-[18px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-tertiary)]"
-          style={{ fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)' }}
+          style={{
+            fontFamily: 'var(--font-mono, "JetBrains Mono", monospace)',
+          }}
         />
         <CommandSuggestions
           open={open}

--- a/src/features/terminal/components/command-suggestions.tsx
+++ b/src/features/terminal/components/command-suggestions.tsx
@@ -77,13 +77,24 @@ export function CommandSuggestions({
         "shadow-[var(--shadow-overlay)]",
       )}
       onMouseDown={(e) => e.preventDefault()}
-      style={{ position: "fixed", left, bottom, width, maxHeight: 280, zIndex: 9999 }}
+      style={{
+        position: "fixed",
+        left,
+        bottom,
+        width,
+        maxHeight: 280,
+        zIndex: 9999,
+      }}
     >
       <div className="flex-1 overflow-y-auto py-1 hide-scrollbar">
         {items.map((s, i) => {
           const isActive = i === activeIndex;
           const Icon =
-            s.kind === "dir" ? Folder : s.kind === "command" ? TerminalSquare : FileText;
+            s.kind === "dir"
+              ? Folder
+              : s.kind === "command"
+                ? TerminalSquare
+                : FileText;
           return (
             <button
               key={`${s.kind}:${s.name}`}
@@ -104,7 +115,9 @@ export function CommandSuggestions({
                 size={11}
                 className={cn(
                   "shrink-0",
-                  s.kind === "dir" ? "text-[var(--accent-primary)]" : "text-[var(--text-tertiary)]",
+                  s.kind === "dir"
+                    ? "text-[var(--accent-primary)]"
+                    : "text-[var(--text-tertiary)]",
                 )}
               />
               <span className="truncate">

--- a/src/features/terminal/components/terminal-panel.tsx
+++ b/src/features/terminal/components/terminal-panel.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import { useTerminalStore, collectPanes, type TreeNode, type PaneNode } from "../stores/terminal-store";
+import {
+  useTerminalStore,
+  collectPanes,
+  type TreeNode,
+  type PaneNode,
+} from "../stores/terminal-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
 import { BlockTerminal } from "./block-terminal";
 import {
@@ -25,8 +30,12 @@ interface PaneRect {
 
 export function TerminalPanel({ tabId }: TerminalPanelProps) {
   const tab = useTerminalStore((s) => s.tabs[tabId]);
-  const { initTab, setActiveTerminalInPane, setActivePane, closeTerminalInPane } =
-    useTerminalStore.use.actions();
+  const {
+    initTab,
+    setActiveTerminalInPane,
+    setActivePane,
+    closeTerminalInPane,
+  } = useTerminalStore.use.actions();
   const rootRef = useRef<HTMLDivElement>(null);
   const [paneRects, setPaneRects] = useState<Record<string, PaneRect>>({});
 
@@ -47,7 +56,9 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
     const rootRect = root.getBoundingClientRect();
     if (rootRect.height === 0 || rootRect.width === 0) return;
 
-    const containers = root.querySelectorAll<HTMLElement>("[data-pane-container]");
+    const containers = root.querySelectorAll<HTMLElement>(
+      "[data-pane-container]",
+    );
     const rects: Record<string, PaneRect> = {};
     let allValid = containers.length > 0;
     containers.forEach((el) => {
@@ -106,7 +117,7 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
     const root = rootRef.current;
     if (!root) return;
     const ro = new ResizeObserver(() =>
-      requestAnimationFrame(() => requestAnimationFrame(measurePanes))
+      requestAnimationFrame(() => requestAnimationFrame(measurePanes)),
     );
     ro.observe(root);
     root
@@ -163,7 +174,12 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
       // it had 2+ tabs open — the source of the "KB toggle works only sometimes"
       // flakiness. Requiring focus-within scopes these keys to the terminal.
       const root = rootRef.current;
-      if (!root || root.offsetParent == null || !root.contains(document.activeElement)) return;
+      if (
+        !root ||
+        root.offsetParent == null ||
+        !root.contains(document.activeElement)
+      )
+        return;
       const t = useTerminalStore.getState().tabs[tabId];
       if (!t) return;
       const panes = collectPanes(t.root);
@@ -176,7 +192,11 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
         if (pane.terminals.length < 2) return;
         e.preventDefault();
         e.stopImmediatePropagation();
-        closeTerminalInPane(tabId, pane.id, pane.activeTerminalId ?? pane.terminals[0]);
+        closeTerminalInPane(
+          tabId,
+          pane.id,
+          pane.activeTerminalId ?? pane.terminals[0],
+        );
         setActivePane(tabId, pane.id);
         return;
       }
@@ -184,14 +204,19 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
       // Tab navigation.
       if (pane.terminals.length < 2) return;
       e.preventDefault();
-      const idx = Math.max(0, pane.terminals.indexOf(pane.activeTerminalId ?? pane.terminals[0]));
+      const idx = Math.max(
+        0,
+        pane.terminals.indexOf(pane.activeTerminalId ?? pane.terminals[0]),
+      );
       const delta = e.key === ";" ? -1 : 1;
-      const next = (idx + delta + pane.terminals.length) % pane.terminals.length;
+      const next =
+        (idx + delta + pane.terminals.length) % pane.terminals.length;
       setActiveTerminalInPane(tabId, pane.id, pane.terminals[next]);
       setActivePane(tabId, pane.id);
     };
     window.addEventListener("keydown", onKey, { capture: true });
-    return () => window.removeEventListener("keydown", onKey, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKey, { capture: true });
   }, [tabId, setActiveTerminalInPane, setActivePane, closeTerminalInPane]);
 
   if (!tab) return null;
@@ -202,7 +227,11 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
     <div ref={rootRef} className="h-full bg-[#000] relative">
       {/* Layout layer — toolbars + empty container divs */}
       <div className="h-full absolute inset-0">
-        <LayoutRenderer node={tab.root} tabId={tabId} activePaneId={tab.activePaneId} />
+        <LayoutRenderer
+          node={tab.root}
+          tabId={tabId}
+          activePaneId={tab.activePaneId}
+        />
       </div>
 
       {/* Terminal layer — flat list, absolutely positioned, NEVER unmounts on tree changes */}
@@ -228,61 +257,130 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
               <BlockTerminal
                 isActive={isActiveInPane && isPaneActive}
                 terminalKey={ptyId}
-                onFocus={() => { setActiveTerminalInPane(tabId, pane.id, ptyId); setActivePane(tabId, pane.id); }}
+                onFocus={() => {
+                  setActiveTerminalInPane(tabId, pane.id, ptyId);
+                  setActivePane(tabId, pane.id);
+                }}
               />
             </div>
           );
-        })
+        }),
       )}
     </div>
   );
 }
 
-function LayoutRenderer({ node, tabId, activePaneId }: { node: TreeNode; tabId: string; activePaneId: string | null }) {
+function LayoutRenderer({
+  node,
+  tabId,
+  activePaneId,
+}: {
+  node: TreeNode;
+  tabId: string;
+  activePaneId: string | null;
+}) {
   if (node.type === "pane") {
-    return <PaneChrome pane={node} tabId={tabId} isActivePane={node.id === activePaneId} />;
+    return (
+      <PaneChrome
+        pane={node}
+        tabId={tabId}
+        isActivePane={node.id === activePaneId}
+      />
+    );
   }
 
   return (
-    <div className={cn("h-full flex", node.direction === "horizontal" ? "flex-row" : "flex-col")}>
+    <div
+      className={cn(
+        "h-full flex",
+        node.direction === "horizontal" ? "flex-row" : "flex-col",
+      )}
+    >
       {node.children.map((child, i) => (
         <div
           key={child.id}
-          className={cn("min-w-0 min-h-0", i > 0 && (node.direction === "horizontal" ? "border-l border-border-default" : "border-t border-border-default"))}
+          className={cn(
+            "min-w-0 min-h-0",
+            i > 0 &&
+              (node.direction === "horizontal"
+                ? "border-l border-border-default"
+                : "border-t border-border-default"),
+          )}
           style={{ flex: 1 }}
         >
-          <LayoutRenderer node={child} tabId={tabId} activePaneId={activePaneId} />
+          <LayoutRenderer
+            node={child}
+            tabId={tabId}
+            activePaneId={activePaneId}
+          />
         </div>
       ))}
     </div>
   );
 }
 
-function PaneChrome({ pane, tabId, isActivePane }: { pane: PaneNode; tabId: string; isActivePane: boolean }) {
-  const { addTerminalToPane, splitPane, closeTerminalInPane, closePane, setActiveTerminalInPane, setActivePane } =
-    useTerminalStore.use.actions();
+function PaneChrome({
+  pane,
+  tabId,
+  isActivePane,
+}: {
+  pane: PaneNode;
+  tabId: string;
+  isActivePane: boolean;
+}) {
+  const {
+    addTerminalToPane,
+    splitPane,
+    closeTerminalInPane,
+    closePane,
+    setActiveTerminalInPane,
+    setActivePane,
+  } = useTerminalStore.use.actions();
   const tab = useTerminalStore((s) => s.tabs[tabId]);
   const busy = useTerminalStore((s) => s.busy);
   const hasSplits = tab?.root.type === "split";
   const activePty = pane.activeTerminalId;
 
   return (
-    <div className={cn("h-full flex flex-col", isActivePane && "ring-1 ring-[#ffffff08] ring-inset")}>
+    <div
+      className={cn(
+        "h-full flex flex-col",
+        isActivePane && "ring-1 ring-[#ffffff08] ring-inset",
+      )}
+    >
       <div className="flex items-center h-[32px] shrink-0 border-b border-border-default bg-bg-primary px-1 gap-0.5">
         <div className="flex items-center gap-0.5 flex-1 min-w-0 overflow-x-auto hide-scrollbar">
           {pane.terminals.map((ptyId) => (
             <div
               key={ptyId}
-              onClick={() => { setActiveTerminalInPane(tabId, pane.id, ptyId); setActivePane(tabId, pane.id); }}
+              onClick={() => {
+                setActiveTerminalInPane(tabId, pane.id, ptyId);
+                setActivePane(tabId, pane.id);
+              }}
               className={cn(
                 "group flex items-center gap-1 px-1.5 h-5 rounded text-[10px] font-mono cursor-pointer shrink-0",
-                ptyId === activePty ? "text-text-primary bg-bg-selected" : "text-text-tertiary hover:text-text-secondary hover:bg-bg-hover"
+                ptyId === activePty
+                  ? "text-text-primary bg-bg-selected"
+                  : "text-text-tertiary hover:text-text-secondary hover:bg-bg-hover",
               )}
             >
-              {busy[ptyId] ? <Loader2 size={9} className="animate-spin text-[var(--accent-primary)]" /> : <TerminalIcon size={9} />}
+              {busy[ptyId] ? (
+                <Loader2
+                  size={9}
+                  className="animate-spin text-[var(--accent-primary)]"
+                />
+              ) : (
+                <TerminalIcon size={9} />
+              )}
               <span>~</span>
               {pane.terminals.length > 1 && (
-                <button onClick={(e) => { e.stopPropagation(); closeTerminalInPane(tabId, pane.id, ptyId); }} className="opacity-0 group-hover:opacity-100 hover:text-text-primary">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    closeTerminalInPane(tabId, pane.id, ptyId);
+                  }}
+                  className="opacity-0 group-hover:opacity-100 hover:text-text-primary"
+                >
                   <X size={8} />
                 </button>
               )}
@@ -290,11 +388,38 @@ function PaneChrome({ pane, tabId, isActivePane }: { pane: PaneNode; tabId: stri
           ))}
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
-          <button onClick={() => { addTerminalToPane(tabId, pane.id); setActivePane(tabId, pane.id); }} className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer" title="New tab"><Plus size={11} /></button>
-          <button onClick={() => splitPane(tabId, pane.id, "horizontal")} className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer" title="Split right"><Columns2 size={11} /></button>
-          <button onClick={() => splitPane(tabId, pane.id, "vertical")} className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer" title="Split down"><Rows2 size={11} /></button>
+          <button
+            onClick={() => {
+              addTerminalToPane(tabId, pane.id);
+              setActivePane(tabId, pane.id);
+            }}
+            className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer"
+            title="New tab"
+          >
+            <Plus size={11} />
+          </button>
+          <button
+            onClick={() => splitPane(tabId, pane.id, "horizontal")}
+            className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer"
+            title="Split right"
+          >
+            <Columns2 size={11} />
+          </button>
+          <button
+            onClick={() => splitPane(tabId, pane.id, "vertical")}
+            className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-colors cursor-pointer"
+            title="Split down"
+          >
+            <Rows2 size={11} />
+          </button>
           {hasSplits && (
-            <button onClick={() => closePane(tabId, pane.id)} className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-white hover:bg-bg-hover transition-colors cursor-pointer" title="Close pane"><X size={11} /></button>
+            <button
+              onClick={() => closePane(tabId, pane.id)}
+              className="flex items-center justify-center w-5 h-5 rounded text-text-tertiary hover:text-white hover:bg-bg-hover transition-colors cursor-pointer"
+              title="Close pane"
+            >
+              <X size={11} />
+            </button>
           )}
         </div>
       </div>

--- a/src/features/terminal/lib/ansi-to-segments.ts
+++ b/src/features/terminal/lib/ansi-to-segments.ts
@@ -18,8 +18,22 @@ export interface AnsiSegment {
 
 // Standard 16-color palette (xterm-ish, tuned to read on the black terminal bg).
 const PALETTE_16 = [
-  "#1a1a1a", "#e06c75", "#98c379", "#e5c07b", "#61afef", "#c678dd", "#56b6c2", "#cccccc",
-  "#5c6370", "#e06c75", "#98c379", "#e5c07b", "#61afef", "#c678dd", "#56b6c2", "#ffffff",
+  "#1a1a1a",
+  "#e06c75",
+  "#98c379",
+  "#e5c07b",
+  "#61afef",
+  "#c678dd",
+  "#56b6c2",
+  "#cccccc",
+  "#5c6370",
+  "#e06c75",
+  "#98c379",
+  "#e5c07b",
+  "#61afef",
+  "#c678dd",
+  "#56b6c2",
+  "#ffffff",
 ];
 
 function color256(n: number): string {
@@ -64,7 +78,12 @@ function applySgr(state: SgrState, params: number[]): void {
     const p = params[i];
     if (p === 0) {
       state.fg = state.bg = undefined;
-      state.bold = state.dim = state.italic = state.underline = state.inverse = false;
+      state.bold =
+        state.dim =
+        state.italic =
+        state.underline =
+        state.inverse =
+          false;
     } else if (p === 1) state.bold = true;
     else if (p === 2) state.dim = true;
     else if (p === 3) state.italic = true;
@@ -150,7 +169,9 @@ export function resolveTerminalOutput(input: string): AnsiSegment[] {
         return Number.isNaN(v) ? def : v;
       };
       if (final === "m") {
-        const params = body.split(";").map((x) => (x === "" ? 0 : parseInt(x, 10)));
+        const params = body
+          .split(";")
+          .map((x) => (x === "" ? 0 : parseInt(x, 10)));
         applySgr(state, params.length ? params : [0]);
         curStyle = styleOf(state);
       } else if (final === "A") row = Math.max(0, row - num(1));
@@ -167,14 +188,19 @@ export function resolveTerminalOutput(input: string): AnsiSegment[] {
         const line = lineAt(row);
         const mode = num(0);
         if (mode === 0) line.length = Math.min(line.length, col);
-        else if (mode === 1) for (let k = 0; k < col && k < line.length; k++) line[k] = { ch: " " };
+        else if (mode === 1)
+          for (let k = 0; k < col && k < line.length; k++)
+            line[k] = { ch: " " };
         else if (mode === 2) line.length = 0;
       }
       // Other CSI (J erase-display, scroll, etc.) ignored — block output.
       i = j + 1;
       continue;
     }
-    if (ch === ESC && (input[i + 1] === "]" || input[i + 1] === ")" || input[i + 1] === "(")) {
+    if (
+      ch === ESC &&
+      (input[i + 1] === "]" || input[i + 1] === ")" || input[i + 1] === "(")
+    ) {
       let j = i + 2;
       while (
         j < n &&
@@ -258,17 +284,27 @@ export function ansiToSegments(input: string): AnsiSegment[] {
       const body = input.slice(i + 2, j);
       if (final === "m") {
         flush();
-        const params = body.split(";").map((x) => (x === "" ? 0 : parseInt(x, 10)));
+        const params = body
+          .split(";")
+          .map((x) => (x === "" ? 0 : parseInt(x, 10)));
         applySgr(state, params.length ? params : [0]);
       }
       // Any other CSI (cursor/erase) is dropped — static output only.
       i = j + 1;
       continue;
     }
-    if (ch === ESC && (input[i + 1] === "]" || input[i + 1] === ")" || input[i + 1] === "(")) {
+    if (
+      ch === ESC &&
+      (input[i + 1] === "]" || input[i + 1] === ")" || input[i + 1] === "(")
+    ) {
       // OSC or charset designation — skip to terminator (BEL or ST).
       let j = i + 2;
-      while (j < n && input.charCodeAt(j) !== 0x07 && !(input.charCodeAt(j) === ESC && input[j + 1] === "\\")) j++;
+      while (
+        j < n &&
+        input.charCodeAt(j) !== 0x07 &&
+        !(input.charCodeAt(j) === ESC && input[j + 1] === "\\")
+      )
+        j++;
       i = input.charCodeAt(j) === ESC ? j + 2 : j + 1;
       continue;
     }

--- a/src/features/terminal/lib/block-parser.ts
+++ b/src/features/terminal/lib/block-parser.ts
@@ -131,7 +131,10 @@ export class BlockStreamParser {
     this.onChange();
   }
 
-  constructor(initialCwd: string, private onChange: () => void) {
+  constructor(
+    initialCwd: string,
+    private onChange: () => void,
+  ) {
     this.cwd = initialCwd;
     // Preamble block: the shell banner / output before the first prompt marker.
     // If shell integration ISN'T active (no OSC 133 ever), EVERYTHING stays
@@ -198,8 +201,16 @@ export class BlockStreamParser {
         let term = -1;
         let termLen = 0;
         while (j < n) {
-          if (s.charCodeAt(j) === 0x07) { term = j; termLen = 1; break; }
-          if (s.charCodeAt(j) === ESC && s[j + 1] === "\\") { term = j; termLen = 2; break; }
+          if (s.charCodeAt(j) === 0x07) {
+            term = j;
+            termLen = 1;
+            break;
+          }
+          if (s.charCodeAt(j) === ESC && s[j + 1] === "\\") {
+            term = j;
+            termLen = 2;
+            break;
+          }
           j++;
         }
         if (term === -1) break; // incomplete OSC; wait
@@ -216,9 +227,13 @@ export class BlockStreamParser {
         if (j >= n) break; // incomplete CSI; wait
         const seq = s.slice(i, j + 1);
         const body = s.slice(i + 2, j);
-        if (body === "?1049" && s[j] === "h") { this.altScreen = true; changed = true; }
-        else if (body === "?1049" && s[j] === "l") { this.altScreen = false; changed = true; }
-        else appendOut(seq); // keep SGR / other CSI in the block output
+        if (body === "?1049" && s[j] === "h") {
+          this.altScreen = true;
+          changed = true;
+        } else if (body === "?1049" && s[j] === "l") {
+          this.altScreen = false;
+          changed = true;
+        } else appendOut(seq); // keep SGR / other CSI in the block output
         i = j + 1;
         continue;
       }
@@ -238,7 +253,12 @@ export class BlockStreamParser {
     // field appears on "Password:" and disappears once other output follows.
     // Skip firehose blocks (a huge dump isn't a prompt) and scan only the tail
     // so the regex stays cheap even on a large block.
-    if (this.current && this.current.running && this.mode === "output" && !this.current.firehose) {
+    if (
+      this.current &&
+      this.current.running &&
+      this.mode === "output" &&
+      !this.current.firehose
+    ) {
       const out = this.current.output;
       const tail = out.length > 256 ? out.slice(-256) : out;
       const next = looksLikePasswordPrompt(tail);
@@ -297,7 +317,7 @@ export class BlockStreamParser {
           exitCode: null,
           running: true,
           startedAt: Date.now(),
-      endedAt: null,
+          endedAt: null,
         };
         this.pendingCommand = "";
         this.bytesInBlock = 0;
@@ -318,7 +338,7 @@ export class BlockStreamParser {
             this.current.command === "" || Number.isNaN(code) ? null : code;
           // Replace with a new object so React sees the change.
           this.blocks = this.blocks.map((b) =>
-            b.id === this.current!.id ? { ...this.current! } : b
+            b.id === this.current!.id ? { ...this.current! } : b,
           );
         }
         this.current = null;

--- a/src/features/terminal/lib/command-completion.ts
+++ b/src/features/terminal/lib/command-completion.ts
@@ -58,7 +58,8 @@ export function parseToken(value: string, caret: number): TokenInfo | null {
   // / ; separator. (Matching the trailing separator char covers all of them.)
   const before = value.slice(0, start).trimEnd();
   const commandPosition = before === "" || /[|&;]$/.test(before);
-  const kind: TokenKind = commandPosition && !isPathLike(token) ? "command" : "path";
+  const kind: TokenKind =
+    commandPosition && !isPathLike(token) ? "command" : "path";
 
   const slash = token.lastIndexOf("/");
   const dirPart = slash >= 0 ? token.slice(0, slash + 1) : "";

--- a/src/features/terminal/lib/linkify-paths.ts
+++ b/src/features/terminal/lib/linkify-paths.ts
@@ -44,7 +44,11 @@ export function splitLinks(text: string): PathRun[] {
   while ((u = URL_RE.exec(text)) !== null) {
     const trimmed = u[0].replace(TRAILING_PUNCT, "");
     if (trimmed.length < 2) continue;
-    matches.push({ start: u.index, end: u.index + trimmed.length, kind: "url" });
+    matches.push({
+      start: u.index,
+      end: u.index + trimmed.length,
+      kind: "url",
+    });
   }
 
   PATH_RE.lastIndex = 0;
@@ -55,7 +59,8 @@ export function splitLinks(text: string): PathRun[] {
     const start = p.index;
     const end = p.index + raw.length;
     // Drop paths that fall inside an already-matched URL.
-    if (matches.some((m) => m.kind === "url" && start < m.end && end > m.start)) continue;
+    if (matches.some((m) => m.kind === "url" && start < m.end && end > m.start))
+      continue;
     matches.push({ start, end, kind: "path" });
   }
 
@@ -66,7 +71,8 @@ export function splitLinks(text: string): PathRun[] {
   let last = 0;
   for (const m of matches) {
     if (m.start < last) continue; // overlap guard (URLs win, added first)
-    if (m.start > last) out.push({ text: text.slice(last, m.start), kind: "text" });
+    if (m.start > last)
+      out.push({ text: text.slice(last, m.start), kind: "text" });
     out.push({
       text: text.slice(m.start, m.end),
       kind: m.kind,

--- a/src/features/terminal/lib/path-link-provider.ts
+++ b/src/features/terminal/lib/path-link-provider.ts
@@ -46,7 +46,10 @@ function installModListeners() {
   });
 }
 
-export function createPathLinkProvider(term: Terminal, terminalId: string): ILinkProvider {
+export function createPathLinkProvider(
+  term: Terminal,
+  terminalId: string,
+): ILinkProvider {
   installModListeners();
   return {
     provideLinks(lineNo, callback) {

--- a/src/features/terminal/lib/terminal-keymap.ts
+++ b/src/features/terminal/lib/terminal-keymap.ts
@@ -35,7 +35,9 @@ function nextWordBoundary(text: string, i: number): number {
 
 export type KeymapResult = string | "handled" | null;
 
-export function createTerminalKeymap(term: Terminal): (e: KeyboardEvent) => KeymapResult {
+export function createTerminalKeymap(
+  term: Terminal,
+): (e: KeyboardEvent) => KeymapResult {
   let sel: { anchor: number; focus: number; row: number } | null = null;
 
   return (e) => {
@@ -44,25 +46,52 @@ export function createTerminalKeymap(term: Terminal): (e: KeyboardEvent) => Keym
 
     // --- Word / line navigation → readline sequences to the shell ---
     if (!shiftKey && !ctrlKey) {
-      if (altKey && key === "ArrowLeft") { sel = null; return "\x1bb"; }    // backward-word
-      if (altKey && key === "ArrowRight") { sel = null; return "\x1bf"; }   // forward-word
-      if (metaKey && key === "ArrowLeft") { sel = null; return "\x01"; }    // beginning-of-line
-      if (metaKey && key === "ArrowRight") { sel = null; return "\x05"; }   // end-of-line
-      if (altKey && key === "Backspace") { sel = null; return "\x1b\x7f"; } // backward-kill-word
-      if (metaKey && key === "Backspace") { sel = null; return "\x15"; }    // kill line to start
+      if (altKey && key === "ArrowLeft") {
+        sel = null;
+        return "\x1bb";
+      } // backward-word
+      if (altKey && key === "ArrowRight") {
+        sel = null;
+        return "\x1bf";
+      } // forward-word
+      if (metaKey && key === "ArrowLeft") {
+        sel = null;
+        return "\x01";
+      } // beginning-of-line
+      if (metaKey && key === "ArrowRight") {
+        sel = null;
+        return "\x05";
+      } // end-of-line
+      if (altKey && key === "Backspace") {
+        sel = null;
+        return "\x1b\x7f";
+      } // backward-kill-word
+      if (metaKey && key === "Backspace") {
+        sel = null;
+        return "\x15";
+      } // kill line to start
     }
 
     // --- Keyboard selection (Shift+←/→, +Option=word, +Cmd=line) ---
     if (shiftKey && (key === "ArrowLeft" || key === "ArrowRight")) {
       const buf = term.buffer.active;
       const row = buf.baseY + buf.cursorY;
-      if (!sel || sel.row !== row) sel = { anchor: buf.cursorX, focus: buf.cursorX, row };
+      if (!sel || sel.row !== row)
+        sel = { anchor: buf.cursorX, focus: buf.cursorX, row };
       const text = buf.getLine(row)?.translateToString(true) ?? "";
       const eol = text.replace(/\s+$/, "").length;
       if (key === "ArrowLeft") {
-        sel.focus = metaKey ? 0 : altKey ? prevWordBoundary(text, sel.focus) : Math.max(0, sel.focus - 1);
+        sel.focus = metaKey
+          ? 0
+          : altKey
+            ? prevWordBoundary(text, sel.focus)
+            : Math.max(0, sel.focus - 1);
       } else {
-        sel.focus = metaKey ? eol : altKey ? nextWordBoundary(text, sel.focus) : Math.min(eol, sel.focus + 1);
+        sel.focus = metaKey
+          ? eol
+          : altKey
+            ? nextWordBoundary(text, sel.focus)
+            : Math.min(eol, sel.focus + 1);
       }
       const start = Math.min(sel.anchor, sel.focus);
       const len = Math.abs(sel.anchor - sel.focus);

--- a/src/features/terminal/stores/terminal-store.ts
+++ b/src/features/terminal/stores/terminal-store.ts
@@ -36,10 +36,18 @@ interface TerminalActions {
   actions: {
     initTab: (tabId: string) => void;
     addTerminalToPane: (tabId: string, paneId: string) => void;
-    splitPane: (tabId: string, paneId: string, direction: SplitDirection) => void;
+    splitPane: (
+      tabId: string,
+      paneId: string,
+      direction: SplitDirection,
+    ) => void;
     closeTerminalInPane: (tabId: string, paneId: string, ptyId: string) => void;
     closePane: (tabId: string, paneId: string) => void;
-    setActiveTerminalInPane: (tabId: string, paneId: string, ptyId: string) => void;
+    setActiveTerminalInPane: (
+      tabId: string,
+      paneId: string,
+      ptyId: string,
+    ) => void;
     setActivePane: (tabId: string, paneId: string) => void;
     setTerminalBusy: (ptyId: string, busy: boolean) => void;
     /** Drop several terminal tabs (used when a workspace is DISCARDED). PTYs
@@ -62,12 +70,22 @@ function findPane(node: TreeNode, paneId: string): PaneNode | null {
   return null;
 }
 
-function splitPaneInTree(node: TreeNode, paneId: string, direction: SplitDirection, newPane: PaneNode): boolean {
+function splitPaneInTree(
+  node: TreeNode,
+  paneId: string,
+  direction: SplitDirection,
+  newPane: PaneNode,
+): boolean {
   if (node.type === "split") {
     for (let i = 0; i < node.children.length; i++) {
       const child = node.children[i];
       if (child.type === "pane" && child.id === paneId) {
-        node.children[i] = { type: "split", id: genId("split"), direction, children: [child, newPane] };
+        node.children[i] = {
+          type: "split",
+          id: genId("split"),
+          direction,
+          children: [child, newPane],
+        };
         return true;
       }
       if (splitPaneInTree(child, paneId, direction, newPane)) return true;
@@ -105,7 +123,12 @@ export const useTerminalStore = createSelectors(
           const paneId = genId("pane");
           set((s) => {
             s.tabs[tabId] = {
-              root: { type: "pane", id: paneId, terminals: [ptyId], activeTerminalId: ptyId },
+              root: {
+                type: "pane",
+                id: paneId,
+                terminals: [ptyId],
+                activeTerminalId: ptyId,
+              },
               activePaneId: paneId,
             };
           });
@@ -129,9 +152,19 @@ export const useTerminalStore = createSelectors(
             if (!t) return;
             const newPtyId = genId("pty");
             const newPaneId = genId("pane");
-            const newPane: PaneNode = { type: "pane", id: newPaneId, terminals: [newPtyId], activeTerminalId: newPtyId };
+            const newPane: PaneNode = {
+              type: "pane",
+              id: newPaneId,
+              terminals: [newPtyId],
+              activeTerminalId: newPtyId,
+            };
             if (t.root.type === "pane" && t.root.id === paneId) {
-              t.root = { type: "split", id: genId("split"), direction, children: [t.root, newPane] };
+              t.root = {
+                type: "split",
+                id: genId("split"),
+                direction,
+                children: [t.root, newPane],
+              };
             } else {
               splitPaneInTree(t.root, paneId, direction, newPane);
             }
@@ -149,7 +182,10 @@ export const useTerminalStore = createSelectors(
             pane.terminals = pane.terminals.filter((id) => id !== ptyId);
             if (pane.terminals.length === 0) {
               const result = removePaneFromTree(t.root, paneId);
-              if (!result) { delete s.tabs[tabId]; return; }
+              if (!result) {
+                delete s.tabs[tabId];
+                return;
+              }
               t.root = result;
               if (t.activePaneId === paneId) {
                 t.activePaneId = collectPanes(t.root)[0]?.id ?? null;
@@ -157,7 +193,10 @@ export const useTerminalStore = createSelectors(
             } else if (pane.activeTerminalId === ptyId) {
               // Activate the LEFT neighbour (the tab that was at closedIdx-1);
               // items before the closed one keep their indices after filtering.
-              const nextIdx = Math.min(Math.max(0, closedIdx - 1), pane.terminals.length - 1);
+              const nextIdx = Math.min(
+                Math.max(0, closedIdx - 1),
+                pane.terminals.length - 1,
+              );
               pane.activeTerminalId = pane.terminals[nextIdx];
             }
           });
@@ -168,7 +207,10 @@ export const useTerminalStore = createSelectors(
             const t = s.tabs[tabId];
             if (!t) return;
             const result = removePaneFromTree(t.root, paneId);
-            if (!result) { delete s.tabs[tabId]; return; }
+            if (!result) {
+              delete s.tabs[tabId];
+              return;
+            }
             t.root = result;
             if (t.activePaneId === paneId) {
               t.activePaneId = collectPanes(t.root)[0]?.id ?? null;
@@ -204,6 +246,6 @@ export const useTerminalStore = createSelectors(
             for (const id of tabIds) delete s.tabs[id];
           }),
       },
-    }))
-  )
+    })),
+  ),
 );

--- a/src/features/terminal/utils/resolve-font.ts
+++ b/src/features/terminal/utils/resolve-font.ts
@@ -43,15 +43,13 @@ function stripWrappingQuotes(name: string): string {
 function quoteFontName(name: string): string {
   const normalized = stripWrappingQuotes(name);
   if (!normalized) return "";
-  if (CSS_GENERIC_FONT_FAMILIES.has(normalized.toLowerCase())) return normalized;
+  if (CSS_GENERIC_FONT_FAMILIES.has(normalized.toLowerCase()))
+    return normalized;
   return `"${normalized.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 function splitFontFamilyList(fontFamily: string): string[] {
-  return fontFamily
-    .split(",")
-    .map(stripWrappingQuotes)
-    .filter(Boolean);
+  return fontFamily.split(",").map(stripWrappingQuotes).filter(Boolean);
 }
 
 function uniqueFontFamilies(families: string[]): string[] {
@@ -82,7 +80,10 @@ export function buildTerminalFontFamily(primaryFont: string): string {
 }
 
 /** Load and verify a font is renderable. Returns false on failure/timeout. */
-async function loadAndVerifyFont(fontName: string, fontSize: number): Promise<boolean> {
+async function loadAndVerifyFont(
+  fontName: string,
+  fontSize: number,
+): Promise<boolean> {
   const test = `${fontSize}px "${stripWrappingQuotes(fontName)}"`;
   try {
     await document.fonts.load(test);

--- a/src/features/unsupported/components/unsupported-view.tsx
+++ b/src/features/unsupported/components/unsupported-view.tsx
@@ -22,7 +22,7 @@ export function UnsupportedView({ filePath }: UnsupportedViewProps) {
       await revealItemInDir(filePath);
     } catch (err) {
       toast.error(
-        `Couldn't reveal in Finder: ${err instanceof Error ? err.message : String(err)}`
+        `Couldn't reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   };
@@ -38,10 +38,14 @@ export function UnsupportedView({ filePath }: UnsupportedViewProps) {
             <FileX2 className="size-5 text-[var(--text-tertiary)]" />
           </div>
           <div className="space-y-1">
-            <div className="text-sm text-[var(--text-primary)] font-mono">{name}</div>
+            <div className="text-sm text-[var(--text-primary)] font-mono">
+              {name}
+            </div>
             <div className="text-[11px] text-[var(--text-tertiary)]">
               File type{" "}
-              <span className="font-mono text-[var(--text-secondary)]">.{ext}</span>{" "}
+              <span className="font-mono text-[var(--text-secondary)]">
+                .{ext}
+              </span>{" "}
               not supported for inline preview.
             </div>
           </div>

--- a/src/features/updater/components/update-available-modal.tsx
+++ b/src/features/updater/components/update-available-modal.tsx
@@ -63,11 +63,11 @@ export function UpdateAvailableModal() {
 
           <p className="mt-1 text-[12px] text-text-secondary leading-relaxed px-1">
             {isError ? (
-              error ?? "Something went wrong while installing the update."
+              (error ?? "Something went wrong while installing the update.")
             ) : (
               <>
-                Atlas{version ? ` ${version}` : ""} has been downloaded. Restart to
-                finish updating.
+                Atlas{version ? ` ${version}` : ""} has been downloaded. Restart
+                to finish updating.
               </>
             )}
           </p>
@@ -106,7 +106,8 @@ export function UpdateAvailableModal() {
 
           {!applying && !isError && (
             <p className="mt-3 text-[10px] text-text-tertiary leading-relaxed px-1">
-              "Later" installs the update automatically the next time you quit Atlas.
+              "Later" installs the update automatically the next time you quit
+              Atlas.
             </p>
           )}
         </Dialog.Content>

--- a/src/features/updater/stores/updater-store.ts
+++ b/src/features/updater/stores/updater-store.ts
@@ -28,7 +28,12 @@ interface UpdaterState {
    *  to the titlebar badge, then reopened). */
   modalOpen: boolean;
   actions: {
-    setDownloading: (version: string, downloaded: number, total: number, phase: string) => void;
+    setDownloading: (
+      version: string,
+      downloaded: number,
+      total: number,
+      phase: string,
+    ) => void;
     setReady: (version: string) => void;
     setError: (message: string) => void;
     setChecking: (checking: boolean) => void;
@@ -55,18 +60,36 @@ const useUpdaterStoreBase = create<UpdaterState>()((set) => ({
       set({
         phase: "downloading",
         version,
-        progress: phase === "verifying" || total <= 0 ? null : Math.min(1, downloaded / total),
+        progress:
+          phase === "verifying" || total <= 0
+            ? null
+            : Math.min(1, downloaded / total),
         error: null,
         // Background download must NOT steal focus — no modal here.
         modalOpen: false,
       }),
-    setReady: (version) => set({ phase: "ready", version, progress: null, error: null, modalOpen: true }),
-    setError: (message) => set({ phase: "error", error: message, modalOpen: true }),
+    setReady: (version) =>
+      set({
+        phase: "ready",
+        version,
+        progress: null,
+        error: null,
+        modalOpen: true,
+      }),
+    setError: (message) =>
+      set({ phase: "error", error: message, modalOpen: true }),
     setChecking: (checking) => set({ checking }),
     beginApply: () => set({ phase: "applying" }),
     openModal: () => set({ modalOpen: true }),
     dismissModal: () => set({ modalOpen: false }),
-    reset: () => set({ phase: "idle", version: null, progress: null, error: null, modalOpen: false }),
+    reset: () =>
+      set({
+        phase: "idle",
+        version: null,
+        progress: null,
+        error: null,
+        modalOpen: false,
+      }),
   },
 }));
 

--- a/src/features/workspaces/components/workspace-sidebar.tsx
+++ b/src/features/workspaces/components/workspace-sidebar.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useWorkspaceGitStore, type GitSummary } from "../stores/workspace-git-store";
+import {
+  useWorkspaceGitStore,
+  type GitSummary,
+} from "../stores/workspace-git-store";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
@@ -37,7 +40,10 @@ import { openAgentSession } from "@/features/chat/lib/open-agent-session";
 import { stripInjectedContext } from "@/features/chat/lib/atlas-context";
 import { AtlasLoader } from "@/components/atlas-loader";
 import { AgentIcons } from "@/components/agent-icons";
-import { useRecentChatsStore, type RecentChat } from "../stores/recent-chats-store";
+import {
+  useRecentChatsStore,
+  type RecentChat,
+} from "../stores/recent-chats-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useOrgStore } from "@/features/organisations/stores/org-store";
 import { OrgSwitcher } from "@/features/organisations/components/org-switcher";
@@ -59,14 +65,21 @@ const HEADER_H = 26;
 
 /** Git status dot: green = clean tree, yellow = dirty, gray = non-repo/unknown. */
 function GitDot({ summary }: { summary?: GitSummary }) {
-  const color = !summary || !summary.isRepo
-    ? "var(--text-tertiary)"
-    : summary.dirty
-      ? "var(--status-warning, #CD9731)"
-      : "var(--accent-positive, #3fb950)";
+  const color =
+    !summary || !summary.isRepo
+      ? "var(--text-tertiary)"
+      : summary.dirty
+        ? "var(--status-warning, #CD9731)"
+        : "var(--accent-positive, #3fb950)";
   return (
     <span
-      title={!summary?.isRepo ? "Not a git repo" : summary.dirty ? "Working tree dirty" : "Working tree clean"}
+      title={
+        !summary?.isRepo
+          ? "Not a git repo"
+          : summary.dirty
+            ? "Working tree dirty"
+            : "Working tree clean"
+      }
       className="shrink-0 h-2 w-2 rounded-full"
       style={{ backgroundColor: color }}
     />
@@ -79,10 +92,14 @@ function NumStatPill({ summary }: { summary?: GitSummary }) {
   return (
     <span className="flex items-center gap-1.5 rounded-full bg-[var(--bg-elevated)] px-1.5 py-[1px] font-mono text-[9px] shrink-0">
       {summary && summary.additions > 0 && (
-        <span className="text-[var(--accent-positive,#3fb950)]">+{summary.additions}</span>
+        <span className="text-[var(--accent-positive,#3fb950)]">
+          +{summary.additions}
+        </span>
       )}
       {summary && summary.deletions > 0 && (
-        <span className="text-[var(--accent-negative,#f85149)]">−{summary.deletions}</span>
+        <span className="text-[var(--accent-negative,#f85149)]">
+          −{summary.deletions}
+        </span>
       )}
     </span>
   );
@@ -101,7 +118,17 @@ function WorkspaceRow({
   groups: WorkspaceGroup[];
   indented?: boolean;
 }) {
-  const { switchTo, closeWorkspace, pin, unpin, setGroup, addGroup, rename, beginRenameWorkspace, endRenameWorkspace } = useWorkspaceStore.use.actions();
+  const {
+    switchTo,
+    closeWorkspace,
+    pin,
+    unpin,
+    setGroup,
+    addGroup,
+    rename,
+    beginRenameWorkspace,
+    endRenameWorkspace,
+  } = useWorkspaceStore.use.actions();
   // Inline-rename lives in the store (like group rename) so it survives the
   // virtualized row remounting. The name shown is the user-chosen workspace
   // label (defaults to the directory name) — renaming only relabels the row,
@@ -169,10 +196,15 @@ function WorkspaceRow({
           />
         ) : (
           <span
-            onDoubleClick={(e) => { e.stopPropagation(); beginRenameWorkspace(ws.id); }}
+            onDoubleClick={(e) => {
+              e.stopPropagation();
+              beginRenameWorkspace(ws.id);
+            }}
             className={cn(
               "block truncate text-[12px] leading-tight pr-16",
-              active ? "text-[var(--text-primary)] font-medium" : "text-[var(--text-secondary)]",
+              active
+                ? "text-[var(--text-primary)] font-medium"
+                : "text-[var(--text-secondary)]",
             )}
           >
             {ws.name}
@@ -192,7 +224,11 @@ function WorkspaceRow({
       {/* Pin + more — absolute BOTTOM-RIGHT, on hover (pin stays if pinned). */}
       <div className="absolute bottom-1 right-1.5 flex items-center gap-0.5">
         <button
-          onClick={(e) => { e.stopPropagation(); if (ws.pinned) unpin(ws.id); else pin(ws.id); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (ws.pinned) unpin(ws.id);
+            else pin(ws.id);
+          }}
           className={cn(
             "p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] transition-opacity",
             ws.pinned ? "opacity-100" : "opacity-0 group-hover:opacity-100",
@@ -201,118 +237,205 @@ function WorkspaceRow({
         >
           {ws.pinned ? <PinOff size={11} /> : <Pin size={11} />}
         </button>
-      <DropdownMenu.Root>
-        <DropdownMenu.Trigger asChild>
-          <button
-            onClick={(e) => e.stopPropagation()}
-            className="p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 transition-opacity outline-none"
-            title="More"
-          >
-            <MoreHorizontal size={12} />
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Portal>
-          <DropdownMenu.Content align="end" sideOffset={4} onClick={(e) => e.stopPropagation()}
-            // On close Radix restores focus to the trigger button. When the
-            // close is caused by selecting "Rename", that focus-return lands
-            // AFTER the rename input has mounted+autofocused, blurring it
-            // instantly → commitRename → edit mode exits. Suppressing the
-            // close auto-focus lets the input keep focus.
-            onCloseAutoFocus={(e) => e.preventDefault()}
-            className="z-[var(--z-max)] min-w-[148px] rounded-md border border-[var(--border-default)] bg-black py-0.5 shadow-[var(--shadow-overlay)] text-[11px] text-[var(--text-secondary)]">
-            <DropdownMenu.Item
-              onSelect={() => beginRenameWorkspace(ws.id)}
-              className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-              <Pencil size={11} /> Rename
-            </DropdownMenu.Item>
-            <DropdownMenu.Item
-              onSelect={() => {
-                void navigator.clipboard
-                  .writeText(ws.path)
-                  .then(() => toast.success("Path copied"))
-                  .catch(() => toast.error("Couldn't copy path"));
-              }}
-              className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-              <Copy size={11} /> Copy path
-            </DropdownMenu.Item>
-            <DropdownMenu.Separator className="my-0.5 h-px bg-[var(--border-default)]" />
-            <DropdownMenu.Sub>
-              <DropdownMenu.SubTrigger className="flex items-center justify-between px-2.5 h-6 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-                Move to group <ChevronRight size={11} />
-              </DropdownMenu.SubTrigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.SubContent className="z-[var(--z-max)] min-w-[140px] rounded-md border border-[var(--border-default)] bg-black py-0.5 shadow-[var(--shadow-overlay)] text-[11px] text-[var(--text-secondary)]">
-                  {groups.map((g) => (
-                    <DropdownMenu.Item key={g.id} onSelect={() => setGroup(ws.id, g.id)}
-                      className="px-2.5 h-6 flex items-center outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-                      {g.name}
-                    </DropdownMenu.Item>
-                  ))}
-                  <DropdownMenu.Item onSelect={() => { const gid = addGroup("New Group"); setGroup(ws.id, gid); }}
-                    className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-                    <FolderPlus size={11} /> New group
-                  </DropdownMenu.Item>
-                  {ws.groupId && (
-                    <>
-                      <DropdownMenu.Separator className="my-0.5 h-px bg-[var(--border-default)]" />
-                      <DropdownMenu.Item onSelect={() => setGroup(ws.id, null)}
-                        className="px-2.5 h-6 flex items-center outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-                        Remove from group
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <button
+              onClick={(e) => e.stopPropagation()}
+              className="p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 transition-opacity outline-none"
+              title="More"
+            >
+              <MoreHorizontal size={12} />
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              align="end"
+              sideOffset={4}
+              onClick={(e) => e.stopPropagation()}
+              // On close Radix restores focus to the trigger button. When the
+              // close is caused by selecting "Rename", that focus-return lands
+              // AFTER the rename input has mounted+autofocused, blurring it
+              // instantly → commitRename → edit mode exits. Suppressing the
+              // close auto-focus lets the input keep focus.
+              onCloseAutoFocus={(e) => e.preventDefault()}
+              className="z-[var(--z-max)] min-w-[148px] rounded-md border border-[var(--border-default)] bg-black py-0.5 shadow-[var(--shadow-overlay)] text-[11px] text-[var(--text-secondary)]"
+            >
+              <DropdownMenu.Item
+                onSelect={() => beginRenameWorkspace(ws.id)}
+                className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default"
+              >
+                <Pencil size={11} /> Rename
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                onSelect={() => {
+                  void navigator.clipboard
+                    .writeText(ws.path)
+                    .then(() => toast.success("Path copied"))
+                    .catch(() => toast.error("Couldn't copy path"));
+                }}
+                className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default"
+              >
+                <Copy size={11} /> Copy path
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator className="my-0.5 h-px bg-[var(--border-default)]" />
+              <DropdownMenu.Sub>
+                <DropdownMenu.SubTrigger className="flex items-center justify-between px-2.5 h-6 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
+                  Move to group <ChevronRight size={11} />
+                </DropdownMenu.SubTrigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.SubContent className="z-[var(--z-max)] min-w-[140px] rounded-md border border-[var(--border-default)] bg-black py-0.5 shadow-[var(--shadow-overlay)] text-[11px] text-[var(--text-secondary)]">
+                    {groups.map((g) => (
+                      <DropdownMenu.Item
+                        key={g.id}
+                        onSelect={() => setGroup(ws.id, g.id)}
+                        className="px-2.5 h-6 flex items-center outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default"
+                      >
+                        {g.name}
                       </DropdownMenu.Item>
-                    </>
-                  )}
-                </DropdownMenu.SubContent>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Sub>
-            <DropdownMenu.Separator className="my-0.5 h-px bg-[var(--border-default)]" />
-            <DropdownMenu.Item onSelect={() => void closeWorkspace(ws.id)}
-              className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--status-error,#f44)] cursor-default">
-              <X size={11} /> Remove from list
-            </DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
-      </DropdownMenu.Root>
+                    ))}
+                    <DropdownMenu.Item
+                      onSelect={() => {
+                        const gid = addGroup("New Group");
+                        setGroup(ws.id, gid);
+                      }}
+                      className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default"
+                    >
+                      <FolderPlus size={11} /> New group
+                    </DropdownMenu.Item>
+                    {ws.groupId && (
+                      <>
+                        <DropdownMenu.Separator className="my-0.5 h-px bg-[var(--border-default)]" />
+                        <DropdownMenu.Item
+                          onSelect={() => setGroup(ws.id, null)}
+                          className="px-2.5 h-6 flex items-center outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default"
+                        >
+                          Remove from group
+                        </DropdownMenu.Item>
+                      </>
+                    )}
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Sub>
+              <DropdownMenu.Separator className="my-0.5 h-px bg-[var(--border-default)]" />
+              <DropdownMenu.Item
+                onSelect={() => void closeWorkspace(ws.id)}
+                className="px-2.5 h-6 flex items-center gap-1.5 outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--status-error,#f44)] cursor-default"
+              >
+                <X size={11} /> Remove from list
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
       </div>
     </div>
   );
 }
 
-function GroupHeaderRow({ group, collapsed, onToggle }: { group: WorkspaceGroup; collapsed: boolean; onToggle: () => void }) {
-  const { pinGroup, unpinGroup, removeGroup, renameGroup, beginRenameGroup, endRenameGroup } = useWorkspaceStore.use.actions();
+function GroupHeaderRow({
+  group,
+  collapsed,
+  onToggle,
+}: {
+  group: WorkspaceGroup;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  const {
+    pinGroup,
+    unpinGroup,
+    removeGroup,
+    renameGroup,
+    beginRenameGroup,
+    endRenameGroup,
+  } = useWorkspaceStore.use.actions();
   // Editing lives in the store (not local state) so it survives the virtualized
   // row remounting, and so a freshly-created group opens straight into rename.
   const editing = useWorkspaceStore.use.editingGroupId() === group.id;
   const [name, setName] = useState(group.name);
   // Seed the field each time we enter edit mode.
-  useEffect(() => { if (editing) setName(group.name); }, [editing, group.name]);
-  const commit = () => { const n = name.trim(); if (n) renameGroup(group.id, n); endRenameGroup(); };
+  useEffect(() => {
+    if (editing) setName(group.name);
+  }, [editing, group.name]);
+  const commit = () => {
+    const n = name.trim();
+    if (n) renameGroup(group.id, n);
+    endRenameGroup();
+  };
   return (
-    <div data-hint style={{ height: HEADER_H }} className="group/h flex items-center gap-1 pl-1 pr-1.5 rounded-md cursor-pointer hover:bg-[var(--bg-hover)] transform-gpu [backface-visibility:hidden]" onClick={editing ? undefined : onToggle}>
-      {collapsed ? <ChevronRight size={12} className="text-[var(--text-tertiary)]" /> : <ChevronDown size={12} className="text-[var(--text-tertiary)]" />}
+    <div
+      data-hint
+      style={{ height: HEADER_H }}
+      className="group/h flex items-center gap-1 pl-1 pr-1.5 rounded-md cursor-pointer hover:bg-[var(--bg-hover)] transform-gpu [backface-visibility:hidden]"
+      onClick={editing ? undefined : onToggle}
+    >
+      {collapsed ? (
+        <ChevronRight size={12} className="text-[var(--text-tertiary)]" />
+      ) : (
+        <ChevronDown size={12} className="text-[var(--text-tertiary)]" />
+      )}
       <Folder size={11} className="text-[var(--text-tertiary)] shrink-0" />
       {editing ? (
-        <input autoFocus value={name} onClick={(e) => e.stopPropagation()} onFocus={(e) => e.target.select()} onChange={(e) => setName(e.target.value)} onBlur={commit}
-          onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Enter") commit(); if (e.key === "Escape") endRenameGroup(); }}
-          className="flex-1 min-w-0 bg-transparent outline-none text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]" />
+        <input
+          autoFocus
+          value={name}
+          onClick={(e) => e.stopPropagation()}
+          onFocus={(e) => e.target.select()}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") commit();
+            if (e.key === "Escape") endRenameGroup();
+          }}
+          className="flex-1 min-w-0 bg-transparent outline-none text-[10px] font-semibold uppercase tracking-wide text-[var(--text-secondary)]"
+        />
       ) : (
-        <span onDoubleClick={(e) => { e.stopPropagation(); beginRenameGroup(group.id); }}
-          className="flex-1 min-w-0 truncate text-[10px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+        <span
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            beginRenameGroup(group.id);
+          }}
+          className="flex-1 min-w-0 truncate text-[10px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]"
+        >
           {group.name}
         </span>
       )}
       {!editing && (
-        <button onClick={(e) => { e.stopPropagation(); beginRenameGroup(group.id); }}
-          className="p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] opacity-0 group-hover/h:opacity-100 transition-opacity" title="Rename group">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            beginRenameGroup(group.id);
+          }}
+          className="p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] opacity-0 group-hover/h:opacity-100 transition-opacity"
+          title="Rename group"
+        >
           <Pencil size={10} />
         </button>
       )}
-      <button onClick={(e) => { e.stopPropagation(); if (group.pinned) unpinGroup(group.id); else pinGroup(group.id); }}
-        className={cn("p-0.5 rounded hover:bg-[var(--bg-elevated)] transition-opacity", group.pinned ? "opacity-100 text-[var(--accent-primary)]" : "opacity-0 group-hover/h:opacity-100 text-[var(--text-tertiary)]")}
-        title={group.pinned ? "Unpin group" : "Pin group"}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (group.pinned) unpinGroup(group.id);
+          else pinGroup(group.id);
+        }}
+        className={cn(
+          "p-0.5 rounded hover:bg-[var(--bg-elevated)] transition-opacity",
+          group.pinned
+            ? "opacity-100 text-[var(--accent-primary)]"
+            : "opacity-0 group-hover/h:opacity-100 text-[var(--text-tertiary)]",
+        )}
+        title={group.pinned ? "Unpin group" : "Pin group"}
+      >
         {group.pinned ? <PinOff size={10} /> : <Pin size={10} />}
       </button>
-      <button onClick={(e) => { e.stopPropagation(); removeGroup(group.id); }}
-        className="p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] opacity-0 group-hover/h:opacity-100 transition-opacity" title="Delete group">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          removeGroup(group.id);
+        }}
+        className="p-0.5 rounded hover:bg-[var(--bg-elevated)] text-[var(--text-tertiary)] opacity-0 group-hover/h:opacity-100 transition-opacity"
+        title="Delete group"
+      >
         <X size={10} />
       </button>
     </div>
@@ -343,10 +466,15 @@ function SectionHeaderRow({
       ) : (
         <ChevronDown size={12} className="text-[var(--text-tertiary)]" />
       )}
-      <span className="text-[10px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">{label}</span>
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+        {label}
+      </span>
       {action && (
         <button
-          onClick={(e) => { e.stopPropagation(); action.onClick(); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            action.onClick();
+          }}
           title={action.title}
           className="ml-auto p-0.5 rounded text-[var(--text-tertiary)] opacity-0 group-hover/s:opacity-100 hover:bg-[var(--bg-elevated)] hover:text-[var(--status-error,#f44)] transition-opacity outline-none"
         >
@@ -357,12 +485,27 @@ function SectionHeaderRow({
   );
 }
 
-function RecentProjectRow({ name, path, onOpen }: { name: string; path: string; onOpen: () => void }) {
+function RecentProjectRow({
+  name,
+  path,
+  onOpen,
+}: {
+  name: string;
+  path: string;
+  onOpen: () => void;
+}) {
   return (
-    <div data-hint onClick={onOpen} style={{ height: ROW_CARD, paddingLeft: 10 }}
-      className="group flex items-center gap-2.5 pr-1.5 rounded-md cursor-pointer hover:bg-[var(--bg-hover)]" title={path}>
+    <div
+      data-hint
+      onClick={onOpen}
+      style={{ height: ROW_CARD, paddingLeft: 10 }}
+      className="group flex items-center gap-2.5 pr-1.5 rounded-md cursor-pointer hover:bg-[var(--bg-hover)]"
+      title={path}
+    >
       <span className="shrink-0 h-1.5 w-1.5 rounded-full bg-[var(--text-secondary)]" />
-      <span className="flex-1 min-w-0 truncate text-[12px] text-[var(--text-secondary)]">{name}</span>
+      <span className="flex-1 min-w-0 truncate text-[12px] text-[var(--text-secondary)]">
+        {name}
+      </span>
     </div>
   );
 }
@@ -376,15 +519,32 @@ function relTime(ms: number): string {
   return `${Math.floor(s / 86400)}d`;
 }
 
-function ChatRow({ chat, running, onOpen }: { chat: RecentChat; running: boolean; onOpen: () => void }) {
+function ChatRow({
+  chat,
+  running,
+  onOpen,
+}: {
+  chat: RecentChat;
+  running: boolean;
+  onOpen: () => void;
+}) {
   // Cersei (the Atlas native agent) gets its own brand mark — falling through
   // to the Claude icon mislabeled Atlas chats in this panel.
-  const AgentIcon = chat.agentType === "codex" ? AgentIcons.Codex : AgentIcons.Claude;
+  const AgentIcon =
+    chat.agentType === "codex" ? AgentIcons.Codex : AgentIcons.Claude;
   return (
-    <div data-hint onClick={onOpen} style={{ height: CHAT_CARD, paddingLeft: 6 }}
-      className="group relative flex items-start gap-2 pr-1.5 py-1.5 border-b border-[var(--border-subtle)] cursor-pointer hover:bg-[var(--bg-hover)] transform-gpu [backface-visibility:hidden]" title={chat.projectPath}>
+    <div
+      data-hint
+      onClick={onOpen}
+      style={{ height: CHAT_CARD, paddingLeft: 6 }}
+      className="group relative flex items-start gap-2 pr-1.5 py-1.5 border-b border-[var(--border-subtle)] cursor-pointer hover:bg-[var(--bg-hover)] transform-gpu [backface-visibility:hidden]"
+      title={chat.projectPath}
+    >
       {running ? (
-        <AtlasLoader size={11} className="mt-0.5 shrink-0 text-[var(--accent-primary)]" />
+        <AtlasLoader
+          size={11}
+          className="mt-0.5 shrink-0 text-[var(--accent-primary)]"
+        />
       ) : chat.agentType === "cersei" ? (
         <AtlasIcon size={14} className="mt-0.5 shrink-0" />
       ) : (
@@ -393,7 +553,9 @@ function ChatRow({ chat, running, onOpen }: { chat: RecentChat; running: boolean
       <div
         className={cn(
           "min-w-0 flex-1 text-[12px] leading-[1.3] line-clamp-2 break-words",
-          running ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)]",
+          running
+            ? "text-[var(--text-primary)]"
+            : "text-[var(--text-secondary)]",
         )}
       >
         {stripInjectedContext(chat.title) || chat.projectName}
@@ -462,16 +624,28 @@ export function WorkspaceSidebar() {
   const toggle = (id: string) => setCollapsed((c) => ({ ...c, [id]: !c[id] }));
 
   // Pinned + Projects (STATIC registry order — clicking never reorders).
-  const pinned = useMemo(() => workspaces.filter((w) => w.pinned), [workspaces]);
-  const projects = useMemo(() => workspaces.filter((w) => !w.pinned), [workspaces]);
+  const pinned = useMemo(
+    () => workspaces.filter((w) => w.pinned),
+    [workspaces],
+  );
+  const projects = useMemo(
+    () => workspaces.filter((w) => !w.pinned),
+    [workspaces],
+  );
   const sortedGroups = useMemo(
-    () => [...groups].sort((a, b) => Number(!!b.pinned) - Number(!!a.pinned) || a.order - b.order),
+    () =>
+      [...groups].sort(
+        (a, b) => Number(!!b.pinned) - Number(!!a.pinned) || a.order - b.order,
+      ),
     [groups],
   );
 
   // Recent projects = picker recents NOT already in the registry. Excludes
   // projects open in ANY org (recents are global) so nothing double-lists.
-  const openPaths = useMemo(() => new Set(allWorkspaces.map((w) => w.path)), [allWorkspaces]);
+  const openPaths = useMemo(
+    () => new Set(allWorkspaces.map((w) => w.path)),
+    [allWorkspaces],
+  );
   const recents = useMemo(
     () => recentProjects.filter((r) => !openPaths.has(r.path)),
     [recentProjects, openPaths],
@@ -506,45 +680,98 @@ export function WorkspaceSidebar() {
   const rows = useMemo<Row[]>(() => {
     const out: Row[] = [];
     if (pinned.length) {
-      out.push({ kind: "section", id: "sec:pinned", label: "Pinned", key: "s:pinned" });
-      if (!collapsed["sec:pinned"]) for (const ws of pinned) out.push({ kind: "ws", ws, indented: false, key: ws.id });
+      out.push({
+        kind: "section",
+        id: "sec:pinned",
+        label: "Pinned",
+        key: "s:pinned",
+      });
+      if (!collapsed["sec:pinned"])
+        for (const ws of pinned)
+          out.push({ kind: "ws", ws, indented: false, key: ws.id });
     }
-    out.push({ kind: "section", id: "sec:projects", label: "Projects", key: "s:projects" });
+    out.push({
+      kind: "section",
+      id: "sec:projects",
+      label: "Projects",
+      key: "s:projects",
+    });
     if (!collapsed["sec:projects"]) {
-      const inGroup = (gid: string) => projects.filter((w) => w.groupId === gid);
+      const inGroup = (gid: string) =>
+        projects.filter((w) => w.groupId === gid);
       for (const g of sortedGroups) {
         const members = inGroup(g.id);
-        out.push({ kind: "group", group: g, count: members.length, key: `g:${g.id}` });
-        if (!collapsed[g.id]) for (const ws of members) out.push({ kind: "ws", ws, indented: true, key: ws.id });
+        out.push({
+          kind: "group",
+          group: g,
+          count: members.length,
+          key: `g:${g.id}`,
+        });
+        if (!collapsed[g.id])
+          for (const ws of members)
+            out.push({ kind: "ws", ws, indented: true, key: ws.id });
       }
-      for (const ws of projects.filter((w) => !w.groupId)) out.push({ kind: "ws", ws, indented: false, key: ws.id });
+      for (const ws of projects.filter((w) => !w.groupId))
+        out.push({ kind: "ws", ws, indented: false, key: ws.id });
     }
     if (recents.length) {
-      out.push({ kind: "section", id: "sec:recent", label: "Recent", key: "s:recent" });
-      if (!collapsed["sec:recent"]) for (const r of recents) out.push({ kind: "recent", name: r.name, path: r.path, key: `r:${r.path}` });
+      out.push({
+        kind: "section",
+        id: "sec:recent",
+        label: "Recent",
+        key: "s:recent",
+      });
+      if (!collapsed["sec:recent"])
+        for (const r of recents)
+          out.push({
+            kind: "recent",
+            name: r.name,
+            path: r.path,
+            key: `r:${r.path}`,
+          });
     }
     if (orgRecentChats.length) {
-      out.push({ kind: "section", id: "sec:chats", label: "Chats", key: "s:chats" });
+      out.push({
+        kind: "section",
+        id: "sec:chats",
+        label: "Chats",
+        key: "s:chats",
+      });
       // Active (live-running) chats float to the top of the stack; the rest keep
       // their most-recent-first order. Capacity (15) is enforced by the store.
       const ordered = [
         ...orgRecentChats.filter(isChatRunning),
         ...orgRecentChats.filter((c) => !isChatRunning(c)),
       ];
-      if (!collapsed["sec:chats"]) for (const c of ordered) out.push({ kind: "chat", chat: c, key: `c:${c.tabId}` });
+      if (!collapsed["sec:chats"])
+        for (const c of ordered)
+          out.push({ kind: "chat", chat: c, key: `c:${c.tabId}` });
     }
     return out;
-  }, [pinned, projects, sortedGroups, collapsed, recents, orgRecentChats, isChatRunning]);
+  }, [
+    pinned,
+    projects,
+    sortedGroups,
+    collapsed,
+    recents,
+    orgRecentChats,
+    isChatRunning,
+  ]);
 
   // Collapse-all / expand-all: collapses every section + group, or expands all.
   const allCollapsibleIds = useMemo(
     () => [...sectionIds, ...groups.map((g) => g.id)],
     [sectionIds, groups],
   );
-  const allCollapsed = allCollapsibleIds.length > 0 && allCollapsibleIds.every((id) => collapsed[id]);
+  const allCollapsed =
+    allCollapsibleIds.length > 0 &&
+    allCollapsibleIds.every((id) => collapsed[id]);
   const toggleAll = () => {
     if (allCollapsed) setCollapsed({});
-    else setCollapsed(Object.fromEntries(allCollapsibleIds.map((id) => [id, true])));
+    else
+      setCollapsed(
+        Object.fromEntries(allCollapsibleIds.map((id) => [id, true])),
+      );
   };
 
   // ── Git summaries: cached at module scope (`workspace-git-store`) so opening
@@ -572,28 +799,49 @@ export function WorkspaceSidebar() {
 
   // Fetch git summaries for the visible workspace rows.
   const items = virtualizer.getVirtualItems();
-  const visiblePaths = items.map((v) => { const r = rows[v.index]; return r?.kind === "ws" ? r.ws.path : null; }).filter(Boolean).join("|");
+  const visiblePaths = items
+    .map((v) => {
+      const r = rows[v.index];
+      return r?.kind === "ws" ? r.ws.path : null;
+    })
+    .filter(Boolean)
+    .join("|");
   useEffect(() => {
     for (const p of visiblePaths.split("|")) if (p) ensureSummary(p);
   }, [visiblePaths, ensureSummary]);
 
-  const openChat = useCallback(async (chat: RecentChat) => {
-    // 1. Focus the chat's project workspace (register it if new).
-    const ws = useWorkspaceStore.getState().workspaces.find((w) => w.path === chat.projectPath);
-    if (ws) await useWorkspaceStore.getState().actions.switchTo(ws.id);
-    else await addWorkspace(chat.projectPath);
-    // 2. Open THIS session (by acp session id — not the tab id, which is reused
-    //    across many sessions). openAgentSession focuses it if already open,
-    //    else loads it into the agent chat.
-    await openAgentSession({
-      acpSessionId: chat.acpSessionId,
-      title: chat.title,
-      cwd: chat.projectPath,
-    });
-  }, [addWorkspace]);
+  const openChat = useCallback(
+    async (chat: RecentChat) => {
+      // 1. Focus the chat's project workspace (register it if new).
+      const ws = useWorkspaceStore
+        .getState()
+        .workspaces.find((w) => w.path === chat.projectPath);
+      if (ws) await useWorkspaceStore.getState().actions.switchTo(ws.id);
+      else await addWorkspace(chat.projectPath);
+      // 2. Open THIS session (by acp session id — not the tab id, which is reused
+      //    across many sessions). openAgentSession focuses it if already open,
+      //    else loads it into the agent chat.
+      await openAgentSession({
+        acpSessionId: chat.acpSessionId,
+        title: chat.title,
+        cwd: chat.projectPath,
+      });
+    },
+    [addWorkspace],
+  );
 
-  const openTabSingleton = (type: "mission-control" | "log" | "settings", title: string) =>
-    addTab({ id: type === "mission-control" ? "mission-control" : type, type, title, closable: true, dirty: false, data: {} });
+  const openTabSingleton = (
+    type: "mission-control" | "log" | "settings",
+    title: string,
+  ) =>
+    addTab({
+      id: type === "mission-control" ? "mission-control" : type,
+      type,
+      title,
+      closable: true,
+      dirty: false,
+      data: {},
+    });
 
   return (
     <aside
@@ -623,7 +871,11 @@ export function WorkspaceSidebar() {
               ? "text-[var(--accent-primary)]"
               : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]",
           )}
-          title={sidebarPinned ? "Unpin sidebar (float as overlay)" : "Pin sidebar (dock into layout)"}
+          title={
+            sidebarPinned
+              ? "Unpin sidebar (float as overlay)"
+              : "Pin sidebar (dock into layout)"
+          }
         >
           {sidebarPinned ? <PinOff size={13} /> : <Pin size={13} />}
         </button>
@@ -632,7 +884,11 @@ export function WorkspaceSidebar() {
           className="p-1 rounded-full text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)] outline-none"
           title={allCollapsed ? "Expand all" : "Collapse all"}
         >
-          {allCollapsed ? <ChevronsUpDown size={13} /> : <ChevronsDownUp size={13} />}
+          {allCollapsed ? (
+            <ChevronsUpDown size={13} />
+          ) : (
+            <ChevronsDownUp size={13} />
+          )}
         </button>
         <AddProjectMenu />
       </div>
@@ -649,27 +905,55 @@ export function WorkspaceSidebar() {
 
       {/* Header actions. */}
       <div className="px-1.5 pb-1 shrink-0 space-y-0.5">
-        <HeaderButton icon={<AtlasIcon size={14} className="rounded-[3px]" />} label="Console" onClick={() => openTabSingleton("mission-control", "Console")} />
-        <HeaderButton icon={<ScrollText size={13} />} label="See Logs" onClick={() => openTabSingleton("log", "Log")} />
+        <HeaderButton
+          icon={<AtlasIcon size={14} className="rounded-[3px]" />}
+          label="Console"
+          onClick={() => openTabSingleton("mission-control", "Console")}
+        />
+        <HeaderButton
+          icon={<ScrollText size={13} />}
+          label="See Logs"
+          onClick={() => openTabSingleton("log", "Log")}
+        />
         <HeaderButton
           icon={<Zap size={13} />}
           label="Skills"
           onClick={() => openSettingsSection("skills")}
         />
-        <HeaderButton icon={<Settings size={13} />} label="Settings" onClick={() => openTabSingleton("settings", "Settings")} />
+        <HeaderButton
+          icon={<Settings size={13} />}
+          label="Settings"
+          onClick={() => openTabSingleton("settings", "Settings")}
+        />
       </div>
 
       {/* Virtualized list. */}
-      <div ref={parentRef} className="flex-1 min-h-0 overflow-y-auto hide-scrollbar px-1.5 pb-2">
+      <div
+        ref={parentRef}
+        className="flex-1 min-h-0 overflow-y-auto hide-scrollbar px-1.5 pb-2"
+      >
         {rows.length === 0 ? (
-          <div className="px-2 py-3 text-[11px] text-[var(--text-tertiary)]">No projects yet.</div>
+          <div className="px-2 py-3 text-[11px] text-[var(--text-tertiary)]">
+            No projects yet.
+          </div>
         ) : (
-          <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+          <div
+            style={{ height: virtualizer.getTotalSize(), position: "relative" }}
+          >
             {items.map((v) => {
               const row = rows[v.index];
               if (!row) return null;
               return (
-                <div key={row.key} style={{ position: "absolute", top: 0, left: 0, width: "100%", transform: `translateY(${v.start}px)` }}>
+                <div
+                  key={row.key}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${v.start}px)`,
+                  }}
+                >
                   {row.kind === "section" ? (
                     <SectionHeaderRow
                       label={row.label}
@@ -677,20 +961,49 @@ export function WorkspaceSidebar() {
                       onToggle={() => toggle(row.id)}
                       action={
                         row.id === "sec:recent"
-                          ? { icon: <Trash2 size={11} />, title: "Clear recent projects", onClick: () => clearRecents() }
+                          ? {
+                              icon: <Trash2 size={11} />,
+                              title: "Clear recent projects",
+                              onClick: () => clearRecents(),
+                            }
                           : row.id === "sec:chats"
-                            ? { icon: <Trash2 size={11} />, title: "Clear chats", onClick: () => orgRecentChats.forEach((c) => removeChat(c.tabId)) }
+                            ? {
+                                icon: <Trash2 size={11} />,
+                                title: "Clear chats",
+                                onClick: () =>
+                                  orgRecentChats.forEach((c) =>
+                                    removeChat(c.tabId),
+                                  ),
+                              }
                             : undefined
                       }
                     />
                   ) : row.kind === "group" ? (
-                    <GroupHeaderRow group={row.group} collapsed={!!collapsed[row.group.id]} onToggle={() => toggle(row.group.id)} />
+                    <GroupHeaderRow
+                      group={row.group}
+                      collapsed={!!collapsed[row.group.id]}
+                      onToggle={() => toggle(row.group.id)}
+                    />
                   ) : row.kind === "ws" ? (
-                    <WorkspaceRow ws={row.ws} active={row.ws.id === displayActiveId} summary={summaries[row.ws.path]} groups={groups} indented={row.indented} />
+                    <WorkspaceRow
+                      ws={row.ws}
+                      active={row.ws.id === displayActiveId}
+                      summary={summaries[row.ws.path]}
+                      groups={groups}
+                      indented={row.indented}
+                    />
                   ) : row.kind === "recent" ? (
-                    <RecentProjectRow name={row.name} path={row.path} onOpen={() => void addWorkspace(row.path)} />
+                    <RecentProjectRow
+                      name={row.name}
+                      path={row.path}
+                      onOpen={() => void addWorkspace(row.path)}
+                    />
                   ) : (
-                    <ChatRow chat={row.chat} running={isChatRunning(row.chat)} onOpen={() => void openChat(row.chat)} />
+                    <ChatRow
+                      chat={row.chat}
+                      running={isChatRunning(row.chat)}
+                      onOpen={() => void openChat(row.chat)}
+                    />
                   )}
                 </div>
               );
@@ -702,10 +1015,20 @@ export function WorkspaceSidebar() {
   );
 }
 
-function HeaderButton({ icon, label, onClick }: { icon: React.ReactNode; label: string; onClick: () => void }) {
+function HeaderButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
   return (
-    <button onClick={onClick}
-      className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors">
+    <button
+      onClick={onClick}
+      className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors"
+    >
       <span className="text-[var(--text-tertiary)]">{icon}</span>
       {label}
     </button>
@@ -720,10 +1043,16 @@ function AddProjectMenu() {
   const { clearRecents } = useProjectStore.use.actions();
   const [query, setQuery] = useState("");
   const filtered = recentProjects.filter(
-    (p) => p.name.toLowerCase().includes(query.toLowerCase()) || p.path.toLowerCase().includes(query.toLowerCase()),
+    (p) =>
+      p.name.toLowerCase().includes(query.toLowerCase()) ||
+      p.path.toLowerCase().includes(query.toLowerCase()),
   );
   return (
-    <DropdownMenu.Root onOpenChange={(o) => { if (!o) setQuery(""); }}>
+    <DropdownMenu.Root
+      onOpenChange={(o) => {
+        if (!o) setQuery("");
+      }}
+    >
       <DropdownMenu.Trigger asChild>
         <button
           className="flex items-center justify-center h-6 w-6 rounded-full border border-[var(--border-default)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] outline-none transition-colors cursor-pointer"
@@ -735,36 +1064,69 @@ function AddProjectMenu() {
       <DropdownMenu.Portal>
         {/* Compact menu primitive — mirrors the source-control "filter files"
          *  dropdown: 26px rows, px-3 on both sides, border-b search header. */}
-        <DropdownMenu.Content align="end" sideOffset={4}
-          className="z-[var(--z-max)] w-[280px] max-h-[360px] rounded-lg border border-[var(--border-default)] bg-[#000] shadow-xl text-[var(--text-secondary)] flex flex-col overflow-hidden">
-          <DropdownMenu.Item onSelect={() => void pickAndAddWorkspace()}
-            className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default shrink-0">
-            <FolderOpen size={13} className="text-[var(--text-tertiary)] shrink-0" />
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className="z-[var(--z-max)] w-[280px] max-h-[360px] rounded-lg border border-[var(--border-default)] bg-[#000] shadow-xl text-[var(--text-secondary)] flex flex-col overflow-hidden"
+        >
+          <DropdownMenu.Item
+            onSelect={() => void pickAndAddWorkspace()}
+            className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default shrink-0"
+          >
+            <FolderOpen
+              size={13}
+              className="text-[var(--text-tertiary)] shrink-0"
+            />
             <span className="flex-1 text-left">Open Folder…</span>
           </DropdownMenu.Item>
           {recentProjects.length > 0 && (
             <>
-              <div className="flex items-center gap-1.5 px-3 h-[30px] border-y border-[var(--border-default)] shrink-0" onKeyDown={(e) => e.stopPropagation()}>
-                <Search size={11} className="text-[var(--text-tertiary)] shrink-0" />
-                <input autoFocus value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search projects…"
-                  className="flex-1 bg-transparent outline-none text-[10px] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]" />
+              <div
+                className="flex items-center gap-1.5 px-3 h-[30px] border-y border-[var(--border-default)] shrink-0"
+                onKeyDown={(e) => e.stopPropagation()}
+              >
+                <Search
+                  size={11}
+                  className="text-[var(--text-tertiary)] shrink-0"
+                />
+                <input
+                  autoFocus
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search projects…"
+                  className="flex-1 bg-transparent outline-none text-[10px] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]"
+                />
               </div>
-              <div className="px-3 pt-1.5 pb-0.5 text-[9px] uppercase tracking-wide text-[var(--text-tertiary)] shrink-0">Recent</div>
+              <div className="px-3 pt-1.5 pb-0.5 text-[9px] uppercase tracking-wide text-[var(--text-tertiary)] shrink-0">
+                Recent
+              </div>
               <div className="overflow-y-auto py-1 hide-scrollbar">
                 {filtered.length === 0 ? (
-                  <div className="px-3 py-2 text-[10px] text-[var(--text-tertiary)] text-center">No matches</div>
+                  <div className="px-3 py-2 text-[10px] text-[var(--text-tertiary)] text-center">
+                    No matches
+                  </div>
                 ) : (
                   filtered.map((p) => (
-                    <DropdownMenu.Item key={p.path} onSelect={() => void addWorkspace(p.path)}
-                      className="w-full flex items-center gap-2 px-3 h-[26px] text-[11px] outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default">
-                      <Folder size={12} className="text-[var(--text-tertiary)] shrink-0" />
-                      <span className="truncate font-mono text-left flex-1">{p.name}</span>
+                    <DropdownMenu.Item
+                      key={p.path}
+                      onSelect={() => void addWorkspace(p.path)}
+                      className="w-full flex items-center gap-2 px-3 h-[26px] text-[11px] outline-none hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-default"
+                    >
+                      <Folder
+                        size={12}
+                        className="text-[var(--text-tertiary)] shrink-0"
+                      />
+                      <span className="truncate font-mono text-left flex-1">
+                        {p.name}
+                      </span>
                     </DropdownMenu.Item>
                   ))
                 )}
               </div>
-              <DropdownMenu.Item onSelect={() => clearRecents()}
-                className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] outline-none border-t border-[var(--border-default)] text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--status-error,#f44)] cursor-pointer shrink-0">
+              <DropdownMenu.Item
+                onSelect={() => clearRecents()}
+                className="w-full flex items-center gap-2 px-3 h-[28px] text-[11px] outline-none border-t border-[var(--border-default)] text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--status-error,#f44)] cursor-pointer shrink-0"
+              >
                 <Trash2 size={12} className="shrink-0" />
                 <span className="flex-1 text-left">Clear recent projects</span>
               </DropdownMenu.Item>

--- a/src/features/workspaces/lib/pick-workspace.ts
+++ b/src/features/workspaces/lib/pick-workspace.ts
@@ -11,7 +11,9 @@ export async function pickAndAddWorkspace(): Promise<void> {
     const { open } = await import("@tauri-apps/plugin-dialog");
     const selected = await open({ directory: true });
     if (selected) {
-      await useWorkspaceStore.getState().actions.addWorkspace(selected as string);
+      await useWorkspaceStore
+        .getState()
+        .actions.addWorkspace(selected as string);
     }
   } catch {
     // dialog not available (e.g. non-Tauri context) — no-op

--- a/src/features/workspaces/lib/use-workspace-prefetch.ts
+++ b/src/features/workspaces/lib/use-workspace-prefetch.ts
@@ -17,7 +17,9 @@ import { useWorkspaceGitStore } from "../stores/workspace-git-store";
 export function useWorkspaceGitPrefetch() {
   // Re-runs only when the SET of workspace paths changes (the signature string
   // is stable otherwise), not on every store mutation.
-  const pathsSig = useWorkspaceStore((s) => s.workspaces.map((w) => w.path).join("\n"));
+  const pathsSig = useWorkspaceStore((s) =>
+    s.workspaces.map((w) => w.path).join("\n"),
+  );
 
   useEffect(() => {
     if (!pathsSig) return;

--- a/src/features/workspaces/lib/workspace-snapshot.ts
+++ b/src/features/workspaces/lib/workspace-snapshot.ts
@@ -91,7 +91,12 @@ export function captureSnapshot(workspaceId: string): void {
   // mirror's persisted fields only (NOT viewsByWs, which is the whole map).
   const ls = useLayoutStore.getState();
   const layoutForHash = {
-    tabs: ls.tabs.map((t) => ({ id: t.id, type: t.type, groupId: t.groupId, data: t.data })),
+    tabs: ls.tabs.map((t) => ({
+      id: t.id,
+      type: t.type,
+      groupId: t.groupId,
+      data: t.data,
+    })),
     groupOrder: ls.groupOrder,
     activeByGroup: ls.activeByGroup,
     focusedGroupId: ls.focusedGroupId,

--- a/src/features/workspaces/stores/workspace-store.ts
+++ b/src/features/workspaces/stores/workspace-store.ts
@@ -194,7 +194,9 @@ function teardownHot(id: string): void {
   useLayoutStore.getState().actions.removeWorkspaceView(id);
   void invoke("fileindex_close_project", { workspaceId: id }).catch(() => {});
   void invoke("git_watch_stop", { workspaceId: id }).catch(() => {});
-  void invoke("recent_files_close_project", { workspaceId: id }).catch(() => {});
+  void invoke("recent_files_close_project", { workspaceId: id }).catch(
+    () => {},
+  );
   void invoke("mention_cache_clear", { workspaceId: id }).catch(() => {});
 }
 
@@ -277,7 +279,9 @@ export const useWorkspaceStore = createSelectors(
           const candidates = mounted
             .filter(evictable)
             .sort((a, b) =>
-              (byId(a)?.lastActiveAt ?? "").localeCompare(byId(b)?.lastActiveAt ?? ""),
+              (byId(a)?.lastActiveAt ?? "").localeCompare(
+                byId(b)?.lastActiveAt ?? "",
+              ),
             );
           if (candidates.length === 0) break; // all pinned/running — exceed cap
           const lru = candidates[0];
@@ -321,7 +325,10 @@ export const useWorkspaceStore = createSelectors(
         //    immediately even though the real `activeWorkspaceId` lags behind.
         const pinnedNow = get().sidebarPinned;
         const wasOpen = get().sidebarOpen && !pinnedNow;
-        set({ optimisticActiveId: id, ...(pinnedNow ? {} : { sidebarOpen: false }) });
+        set({
+          optimisticActiveId: id,
+          ...(pinnedNow ? {} : { sidebarOpen: false }),
+        });
 
         // A switch already in flight → don't DROP the click; remember the latest
         // target and run it when the current one settles (coalesce). The close +
@@ -369,7 +376,10 @@ export const useWorkspaceStore = createSelectors(
             // The snapshot is then taken AFTER the flush so it reflects the
             // just-saved state. `flushAll` swallows per-store errors, so a bad
             // flush can't block the switch.
-            await flushAll({ workspaceId: activeWorkspaceId, path: outgoingPath });
+            await flushAll({
+              workspaceId: activeWorkspaceId,
+              path: outgoingPath,
+            });
             captureSnapshot(activeWorkspaceId);
           }
 
@@ -459,9 +469,8 @@ export const useWorkspaceStore = createSelectors(
 
         if (isActive) {
           // Switch to the most-recently-active remaining workspace, or clear.
-          const next = [...remaining].sort(
-            (a, b) =>
-              (b.lastActiveAt ?? "").localeCompare(a.lastActiveAt ?? ""),
+          const next = [...remaining].sort((a, b) =>
+            (b.lastActiveAt ?? "").localeCompare(a.lastActiveAt ?? ""),
           )[0];
           if (next) {
             set({ activeWorkspaceId: null });
@@ -551,7 +560,10 @@ export const useWorkspaceStore = createSelectors(
           orgId: activeOrgId(),
         };
         // Open the new group straight into inline-rename so the user can name it.
-        set((s) => ({ groups: [...s.groups, group], editingGroupId: group.id }));
+        set((s) => ({
+          groups: [...s.groups, group],
+          editingGroupId: group.id,
+        }));
         scheduleAppStateSave();
         return group.id;
       },
@@ -575,13 +587,17 @@ export const useWorkspaceStore = createSelectors(
       },
       pinGroup: (id) => {
         set((s) => ({
-          groups: s.groups.map((g) => (g.id === id ? { ...g, pinned: true } : g)),
+          groups: s.groups.map((g) =>
+            g.id === id ? { ...g, pinned: true } : g,
+          ),
         }));
         scheduleAppStateSave();
       },
       unpinGroup: (id) => {
         set((s) => ({
-          groups: s.groups.map((g) => (g.id === id ? { ...g, pinned: false } : g)),
+          groups: s.groups.map((g) =>
+            g.id === id ? { ...g, pinned: false } : g,
+          ),
         }));
         scheduleAppStateSave();
       },
@@ -592,15 +608,21 @@ export const useWorkspaceStore = createSelectors(
           const sidebarPinned = !s.sidebarPinned;
           try {
             localStorage.setItem(SIDEBAR_PINNED_KEY, sidebarPinned ? "1" : "0");
-          } catch { /* ignore */ }
+          } catch {
+            /* ignore */
+          }
           // Pinning docks it into view immediately; unpinning leaves the
           // (now overlay) sidebar in whatever open state it was.
-          return sidebarPinned ? { sidebarPinned, sidebarOpen: true } : { sidebarPinned };
+          return sidebarPinned
+            ? { sidebarPinned, sidebarOpen: true }
+            : { sidebarPinned };
         }),
       setSidebarPinned: (pinned) => {
         try {
           localStorage.setItem(SIDEBAR_PINNED_KEY, pinned ? "1" : "0");
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
         set({ sidebarPinned: pinned });
       },
 

--- a/src/hooks/use-hotkey.ts
+++ b/src/hooks/use-hotkey.ts
@@ -12,7 +12,8 @@ function matchKey(e: KeyboardEvent, key: string) {
   if (e.key.toLowerCase() === k) return true;
   // Option/Alt on macOS substitutes the typed character (e.g. option+b → "∫"),
   // so fall back to event.code (e.g. "KeyB").
-  if (k.length === 1 && /[a-z]/.test(k) && e.code === `Key${key.toUpperCase()}`) return true;
+  if (k.length === 1 && /[a-z]/.test(k) && e.code === `Key${key.toUpperCase()}`)
+    return true;
   if (k === "[" && e.code === "BracketLeft") return true;
   if (k === "]" && e.code === "BracketRight") return true;
   // Punctuation that Option also rewrites (split-view shortcuts ⌥;/⌥'/⌘\).
@@ -24,7 +25,7 @@ function matchKey(e: KeyboardEvent, key: string) {
 }
 
 export function useHotkeys(
-  bindings: Array<{ combo: KeyCombo; action: () => void }>
+  bindings: Array<{ combo: KeyCombo; action: () => void }>,
 ) {
   const bindingsRef = useRef(bindings);
   bindingsRef.current = bindings;

--- a/src/lib/create-selectors.ts
+++ b/src/lib/create-selectors.ts
@@ -5,7 +5,7 @@ type WithSelectors<S> = S extends { getState: () => infer T }
   : never;
 
 export const createSelectors = <S extends UseBoundStore<StoreApi<object>>>(
-  _store: S
+  _store: S,
 ) => {
   const store = _store as WithSelectors<typeof _store>;
   store.use = {} as typeof store.use;

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -8,44 +8,131 @@
  * binary bytes into CodeMirror.
  */
 
-export type FileKind = "text" | "image" | "svg" | "video" | "audio" | "pdf" | "unsupported";
+export type FileKind =
+  | "text"
+  | "image"
+  | "svg"
+  | "video"
+  | "audio"
+  | "pdf"
+  | "unsupported";
 
 // Extensions the CodeMirror editor handles (or can usefully attempt — even
 // without a language extension, plaintext display is fine).
 const TEXT_EXTS = new Set([
   // Code
-  "ts", "tsx", "js", "jsx", "mjs", "cjs",
-  "rs", "py", "go", "rb", "java", "kt", "swift",
-  "c", "cc", "cpp", "h", "hpp", "hh",
-  "cs", "fs", "ml", "scala", "clj", "ex", "exs",
-  "php", "lua", "r", "jl", "dart", "zig", "nim",
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "rs",
+  "py",
+  "go",
+  "rb",
+  "java",
+  "kt",
+  "swift",
+  "c",
+  "cc",
+  "cpp",
+  "h",
+  "hpp",
+  "hh",
+  "cs",
+  "fs",
+  "ml",
+  "scala",
+  "clj",
+  "ex",
+  "exs",
+  "php",
+  "lua",
+  "r",
+  "jl",
+  "dart",
+  "zig",
+  "nim",
   // Web
-  "html", "htm", "css", "scss", "sass", "less",
-  "vue", "svelte", "astro",
+  "html",
+  "htm",
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "vue",
+  "svelte",
+  "astro",
   // Data / config
-  "json", "jsonc", "yaml", "yml", "toml", "ini", "env",
-  "xml", "csv", "tsv",
+  "json",
+  "jsonc",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "env",
+  "xml",
+  "csv",
+  "tsv",
   // Shell / scripts
-  "sh", "zsh", "bash", "fish", "ps1", "bat", "cmd",
+  "sh",
+  "zsh",
+  "bash",
+  "fish",
+  "ps1",
+  "bat",
+  "cmd",
   // Docs
-  "md", "mdx", "txt", "rst", "tex", "org",
+  "md",
+  "mdx",
+  "txt",
+  "rst",
+  "tex",
+  "org",
   // Misc
-  "sql", "graphql", "gql", "proto", "thrift",
-  "dockerfile", "makefile", "gitignore", "gitattributes",
-  "editorconfig", "prettierrc", "eslintrc", "babelrc",
-  "log", "lock",
+  "sql",
+  "graphql",
+  "gql",
+  "proto",
+  "thrift",
+  "dockerfile",
+  "makefile",
+  "gitignore",
+  "gitattributes",
+  "editorconfig",
+  "prettierrc",
+  "eslintrc",
+  "babelrc",
+  "log",
+  "lock",
 ]);
 
 const IMAGE_EXTS = new Set([
-  "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico", "avif", "tiff", "tif", "heic",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "bmp",
+  "ico",
+  "avif",
+  "tiff",
+  "tif",
+  "heic",
 ]);
 
-const VIDEO_EXTS = new Set([
-  "mp4", "mov", "webm", "mkv", "avi", "m4v",
-]);
+const VIDEO_EXTS = new Set(["mp4", "mov", "webm", "mkv", "avi", "m4v"]);
 
 const AUDIO_EXTS = new Set([
-  "mp3", "wav", "flac", "aac", "ogg", "oga", "opus", "m4a",
+  "mp3",
+  "wav",
+  "flac",
+  "aac",
+  "ogg",
+  "oga",
+  "opus",
+  "m4a",
 ]);
 
 const PDF_EXTS = new Set(["pdf"]);
@@ -55,9 +142,23 @@ const PDF_EXTS = new Set(["pdf"]);
 const SVG_EXTS = new Set(["svg"]);
 
 const EXTENSIONLESS_TEXT_NAMES = new Set([
-  "readme", "license", "licence", "notice", "authors", "contributors",
-  "changelog", "copying", "install", "todo", "makefile", "dockerfile",
-  "gemfile", "rakefile", "procfile", "vagrantfile", "pipfile",
+  "readme",
+  "license",
+  "licence",
+  "notice",
+  "authors",
+  "contributors",
+  "changelog",
+  "copying",
+  "install",
+  "todo",
+  "makefile",
+  "dockerfile",
+  "gemfile",
+  "rakefile",
+  "procfile",
+  "vagrantfile",
+  "pipfile",
 ]);
 
 export function classifyFile(path: string): FileKind {

--- a/src/lib/markdown-cache.tsx
+++ b/src/lib/markdown-cache.tsx
@@ -141,7 +141,10 @@ function parseLarge(source: string): Promise<string> {
     p = new Promise<string>((resolve) => {
       const startedAt = performance.now();
       const w2 = window as Window & {
-        requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => number;
+        requestIdleCallback?: (
+          cb: () => void,
+          opts?: { timeout?: number },
+        ) => number;
       };
       const schedule = () =>
         typeof w2.requestIdleCallback === "function"
@@ -224,7 +227,8 @@ export function CachedMarkdown({ source, className }: CachedMarkdownProps) {
       if (copyBtn instanceof HTMLElement) {
         e.preventDefault();
         const pre = copyBtn.closest("pre");
-        const text = pre?.querySelector("code")?.textContent ?? pre?.textContent ?? "";
+        const text =
+          pre?.querySelector("code")?.textContent ?? pre?.textContent ?? "";
         void navigator.clipboard.writeText(text).catch(() => {});
         copyBtn.textContent = "Copied";
         window.setTimeout(() => {
@@ -235,7 +239,11 @@ export function CachedMarkdown({ source, className }: CachedMarkdownProps) {
       // External links: open in the system browser via the opener plugin
       // rather than letting an `<a>` navigate the WKWebView away from Atlas.
       const anchor = target?.closest?.("a");
-      if (anchor instanceof HTMLAnchorElement && anchor.href && /^https?:/i.test(anchor.href)) {
+      if (
+        anchor instanceof HTMLAnchorElement &&
+        anchor.href &&
+        /^https?:/i.test(anchor.href)
+      ) {
         e.preventDefault();
         const href = anchor.href;
         void import("@tauri-apps/plugin-opener")

--- a/src/lib/markdown-render.ts
+++ b/src/lib/markdown-render.ts
@@ -107,7 +107,111 @@ function baseName(s: string): string {
 
 // Lucide icon node data (v0.468.0) per mention kind — identical to the glyphs
 // the `#`/`@` picker renders, so a sent message matches what you typed.
-const MENTION_GLYPH: Record<string, [string, Record<string, string | number>][]> = {"skill":[["path",{"d":"M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"}]],"command":[["rect",{"width":"18","height":"18","x":"3","y":"3","rx":"2"}],["line",{"x1":"9","x2":"15","y1":"15","y2":"9"}]],"agent":[["path",{"d":"M12 8V4H8"}],["rect",{"width":"16","height":"12","x":"4","y":"8","rx":"2"}],["path",{"d":"M2 14h2"}],["path",{"d":"M20 14h2"}],["path",{"d":"M15 13v2"}],["path",{"d":"M9 13v2"}]],"rule":[["path",{"d":"m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z"}],["path",{"d":"m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z"}],["path",{"d":"M7 21h10"}],["path",{"d":"M12 3v18"}],["path",{"d":"M3 7h2c2 0 5-1 7-2 2 1 5 2 7 2h2"}]],"file":[["path",{"d":"M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"}],["path",{"d":"M14 2v4a2 2 0 0 0 2 2h4"}],["path",{"d":"M10 9H8"}],["path",{"d":"M16 13H8"}],["path",{"d":"M16 17H8"}]],"folder":[["path",{"d":"M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"}]],"symbol":[["line",{"x1":"4","x2":"20","y1":"9","y2":"9"}],["line",{"x1":"4","x2":"20","y1":"15","y2":"15"}],["line",{"x1":"10","x2":"8","y1":"3","y2":"21"}],["line",{"x1":"16","x2":"14","y1":"3","y2":"21"}]],"knowledge":[["path",{"d":"M12 7v14"}],["path",{"d":"M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"}]],"repo":[["path",{"d":"M9 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v5"}],["circle",{"cx":"13","cy":"12","r":"2"}],["path",{"d":"M18 19c-2.8 0-5-2.2-5-5v8"}],["circle",{"cx":"20","cy":"19","r":"2"}]],"paper":[["path",{"d":"M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2Zm0 0a2 2 0 0 1-2-2v-9c0-1.1.9-2 2-2h2"}],["path",{"d":"M18 14h-8"}],["path",{"d":"M15 18h-5"}],["path",{"d":"M10 6h8v4h-8V6Z"}]],"branch":[["line",{"x1":"6","x2":"6","y1":"3","y2":"15"}],["circle",{"cx":"18","cy":"6","r":"3"}],["circle",{"cx":"6","cy":"18","r":"3"}],["path",{"d":"M18 9a9 9 0 0 1-9 9"}]],"past_message":[["path",{"d":"M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"}]],"past_session":[["path",{"d":"M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"}]]};
+const MENTION_GLYPH: Record<
+  string,
+  [string, Record<string, string | number>][]
+> = {
+  skill: [
+    [
+      "path",
+      {
+        d: "M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z",
+      },
+    ],
+  ],
+  command: [
+    ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2" }],
+    ["line", { x1: "9", x2: "15", y1: "15", y2: "9" }],
+  ],
+  agent: [
+    ["path", { d: "M12 8V4H8" }],
+    ["rect", { width: "16", height: "12", x: "4", y: "8", rx: "2" }],
+    ["path", { d: "M2 14h2" }],
+    ["path", { d: "M20 14h2" }],
+    ["path", { d: "M15 13v2" }],
+    ["path", { d: "M9 13v2" }],
+  ],
+  rule: [
+    ["path", { d: "m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" }],
+    ["path", { d: "m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" }],
+    ["path", { d: "M7 21h10" }],
+    ["path", { d: "M12 3v18" }],
+    ["path", { d: "M3 7h2c2 0 5-1 7-2 2 1 5 2 7 2h2" }],
+  ],
+  file: [
+    [
+      "path",
+      { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" },
+    ],
+    ["path", { d: "M14 2v4a2 2 0 0 0 2 2h4" }],
+    ["path", { d: "M10 9H8" }],
+    ["path", { d: "M16 13H8" }],
+    ["path", { d: "M16 17H8" }],
+  ],
+  folder: [
+    [
+      "path",
+      {
+        d: "M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z",
+      },
+    ],
+  ],
+  symbol: [
+    ["line", { x1: "4", x2: "20", y1: "9", y2: "9" }],
+    ["line", { x1: "4", x2: "20", y1: "15", y2: "15" }],
+    ["line", { x1: "10", x2: "8", y1: "3", y2: "21" }],
+    ["line", { x1: "16", x2: "14", y1: "3", y2: "21" }],
+  ],
+  knowledge: [
+    ["path", { d: "M12 7v14" }],
+    [
+      "path",
+      {
+        d: "M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z",
+      },
+    ],
+  ],
+  repo: [
+    [
+      "path",
+      {
+        d: "M9 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v5",
+      },
+    ],
+    ["circle", { cx: "13", cy: "12", r: "2" }],
+    ["path", { d: "M18 19c-2.8 0-5-2.2-5-5v8" }],
+    ["circle", { cx: "20", cy: "19", r: "2" }],
+  ],
+  paper: [
+    [
+      "path",
+      {
+        d: "M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2Zm0 0a2 2 0 0 1-2-2v-9c0-1.1.9-2 2-2h2",
+      },
+    ],
+    ["path", { d: "M18 14h-8" }],
+    ["path", { d: "M15 18h-5" }],
+    ["path", { d: "M10 6h8v4h-8V6Z" }],
+  ],
+  branch: [
+    ["line", { x1: "6", x2: "6", y1: "3", y2: "15" }],
+    ["circle", { cx: "18", cy: "6", r: "3" }],
+    ["circle", { cx: "6", cy: "18", r: "3" }],
+    ["path", { d: "M18 9a9 9 0 0 1-9 9" }],
+  ],
+  past_message: [
+    [
+      "path",
+      { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" },
+    ],
+  ],
+  past_session: [
+    [
+      "path",
+      { d: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" },
+    ],
+  ],
+};
 
 /** Build the kind glyph as a hast `<span class=icon><svg>…</svg></span>`. */
 function iconWrap(kind: string): Hast | null {
@@ -177,7 +281,8 @@ function splitMentionText(value: string): Hast[] | null {
   let m: RegExpExecArray | null;
   while ((m = MENTION_TOKEN_RE.exec(value)) !== null) {
     found = true;
-    if (m.index > last) out.push({ type: "text", value: value.slice(last, m.index) });
+    if (m.index > last)
+      out.push({ type: "text", value: value.slice(last, m.index) });
     let val = m[2];
     let trailing = "";
     const tm = val.match(/[.,;:!?)\]]+$/);

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -14,9 +14,17 @@ interface MarkdownProps {
  * Shared Markdown renderer used by the chat assistant bubbles and the canvas
  * note cards/inspector. Styled overrides match the Atlas design tokens.
  */
-export const Markdown = memo(function Markdown({ children, className }: MarkdownProps) {
+export const Markdown = memo(function Markdown({
+  children,
+  className,
+}: MarkdownProps) {
   return (
-    <div className={cn("prose-chat text-[var(--text-primary)] leading-relaxed break-words select-text", className)}>
+    <div
+      className={cn(
+        "prose-chat text-[var(--text-primary)] leading-relaxed break-words select-text",
+        className,
+      )}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeHighlight]}
@@ -68,19 +76,39 @@ export const Markdown = memo(function Markdown({ children, className }: Markdown
             );
           },
           ul(props) {
-            return <ul className="list-disc pl-5 space-y-0.5 my-2">{props.children}</ul>;
+            return (
+              <ul className="list-disc pl-5 space-y-0.5 my-2">
+                {props.children}
+              </ul>
+            );
           },
           ol(props) {
-            return <ol className="list-decimal pl-5 space-y-0.5 my-2">{props.children}</ol>;
+            return (
+              <ol className="list-decimal pl-5 space-y-0.5 my-2">
+                {props.children}
+              </ol>
+            );
           },
           h1(props) {
-            return <h1 className="text-base font-semibold mt-3 mb-1">{props.children}</h1>;
+            return (
+              <h1 className="text-base font-semibold mt-3 mb-1">
+                {props.children}
+              </h1>
+            );
           },
           h2(props) {
-            return <h2 className="text-sm font-semibold mt-3 mb-1">{props.children}</h2>;
+            return (
+              <h2 className="text-sm font-semibold mt-3 mb-1">
+                {props.children}
+              </h2>
+            );
           },
           h3(props) {
-            return <h3 className="text-sm font-semibold mt-2 mb-1">{props.children}</h3>;
+            return (
+              <h3 className="text-sm font-semibold mt-2 mb-1">
+                {props.children}
+              </h3>
+            );
           },
           p(props) {
             return <p className="my-1.5">{props.children}</p>;
@@ -95,12 +123,18 @@ export const Markdown = memo(function Markdown({ children, className }: Markdown
           table(props) {
             return (
               <div className="my-3 rounded-md border border-[var(--border-default)] overflow-hidden">
-                <table className="w-full text-[12px] border-collapse">{props.children}</table>
+                <table className="w-full text-[12px] border-collapse">
+                  {props.children}
+                </table>
               </div>
             );
           },
           thead(props) {
-            return <thead className="bg-[var(--bg-elevated)]">{props.children}</thead>;
+            return (
+              <thead className="bg-[var(--bg-elevated)]">
+                {props.children}
+              </thead>
+            );
           },
           th(props) {
             return (
@@ -111,7 +145,9 @@ export const Markdown = memo(function Markdown({ children, className }: Markdown
           },
           tr(props) {
             return (
-              <tr className="border-b border-[var(--border-subtle)] last:border-b-0">{props.children}</tr>
+              <tr className="border-b border-[var(--border-subtle)] last:border-b-0">
+                {props.children}
+              </tr>
             );
           },
           td(props) {

--- a/src/lib/open-file.ts
+++ b/src/lib/open-file.ts
@@ -62,7 +62,9 @@ export async function openFileOrReveal(path: string): Promise<void> {
   openWithKind(path, kind);
 }
 
-function tabTypeFor(kind: FileKind): "editor" | "media" | "svg" | "pdf" | "unsupported" {
+function tabTypeFor(
+  kind: FileKind,
+): "editor" | "media" | "svg" | "pdf" | "unsupported" {
   if (kind === "text") return "editor";
   if (kind === "image" || kind === "video" || kind === "audio") return "media";
   if (kind === "svg") return "svg";

--- a/src/lib/safe-unlisten.ts
+++ b/src/lib/safe-unlisten.ts
@@ -27,6 +27,8 @@ export function safeUnlisten(un: UnlistenFn | null | undefined): void {
 }
 
 /** Resolve a pending `listen(...)` promise and unlisten it safely. */
-export function safeUnlistenPromise(p: Promise<UnlistenFn> | null | undefined): void {
+export function safeUnlistenPromise(
+  p: Promise<UnlistenFn> | null | undefined,
+): void {
   p?.then(safeUnlisten).catch(() => {});
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,8 +15,8 @@ void initTelemetry();
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 5 * 60 * 1000,    // 5 min before refetch
-      gcTime: 30 * 60 * 1000,       // 30 min cache lifetime
+      staleTime: 5 * 60 * 1000, // 5 min before refetch
+      gcTime: 30 * 60 * 1000, // 30 min cache lifetime
       retry: 1,
       refetchOnWindowFocus: false,
     },
@@ -30,5 +30,5 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <App />
       </QueryClientProvider>
     </TelemetryErrorBoundary>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -73,25 +73,49 @@
   --animate-slide-in-right: slide-in-right 0.18s cubic-bezier(0.32, 0.72, 0, 1);
 
   @keyframes slide-in-right {
-    from { transform: translateX(100%); }
-    to { transform: translateX(0); }
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
   }
 
   @keyframes fade-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
   @keyframes fade-out {
-    from { opacity: 1; }
-    to { opacity: 0; }
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
   }
   @keyframes scale-in {
-    from { opacity: 0; transform: scale(0.95); }
-    to { opacity: 1; transform: scale(1); }
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
   }
   @keyframes scale-out {
-    from { opacity: 1; transform: scale(1); }
-    to { opacity: 0; transform: scale(0.95); }
+    from {
+      opacity: 1;
+      transform: scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: scale(0.95);
+    }
   }
 }
 
@@ -165,15 +189,33 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.atlas-mention-chip[data-mention-kind="file"]         { color: var(--accent-primary); }
-.atlas-mention-chip[data-mention-kind="folder"]       { color: var(--accent-primary); }
-.atlas-mention-chip[data-mention-kind="symbol"]       { color: var(--status-success); }
-.atlas-mention-chip[data-mention-kind="knowledge"]    { color: var(--accent-primary); }
-.atlas-mention-chip[data-mention-kind="repo"]         { color: var(--status-success); }
-.atlas-mention-chip[data-mention-kind="paper"]        { color: var(--status-warning); }
-.atlas-mention-chip[data-mention-kind="branch"]       { color: var(--text-secondary); }
-.atlas-mention-chip[data-mention-kind="past_message"] { color: var(--text-secondary); }
-.atlas-mention-chip[data-mention-kind="past_session"] { color: var(--text-secondary); }
+.atlas-mention-chip[data-mention-kind="file"] {
+  color: var(--accent-primary);
+}
+.atlas-mention-chip[data-mention-kind="folder"] {
+  color: var(--accent-primary);
+}
+.atlas-mention-chip[data-mention-kind="symbol"] {
+  color: var(--status-success);
+}
+.atlas-mention-chip[data-mention-kind="knowledge"] {
+  color: var(--accent-primary);
+}
+.atlas-mention-chip[data-mention-kind="repo"] {
+  color: var(--status-success);
+}
+.atlas-mention-chip[data-mention-kind="paper"] {
+  color: var(--status-warning);
+}
+.atlas-mention-chip[data-mention-kind="branch"] {
+  color: var(--text-secondary);
+}
+.atlas-mention-chip[data-mention-kind="past_message"] {
+  color: var(--text-secondary);
+}
+.atlas-mention-chip[data-mention-kind="past_session"] {
+  color: var(--text-secondary);
+}
 
 /* Hover preview card for media (`@file` image/video) mention chips. Appended to
    document.body by the CM ChipWidget; positioned inline via fixed coords. */
@@ -193,10 +235,18 @@
   object-fit: contain;
 }
 /* Invokable capabilities — distinguished by glyph/sigil, not color (white). */
-.atlas-mention-chip[data-mention-kind="skill"]        { color: var(--accent-primary); }
-.atlas-mention-chip[data-mention-kind="command"]      { color: var(--accent-primary); }
-.atlas-mention-chip[data-mention-kind="agent"]        { color: var(--accent-primary); }
-.atlas-mention-chip[data-mention-kind="rule"]         { color: var(--accent-primary); }
+.atlas-mention-chip[data-mention-kind="skill"] {
+  color: var(--accent-primary);
+}
+.atlas-mention-chip[data-mention-kind="command"] {
+  color: var(--accent-primary);
+}
+.atlas-mention-chip[data-mention-kind="agent"] {
+  color: var(--accent-primary);
+}
+.atlas-mention-chip[data-mention-kind="rule"] {
+  color: var(--accent-primary);
+}
 
 /* Inline variant for sent chat messages: flows in selectable prose, carries the
    same kind glyph the picker/composer use so a sent message matches what you
@@ -249,9 +299,13 @@
   }
 
   /* Re-enable text selection in content areas */
-  input, textarea, [contenteditable],
-  .cm-content, .select-text,
-  pre, code {
+  input,
+  textarea,
+  [contenteditable],
+  .cm-content,
+  .select-text,
+  pre,
+  code {
     user-select: text;
     -webkit-user-select: text;
   }
@@ -322,7 +376,8 @@
     color: var(--text-primary);
   }
 
-  img, a {
+  img,
+  a {
     -webkit-user-drag: none;
   }
 
@@ -352,7 +407,9 @@
   }
 
   /* Global transitions — only background-color to avoid icon jitter from color/opacity transitions */
-  button, a, select {
+  button,
+  a,
+  select {
     transition: background-color 120ms ease-out;
   }
 
@@ -424,7 +481,6 @@
     color: var(--cm-fold-fg, #555);
   }
 
-
   /* xterm.js — force monospace font in production. The DOM renderer normally
      injects a <style> tag with our `fontFamily` option, but in the bundled
      macOS app the rows and char-measure element were inheriting the body's
@@ -434,7 +490,9 @@
   .xterm-rows,
   .xterm .xterm-char-measure-element,
   .xterm-helper-textarea {
-    font-family: Menlo, Monaco, "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", "Courier New", monospace !important;
+    font-family:
+      Menlo, Monaco, "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono",
+      "Courier New", monospace !important;
     font-variant-ligatures: none !important;
     letter-spacing: 0 !important;
   }
@@ -442,7 +500,9 @@
   /* Hidden scrollbars for panel content */
   .hide-scrollbar {
     scrollbar-width: none;
-    &::-webkit-scrollbar { display: none; }
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   /* Prevent overscroll bounce between panels */
@@ -460,48 +520,71 @@
     word-break: break-word;
     overflow-wrap: break-word;
   }
-  .reader-content h1, .reader-content h2, .reader-content h3,
-  .reader-content h4, .reader-content h5, .reader-content h6 {
+  .reader-content h1,
+  .reader-content h2,
+  .reader-content h3,
+  .reader-content h4,
+  .reader-content h5,
+  .reader-content h6 {
     color: var(--text-primary);
     font-weight: 600;
     margin: 1.2em 0 0.4em;
     line-height: 1.3;
   }
-  .reader-content h1 { font-size: 1.4em; }
-  .reader-content h2 { font-size: 1.2em; }
-  .reader-content h3 { font-size: 1.05em; }
-  .reader-content p { margin: 0.6em 0; }
+  .reader-content h1 {
+    font-size: 1.4em;
+  }
+  .reader-content h2 {
+    font-size: 1.2em;
+  }
+  .reader-content h3 {
+    font-size: 1.05em;
+  }
+  .reader-content p {
+    margin: 0.6em 0;
+  }
   .reader-content a {
     color: var(--accent-primary);
     text-decoration: underline;
     text-underline-offset: 2px;
     cursor: pointer;
   }
-  .reader-content a:hover { color: var(--accent-primary-hover); }
+  .reader-content a:hover {
+    color: var(--accent-primary-hover);
+  }
   .reader-content img {
     max-width: 100%;
     height: auto;
     border-radius: 4px;
     margin: 0.5em 0;
   }
-  .reader-content ul, .reader-content ol {
+  .reader-content ul,
+  .reader-content ol {
     padding-left: 1.5em;
     margin: 0.5em 0;
   }
-  .reader-content li { margin: 0.2em 0; }
-  .reader-content pre, .reader-content code {
+  .reader-content li {
+    margin: 0.2em 0;
+  }
+  .reader-content pre,
+  .reader-content code {
     font-family: var(--font-mono);
     font-size: 0.9em;
     background: var(--bg-secondary);
     border-radius: 3px;
   }
-  .reader-content code { padding: 0.15em 0.3em; }
+  .reader-content code {
+    padding: 0.15em 0.3em;
+  }
   .reader-content pre {
     padding: 0.8em;
     overflow-x: auto;
     margin: 0.6em 0;
   }
-  .reader-content pre code { padding: 0; background: none; }
+  .reader-content pre code {
+    padding: 0;
+    background: none;
+  }
   .reader-content blockquote {
     border-left: 3px solid var(--border-default);
     padding-left: 1em;
@@ -514,24 +597,48 @@
     margin: 0.6em 0;
     font-size: 0.9em;
   }
-  .reader-content th, .reader-content td {
+  .reader-content th,
+  .reader-content td {
     border: 1px solid var(--border-default);
     padding: 0.4em 0.6em;
     text-align: left;
   }
-  .reader-content th { background: var(--bg-secondary); color: var(--text-primary); font-weight: 600; }
-  .reader-content hr { border: none; border-top: 1px solid var(--border-subtle); margin: 1em 0; }
-  .reader-content nav, .reader-content aside,
-  .reader-content img, .reader-content video, .reader-content audio,
-  .reader-content picture, .reader-content figure, .reader-content canvas,
-  .reader-content svg, .reader-content iframe, .reader-content object { display: none; }
+  .reader-content th {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+  .reader-content hr {
+    border: none;
+    border-top: 1px solid var(--border-subtle);
+    margin: 1em 0;
+  }
+  .reader-content nav,
+  .reader-content aside,
+  .reader-content img,
+  .reader-content video,
+  .reader-content audio,
+  .reader-content picture,
+  .reader-content figure,
+  .reader-content canvas,
+  .reader-content svg,
+  .reader-content iframe,
+  .reader-content object {
+    display: none;
+  }
 }
 
 /* Pill enter animation — used by the floating row above the chat composer
    (setup banner, scroll-to-bottom button). Slides up + fades in. */
 @keyframes atlas-pill-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 .atlas-pill-in {
   animation: atlas-pill-in 200ms ease-out both;
@@ -553,8 +660,14 @@
    isolate its compositing layer and flatten the blur to plain transparency.
    See the note in app-layout.tsx. */
 @keyframes atlas-panel-in-br {
-  from { opacity: 0; transform: translate3d(6px, 10px, 0) scale(0.965); }
-  to   { opacity: 1; transform: translate3d(0, 0, 0) scale(1); }
+  from {
+    opacity: 0;
+    transform: translate3d(6px, 10px, 0) scale(0.965);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
 }
 .atlas-panel-in-br {
   transform-origin: 100% 100%;
@@ -563,8 +676,14 @@
 
 /* Brief highlight when jumping to a message (Cmd+F / links panel). */
 @keyframes atlas-jump-flash-kf {
-  0%   { background-color: var(--accent-primary); opacity: 0.14; }
-  100% { background-color: transparent; opacity: 0; }
+  0% {
+    background-color: var(--accent-primary);
+    opacity: 0.14;
+  }
+  100% {
+    background-color: transparent;
+    opacity: 0;
+  }
 }
 .atlas-jump-flash {
   position: relative;
@@ -581,8 +700,14 @@
 /* Streaming caret — a thin blinking bar appended after the live
    assistant text so an in-progress turn reads like a terminal cursor. */
 @keyframes atlas-blink {
-  0%, 49%   { opacity: 1; }
-  50%, 100% { opacity: 0; }
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
 }
 .atlas-stream-caret {
   display: inline-block;
@@ -598,13 +723,19 @@
 /* Respect the OS "reduce motion" setting — hold the caret steady and
    neutralize our entrance/blink animations (keep their end state). */
 @media (prefers-reduced-motion: reduce) {
-  .atlas-stream-caret { animation: none; }
+  .atlas-stream-caret {
+    animation: none;
+  }
   .atlas-pill-in,
   .atlas-panel-in-br,
-  .atlas-fade-in { animation: none; }
+  .atlas-fade-in {
+    animation: none;
+  }
   .animate-scale-in,
   .animate-fade-in,
-  .animate-slide-in-right { animation: none !important; }
+  .animate-slide-in-right {
+    animation: none !important;
+  }
 }
 
 /* Active match in the terminal search (brighter than the other matches). */
@@ -630,7 +761,8 @@
   gap: 6px !important;
   padding: 4px 10px !important;
   background: var(--bg-elevated) !important;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !important;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !important;
   font-size: 12px !important;
   color: var(--text-secondary) !important;
   position: relative !important;
@@ -658,7 +790,9 @@
   outline: none !important;
   min-width: 200px !important;
   margin: 0 !important;
-  transition: border-color 120ms, background-color 120ms !important;
+  transition:
+    border-color 120ms,
+    background-color 120ms !important;
 }
 .cm-panel.cm-search input[type="text"]:hover {
   background-color: var(--bg-hover) !important;
@@ -688,7 +822,9 @@
   font-family: inherit !important;
   font-weight: 500 !important;
   cursor: pointer !important;
-  transition: background-color 120ms, color 120ms !important;
+  transition:
+    background-color 120ms,
+    color 120ms !important;
   text-transform: none !important;
   margin: 0 !important;
   box-shadow: none !important;
@@ -751,7 +887,9 @@
   position: relative !important;
   margin: 0 !important;
   padding: 0 !important;
-  transition: background-color 120ms, border-color 120ms !important;
+  transition:
+    background-color 120ms,
+    border-color 120ms !important;
   flex-shrink: 0 !important;
 }
 .cm-panel.cm-search label input[type="checkbox"]:checked {
@@ -806,13 +944,37 @@
    utilities to each tag via react-markdown's `components` override; the
    cached pipeline emits bare HTML, so the same rules live as plain CSS
    here. Tokens match the values that were inline. */
-.prose-chat h1 { font-size: 1rem; font-weight: 600; margin: 0.75rem 0 0.25rem; }
-.prose-chat h2 { font-size: 0.875rem; font-weight: 600; margin: 0.75rem 0 0.25rem; }
-.prose-chat h3 { font-size: 0.875rem; font-weight: 600; margin: 0.5rem 0 0.25rem; }
-.prose-chat p { margin: 0.375rem 0; }
-.prose-chat ul { list-style-type: disc; padding-left: 1.25rem; margin: 0.5rem 0; }
-.prose-chat ol { list-style-type: decimal; padding-left: 1.25rem; margin: 0.5rem 0; }
-.prose-chat li + li { margin-top: 0.125rem; }
+.prose-chat h1 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0.75rem 0 0.25rem;
+}
+.prose-chat h2 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0.75rem 0 0.25rem;
+}
+.prose-chat h3 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0.5rem 0 0.25rem;
+}
+.prose-chat p {
+  margin: 0.375rem 0;
+}
+.prose-chat ul {
+  list-style-type: disc;
+  padding-left: 1.25rem;
+  margin: 0.5rem 0;
+}
+.prose-chat ol {
+  list-style-type: decimal;
+  padding-left: 1.25rem;
+  margin: 0.5rem 0;
+}
+.prose-chat li + li {
+  margin-top: 0.125rem;
+}
 .prose-chat blockquote {
   border-left: 2px solid var(--border-default);
   padding-left: 0.75rem;
@@ -845,7 +1007,9 @@
   opacity: 0;
   transition: opacity 120ms ease-out;
 }
-.prose-chat pre:hover .atlas-code-bar { opacity: 1; }
+.prose-chat pre:hover .atlas-code-bar {
+  opacity: 1;
+}
 .atlas-code-lang {
   font-size: 9px;
   text-transform: uppercase;
@@ -862,9 +1026,14 @@
   background: var(--bg-elevated);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color 120ms ease-out, background 120ms ease-out;
+  transition:
+    color 120ms ease-out,
+    background 120ms ease-out;
 }
-.atlas-code-copy:hover { color: var(--text-primary); background: var(--bg-hover); }
+.atlas-code-copy:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
 .prose-chat code {
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
@@ -884,9 +1053,15 @@
   color: var(--accent-primary);
   text-decoration: underline;
 }
-.prose-chat a:hover { opacity: 0.8; }
-.prose-chat strong { font-weight: 600; }
-.prose-chat em { font-style: italic; }
+.prose-chat a:hover {
+  opacity: 0.8;
+}
+.prose-chat strong {
+  font-weight: 600;
+}
+.prose-chat em {
+  font-style: italic;
+}
 .prose-chat hr {
   border: none;
   border-top: 1px solid var(--border-default);
@@ -901,7 +1076,9 @@
   border-radius: 0.375rem;
   overflow: hidden;
 }
-.prose-chat thead { background: var(--bg-elevated); }
+.prose-chat thead {
+  background: var(--bg-elevated);
+}
 .prose-chat th {
   padding: 0.5rem 0.75rem;
   text-align: left;
@@ -911,9 +1088,15 @@
   border-bottom: 1px solid var(--border-default);
   border-right: 1px solid var(--border-default);
 }
-.prose-chat th:last-child { border-right: none; }
-.prose-chat tr { border-bottom: 1px solid var(--border-subtle); }
-.prose-chat tbody tr:last-child { border-bottom: none; }
+.prose-chat th:last-child {
+  border-right: none;
+}
+.prose-chat tr {
+  border-bottom: 1px solid var(--border-subtle);
+}
+.prose-chat tbody tr:last-child {
+  border-bottom: none;
+}
 .prose-chat td {
   padding: 0.5rem 0.75rem;
   vertical-align: top;
@@ -922,7 +1105,9 @@
   border-right: 1px solid var(--border-subtle);
   word-break: break-word;
 }
-.prose-chat td:last-child { border-right: none; }
+.prose-chat td:last-child {
+  border-right: none;
+}
 /* Task list items (remark-gfm output) — drop the disc bullet so the
    checkbox stands alone. */
 .prose-chat li.task-list-item,
@@ -941,23 +1126,41 @@
 .atlas-loader {
   --g: 9px;
   aspect-ratio: 1.6;
-  --c: no-repeat repeating-linear-gradient(90deg, currentColor 0 20%, #0000 0 40%);
+  --c: no-repeat
+    repeating-linear-gradient(90deg, currentColor 0 20%, #0000 0 40%);
   background: var(--c), var(--c), var(--c), var(--c);
   background-size: 62.5% 26%;
   animation: atlas-l23 1s infinite;
 }
 @keyframes atlas-l23 {
-  0%, 10% {
-    background-position: 50% calc(0*100%/3), 50% calc(1*100%/3), 50% calc(2*100%/3), 50% calc(3*100%/3);
+  0%,
+  10% {
+    background-position:
+      50% calc(0 * 100% / 3),
+      50% calc(1 * 100% / 3),
+      50% calc(2 * 100% / 3),
+      50% calc(3 * 100% / 3);
   }
   33% {
-    background-position: 100% calc(0*100%/3), calc(100% - var(--g)) calc(1*100%/3), var(--g) calc(2*100%/3), 0 calc(3*100%/3);
+    background-position:
+      100% calc(0 * 100% / 3),
+      calc(100% - var(--g)) calc(1 * 100% / 3),
+      var(--g) calc(2 * 100% / 3),
+      0 calc(3 * 100% / 3);
   }
   66% {
-    background-position: 0 calc(0*100%/3), var(--g) calc(1*100%/3), calc(100% - var(--g)) calc(2*100%/3), 100% calc(3*100%/3);
+    background-position:
+      0 calc(0 * 100% / 3),
+      var(--g) calc(1 * 100% / 3),
+      calc(100% - var(--g)) calc(2 * 100% / 3),
+      100% calc(3 * 100% / 3);
   }
-  90%, 100% {
-    background-position: 50% calc(0*100%/3), 50% calc(1*100%/3), 50% calc(2*100%/3), 50% calc(3*100%/3);
+  90%,
+  100% {
+    background-position:
+      50% calc(0 * 100% / 3),
+      50% calc(1 * 100% / 3),
+      50% calc(2 * 100% / 3),
+      50% calc(3 * 100% / 3);
   }
 }
-

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -27,8 +27,8 @@
      subtle ladder between rail (#0a) / canvas (#0a) / panel (#0f)
      that the design relies on. */
   --bg-canvas: #0a0a0a;
-  --bg-rail:   #0a0a0a;
-  --bg-elevated-2: #161616;  /* card/elevated above --bg-raised */
+  --bg-rail: #0a0a0a;
+  --bg-elevated-2: #161616; /* card/elevated above --bg-raised */
 
   /* Compat aliases */
   --bg-primary: var(--bg-surface);
@@ -41,9 +41,9 @@
      their historical near-black hexes) so the Atlas interface-theme picker can
      recolor them per theme. `applyAtlasTheme` overrides these at runtime; the
      Atlas Black theme clears the overrides so these defaults apply verbatim. */
-  --panel-rail-bg: #0f0f0f;  /* workspace sidebar (<aside>, rendered at /80) */
-  --panel-bg:      #060706;  /* left panel — file tree / explorer */
-  --panel-bg-2:    #0d0e0d;  /* right panel — source control */
+  --panel-rail-bg: #0f0f0f; /* workspace sidebar (<aside>, rendered at /80) */
+  --panel-bg: #060706; /* left panel — file tree / explorer */
+  --panel-bg-2: #0d0e0d; /* right panel — source control */
 
   /* === Text — monochromatic grays === */
   --text-primary: #ffffff;
@@ -72,32 +72,32 @@
      chip square gets a faint per-agent tint. Surface via .agent-*
      utility classes below (so `<span class="agent-claude">` exposes
      --agent, --agent-bg, --agent-chip locally). */
-  --agent-claude-chip:    #c98263;
-  --agent-claude-chip-bg: rgba(201, 130, 99, 0.10);
-  --agent-gpt-chip:       #5fb39a;
-  --agent-gpt-chip-bg:    rgba(95, 179, 154, 0.10);
-  --agent-gemini-chip:    #7aa7e8;
-  --agent-gemini-chip-bg: rgba(122, 167, 232, 0.10);
-  --agent-local-chip:     #b8a3df;
-  --agent-local-chip-bg:  rgba(184, 163, 223, 0.10);
-  --agent-cursor-chip:    #d9b56e;
-  --agent-cursor-chip-bg: rgba(217, 181, 110, 0.10);
-  --agent-amp-chip:       #d68aae;
-  --agent-amp-chip-bg:    rgba(214, 138, 174, 0.10);
-  --agent-codex-chip:     #10a37f;
-  --agent-codex-chip-bg:  rgba(16, 163, 127, 0.10);
+  --agent-claude-chip: #c98263;
+  --agent-claude-chip-bg: rgba(201, 130, 99, 0.1);
+  --agent-gpt-chip: #5fb39a;
+  --agent-gpt-chip-bg: rgba(95, 179, 154, 0.1);
+  --agent-gemini-chip: #7aa7e8;
+  --agent-gemini-chip-bg: rgba(122, 167, 232, 0.1);
+  --agent-local-chip: #b8a3df;
+  --agent-local-chip-bg: rgba(184, 163, 223, 0.1);
+  --agent-cursor-chip: #d9b56e;
+  --agent-cursor-chip-bg: rgba(217, 181, 110, 0.1);
+  --agent-amp-chip: #d68aae;
+  --agent-amp-chip-bg: rgba(214, 138, 174, 0.1);
+  --agent-codex-chip: #10a37f;
+  --agent-codex-chip-bg: rgba(16, 163, 127, 0.1);
 
   /* === Semantic status === */
   --status-success: #4d4d4d;
   --status-success-muted: rgba(77, 77, 77, 0.12);
-  --status-warning: #CD9731;
+  --status-warning: #cd9731;
   --status-warning-muted: rgba(205, 151, 49, 0.12);
-  --status-error: #F44747;
+  --status-error: #f44747;
   --status-error-muted: rgba(244, 71, 71, 0.12);
-  --status-info: #6796E6;
+  --status-info: #6796e6;
   --status-info-muted: rgba(103, 150, 230, 0.12);
   --status-purple: #999999;
-  --status-orange: #CD9731;
+  --status-orange: #cd9731;
 
   /* Session line counts — the one deliberately chromatic pair in the
      Artifacts surface. The app's diff views stay monochrome; a session's
@@ -136,7 +136,8 @@
 
   /* === Typography === */
   --font-ui: -apple-system, "SF Pro Text", system-ui, sans-serif;
-  --font-mono: "SF Mono", "Geist Mono", "JetBrains Mono", "Fira Code", monospace;
+  --font-mono:
+    "SF Mono", "Geist Mono", "JetBrains Mono", "Fira Code", monospace;
   --font-sans: var(--font-ui);
   --font-display: -apple-system, "SF Pro Display", system-ui, sans-serif;
 
@@ -203,13 +204,24 @@
   font-weight: 600;
 }
 
-.mono   { font-family: var(--font-mono); font-feature-settings: "zero", "ss02"; }
-.tnum   { font-variant-numeric: tabular-nums; }
+.mono {
+  font-family: var(--font-mono);
+  font-feature-settings: "zero", "ss02";
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
 
 .kbd {
-  display: inline-flex; align-items: center; justify-content: center;
-  min-width: 18px; height: 18px; padding: 0 5px;
-  font-family: var(--font-mono); font-size: 10px; font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
   color: var(--text-tertiary);
   background: var(--bg-raised);
   border: 1px solid var(--border-default);
@@ -218,8 +230,11 @@
 }
 
 .pill {
-  display: inline-flex; align-items: center; gap: 6px;
-  height: 22px; padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 8px;
   border-radius: 9999px;
   font-size: 11px;
   color: var(--text-secondary);
@@ -227,29 +242,79 @@
   border: 1px solid var(--border-default);
   white-space: nowrap;
 }
-.pill-bare { background: transparent; }
+.pill-bare {
+  background: transparent;
+}
 
-.dot       { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex: none; display: inline-block; }
-.dot-lg    { width: 8px; height: 8px; }
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+  display: inline-block;
+}
+.dot-lg {
+  width: 8px;
+  height: 8px;
+}
 
 /* Per-agent color helpers — surface --agent / --agent-bg / --agent-chip
    so children read them off CSS custom properties. */
-.agent-claude { --agent: var(--text-primary); --agent-bg: rgba(255, 255, 255, 0.06); --agent-chip: var(--text-primary); }
-.agent-gpt    { --agent: var(--text-primary); --agent-bg: var(--agent-gpt-chip-bg);    --agent-chip: var(--agent-gpt-chip); }
-.agent-gemini { --agent: var(--text-primary); --agent-bg: var(--agent-gemini-chip-bg); --agent-chip: var(--agent-gemini-chip); }
-.agent-local  { --agent: var(--text-primary); --agent-bg: var(--agent-local-chip-bg);  --agent-chip: var(--agent-local-chip); }
-.agent-cursor { --agent: var(--text-primary); --agent-bg: var(--agent-cursor-chip-bg); --agent-chip: var(--agent-cursor-chip); }
-.agent-amp    { --agent: var(--text-primary); --agent-bg: var(--agent-amp-chip-bg);    --agent-chip: var(--agent-amp-chip); }
-.agent-codex  { --agent: var(--text-primary); --agent-bg: rgba(255, 255, 255, 0.06); --agent-chip: var(--text-primary); }
+.agent-claude {
+  --agent: var(--text-primary);
+  --agent-bg: rgba(255, 255, 255, 0.06);
+  --agent-chip: var(--text-primary);
+}
+.agent-gpt {
+  --agent: var(--text-primary);
+  --agent-bg: var(--agent-gpt-chip-bg);
+  --agent-chip: var(--agent-gpt-chip);
+}
+.agent-gemini {
+  --agent: var(--text-primary);
+  --agent-bg: var(--agent-gemini-chip-bg);
+  --agent-chip: var(--agent-gemini-chip);
+}
+.agent-local {
+  --agent: var(--text-primary);
+  --agent-bg: var(--agent-local-chip-bg);
+  --agent-chip: var(--agent-local-chip);
+}
+.agent-cursor {
+  --agent: var(--text-primary);
+  --agent-bg: var(--agent-cursor-chip-bg);
+  --agent-chip: var(--agent-cursor-chip);
+}
+.agent-amp {
+  --agent: var(--text-primary);
+  --agent-bg: var(--agent-amp-chip-bg);
+  --agent-chip: var(--agent-amp-chip);
+}
+.agent-codex {
+  --agent: var(--text-primary);
+  --agent-bg: rgba(255, 255, 255, 0.06);
+  --agent-chip: var(--text-primary);
+}
 
 .amark {
-  width: 22px; height: 22px;
+  width: 22px;
+  height: 22px;
   border-radius: 6px;
-  display: inline-flex; align-items: center; justify-content: center;
-  font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
   color: var(--agent-chip, var(--text-primary));
   background: var(--agent-bg, var(--bg-raised));
   border: 1px solid var(--border-default);
   flex: none;
 }
-.amark-lg { width: 32px; height: 32px; font-size: 12px; border-radius: 8px; }
+.amark-lg {
+  width: 32px;
+  height: 32px;
+  font-size: 12px;
+  border-radius: 8px;
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -14,7 +14,11 @@ export const AGENT_PLUGIN_ID: Record<SwitchableAgent, string> = {
 };
 
 /** The coding agents Atlas ships, in switch order (for option+/). */
-export const SWITCHABLE_AGENTS: SwitchableAgent[] = ["claude-code", "codex", "cersei"];
+export const SWITCHABLE_AGENTS: SwitchableAgent[] = [
+  "claude-code",
+  "codex",
+  "cersei",
+];
 
 export const AGENT_LABEL: Record<SwitchableAgent, string> = {
   "claude-code": "Claude Code",
@@ -48,7 +52,9 @@ export function hasInFlightToolCalls(
 ): boolean {
   if (!session) return false;
   return session.messages.some((m) =>
-    m.toolCalls.some((tc) => tc.status === "pending" || tc.status === "running"),
+    m.toolCalls.some(
+      (tc) => tc.status === "pending" || tc.status === "running",
+    ),
   );
 }
 export type MessageRole = "user" | "assistant" | "system" | "tool";
@@ -65,7 +71,10 @@ export const CLAUDE_PERMISSION_MODES: ClaudePermissionMode[] = [
   "bypassPermissions",
 ];
 
-export const CLAUDE_PERMISSION_MODE_LABEL: Record<ClaudePermissionMode, string> = {
+export const CLAUDE_PERMISSION_MODE_LABEL: Record<
+  ClaudePermissionMode,
+  string
+> = {
   default: "Default",
   acceptEdits: "Accept Edits",
   plan: "Plan Mode",

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -110,19 +110,90 @@ export interface SessionSnapshot {
  * `kind` discriminates; `agent_id` + `session_id` route to the right tab.
  */
 export type AgentDelta =
-  | { kind: "status"; agent_id: AgentId; session_id: AcpSessionId; status: SessionStatus; turn_seq?: number }
-  | { kind: "message_appended"; agent_id: AgentId; session_id: AcpSessionId; message: SessionMessage }
-  | { kind: "text_chunk"; agent_id: AgentId; session_id: AcpSessionId; message_id: string; delta: string }
-  | { kind: "thinking_chunk"; agent_id: AgentId; session_id: AcpSessionId; message_id: string; delta: string }
-  | { kind: "tool_call_upserted"; agent_id: AgentId; session_id: AcpSessionId; message_id: string; tool_call: ToolCall }
-  | { kind: "plan_updated"; agent_id: AgentId; session_id: AcpSessionId; plan: PlanEntry[] }
-  | { kind: "mode_changed"; agent_id: AgentId; session_id: AcpSessionId; mode_id: string }
-  | { kind: "model_changed"; agent_id: AgentId; session_id: AcpSessionId; model_id: string }
-  | { kind: "available_commands"; agent_id: AgentId; session_id: AcpSessionId; commands: unknown[] }
-  | { kind: "usage_updated"; agent_id: AgentId; session_id: AcpSessionId; usage: Usage }
-  | { kind: "context_usage"; agent_id: AgentId; session_id: AcpSessionId; used: number; size: number; cost: number }
-  | { kind: "compaction"; agent_id: AgentId; session_id: AcpSessionId; active: boolean }
-  | { kind: "compression_saved"; agent_id: AgentId; session_id: AcpSessionId; saved_tokens: number }
+  | {
+      kind: "status";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      status: SessionStatus;
+      turn_seq?: number;
+    }
+  | {
+      kind: "message_appended";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      message: SessionMessage;
+    }
+  | {
+      kind: "text_chunk";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      message_id: string;
+      delta: string;
+    }
+  | {
+      kind: "thinking_chunk";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      message_id: string;
+      delta: string;
+    }
+  | {
+      kind: "tool_call_upserted";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      message_id: string;
+      tool_call: ToolCall;
+    }
+  | {
+      kind: "plan_updated";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      plan: PlanEntry[];
+    }
+  | {
+      kind: "mode_changed";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      mode_id: string;
+    }
+  | {
+      kind: "model_changed";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      model_id: string;
+    }
+  | {
+      kind: "available_commands";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      commands: unknown[];
+    }
+  | {
+      kind: "usage_updated";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      usage: Usage;
+    }
+  | {
+      kind: "context_usage";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      used: number;
+      size: number;
+      cost: number;
+    }
+  | {
+      kind: "compaction";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      active: boolean;
+    }
+  | {
+      kind: "compression_saved";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      saved_tokens: number;
+    }
   | {
       kind: "permission_request";
       agent_id: AgentId;
@@ -131,8 +202,39 @@ export type AgentDelta =
       tool_call: unknown;
       options: unknown;
     }
-  | { kind: "permission_resolved"; agent_id: AgentId; session_id: AcpSessionId; request_id: string }
-  | { kind: "turn_finished"; agent_id: AgentId; session_id: AcpSessionId; stop_reason: string; turn_seq?: number }
-  | { kind: "turn_failed"; agent_id: AgentId; session_id: AcpSessionId; error: string; turn_seq?: number; error_kind?: "auth" | "transient" | "fatal" | "process_dead" | "unknown" }
-  | { kind: "retry_status"; agent_id: AgentId; session_id: AcpSessionId; attempt: number; max_attempts: number; delay_ms: number; last_error: string }
-  | { kind: "agent_disconnected"; agent_id: AgentId; session_id: AcpSessionId; reason: string };
+  | {
+      kind: "permission_resolved";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      request_id: string;
+    }
+  | {
+      kind: "turn_finished";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      stop_reason: string;
+      turn_seq?: number;
+    }
+  | {
+      kind: "turn_failed";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      error: string;
+      turn_seq?: number;
+      error_kind?: "auth" | "transient" | "fatal" | "process_dead" | "unknown";
+    }
+  | {
+      kind: "retry_status";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      attempt: number;
+      max_attempts: number;
+      delay_ms: number;
+      last_error: string;
+    }
+  | {
+      kind: "agent_disconnected";
+      agent_id: AgentId;
+      session_id: AcpSessionId;
+      reason: string;
+    };

--- a/src/ui/kbd.tsx
+++ b/src/ui/kbd.tsx
@@ -9,7 +9,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
         "pointer-events-none inline-flex h-[18px] w-fit min-w-[18px] items-center justify-center gap-1 rounded-[4px]",
         "bg-bg-elevated border border-border-default px-1.5 font-sans text-[10px] leading-none font-medium text-text-tertiary select-none",
         "[&_svg:not([class*='size-'])]:size-3",
-        className
+        className,
       )}
       {...props}
     />

--- a/src/ui/scroll-area.tsx
+++ b/src/ui/scroll-area.tsx
@@ -6,15 +6,11 @@ interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {}
 const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
   ({ className, children, ...props }, ref) => {
     return (
-      <div
-        ref={ref}
-        className={cn("overflow-auto", className)}
-        {...props}
-      >
+      <div ref={ref} className={cn("overflow-auto", className)} {...props}>
         {children}
       </div>
     );
-  }
+  },
 );
 ScrollArea.displayName = "ScrollArea";
 

--- a/src/ui/secret-input.tsx
+++ b/src/ui/secret-input.tsx
@@ -10,11 +10,10 @@ import { cn } from "@/lib/utils";
  * Controlled like a normal input via `value`/`onChange`. `onSubmit` fires on
  * Enter. `copyable` enables the inline copy button (copies the current value).
  */
-export interface SecretInputProps
-  extends Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    "type" | "onSubmit"
-  > {
+export interface SecretInputProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type" | "onSubmit"
+> {
   value: string;
   onValueChange?: (next: string) => void;
   onSubmit?: () => void;


### PR DESCRIPTION
#59 

1. Merge a standalone, no-logic-change formatting pass brings `src/` in line with the current Prettier config. Reviewing this is purely mechanical with no behavior changes.
 
2. Once merged, add a formatting check to CI (`.github/workflows/ci.yml`) e.g. `prettier --check src/` alongside the existing `typecheck` job - so drift can't silently reaccumulate.
  
3. Optionally, a `lint-staged`/husky pre-commit hook so formatting is applied before it ever reaches a PR.

 Without (2)/(3), we'll just be back here again after enough PRs land.
