### PR TITLE
fix: avoid em dashes in notification titles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -525,7 +525,7 @@ export function App() {
         const proj = useProjectStore.getState().currentProject;
         const projectName = proj?.name ?? "Atlas";
         sendNotification({
-          title: `Atlas — ${projectName}`,
+          title: `Atlas: ${projectName}`,
           body: "Agent task finished.",
         });
       } catch (e) {
@@ -550,7 +550,7 @@ export function App() {
         const proj = useProjectStore.getState().currentProject;
         const projectName = proj?.name ?? "Atlas";
         sendNotification({
-          title: `Atlas — ${projectName} needs permission`,
+          title: `Atlas: ${projectName} needs permission`,
           body: `Approve "${toolTitle}" to continue.`,
         });
       } catch (e) {


### PR DESCRIPTION
Fixes #35

Replaces em dashes in both OS notification titles with colons while preserving the existing notification behavior.

Verification:
- git diff --check
- Confirmed notification titles no longer contain em dashes