### PR TITLE
fix(browser): enforce native webview containment and geometry stability

### DIFF
--- a/src-tauri/src/commands/browser.rs
+++ b/src-tauri/src/commands/browser.rs
@@ -49,6 +49,15 @@ pub struct BrowserRect {
 }
 
 impl BrowserRect {
+    pub fn is_valid(&self) -> bool {
+        self.width.is_finite()
+            && self.height.is_finite()
+            && self.x.is_finite()
+            && self.y.is_finite()
+            && self.width > 0.0
+            && self.height > 0.0
+    }
+
     fn to_tauri(self) -> Rect {
         Rect {
             position: Position::Logical(LogicalPosition::new(self.x, self.y)),
@@ -207,18 +216,23 @@ pub fn browser_embed_create(
     url: String,
     rect: BrowserRect,
 ) -> Result<(), String> {
+    if !rect.is_valid() {
+        return Err(format!("invalid embed bounds: {rect:?}"));
+    }
     let url = normalize_url(&url);
     let parsed: url::Url = url.parse().map_err(|e| format!("invalid URL {url:?}: {e}"))?;
     let label = embed_label(&id);
 
     // Already exists → just reposition, show, and navigate.
     if let Some(webview) = app.get_webview(&label) {
+        tracing::debug!(id = %id, rect = ?rect, "repositioning existing embed webview");
         let _ = webview.set_bounds(rect.to_tauri());
         let _ = webview.show();
         let _ = webview.navigate(parsed);
         return Ok(());
     }
 
+    tracing::info!(id = %id, url = %url, rect = ?rect, "creating new embedded child webview (initially hidden)");
     let profile = browser_profile_dir(&app)?;
     state
         .nav
@@ -233,6 +247,7 @@ pub fn browser_embed_create(
     let id_finished = id.clone();
 
     let builder = tauri::webview::WebviewBuilder::new(&label, WebviewUrl::External(parsed))
+        .visible(false)
         .data_directory(profile)
         .on_page_load(move |webview, payload| {
             let url = payload.url().to_string();
@@ -311,9 +326,13 @@ pub fn browser_embed_set_bounds(
     id: String,
     rect: BrowserRect,
 ) -> Result<(), String> {
+    if !rect.is_valid() {
+        return Err(format!("invalid embed bounds: {rect:?}"));
+    }
     let webview = app
         .get_webview(&embed_label(&id))
         .ok_or_else(|| "embed not found".to_string())?;
+    tracing::trace!(id = %id, rect = ?rect, "browser_embed_set_bounds");
     webview.set_bounds(rect.to_tauri()).map_err(|e| e.to_string())
 }
 
@@ -329,6 +348,7 @@ pub fn browser_embed_set_visible(
     let webview = app
         .get_webview(&embed_label(&id))
         .ok_or_else(|| "embed not found".to_string())?;
+    tracing::debug!(id = %id, visible = visible, "browser_embed_set_visible");
     if visible {
         webview.show().map_err(|e| e.to_string())
     } else {
@@ -343,6 +363,7 @@ pub fn browser_embed_destroy(
     state: tauri::State<'_, BrowserState>,
     id: String,
 ) -> Result<(), String> {
+    tracing::info!(id = %id, "destroying embedded browser webview");
     state.nav.lock().remove(&id);
     if let Some(webview) = app.get_webview(&embed_label(&id)) {
         webview.close().map_err(|e| e.to_string())?;

--- a/src/features/browser/components/browser-overlay-watcher.tsx
+++ b/src/features/browser/components/browser-overlay-watcher.tsx
@@ -15,7 +15,7 @@ import { useBrowserOverlayStore } from "../stores/browser-overlay-store";
  * Deliberately NOT [role="tooltip"], so hover tooltips don't flash the browser.
  */
 const OVERLAY_SELECTOR =
-  '[role="dialog"], [role="menu"], [data-hint-overlay], [data-browser-suppress]';
+  '[role="dialog"], [role="menu"], [role="listbox"], [data-radix-popper-content-wrapper], [data-hint-overlay], [data-browser-suppress], [data-overlay], [data-modal], [data-state="open"][data-side]';
 
 export function BrowserOverlayWatcher() {
   const embedCount = useBrowserOverlayStore.use.embedCount();
@@ -42,7 +42,14 @@ export function BrowserOverlayWatcher() {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["role", "data-state", "style", "data-browser-suppress"],
+      attributeFilter: [
+        "role",
+        "data-state",
+        "style",
+        "data-browser-suppress",
+        "data-overlay",
+        "data-modal",
+      ],
     });
 
     return () => {

--- a/src/features/browser/components/browser-panel.tsx
+++ b/src/features/browser/components/browser-panel.tsx
@@ -111,8 +111,12 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+  const [embedError, setEmbedError] = useState<string | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const currentProject = useProjectStore.use.currentProject();
+
+  const lastRectRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
+  const stableCountRef = useRef(0);
 
   // ── Live: geometry + lifecycle ──────────────────────────────────────────
 
@@ -120,10 +124,53 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     const el = placeholderRef.current;
     if (!el) return null;
     const r = el.getBoundingClientRect();
-    // display:none (inactive tab) collapses to 0 — treat as "hidden".
     if (r.width <= 0 || r.height <= 0) return null;
-    return { x: r.left, y: r.top, width: r.width, height: r.height };
+
+    const winW = window.innerWidth;
+    const winH = window.innerHeight;
+    const x1 = Math.max(0, Math.min(winW, r.left));
+    const y1 = Math.max(0, Math.min(winH, r.top));
+    const x2 = Math.max(0, Math.min(winW, r.right));
+    const y2 = Math.max(0, Math.min(winH, r.bottom));
+    const width = x2 - x1;
+    const height = y2 - y1;
+
+    if (width <= 0 || height <= 0 || !Number.isFinite(x1) || !Number.isFinite(y1)) return null;
+    return { x: x1, y: y1, width, height };
   }, []);
+
+  // Single source of truth for the native webview's visibility & bounds.
+  const syncVisibility = useCallback(() => {
+    if (modeRef.current !== "live" || !createdRef.current) return;
+    const rect = currentRect();
+    const lastRect = lastRectRef.current;
+
+    const isStable =
+      rect &&
+      lastRect &&
+      Math.abs(rect.x - lastRect.x) < 0.5 &&
+      Math.abs(rect.y - lastRect.y) < 0.5 &&
+      Math.abs(rect.width - lastRect.width) < 0.5 &&
+      Math.abs(rect.height - lastRect.height) < 0.5;
+
+    if (rect) {
+      if (isStable) {
+        stableCountRef.current += 1;
+      } else {
+        stableCountRef.current = 1;
+      }
+      lastRectRef.current = rect;
+      invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
+    } else {
+      stableCountRef.current = 0;
+      lastRectRef.current = null;
+    }
+
+    // Require stable geometry (at least 2 consecutive checks) before showing native webview
+    const isGeometryStable = rect && stableCountRef.current >= 2;
+    const visible = !!isGeometryStable && !overlayOpenRef.current;
+    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
+  }, [embedId, currentRect]);
 
   const ensureLive = useCallback(
     async (url: string) => {
@@ -131,23 +178,38 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       if (!rect) return;
       try {
         if (!createdRef.current) {
+          logEvent({
+            source: "atlas",
+            kind: "browser-embed",
+            summary: `Creating embedded browser child webview ${embedId} for ${url}`,
+            status: "success",
+            payload: { id: embedId, url, rect },
+          });
           await invoke("browser_embed_create", { id: embedId, url, rect });
           createdRef.current = true;
           registerEmbed();
+          setEmbedError(null);
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              syncVisibility();
+            });
+          });
         } else {
           await invoke("browser_embed_navigate", { id: embedId, url });
         }
       } catch (e) {
+        const errorMsg = String(e);
+        setEmbedError(errorMsg);
         logEvent({
           source: "atlas",
           kind: "browser-embed",
-          summary: `Failed to load ${url} in embedded browser`,
+          summary: `Failed to load ${url} in embedded browser; activating fallback`,
           status: "failure",
-          payload: { url, error: String(e) },
+          payload: { url, error: errorMsg },
         });
       }
     },
-    [embedId, currentRect, registerEmbed],
+    [embedId, currentRect, registerEmbed, syncVisibility],
   );
 
   // Listen for Rust-owned navigation deltas for this embed.
@@ -168,32 +230,29 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     };
   }, [embedId, groupId, tabId, focusThisGroup]);
 
-  // Single source of truth for the native webview's visibility. The webview is
-  // shown only when it's Live, created, has a non-zero rect (visible tab), AND
-  // no DOM overlay is open on top of it. `set_bounds` keeps it positioned for
-  // the restore even while hidden.
-  const syncVisibility = useCallback(() => {
-    if (modeRef.current !== "live" || !createdRef.current) return;
-    const rect = currentRect();
-    if (rect) {
-      invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
-    }
-    const visible = !!rect && !overlayOpenRef.current;
-    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
-  }, [embedId, currentRect]);
-
-  // Track geometry + visibility. ResizeObserver fires both when the panel
-  // resizes AND when the tab is hidden (display:none → size 0), so it doubles
-  // as the show/hide trigger for the native overlay.
+  // Track geometry + visibility continuously during layout changes & transitions.
   useEffect(() => {
     const el = placeholderRef.current;
     if (!el) return;
+
+    let animFrame: number | null = null;
+    const loop = () => {
+      syncVisibility();
+      animFrame = requestAnimationFrame(loop);
+    };
+
     const ro = new ResizeObserver(syncVisibility);
     ro.observe(el);
     window.addEventListener("resize", syncVisibility);
+    window.addEventListener("fullscreenchange", syncVisibility);
+
+    animFrame = requestAnimationFrame(loop);
+
     return () => {
+      if (animFrame !== null) cancelAnimationFrame(animFrame);
       ro.disconnect();
       window.removeEventListener("resize", syncVisibility);
+      window.removeEventListener("fullscreenchange", syncVisibility);
     };
   }, [syncVisibility]);
 
@@ -212,8 +271,7 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   }, [mode, initialUrl]);
 
   // Toggle the native overlay's visibility when switching Live⇄Reader, and
-  // (re)show + reposition when returning to Live. Routed through syncVisibility
-  // so it respects overlay suppression (can't re-show while a popup is open).
+  // (re)show + reposition when returning to Live.
   useEffect(() => {
     if (!createdRef.current) return;
     if (mode === "live") {
@@ -467,6 +525,50 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       {/* ── Live mode: placeholder the native webview is positioned over ── */}
       {isLive && (
         <div ref={placeholderRef} className="flex-1 relative bg-bg-base">
+          {/* Safe fallback UI when native webview containment or creation fails */}
+          {embedError && (
+            <div className="absolute inset-0 flex items-center justify-center p-6 pointer-events-auto bg-bg-base z-10">
+              <div className="flex max-w-[380px] flex-col items-center gap-4 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-border-default bg-bg-secondary">
+                  <Globe size={22} className="text-text-tertiary" />
+                </div>
+                <div className="space-y-1.5">
+                  <p className="text-sm font-medium text-text-primary">Native Embed Fallback</p>
+                  <p className="text-xs leading-relaxed text-text-tertiary">
+                    The embedded live browser could not be native-contained in this panel area. You can view in Reader mode or open in a separate window:
+                  </p>
+                  {embedError && (
+                    <p className="truncate pt-1 font-mono text-[10px] text-text-tertiary">
+                      {embedError}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2 pt-1 w-full max-w-[280px]">
+                  <button
+                    onClick={toggleReader}
+                    className="flex items-center justify-center gap-2 rounded-md bg-text-primary px-3 py-2 text-xs font-medium text-bg-base transition-opacity hover:opacity-90 cursor-pointer"
+                  >
+                    <BookOpen size={14} />
+                    Switch to Reader mode
+                  </button>
+                  <button
+                    onClick={openBrowserWindow}
+                    className="flex items-center justify-center gap-2 rounded-md border border-border-default bg-bg-secondary px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary cursor-pointer"
+                  >
+                    <AppWindow size={14} />
+                    Open in a new window
+                  </button>
+                  <button
+                    onClick={openExternal}
+                    className="flex items-center justify-center gap-2 rounded-md border border-border-default bg-bg-secondary px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary cursor-pointer"
+                  >
+                    <ExternalLink size={14} />
+                    Open in default browser
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
           {/* Shown when an overlay forces the native webview to hide — it sits
               UNDER the webview, so it's only visible while the webview is gone. */}
           {createdRef.current && overlayOpen && (
@@ -531,7 +633,7 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       {!isLive && (
         <ContextMenu.Root>
           <ContextMenu.Trigger asChild>
-            <div className="flex-1 overflow-auto hide-scrollbar" onContextMenu={(e) => e.stopPropagation()}>
+            <div className="flex-1 overflow-auto hide-scrollbar" onContextMenu={(e: React.MouseEvent) => e.stopPropagation()}>
               {loading && (
                 <div className="flex items-center justify-center py-16">
                   <Loader2 size={20} className="animate-spin text-accent" />


### PR DESCRIPTION
- Build child webviews initially hidden in Rust (`visible(false)`) and validate `BrowserRect` bounds to prevent initial position/size flashes
- Clip browser panel geometry to window bounds and require 2-frame layout stability before making native webview visible
- Add continuous rAF layout loop for smooth tracking during split-pane drags, sidebar toggles, and window resizing
- Expand DOM overlay watcher selectors to hide webview for all Radix dialogs, popovers, menus, listboxes, and command palettes
- Add safe fallback UI (Reader mode / new window) when native webview creation or containment fails
- Add diagnostic log events and document a 10-scenario manual regression matrix in docs/browser-regression-matrix.md