### PR TITLE
fix: determinstic focus mechanism for terminals instead of race

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { LayoutSwitcher } from "@/features/layout/components/layout-switcher";
 import { SearchOverlay } from "@/components/search-overlay";
 import { useHotkeys } from "@/hooks/use-hotkey";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
+import { useTerminalStore } from "@/features/terminal/stores/terminal-store";
 import {
   useProjectStore,
   type AppStateWire,
@@ -341,11 +342,8 @@ export function App() {
     const groupTabs = st.tabs.filter((t) => groupOf(t) === g);
     const activeTab = st.tabs.find((t) => t.id === st.activeByGroup[g]);
 
-    const focusTerminalSoon = () => {
-      // Ask the active block terminal to focus once the tab is mounted/visible.
-      requestAnimationFrame(() => {
-        window.dispatchEvent(new CustomEvent("atlas:focus-terminal"));
-      });
+    const focusTerminalSoon = (tabId: string) => {
+      useTerminalStore.getState().actions.requestTerminalFocus(tabId);
     };
 
     if (activeTab?.type === "terminal") {
@@ -363,17 +361,18 @@ export function App() {
     const existing = groupTabs.find((t) => t.type === "terminal");
     if (existing) {
       setActiveTab(existing.id);
-      focusTerminalSoon();
+      focusTerminalSoon(existing.id);
     } else {
+      const newTabId = `terminal-${Date.now()}`;
       addTab({
-        id: `terminal-${Date.now()}`,
+        id: newTabId,
         type: "terminal",
         title: "Terminal",
         closable: true,
         dirty: false,
         data: {},
       });
-      focusTerminalSoon();
+      focusTerminalSoon(newTabId);
     }
   };
   const currentProject = useProjectStore.use.currentProject();

--- a/src/features/terminal/components/block-terminal.tsx
+++ b/src/features/terminal/components/block-terminal.tsx
@@ -73,6 +73,9 @@ function renderHL(text: string, query: string): ReactNode {
 interface BlockTerminalProps {
   isActive: boolean;
   onFocus: () => void;
+  /** The terminal tab id (layout/terminal store), used to bind pending focus
+   *  requests to the correct terminal tab. */
+  tabId: string;
   /** The layout terminal id (terminal-store), used to report busy state to the
    *  tab strip. Distinct from the internal PTY session id. */
   terminalKey: string;
@@ -104,10 +107,11 @@ const XTERM_THEME = {
  * The React command input sends lines to the shell; when an alt-screen app is
  * running, keystrokes go to xterm instead.
  */
-export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalProps) {
+export function BlockTerminal({ isActive, onFocus, tabId, terminalKey }: BlockTerminalProps) {
   const [blocks, setBlocks] = useState<TerminalBlock[]>([]);
   const [altScreen, setAltScreen] = useState(false);
   const [cwd, setCwd] = useState<string>("");
+  const [surfaceReady, setSurfaceReady] = useState(false);
   const [git, setGit] = useState<TermGit | null>(null);
   const [search, setSearch] = useState({ open: false, query: "" });
   const [matchCount, setMatchCount] = useState(0);
@@ -117,6 +121,7 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
   const parserRef = useRef<BlockStreamParser | null>(null);
   const decoderRef = useRef(new TextDecoder());
   const ptyRef = useRef<string | null>(null);
+  const focusPendingRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const commandInputRef = useRef<CommandInputHandle>(null);
   // zsh integration ZDOTDIR (for relaunching root shells with integration).
@@ -131,6 +136,9 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
   const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
   const fitRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
   const xtermHostRef = useRef<HTMLDivElement>(null);
+
+  const pendingFocus = useTerminalStore((s) => s.pendingFocus);
+  const { clearPendingTerminalFocus } = useTerminalStore.use.actions();
 
   useEffect(() => {
     let disposed = false;
@@ -186,6 +194,7 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
       }
       xtermRef.current = term;
       fitRef.current = fit;
+      setSurfaceReady(true);
 
       let cols = 80;
       let rows = 24;
@@ -296,23 +305,35 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
     if (el && !altScreen) el.scrollTop = el.scrollHeight;
   }, [blocks, altScreen]);
 
+  const focusTerminalSurface = useCallback(() => {
+    if (!isActive) return;
+    onFocus();
+    if (altScreen) {
+      if (!surfaceReady) return;
+      xtermRef.current?.focus();
+    } else {
+      commandInputRef.current?.focus();
+    }
+  }, [altScreen, isActive, onFocus, surfaceReady]);
   // Focus the right surface: xterm while an alt-screen app runs, else the input.
   useEffect(() => {
     if (!isActive) return;
-    if (altScreen) xtermRef.current?.focus();
-    else commandInputRef.current?.focus();
-  }, [isActive, altScreen]);
+    focusTerminalSurface();
+  }, [isActive, altScreen, surfaceReady, focusTerminalSurface]);
 
   // External focus request (⌘J / focus-terminal shortcut).
   useEffect(() => {
-    const handler = () => {
-      if (!isActive) return;
-      if (parserRef.current?.altScreen) xtermRef.current?.focus();
-      else commandInputRef.current?.focus();
-    };
-    window.addEventListener("atlas:focus-terminal", handler);
-    return () => window.removeEventListener("atlas:focus-terminal", handler);
-  }, [isActive]);
+    if (!pendingFocus || pendingFocus.tabId !== tabId || !isActive) return;
+    focusPendingRef.current = true;
+  }, [isActive, pendingFocus, tabId]);
+
+  useEffect(() => {
+    if (!focusPendingRef.current) return;
+    if (!isActive || !surfaceReady) return;
+    focusTerminalSurface();
+    focusPendingRef.current = false;
+    clearPendingTerminalFocus();
+  }, [altScreen, clearPendingTerminalFocus, focusTerminalSurface, isActive, surfaceReady]);
 
   // A command is running when the live (last) block is still open. Surface it
   // as a spinner in the footer and report it to the tab strip via the store.

--- a/src/features/terminal/components/terminal-panel.tsx
+++ b/src/features/terminal/components/terminal-panel.tsx
@@ -228,6 +228,7 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
               <BlockTerminal
                 isActive={isActiveInPane && isPaneActive}
                 terminalKey={ptyId}
+                tabId={tabId}
                 onFocus={() => { setActiveTerminalInPane(tabId, pane.id, ptyId); setActivePane(tabId, pane.id); }}
               />
             </div>

--- a/src/features/terminal/stores/terminal-store.ts
+++ b/src/features/terminal/stores/terminal-store.ts
@@ -25,11 +25,17 @@ export interface TerminalTabState {
   activePaneId: string | null;
 }
 
+interface PendingTerminalFocus {
+  tabId: string;
+  requestId: number;
+}
+
 interface TerminalState {
   tabs: Record<string, TerminalTabState>;
   /** Per-terminal "a command is running" flag, keyed by the layout terminal id.
    *  Surfaced as a spinner on the tab strip; the BlockTerminal reports it. */
   busy: Record<string, boolean>;
+  pendingFocus: PendingTerminalFocus | null;
 }
 
 interface TerminalActions {
@@ -42,6 +48,8 @@ interface TerminalActions {
     setActiveTerminalInPane: (tabId: string, paneId: string, ptyId: string) => void;
     setActivePane: (tabId: string, paneId: string) => void;
     setTerminalBusy: (ptyId: string, busy: boolean) => void;
+    requestTerminalFocus: (tabId: string) => void;
+    clearPendingTerminalFocus: () => void;
     /** Drop several terminal tabs (used when a workspace is DISCARDED). PTYs
      *  are already closed by the BlockTerminal unmount; this frees the trees. */
     removeTabs: (tabIds: string[]) => void;
@@ -98,6 +106,7 @@ export const useTerminalStore = createSelectors(
     immer((set, get) => ({
       tabs: {},
       busy: {},
+      pendingFocus: null,
       actions: {
         initTab: (tabId) => {
           if (get().tabs[tabId]) return;
@@ -199,6 +208,17 @@ export const useTerminalStore = createSelectors(
           });
         },
 
+        requestTerminalFocus: (tabId) => {
+          set((s) => {
+            s.pendingFocus = { tabId, requestId: (s.pendingFocus?.requestId ?? 0) + 1 };
+          });
+        },
+
+        clearPendingTerminalFocus: () => {
+          set((s) => {
+            s.pendingFocus = null;
+          });
+        },
         removeTabs: (tabIds) =>
           set((s) => {
             for (const id of tabIds) delete s.tabs[id];


### PR DESCRIPTION
#78 

A deterministic terminal focus handoff for `Cmd+J` so the cursor reliably lands in the intended terminal input after opening or revealing a terminal. The change replaces the previous one frame focus event with a pending focus contract stored in the terminal store. Then lets each terminal instance claim focus only when its tab is active and its surface is ready. This makes focus behavior reliable across first open, hidden terminal, split view, and workspace switch scenarios while avoiding focus steals when toggling away from the terminal.