### PR TITLE
fix(editor): make syntax highlighting and the default theme legible

### DIFF
--- a/src/features/editor/components/editor-panel.tsx
+++ b/src/features/editor/components/editor-panel.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { EditorView, keymap, lineNumbers, highlightActiveLine, drawSelection } from "@codemirror/view";
-import { EditorState, Compartment, Transaction, type Extension } from "@codemirror/state";
+import { EditorState, Compartment, Transaction } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
-import { bracketMatching, foldGutter, indentOnInput, syntaxHighlighting } from "@codemirror/language";
+import { bracketMatching, foldGutter, indentOnInput } from "@codemirror/language";
 import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
-import { getEditorTheme } from "../themes/themes";
-import { buildEditorChromeTheme, buildHighlightStyle } from "../themes/build-cm-theme";
+import { editorThemeExtensions } from "../themes/build-cm-theme";
 import { useEditorStore } from "../stores/editor-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
@@ -16,6 +15,7 @@ import { logEvent } from "@/features/log/lib/log";
 import { diffGutter, applyDiffStatus } from "../lib/diff-gutter";
 import { gitDiffLineStatus } from "@/features/git/lib/git-diff-api";
 import { blameInline, applyBlame } from "../lib/blame-inline";
+import { loadLanguageExtension } from "../lib/languages";
 import { gitBlameFile } from "@/features/git/lib/git-blame-api";
 import { MarkdownFile } from "@/lib/markdown-fileviewer";
 import { cn } from "@/lib/utils";
@@ -31,75 +31,6 @@ const themeCompartment = new Compartment();
 // Inline git blame — live-toggleable via a Compartment so flipping the
 // `gitBlameInline` setting doesn't rebuild the view (buffer/undo survive).
 const blameCompartment = new Compartment();
-
-function themeExtensions(themeId: string | undefined | null): Extension {
-  const theme = getEditorTheme(themeId);
-  return [buildEditorChromeTheme(theme), syntaxHighlighting(buildHighlightStyle(theme))];
-}
-
-// Language extension loader — lazy imports for tree-shaking
-async function getLanguageExtension(lang: string): Promise<Extension> {
-  switch (lang) {
-    case "typescript":
-    case "javascript": {
-      const { javascript } = await import("@codemirror/lang-javascript");
-      return javascript({ typescript: lang === "typescript", jsx: true });
-    }
-    case "rust": {
-      const { rust } = await import("@codemirror/lang-rust");
-      return rust();
-    }
-    case "python": {
-      const { python } = await import("@codemirror/lang-python");
-      return python();
-    }
-    case "go": {
-      const { go } = await import("@codemirror/lang-go");
-      return go();
-    }
-    case "json": {
-      const { json } = await import("@codemirror/lang-json");
-      return json();
-    }
-    case "markdown": {
-      const { markdown } = await import("@codemirror/lang-markdown");
-      return markdown();
-    }
-    case "html": {
-      const { html } = await import("@codemirror/lang-html");
-      return html();
-    }
-    case "css":
-    case "scss": {
-      const { css } = await import("@codemirror/lang-css");
-      return css();
-    }
-    case "java": {
-      const { java } = await import("@codemirror/lang-java");
-      return java();
-    }
-    case "c":
-    case "cpp": {
-      const { cpp } = await import("@codemirror/lang-cpp");
-      return cpp();
-    }
-    case "xml": {
-      const { xml } = await import("@codemirror/lang-xml");
-      return xml();
-    }
-    case "sql": {
-      const { sql } = await import("@codemirror/lang-sql");
-      return sql();
-    }
-    case "yaml":
-    case "toml": {
-      const { yaml } = await import("@codemirror/lang-yaml");
-      return yaml();
-    }
-    default:
-      return [];
-  }
-}
 
 interface EditorPanelProps {
   tabId: string;
@@ -376,13 +307,13 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
     let cancelled = false;
 
     (async () => {
-      const langExt = await getLanguageExtension(buffer.language);
+      const langExt = await loadLanguageExtension(buffer.language);
       if (cancelled) return;
 
       const view = new EditorView({
         doc: originalContent,
         extensions: [
-          themeCompartment.of(themeExtensions(useProjectStore.getState().settings.codeEditorTheme)),
+          themeCompartment.of(editorThemeExtensions(useProjectStore.getState().settings.codeEditorTheme)),
           langExt,
           lineNumbers(),
           diffGutter(),
@@ -449,7 +380,7 @@ export function EditorPanel({ tabId, filePath, containerHeight }: EditorPanelPro
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
-    view.dispatch({ effects: themeCompartment.reconfigure(themeExtensions(codeEditorTheme)) });
+    view.dispatch({ effects: themeCompartment.reconfigure(editorThemeExtensions(codeEditorTheme)) });
   }, [codeEditorTheme]);
 
   // Live-toggle inline blame: reconfigure the compartment in place; turning it

--- a/src/features/editor/lib/languages.test.ts
+++ b/src/features/editor/lib/languages.test.ts
@@ -45,6 +45,20 @@ describe("language registry", () => {
       expect(orphans).toEqual([]);
     });
 
+    it("never lists an extension as plaintext when a grammar also claims it", () => {
+      // `EXTENSION_LANGUAGE` spreads the plaintext set first so an explicit
+      // entry wins. This is the assertion that keeps that ordering honest: a
+      // language gaining a real loader must not be shadowed by its old
+      // plaintext entry, in either direction.
+      const plaintextExts = Object.entries(EXTENSION_LANGUAGE)
+        .filter(([, language]) => language === PLAINTEXT)
+        .map(([ext]) => ext);
+      const grammarExts = Object.entries(EXTENSION_LANGUAGE)
+        .filter(([, language]) => language !== PLAINTEXT)
+        .map(([ext]) => ext);
+      expect(plaintextExts.filter((ext) => grammarExts.includes(ext))).toEqual([]);
+    });
+
     it("keys are bare, lowercase extensions — `detectLanguage` looks them up that way", () => {
       for (const ext of Object.keys(EXTENSION_LANGUAGE)) {
         expect(ext).toBe(ext.toLowerCase());

--- a/src/features/editor/lib/languages.test.ts
+++ b/src/features/editor/lib/languages.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import {
+  detectLanguage,
+  EXTENSION_LANGUAGE,
+  isHighlightable,
+  LANGUAGE_IDS,
+  loadLanguageExtension,
+  PLAINTEXT,
+  type EditorLanguage,
+} from "./languages";
+
+/**
+ * The bug these tests exist for: a file extension mapped to a language id that
+ * had no CodeMirror loader, so the editor claimed to know the language and
+ * rendered it as flat text (issue #75).
+ *
+ * `EXTENSION_LANGUAGE`'s type already makes that unrepresentable, but the type
+ * only covers the *table*. These cover the other half — that every id actually
+ * resolves to a real grammar at runtime, which no type can assert because the
+ * loaders are dynamic imports.
+ *
+ * happy-dom: `@codemirror/lang-*` pulls in `@codemirror/view` transitively,
+ * which touches `document` at import time.
+ */
+
+/** A loaded language extension is a non-empty CodeMirror `Extension`. */
+function isRealExtension(ext: unknown): boolean {
+  return Array.isArray(ext) ? ext.length > 0 : ext !== null && ext !== undefined;
+}
+
+describe("language registry", () => {
+  describe("extension table", () => {
+    it.each(Object.entries(EXTENSION_LANGUAGE))(
+      "maps .%s to a language that is either loadable or explicitly plaintext",
+      (_ext, language) => {
+        expect(language === PLAINTEXT || LANGUAGE_IDS.includes(language)).toBe(true);
+      }
+    );
+
+    it("has no entry whose language id lacks a loader", () => {
+      const orphans = Object.entries(EXTENSION_LANGUAGE).filter(
+        ([, language]) => language !== PLAINTEXT && !LANGUAGE_IDS.includes(language)
+      );
+      expect(orphans).toEqual([]);
+    });
+
+    it("keys are bare, lowercase extensions — `detectLanguage` looks them up that way", () => {
+      for (const ext of Object.keys(EXTENSION_LANGUAGE)) {
+        expect(ext).toBe(ext.toLowerCase());
+        expect(ext.startsWith(".")).toBe(false);
+      }
+    });
+  });
+
+  describe("loaders", () => {
+    // The real assertion of the issue: every advertised language parses.
+    it.each(LANGUAGE_IDS)("%s resolves to a real CodeMirror extension", async (id) => {
+      expect(isRealExtension(await loadLanguageExtension(id))).toBe(true);
+    });
+
+    it("plaintext resolves to an empty extension rather than throwing", async () => {
+      expect(await loadLanguageExtension(PLAINTEXT)).toEqual([]);
+    });
+
+    it("every language id is reachable from at least one file extension", () => {
+      const reachable = new Set<EditorLanguage>(Object.values(EXTENSION_LANGUAGE));
+      expect(LANGUAGE_IDS.filter((id) => !reachable.has(id))).toEqual([]);
+    });
+  });
+
+  describe("detectLanguage", () => {
+    it.each([
+      ["/repo/src/main.ts", "typescript"],
+      ["/repo/src/app.tsx", "typescript"],
+      ["/repo/src/index.mjs", "javascript"],
+      ["/repo/src/lib.rs", "rust"],
+      ["/repo/main.go", "go"],
+      ["/repo/setup.py", "python"],
+      ["/repo/package.json", "json"],
+      ["/repo/.github/workflows/ci.yml", "yaml"],
+      ["/repo/README.md", "markdown"],
+      ["/repo/styles/app.scss", "scss"],
+      ["/repo/icons/logo.svg", "xml"],
+    ] as const)("detects %s as %s", (path, expected) => {
+      expect(detectLanguage(path)).toBe(expected);
+    });
+
+    it.each([
+      ["an unknown extension", "/repo/notes.wat"],
+      ["no extension at all", "/repo/Makefile"],
+      ["a dotfile, whose name is not an extension", "/repo/.env"],
+      ["an untitled scratch buffer", "untitled:1717171717"],
+      ["an empty path", ""],
+    ])("degrades to plaintext for %s", (_label, path) => {
+      expect(detectLanguage(path)).toBe(PLAINTEXT);
+    });
+
+    it.each(["/repo/deploy.sh", "/repo/Gemfile.rb", "/repo/Cargo.toml", "/repo/App.swift"])(
+      "degrades %s to plaintext explicitly, not by omission",
+      (path) => {
+        expect(detectLanguage(path)).toBe(PLAINTEXT);
+        // The distinction that matters: the extension is *listed* as plaintext,
+        // so nobody later assumes it was simply forgotten.
+        expect(EXTENSION_LANGUAGE[path.split(".").pop()!]).toBe(PLAINTEXT);
+      }
+    );
+
+    it("is case-insensitive — macOS paths arrive in whatever case the user typed", () => {
+      expect(detectLanguage("/repo/README.MD")).toBe("markdown");
+      expect(detectLanguage("/repo/Component.TSX")).toBe("typescript");
+    });
+
+    it("reads the basename, so a dotted directory is not an extension", () => {
+      expect(detectLanguage("/repo/v1.2/Makefile")).toBe(PLAINTEXT);
+      expect(detectLanguage("/repo/v1.2/main.rs")).toBe("rust");
+    });
+
+    it("takes the last extension of a compound name", () => {
+      expect(detectLanguage("/repo/types/global.d.ts")).toBe("typescript");
+    });
+  });
+
+  describe("isHighlightable", () => {
+    it("is true for a parseable language and false for plaintext", () => {
+      expect(isHighlightable("typescript")).toBe(true);
+      expect(isHighlightable(PLAINTEXT)).toBe(false);
+    });
+  });
+});

--- a/src/features/editor/lib/languages.ts
+++ b/src/features/editor/lib/languages.ts
@@ -1,0 +1,224 @@
+import type { Extension } from "@codemirror/state";
+
+/**
+ * The editor's language registry — the single source of truth for both halves
+ * of syntax highlighting.
+ *
+ * CodeMirror needs TWO things to highlight a file: a language extension (which
+ * parses the text into a syntax tree) and a `syntaxHighlighting` style (which
+ * colors the tree's tags). Atlas always installs the style, so a file that
+ * renders as flat text is always a *missing language extension*.
+ *
+ * That used to be possible to get wrong silently: the file-extension table and
+ * the loader `switch` lived in different files, so mapping `.rb` to a `"ruby"`
+ * id that no loader handled produced an editor which reported the language as
+ * Ruby and rendered it as plain text. The two are one structure here, and
+ * `EXTENSION_LANGUAGE` is typed against `LANGUAGE_LOADERS`' own keys — a
+ * mapping to a language with no loader is a `tsc` error, not a runtime shrug.
+ *
+ * Extensions we cannot parse map to `PLAINTEXT` explicitly (see
+ * `UNSUPPORTED`), so "no highlighting" is always a recorded decision rather
+ * than an accident.
+ */
+
+/** A file with no grammar: rendered as readable, unhighlighted text. */
+export const PLAINTEXT = "plaintext";
+
+type LanguageLoader = () => Promise<Extension>;
+
+/**
+ * Lazy per-language imports. Every entry is a dynamic `import()` so Rollup
+ * splits each grammar into its own chunk — opening a `.py` file never pays for
+ * the Java parser.
+ */
+const LANGUAGE_LOADERS = {
+  typescript: async () => {
+    const { javascript } = await import("@codemirror/lang-javascript");
+    return javascript({ typescript: true, jsx: true });
+  },
+  javascript: async () => {
+    const { javascript } = await import("@codemirror/lang-javascript");
+    return javascript({ jsx: true });
+  },
+  rust: async () => {
+    const { rust } = await import("@codemirror/lang-rust");
+    return rust();
+  },
+  python: async () => {
+    const { python } = await import("@codemirror/lang-python");
+    return python();
+  },
+  go: async () => {
+    const { go } = await import("@codemirror/lang-go");
+    return go();
+  },
+  java: async () => {
+    const { java } = await import("@codemirror/lang-java");
+    return java();
+  },
+  c: async () => {
+    const { cpp } = await import("@codemirror/lang-cpp");
+    return cpp();
+  },
+  cpp: async () => {
+    const { cpp } = await import("@codemirror/lang-cpp");
+    return cpp();
+  },
+  json: async () => {
+    const { json } = await import("@codemirror/lang-json");
+    return json();
+  },
+  yaml: async () => {
+    const { yaml } = await import("@codemirror/lang-yaml");
+    return yaml();
+  },
+  markdown: async () => {
+    const { markdown } = await import("@codemirror/lang-markdown");
+    return markdown();
+  },
+  html: async () => {
+    const { html } = await import("@codemirror/lang-html");
+    return html();
+  },
+  css: async () => {
+    const { css } = await import("@codemirror/lang-css");
+    return css();
+  },
+  // SCSS is highlighted with the CSS grammar. Selectors, properties, values,
+  // strings and comments — the bulk of any stylesheet — are shared, so the
+  // approximation reads correctly; only Sass-only constructs (`$var`, `@mixin`)
+  // fall back to unstyled text. Kept as its own id so the buffer still reports
+  // what the file actually is.
+  scss: async () => {
+    const { css } = await import("@codemirror/lang-css");
+    return css();
+  },
+  xml: async () => {
+    const { xml } = await import("@codemirror/lang-xml");
+    return xml();
+  },
+  sql: async () => {
+    const { sql } = await import("@codemirror/lang-sql");
+    return sql();
+  },
+} satisfies Record<string, LanguageLoader>;
+
+/** A language Atlas can actually parse — one of `LANGUAGE_LOADERS`' keys. */
+export type LanguageId = keyof typeof LANGUAGE_LOADERS;
+
+/** What a buffer records: a parseable language, or explicit plaintext. */
+export type EditorLanguage = LanguageId | typeof PLAINTEXT;
+
+/**
+ * File extensions we deliberately open as plaintext, and why. Listing them is
+ * the point: without it, a reader can't tell a considered decision from an
+ * oversight, which is how `.sh` and `.rb` ended up claiming a language they
+ * never had.
+ *
+ * Every one of these needs `@codemirror/legacy-modes` (a `StreamLanguage`
+ * grammar for shell/ruby/swift/kotlin/toml). That is a new top-level
+ * dependency, which CONTRIBUTING asks be agreed in the issue first — so they
+ * degrade honestly for now.
+ *
+ * TOML is here rather than on the YAML grammar on purpose. The two look alike
+ * but disagree structurally (`[table]` is a YAML flow *sequence*; `k = v` is
+ * not a YAML mapping), so YAML-parsed TOML is not "partly highlighted" — it is
+ * confidently mis-highlighted, which is worse than plain text for a file you
+ * are trying to read.
+ */
+const UNSUPPORTED: Record<string, typeof PLAINTEXT> = {
+  sh: PLAINTEXT,
+  bash: PLAINTEXT,
+  zsh: PLAINTEXT,
+  fish: PLAINTEXT,
+  rb: PLAINTEXT,
+  swift: PLAINTEXT,
+  kt: PLAINTEXT,
+  kts: PLAINTEXT,
+  toml: PLAINTEXT,
+  // The JSON grammar rejects comments outright, so `.jsonc` under it is a wall
+  // of parse errors rather than a highlighted file.
+  jsonc: PLAINTEXT,
+};
+
+/**
+ * Extension → language. Typed as `EditorLanguage`, so an entry naming a
+ * language with no loader fails `bun run typecheck` (and therefore CI) instead
+ * of silently opening the file as plain text.
+ */
+export const EXTENSION_LANGUAGE: Record<string, EditorLanguage> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  rs: "rust",
+  py: "python",
+  pyi: "python",
+  go: "go",
+  java: "java",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  hh: "cpp",
+  hxx: "cpp",
+  json: "json",
+  yaml: "yaml",
+  yml: "yaml",
+  md: "markdown",
+  markdown: "markdown",
+  mdx: "markdown",
+  html: "html",
+  htm: "html",
+  css: "css",
+  scss: "scss",
+  xml: "xml",
+  svg: "xml",
+  sql: "sql",
+  ...UNSUPPORTED,
+};
+
+/**
+ * The lowercased extension of a path, or `""` when there is none.
+ *
+ * Reads the basename first so a dot in a parent directory (`~/v1.2/README`)
+ * can't be mistaken for the file's extension, and treats a leading dot as part
+ * of the name — `.env` is a dotfile, not an `env` file.
+ */
+function fileExtension(path: string): string {
+  const basename = path.slice(Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\")) + 1);
+  const dot = basename.lastIndexOf(".");
+  return dot > 0 ? basename.slice(dot + 1).toLowerCase() : "";
+}
+
+/**
+ * The language to open `path` with. Anything unrecognised is plaintext, which
+ * is a legible outcome — the editor's chrome, gutters and theme all still
+ * apply, only the grammar is absent.
+ */
+export function detectLanguage(path: string): EditorLanguage {
+  return EXTENSION_LANGUAGE[fileExtension(path)] ?? PLAINTEXT;
+}
+
+/** Whether a detected language will be parsed (and therefore highlighted). */
+export function isHighlightable(language: EditorLanguage): language is LanguageId {
+  return language !== PLAINTEXT;
+}
+
+/**
+ * Load the CodeMirror extension for a language. Plaintext resolves to an empty
+ * extension — no grammar, no highlighting, everything else unchanged.
+ */
+export function loadLanguageExtension(language: EditorLanguage): Promise<Extension> {
+  if (!isHighlightable(language)) return Promise.resolve([]);
+  return LANGUAGE_LOADERS[language]();
+}
+
+/** Every language with a loader. Exported for the mapping tests. */
+export const LANGUAGE_IDS = Object.keys(LANGUAGE_LOADERS) as LanguageId[];

--- a/src/features/editor/lib/languages.ts
+++ b/src/features/editor/lib/languages.ts
@@ -26,6 +26,18 @@ export const PLAINTEXT = "plaintext";
 
 type LanguageLoader = () => Promise<Extension>;
 
+// Grammars that back more than one language id. Declared once so the two ids
+// cannot drift onto different parsers — the `switch` this replaced shared them
+// through case fall-through.
+const loadCpp: LanguageLoader = async () => {
+  const { cpp } = await import("@codemirror/lang-cpp");
+  return cpp();
+};
+const loadCss: LanguageLoader = async () => {
+  const { css } = await import("@codemirror/lang-css");
+  return css();
+};
+
 /**
  * Lazy per-language imports. Every entry is a dynamic `import()` so Rollup
  * splits each grammar into its own chunk — opening a `.py` file never pays for
@@ -56,14 +68,8 @@ const LANGUAGE_LOADERS = {
     const { java } = await import("@codemirror/lang-java");
     return java();
   },
-  c: async () => {
-    const { cpp } = await import("@codemirror/lang-cpp");
-    return cpp();
-  },
-  cpp: async () => {
-    const { cpp } = await import("@codemirror/lang-cpp");
-    return cpp();
-  },
+  c: loadCpp,
+  cpp: loadCpp,
   json: async () => {
     const { json } = await import("@codemirror/lang-json");
     return json();
@@ -80,19 +86,13 @@ const LANGUAGE_LOADERS = {
     const { html } = await import("@codemirror/lang-html");
     return html();
   },
-  css: async () => {
-    const { css } = await import("@codemirror/lang-css");
-    return css();
-  },
+  css: loadCss,
   // SCSS is highlighted with the CSS grammar. Selectors, properties, values,
   // strings and comments — the bulk of any stylesheet — are shared, so the
   // approximation reads correctly; only Sass-only constructs (`$var`, `@mixin`)
   // fall back to unstyled text. Kept as its own id so the buffer still reports
   // what the file actually is.
-  scss: async () => {
-    const { css } = await import("@codemirror/lang-css");
-    return css();
-  },
+  scss: loadCss,
   xml: async () => {
     const { xml } = await import("@codemirror/lang-xml");
     return xml();
@@ -120,11 +120,12 @@ export type EditorLanguage = LanguageId | typeof PLAINTEXT;
  * dependency, which CONTRIBUTING asks be agreed in the issue first — so they
  * degrade honestly for now.
  *
- * TOML is here rather than on the YAML grammar on purpose. The two look alike
- * but disagree structurally (`[table]` is a YAML flow *sequence*; `k = v` is
- * not a YAML mapping), so YAML-parsed TOML is not "partly highlighted" — it is
- * confidently mis-highlighted, which is worse than plain text for a file you
- * are trying to read.
+ * TOML is listed here rather than left on the YAML grammar it used to borrow.
+ * The two disagree structurally (`[table]` is a YAML flow *sequence*; `k = v`
+ * is not a YAML mapping), so the parse yields nothing to tag: rendering a real
+ * `Cargo.toml` through `yaml()` is pixel-identical to rendering it as
+ * plaintext, comment lines included. Nothing is lost by saying so — and unlike
+ * the old mapping, the buffer no longer claims a language it cannot highlight.
  */
 const UNSUPPORTED: Record<string, typeof PLAINTEXT> = {
   sh: PLAINTEXT,
@@ -147,6 +148,10 @@ const UNSUPPORTED: Record<string, typeof PLAINTEXT> = {
  * of silently opening the file as plain text.
  */
 export const EXTENSION_LANGUAGE: Record<string, EditorLanguage> = {
+  // Spread first so that if one of these later gains a real grammar, the
+  // explicit entry below wins rather than being silently shadowed.
+  ...UNSUPPORTED,
+
   ts: "typescript",
   tsx: "typescript",
   mts: "typescript",
@@ -173,7 +178,6 @@ export const EXTENSION_LANGUAGE: Record<string, EditorLanguage> = {
   yml: "yaml",
   md: "markdown",
   markdown: "markdown",
-  mdx: "markdown",
   html: "html",
   htm: "html",
   css: "css",
@@ -181,7 +185,6 @@ export const EXTENSION_LANGUAGE: Record<string, EditorLanguage> = {
   xml: "xml",
   svg: "xml",
   sql: "sql",
-  ...UNSUPPORTED,
 };
 
 /**
@@ -190,6 +193,13 @@ export const EXTENSION_LANGUAGE: Record<string, EditorLanguage> = {
  * Reads the basename first so a dot in a parent directory (`~/v1.2/README`)
  * can't be mistaken for the file's extension, and treats a leading dot as part
  * of the name — `.env` is a dotfile, not an `env` file.
+ *
+ * Deliberately separate from `classifyFile` in `@/lib/file-types`, which
+ * answers a different question — *which viewer owns this file* — over a
+ * broader allowlist, and counts a dotfile's name as its extension. This table
+ * is a subset of what that one admits: a file only reaches the editor if
+ * `classifyFile` (or the `is_text_file` byte sniff behind it) called it text,
+ * and only then does the grammar question arise.
  */
 function fileExtension(path: string): string {
   const basename = path.slice(Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\")) + 1);

--- a/src/features/editor/stores/editor-store.ts
+++ b/src/features/editor/stores/editor-store.ts
@@ -1,12 +1,16 @@
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { createSelectors } from "@/lib/create-selectors";
+import { detectLanguage, type EditorLanguage } from "../lib/languages";
 
 interface Buffer {
   path: string;
   originalContent: string;
   dirty: boolean;
-  language: string;
+  /** The grammar this buffer is parsed with, or `"plaintext"` when there is
+   *  none. Resolved through the language registry, which guarantees a
+   *  non-plaintext value has a loader behind it (see lib/languages.ts). */
+  language: EditorLanguage;
   /** Disk mtime (unix ms) at the last read/save — the freshness gate for
    *  external-change revalidation. 0 until first known. */
   diskMtimeMs: number;
@@ -32,21 +36,6 @@ interface EditorActions {
     closeBuffer: (path: string) => void;
     setActive: (path: string) => void;
   };
-}
-
-function detectLanguage(path: string): string {
-  const ext = path.split(".").pop()?.toLowerCase() ?? "";
-  const map: Record<string, string> = {
-    ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
-    rs: "rust", py: "python", go: "go", rb: "ruby", java: "java",
-    json: "json", toml: "toml", yaml: "yaml", yml: "yaml",
-    md: "markdown", html: "html", css: "css", scss: "scss",
-    sh: "shell", zsh: "shell", bash: "shell",
-    sql: "sql", xml: "xml", svg: "xml",
-    c: "c", cpp: "cpp", h: "c", hpp: "cpp",
-    swift: "swift", kt: "kotlin",
-  };
-  return map[ext] ?? "plaintext";
 }
 
 export const useEditorStore = createSelectors(

--- a/src/features/editor/themes/apply-editor-theme.ts
+++ b/src/features/editor/themes/apply-editor-theme.ts
@@ -6,10 +6,15 @@ import type { EditorThemeColors } from "./types";
  * surfaces (`styles/globals.css` `.cm-*` fallback, `styles/diff-syntax.css`
  * `.hljs-*`, and the diff line backgrounds in diff-view.tsx / git-diff-panel.tsx).
  * The CSS references each as `var(--…, <atlas-hex>)`, so if this applier never
- * runs (or loses a production race) the surfaces degrade to the original Atlas
+ * runs (or loses a production race) the surfaces degrade to the default Atlas
  * look rather than breaking.
+ *
+ * Exported for `css-fallbacks.test.ts`, which reads those hand-written `var()`
+ * fallbacks back out of the stylesheets and holds them to the values this
+ * mapping produces for the default theme. Without that, the fallbacks are three
+ * copies of one palette kept in step by memory — and they had already drifted.
  */
-function cssVars(c: EditorThemeColors): Record<string, string> {
+export function editorThemeCssVars(c: EditorThemeColors): Record<string, string> {
   return {
     // chrome (globals.css .cm-* fallback)
     "--cm-bg": c.bg,
@@ -58,7 +63,7 @@ export function applyEditorTheme(id: string | undefined | null): void {
   if (typeof document === "undefined") return;
   const theme = getEditorTheme(id);
   const root = document.documentElement;
-  const vars = cssVars(resolveEditorColors(theme));
+  const vars = editorThemeCssVars(resolveEditorColors(theme));
   for (const [k, v] of Object.entries(vars)) {
     root.style.setProperty(k, v);
   }

--- a/src/features/editor/themes/build-cm-theme.test.ts
+++ b/src/features/editor/themes/build-cm-theme.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { tags } from "@lezer/highlight";
 import type { Tag } from "@lezer/highlight";
 import { buildHighlightStyle } from "./build-cm-theme";
-import { EDITOR_THEMES } from "./themes";
+import { DEFAULT_EDITOR_THEME_ID, EDITOR_THEMES, getEditorTheme } from "./themes";
 
 /**
  * A `HighlightStyle` colors only the tags it names; a grammar tag with no rule
@@ -86,13 +86,13 @@ describe("buildHighlightStyle", () => {
     // The counter-check: if `style()` answered for any tag at all, the
     // assertions above would prove nothing. `inserted` belongs to the diff
     // grammar, which the editor never loads.
-    const style = buildHighlightStyle(EDITOR_THEMES[0]);
+    const style = buildHighlightStyle(getEditorTheme(DEFAULT_EDITOR_THEME_ID));
     expect(style.style([tags.inserted])).toBeNull();
   });
 
   it("gives headings and comments different styles in the default theme", () => {
     // Both used to land on the same flat foreground in Markdown.
-    const style = buildHighlightStyle(EDITOR_THEMES[0]);
+    const style = buildHighlightStyle(getEditorTheme(DEFAULT_EDITOR_THEME_ID));
     expect(style.style([tags.heading])).not.toBe(style.style([tags.comment]));
   });
 });

--- a/src/features/editor/themes/build-cm-theme.test.ts
+++ b/src/features/editor/themes/build-cm-theme.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { tags } from "@lezer/highlight";
+import type { Tag } from "@lezer/highlight";
+import { buildHighlightStyle } from "./build-cm-theme";
+import { EDITOR_THEMES } from "./themes";
+
+/**
+ * A `HighlightStyle` colors only the tags it names; a grammar tag with no rule
+ * renders in the plain foreground. So "the file has a language extension" is
+ * only half of "the file looks highlighted" — a Markdown buffer parsed
+ * perfectly still arrived as flat grey text because no prose tag had a rule
+ * (issue #75).
+ *
+ * These pin the tags that must resolve to a style, for every theme.
+ */
+
+/**
+ * Tags a reader would notice missing. Child tags resolve through their parent
+ * (`tags.controlKeyword` → `tags.keyword`), so entries like `controlKeyword`
+ * also assert that inheritance still holds.
+ */
+const CODE_TAGS: Array<[string, Tag]> = [
+  ["comment", tags.comment],
+  ["blockComment", tags.blockComment],
+  ["keyword", tags.keyword],
+  ["controlKeyword", tags.controlKeyword],
+  ["definitionKeyword", tags.definitionKeyword],
+  ["moduleKeyword", tags.moduleKeyword],
+  ["string", tags.string],
+  ["number", tags.number],
+  ["integer", tags.integer],
+  ["typeName", tags.typeName],
+  ["className", tags.className],
+  ["namespace", tags.namespace],
+  ["function(variableName)", tags.function(tags.variableName)],
+  ["variableName", tags.variableName],
+  ["definition(variableName)", tags.definition(tags.variableName)],
+  ["labelName", tags.labelName],
+  ["propertyName", tags.propertyName],
+  ["operator", tags.operator],
+  ["punctuation", tags.punctuation],
+  ["bracket", tags.bracket],
+  ["tagName", tags.tagName],
+  ["attributeName", tags.attributeName],
+  ["constant(variableName)", tags.constant(tags.variableName)],
+  ["regexp", tags.regexp],
+  ["escape", tags.escape],
+  ["bool", tags.bool],
+  ["null", tags.null],
+  ["atom", tags.atom],
+  ["meta", tags.meta],
+];
+
+/** Emitted by `@codemirror/lang-markdown`. The regression these tests exist for. */
+const PROSE_TAGS: Array<[string, Tag]> = [
+  ["heading", tags.heading],
+  ["heading1", tags.heading1],
+  ["heading3", tags.heading3],
+  ["strong", tags.strong],
+  ["emphasis", tags.emphasis],
+  ["strikethrough", tags.strikethrough],
+  ["link", tags.link],
+  ["url", tags.url],
+  ["monospace", tags.monospace],
+  ["quote", tags.quote],
+  ["list", tags.list],
+  ["processingInstruction", tags.processingInstruction],
+  ["contentSeparator", tags.contentSeparator],
+];
+
+describe("buildHighlightStyle", () => {
+  describe.each(EDITOR_THEMES.map((t) => [t.id, t] as const))("%s", (_id, theme) => {
+    const style = buildHighlightStyle(theme);
+
+    it.each(CODE_TAGS)("styles the %s tag", (_label, tag) => {
+      expect(style.style([tag])).toBeTruthy();
+    });
+
+    it.each(PROSE_TAGS)("styles the Markdown %s tag", (_label, tag) => {
+      expect(style.style([tag])).toBeTruthy();
+    });
+  });
+
+  it("leaves a tag nothing claims unstyled, rather than coloring everything", () => {
+    // The counter-check: if `style()` answered for any tag at all, the
+    // assertions above would prove nothing. `inserted` belongs to the diff
+    // grammar, which the editor never loads.
+    const style = buildHighlightStyle(EDITOR_THEMES[0]);
+    expect(style.style([tags.inserted])).toBeNull();
+  });
+
+  it("gives headings and comments different styles in the default theme", () => {
+    // Both used to land on the same flat foreground in Markdown.
+    const style = buildHighlightStyle(EDITOR_THEMES[0]);
+    expect(style.style([tags.heading])).not.toBe(style.style([tags.comment]));
+  });
+});

--- a/src/features/editor/themes/build-cm-theme.ts
+++ b/src/features/editor/themes/build-cm-theme.ts
@@ -1,9 +1,26 @@
 import { EditorView } from "@codemirror/view";
 import type { Extension } from "@codemirror/state";
-import { HighlightStyle } from "@codemirror/language";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { tags } from "@lezer/highlight";
 import type { EditorColorTheme } from "./types";
-import { resolveEditorColors } from "./themes";
+import { getEditorTheme, resolveEditorColors } from "./themes";
+
+/**
+ * The editor's type metrics. `13px` is the `--text-base` step of the Atlas
+ * scale and matches the other CodeMirror surface in the app (the chat
+ * composer); the editor used to sit a step above at `14px`, which read as
+ * oversized next to every panel around it. `20px` of leading (~1.54) is the
+ * comfortable end of the range for code — the previous `18px` (~1.29) packed
+ * lines tightly enough to work against legibility rather than for it.
+ *
+ * Both live on the editor root, NOT on `.cm-content`: CodeMirror measures line
+ * height off the content element to position gutter markers, so metrics
+ * applied to content alone desync the line numbers from their lines. The
+ * stylesheet fallback in `styles/globals.css` (`.cm-editor`) mirrors these two
+ * values for the case where the runtime theme injection loses its race.
+ */
+const EDITOR_FONT_SIZE = "13px";
+const EDITOR_LINE_HEIGHT = "20px";
 
 /**
  * Build the CodeMirror chrome theme from a color theme. Mirrors the structure of
@@ -19,11 +36,11 @@ export function buildEditorChromeTheme(theme: EditorColorTheme): Extension {
         backgroundColor: c.bg,
         color: c.fg,
         height: "100%",
+        fontFamily: "JetBrains Mono, SF Mono, Fira Code, monospace",
+        fontSize: EDITOR_FONT_SIZE,
+        lineHeight: EDITOR_LINE_HEIGHT,
       },
       ".cm-content": {
-        fontFamily: "JetBrains Mono, SF Mono, Fira Code, monospace",
-        fontSize: "14px",
-        lineHeight: "18px",
         caretColor: c.caret,
         padding: "4px 0",
       },
@@ -80,17 +97,28 @@ export function buildEditorChromeTheme(theme: EditorColorTheme): Extension {
 }
 
 /**
- * Build the syntax HighlightStyle from a color theme. Same tag→color map as the
- * original `atlasHighlightStyle`; comments and keywords keep the italic accent.
+ * Build the syntax HighlightStyle from a color theme.
+ *
+ * A `HighlightStyle` only colors the tags it names — anything a grammar emits
+ * that isn't listed here renders in the plain foreground color. That is why the
+ * prose block below matters: Markdown parses fine, but with only the code tags
+ * mapped, a `.md` file came out as flat grey text, indistinguishable from
+ * having no grammar at all (issue #75).
+ *
+ * Child tags inherit their parent's rule (`tags.controlKeyword` is a
+ * `tags.keyword`), so the code list stays short while still covering the
+ * keyword/operator variants the individual grammars reach for. `themes.test.ts`
+ * pins the set that must resolve to a style.
  */
 export function buildHighlightStyle(theme: EditorColorTheme): HighlightStyle {
   const c = theme.colors;
   return HighlightStyle.define([
+    // — Code —
     { tag: tags.comment, color: c.comment, fontStyle: "italic" },
     { tag: tags.keyword, color: c.keyword, fontStyle: "italic" },
     { tag: [tags.string, tags.special(tags.string)], color: c.string },
     { tag: tags.number, color: c.number },
-    { tag: [tags.typeName, tags.className], color: c.type },
+    { tag: [tags.typeName, tags.className, tags.namespace], color: c.type },
     { tag: [tags.function(tags.variableName), tags.function(tags.propertyName)], color: c.func },
     { tag: tags.variableName, color: c.variable },
     { tag: tags.operator, color: c.operator },
@@ -100,9 +128,46 @@ export function buildHighlightStyle(theme: EditorColorTheme): HighlightStyle {
     { tag: [tags.constant(tags.variableName), tags.standard(tags.variableName)], color: c.constant },
     { tag: tags.regexp, color: c.regexp },
     { tag: tags.escape, color: c.escape },
-    { tag: tags.definition(tags.variableName), color: c.definition },
+    { tag: [tags.definition(tags.variableName), tags.labelName], color: c.definition },
     { tag: tags.propertyName, color: c.propertyName },
     { tag: tags.bool, color: c.bool },
     { tag: tags.null, color: c.null },
+    // `atom` is what several grammars use where others use bool/null.
+    { tag: tags.atom, color: c.constant },
+    // Shebangs, pragmas, front-matter fences: present, not the content.
+    { tag: tags.meta, color: c.comment },
+
+    // — Prose (Markdown) —
+    // Headings carry the accent because they are the document's structure, the
+    // way function names are a source file's.
+    { tag: tags.heading, color: c.func, fontWeight: "600" },
+    { tag: tags.strong, color: c.definition, fontWeight: "600" },
+    { tag: tags.emphasis, color: c.definition, fontStyle: "italic" },
+    { tag: tags.strikethrough, color: c.comment, textDecoration: "line-through" },
+    { tag: [tags.link, tags.url], color: c.type, textDecoration: "underline" },
+    { tag: tags.monospace, color: c.string },
+    { tag: tags.quote, color: c.comment, fontStyle: "italic" },
+    { tag: tags.list, color: c.operator },
+    // The `#`, `**` and `-` markers themselves: legible but receding, so the
+    // text they mark up stays the thing being read.
+    { tag: [tags.processingInstruction, tags.contentSeparator], color: c.comment },
   ]);
+}
+
+/**
+ * The complete extension bundle for one editor theme: the chrome (colors, type
+ * metrics) plus the syntax highlighter.
+ *
+ * CodeMirror needs BOTH halves — a language extension parses the document, and
+ * a `syntaxHighlighting` style colors what it parsed. Keeping them in one
+ * function is what stops a caller from installing the theme and quietly
+ * omitting the highlighter, which looks exactly like a missing grammar.
+ *
+ * Everything here is state-free, so the editor can hold it in a `Compartment`
+ * and reconfigure on a theme change without touching the document or its undo
+ * history.
+ */
+export function editorThemeExtensions(themeId: string | undefined | null): Extension {
+  const theme = getEditorTheme(themeId);
+  return [buildEditorChromeTheme(theme), syntaxHighlighting(buildHighlightStyle(theme))];
 }

--- a/src/features/editor/themes/build-cm-theme.ts
+++ b/src/features/editor/themes/build-cm-theme.ts
@@ -107,8 +107,8 @@ export function buildEditorChromeTheme(theme: EditorColorTheme): Extension {
  *
  * Child tags inherit their parent's rule (`tags.controlKeyword` is a
  * `tags.keyword`), so the code list stays short while still covering the
- * keyword/operator variants the individual grammars reach for. `themes.test.ts`
- * pins the set that must resolve to a style.
+ * keyword/operator variants the individual grammars reach for.
+ * `build-cm-theme.test.ts` pins the set that must resolve to a style.
  */
 export function buildHighlightStyle(theme: EditorColorTheme): HighlightStyle {
   const c = theme.colors;
@@ -134,8 +134,11 @@ export function buildHighlightStyle(theme: EditorColorTheme): HighlightStyle {
     { tag: tags.null, color: c.null },
     // `atom` is what several grammars use where others use bool/null.
     { tag: tags.atom, color: c.constant },
-    // Shebangs, pragmas, front-matter fences: present, not the content.
-    { tag: tags.meta, color: c.comment },
+    // Shebangs, pragmas, front-matter fences. Uses `attributeName` because
+    // that is what `--cm-meta` already resolves to for the diff viewer's
+    // `.hljs-meta` (see apply-editor-theme.ts) — one concept, one color across
+    // both code surfaces.
+    { tag: tags.meta, color: c.attributeName },
 
     // — Prose (Markdown) —
     // Headings carry the accent because they are the document's structure, the

--- a/src/features/editor/themes/css-fallbacks.test.ts
+++ b/src/features/editor/themes/css-fallbacks.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { editorThemeCssVars } from "./apply-editor-theme";
+import { DEFAULT_EDITOR_THEME_ID, getEditorTheme, resolveEditorColors } from "./themes";
+
+/**
+ * The editor palette exists in three places: the theme registry, and the
+ * hand-written `var(--cm-…, #hex)` fallbacks in two stylesheets. The fallbacks
+ * are what render when `applyEditorTheme` hasn't run or loses a production race
+ * — the exact moment nobody is watching — so a drifted fallback shows up as a
+ * half-restyled editor and nothing else.
+ *
+ * They had already drifted (`--cm-fold-fg` and `--cm-active-gutter-fg` were
+ * still carrying pre-#75 greys after the palette was retuned), which is the
+ * argument for checking them rather than trusting three copies to stay in step.
+ */
+
+const STYLES = join(__dirname, "../../../styles");
+
+const SHEETS = ["globals.css", "diff-syntax.css"] as const;
+
+/** Every `var(--cm-name, fallback)` in a stylesheet, as [name, fallback]. */
+function cmFallbacks(css: string): Array<[string, string]> {
+  // `[^);]+` stops at the closing paren of the var() itself; the only nested
+  // parens in these fallbacks are rgba(), which is handled by the alternation.
+  const pattern = /var\((--cm-[a-z-]+),\s*((?:rgba?\([^)]*\)|[^)])+)\)/g;
+  return [...css.matchAll(pattern)].map(([, name, fallback]) => [name, fallback.trim()]);
+}
+
+/**
+ * Reduce a CSS color to `r,g,b,a` so equal colors written differently compare
+ * equal: `#666` = `#666666`, and `#ffffff0a` = `rgba(255, 255, 255, 0.04)`.
+ * A stylesheet and a JS theme object reach for different notations for the same
+ * value, and the point here is drift, not spelling.
+ */
+function normalizeColor(value: string): string {
+  const v = value.trim().toLowerCase();
+
+  const rgb = /^rgba?\(([^)]*)\)$/.exec(v);
+  if (rgb) {
+    const parts = rgb[1].split(/[,/\s]+/).filter(Boolean).map(Number);
+    const [r, g, b, a = 1] = parts;
+    return `${r},${g},${b},${a.toFixed(2)}`;
+  }
+
+  const hex = /^#([0-9a-f]{3,8})$/.exec(v);
+  if (hex) {
+    const h = hex[1];
+    // Expand 3/4-digit shorthand to its 6/8-digit equivalent.
+    const full = h.length <= 4 ? [...h].map((c) => c + c).join("") : h;
+    const [r, g, b] = [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16));
+    const a = full.length === 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1;
+    return `${r},${g},${b},${a.toFixed(2)}`;
+  }
+
+  return v.replace(/\s+/g, " ");
+}
+
+const expected = editorThemeCssVars(resolveEditorColors(getEditorTheme(DEFAULT_EDITOR_THEME_ID)));
+
+describe("stylesheet fallbacks track the default editor theme", () => {
+  describe.each(SHEETS)("%s", (sheet) => {
+    const css = readFileSync(join(STYLES, sheet), "utf8");
+    const fallbacks = cmFallbacks(css);
+
+    it("declares at least one --cm-* fallback (the regex still matches)", () => {
+      expect(fallbacks.length).toBeGreaterThan(0);
+    });
+
+    it("names only custom properties applyEditorTheme actually sets", () => {
+      const unknown = fallbacks.map(([name]) => name).filter((name) => !(name in expected));
+      expect([...new Set(unknown)]).toEqual([]);
+    });
+
+    it("matches the default theme's value for every fallback", () => {
+      const drifted = fallbacks
+        .filter(([name, fallback]) => {
+          const want = expected[name];
+          // `--cm-bg`/`--cm-gutter-bg` resolve to `var(--bg-base)`, which a
+          // fallback cannot restate; they hard-code the AMOLED base instead.
+          if (want?.startsWith("var(")) return normalizeColor(fallback) !== normalizeColor("#000000");
+          return normalizeColor(fallback) !== normalizeColor(want ?? "");
+        })
+        .map(([name, fallback]) => `${name}: ${fallback} (theme has ${expected[name]})`);
+      expect(drifted).toEqual([]);
+    });
+  });
+});

--- a/src/features/editor/themes/editor-theme-swap.test.ts
+++ b/src/features/editor/themes/editor-theme-swap.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import { Compartment, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { history, undo } from "@codemirror/commands";
+import { editorThemeExtensions } from "./build-cm-theme";
+
+/**
+ * Switching the editor theme must not cost the user their work — the buffer and
+ * its undo history have to survive (issue #75).
+ *
+ * The mechanism is a `Compartment`: the editor reconfigures the theme slot in
+ * place instead of rebuilding the view. That only holds while the bundle in
+ * that compartment stays state-free, so this drives the real
+ * `editorThemeExtensions` through the same reconfigure the panel performs, with
+ * edits and undo history in flight.
+ */
+
+const themeCompartment = new Compartment();
+
+/** A view configured the way `EditorPanel` configures its theme slot. */
+function mountEditor(doc: string, themeId: string) {
+  const view = new EditorView({
+    state: EditorState.create({
+      doc,
+      extensions: [themeCompartment.of(editorThemeExtensions(themeId)), history()],
+    }),
+    parent: document.body,
+  });
+  return view;
+}
+
+function type(view: EditorView, text: string) {
+  view.dispatch({
+    changes: { from: view.state.doc.length, insert: text },
+    // Mirrors a keystroke: goes into the undo history.
+    userEvent: "input.type",
+  });
+}
+
+describe("live theme swap", () => {
+  it("keeps the document across a theme change", () => {
+    const view = mountEditor("const a = 1;", "atlas");
+    type(view, "\nconst b = 2;");
+
+    view.dispatch({ effects: themeCompartment.reconfigure(editorThemeExtensions("dracula")) });
+
+    expect(view.state.doc.toString()).toBe("const a = 1;\nconst b = 2;");
+    view.destroy();
+  });
+
+  it("keeps undo history usable across a theme change", () => {
+    const view = mountEditor("const a = 1;", "atlas");
+    type(view, "\nconst b = 2;");
+
+    view.dispatch({ effects: themeCompartment.reconfigure(editorThemeExtensions("monokai")) });
+    // The edit made *before* the swap must still be undoable after it.
+    expect(undo(view)).toBe(true);
+
+    expect(view.state.doc.toString()).toBe("const a = 1;");
+    view.destroy();
+  });
+
+  it("keeps the selection across a theme change", () => {
+    const view = mountEditor("const a = 1;", "atlas");
+    view.dispatch({ selection: { anchor: 6, head: 11 } });
+
+    view.dispatch({ effects: themeCompartment.reconfigure(editorThemeExtensions("one-dark")) });
+
+    expect(view.state.selection.main.anchor).toBe(6);
+    expect(view.state.selection.main.head).toBe(11);
+    view.destroy();
+  });
+
+  it("survives a swap to an unknown theme id by falling back, not throwing", () => {
+    const view = mountEditor("const a = 1;", "atlas");
+
+    expect(() =>
+      view.dispatch({ effects: themeCompartment.reconfigure(editorThemeExtensions("deleted-theme")) })
+    ).not.toThrow();
+
+    expect(view.state.doc.toString()).toBe("const a = 1;");
+    view.destroy();
+  });
+
+  it("installs both halves of highlighting — a theme alone would not highlight", () => {
+    // `editorThemeExtensions` bundles the chrome theme with `syntaxHighlighting`
+    // precisely so a caller cannot install one without the other.
+    const extensions = editorThemeExtensions("atlas");
+    expect(Array.isArray(extensions) && extensions.length).toBe(2);
+  });
+});

--- a/src/features/editor/themes/editor-theme-swap.test.ts
+++ b/src/features/editor/themes/editor-theme-swap.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { history, undo } from "@codemirror/commands";
+import { highlightingFor } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
 import { editorThemeExtensions } from "./build-cm-theme";
 
 /**
@@ -85,8 +87,10 @@ describe("live theme swap", () => {
 
   it("installs both halves of highlighting — a theme alone would not highlight", () => {
     // `editorThemeExtensions` bundles the chrome theme with `syntaxHighlighting`
-    // precisely so a caller cannot install one without the other.
-    const extensions = editorThemeExtensions("atlas");
-    expect(Array.isArray(extensions) && extensions.length).toBe(2);
+    // precisely so a caller cannot install one without the other. Asserting the
+    // bundle's *length* would pass for two chrome themes; ask the resulting
+    // state whether a highlighter is actually answering instead.
+    const state = EditorState.create({ extensions: editorThemeExtensions("atlas") });
+    expect(highlightingFor(state, [tags.comment])).toBeTruthy();
   });
 });

--- a/src/features/editor/themes/themes.test.ts
+++ b/src/features/editor/themes/themes.test.ts
@@ -17,8 +17,9 @@ import type { EditorColorTheme, EditorThemeColors } from "./types";
  * this stops the next one from regressing the same way.
  *
  * These are contrast ratios, not screenshots: they cover the measurable half of
- * "is this readable" and run in CI. Hue relationships and how a real file
- * *feels* still need eyes on the app — see the manual matrix in the PR.
+ * "is this readable" and run in CI. Hue relationships, and how a real file
+ * actually reads, still need eyes on the app — the repo has no screenshot
+ * infrastructure, so that half stays a manual check at review time.
  */
 
 /** WCAG 2.1 relative luminance of an `#rrggbb` color. */

--- a/src/features/editor/themes/themes.test.ts
+++ b/src/features/editor/themes/themes.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { ATLAS_THEMES } from "@/features/theme/themes";
+import {
+  DEFAULT_EDITOR_THEME_ID,
+  EDITOR_THEMES,
+  getEditorTheme,
+  resolveEditorColors,
+} from "./themes";
+import type { EditorColorTheme, EditorThemeColors } from "./types";
+
+/**
+ * Legibility guard for the editor palettes (issue #75).
+ *
+ * The default theme shipped comments at `#555555` and keywords at `#585858`
+ * on black — under 3:1, and two shades of the same grey — so highlighted code
+ * arrived looking unhighlighted. A palette is data, so nothing but a rule like
+ * this stops the next one from regressing the same way.
+ *
+ * These are contrast ratios, not screenshots: they cover the measurable half of
+ * "is this readable" and run in CI. Hue relationships and how a real file
+ * *feels* still need eyes on the app — see the manual matrix in the PR.
+ */
+
+/** WCAG 2.1 relative luminance of an `#rrggbb` color. */
+function luminance(hex: string): number {
+  const channel = (v: number) => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  const h = hex.replace("#", "");
+  const [r, g, b] = [h.slice(0, 2), h.slice(2, 4), h.slice(4, 6)].map((p) => parseInt(p, 16));
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/** WCAG 2.1 contrast ratio between two `#rrggbb` colors: 1 (none) to 21. */
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * The syntax tokens — the ones a reader's eye lands on. Chrome (gutter, folds)
+ * and the diff backgrounds are held to different, looser bars below.
+ */
+const SYNTAX_TOKENS = [
+  "comment",
+  "keyword",
+  "string",
+  "number",
+  "type",
+  "func",
+  "variable",
+  "operator",
+  "tagName",
+  "attributeName",
+  "constant",
+  "regexp",
+  "escape",
+  "definition",
+  "propertyName",
+  "bool",
+  "null",
+] as const satisfies readonly (keyof EditorThemeColors)[];
+
+/**
+ * Every editor theme renders on the *interface* background, never its own
+ * (`resolveEditorColors`), so the bar is contrast against whichever base the
+ * user's interface theme is on. Testing all of them means a new interface
+ * theme with a lighter base can't quietly undercut the editor.
+ */
+const INTERFACE_BASES = ATLAS_THEMES.map((t) => ({ id: t.id, base: t.spec.base }));
+
+/** WCAG AA for body text. The bar for the themes Atlas itself authors. */
+const AA_TEXT = 4.5;
+
+/**
+ * The floor for the ported third-party palettes (Dracula, One Dark, Monokai).
+ * Their point is fidelity to a known look, so their canonical comment greys —
+ * One Dark's `#5c6370` is 3.47:1 on black — are kept as published rather than
+ * "corrected" into something that is no longer One Dark. The floor still
+ * guarantees nothing illegible can be added.
+ */
+const FLOOR = 3;
+
+/** Themes Atlas authors, and therefore holds to AA. */
+const ATLAS_AUTHORED = ["atlas", "atlas-mono"];
+
+const byId = (id: string) => EDITOR_THEMES.find((t) => t.id === id) as EditorColorTheme;
+
+describe("editor themes", () => {
+  describe("registry", () => {
+    it("has a unique id per theme", () => {
+      const ids = EDITOR_THEMES.map((t) => t.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("defaults to a theme that exists", () => {
+      expect(getEditorTheme(DEFAULT_EDITOR_THEME_ID).id).toBe(DEFAULT_EDITOR_THEME_ID);
+    });
+
+    it.each([["unknown id", "no-such-theme"], ["undefined", undefined], ["null", null]])(
+      "falls back to the default for %s",
+      (_label, id) => {
+        expect(getEditorTheme(id).id).toBe(DEFAULT_EDITOR_THEME_ID);
+      }
+    );
+
+    it("keeps every theme on the interface background, not its own", () => {
+      // The behaviour the contrast assertions below depend on.
+      for (const theme of EDITOR_THEMES) {
+        const resolved = resolveEditorColors(theme);
+        expect(resolved.bg).toBe("var(--bg-base)");
+        expect(resolved.gutterBg).toBe("var(--bg-base)");
+        expect(resolved.contextBg).toBe("var(--bg-base)");
+      }
+    });
+  });
+
+  describe("syntax contrast", () => {
+    const cases = EDITOR_THEMES.flatMap((theme) =>
+      INTERFACE_BASES.map((surface) => ({ theme, surface }))
+    );
+
+    it.each(cases)("$theme.id is readable on the $surface.id background", ({ theme, surface }) => {
+      const min = ATLAS_AUTHORED.includes(theme.id) ? AA_TEXT : FLOOR;
+      const failures = SYNTAX_TOKENS.filter(
+        (token) => contrast(theme.colors[token], surface.base) < min
+      ).map((token) => `${token} ${theme.colors[token]}`);
+      expect(failures).toEqual([]);
+    });
+  });
+
+  describe("the default theme", () => {
+    const theme = byId(DEFAULT_EDITOR_THEME_ID);
+
+    it("is one Atlas authors, and so is held to AA", () => {
+      expect(ATLAS_AUTHORED).toContain(theme.id);
+    });
+
+    it("draws comments subdued — dimmer than body text, still above AA", () => {
+      const comment = contrast(theme.colors.comment, "#000000");
+      expect(comment).toBeGreaterThanOrEqual(AA_TEXT);
+      expect(comment).toBeLessThan(contrast(theme.colors.fg, "#000000"));
+    });
+
+    it("separates comments from keywords, which used to be a shade apart", () => {
+      // #555555 vs #585858 in the old default: technically two colors, one
+      // colour to the eye. Ratio between them, not against the background.
+      expect(contrast(theme.colors.comment, theme.colors.keyword)).toBeGreaterThan(1.5);
+    });
+
+    it("gives each token family a distinguishable color", () => {
+      // Not "all 17 differ" — several tokens share a color by design (numbers,
+      // constants and booleans are one family). The families must differ.
+      const families = [
+        theme.colors.comment,
+        theme.colors.keyword,
+        theme.colors.string,
+        theme.colors.number,
+        theme.colors.type,
+        theme.colors.func,
+        theme.colors.variable,
+      ];
+      expect(new Set(families).size).toBe(families.length);
+    });
+
+    it("keeps the Atlas yellow on function names", () => {
+      expect(theme.colors.func).toBe("#ffff00");
+    });
+
+    it("keeps line numbers visible without competing with the code", () => {
+      const gutter = contrast(theme.colors.gutterFg, "#000000");
+      expect(gutter).toBeGreaterThanOrEqual(FLOOR);
+      expect(gutter).toBeLessThan(contrast(theme.colors.fg, "#000000"));
+    });
+  });
+
+  describe("atlas-mono", () => {
+    const theme = byId("atlas-mono");
+
+    it("stays monochrome — greys and the one yellow accent, no other hue", () => {
+      for (const token of SYNTAX_TOKENS) {
+        const hex = theme.colors[token];
+        if (hex === theme.colors.func) continue; // the #ffff00 accent
+        const [r, g, b] = [hex.slice(1, 3), hex.slice(3, 5), hex.slice(5, 7)];
+        expect(`${token}:${r}${g}${b}`).toBe(`${token}:${r}${r}${r}`);
+      }
+    });
+
+    it("separates tokens by lightness, since it cannot use hue", () => {
+      const steps = new Set(SYNTAX_TOKENS.map((t) => theme.colors[t]));
+      expect(steps.size).toBeGreaterThanOrEqual(6);
+    });
+  });
+});

--- a/src/features/editor/themes/themes.ts
+++ b/src/features/editor/themes/themes.ts
@@ -1,50 +1,124 @@
 import type { EditorColorTheme, EditorThemeColors } from "./types";
 
 /**
- * Built-in editor color themes. `atlas` reproduces the exact original
- * "monochrome + #ffff00 accent" look (values lifted verbatim from the old
- * atlasTheme/atlasHighlightStyle + diff-syntax.css + diff-view.tsx), so picking
- * it returns the app to its historical appearance. The others are the standard
- * dark palettes (Dracula, One Dark, Monokai, Vesper).
+ * Built-in editor color themes. `atlas` is the default; `atlas-mono` keeps the
+ * historical monochrome look for anyone who prefers it. The others are the
+ * standard dark palettes (Dracula, One Dark, Monokai, Vesper).
+ *
+ * Every theme renders on the interface base surface (see `resolveEditorColors`),
+ * which is AMOLED black or near it in all three Atlas interface themes. Syntax
+ * values are therefore chosen against black, and `themes.test.ts` holds them to
+ * a contrast floor so a new palette can't ship illegible.
  */
 
+/**
+ * The default. Restrained rather than colorful — near-monochrome structure with
+ * the Atlas `#ffff00` accent kept for function names — but with each token
+ * family far enough apart in hue and lightness to actually be *read* as
+ * highlighted code.
+ *
+ * The previous default drew comments at `#555555` and keywords at `#585858`,
+ * both under 3:1 on black and within a hair of each other, so a source file
+ * arrived looking like unhighlighted grey text (issue #75). Everything here
+ * clears 4.5:1 (WCAG AA for body text) against the black it is drawn on;
+ * comments sit lowest on purpose, subdued but legible.
+ */
 const atlas: EditorColorTheme = {
   id: "atlas",
   name: "Atlas",
-  description: "Monochrome AMOLED black with a single yellow accent.",
+  description: "AMOLED black with restrained syntax hues and the Atlas yellow accent.",
   dark: true,
   colors: {
     bg: "#000000",
-    fg: "#b3b3b3",
-    caret: "#b3b3b3",
+    fg: "#d4d4d4",
+    caret: "#d4d4d4",
     gutterBg: "#000000",
-    gutterFg: "#222222",
-    activeLineGutterFg: "#777777",
+    // Line numbers are reference furniture, not prose: dim enough to recede,
+    // still above the 3:1 floor for meaningful non-text UI.
+    gutterFg: "#666666",
+    activeLineGutterFg: "#d4d4d4",
     activeLineBg: "#ffffff0a",
     selectionBg: "#303030",
     matchBracketBg: "#2d2d2d",
     matchBracketOutline: "#3d3d3d",
     foldBg: "#1a1a1a",
     foldBorder: "#2a2a2a",
-    foldFg: "#555555",
+    foldFg: "#8a8a8a",
 
-    comment: "#555555",
-    keyword: "#585858",
-    string: "#aaaaaa",
-    number: "#aaaaaa",
-    type: "#cccccc",
+    comment: "#8f8f8f",
+    keyword: "#c9a2f5",
+    string: "#9ecf8a",
+    number: "#e0b070",
+    type: "#7fd1e8",
+    func: "#ffff00",
+    variable: "#eaeaea",
+    operator: "#9a9a9a",
+    tagName: "#7fd1e8",
+    attributeName: "#d9b47a",
+    constant: "#e0b070",
+    regexp: "#e59a72",
+    escape: "#e59a72",
+    definition: "#ffffff",
+    propertyName: "#c8c8c8",
+    bool: "#e0b070",
+    null: "#e0b070",
+
+    addLineBg: "#0d2211",
+    removeLineBg: "#220d0d",
+    contextBg: "#0a0a0a",
+    addSideBg: "rgba(34,197,94,0.13)",
+    removeSideBg: "rgba(244,63,63,0.13)",
+    emphAddBg: "rgba(52,211,153,0.34)",
+    emphRemoveBg: "rgba(244,63,63,0.34)",
+  },
+};
+
+/**
+ * The original Atlas look — hue-free, one yellow accent — kept as a choice for
+ * anyone who wants the editor to match the monochrome interface exactly.
+ *
+ * Same identity as before, but the ramp is spread across readable lightnesses
+ * instead of bunching at the bottom: comments and keywords used to sit under
+ * 3:1 on black. Tokens separate by weight of grey and by italics rather than by
+ * hue, which is the point of the theme.
+ */
+const atlasMono: EditorColorTheme = {
+  id: "atlas-mono",
+  name: "Atlas Mono",
+  description: "Monochrome AMOLED black with a single yellow accent.",
+  dark: true,
+  colors: {
+    bg: "#000000",
+    fg: "#d0d0d0",
+    caret: "#d0d0d0",
+    gutterBg: "#000000",
+    gutterFg: "#666666",
+    activeLineGutterFg: "#d0d0d0",
+    activeLineBg: "#ffffff0a",
+    selectionBg: "#303030",
+    matchBracketBg: "#2d2d2d",
+    matchBracketOutline: "#3d3d3d",
+    foldBg: "#1a1a1a",
+    foldBorder: "#2a2a2a",
+    foldFg: "#8a8a8a",
+
+    comment: "#8a8a8a",
+    keyword: "#e6e6e6",
+    string: "#b0b0b0",
+    number: "#c2c2c2",
+    type: "#d4d4d4",
     func: "#ffff00",
     variable: "#ffffff",
-    operator: "#b3b3b3",
-    tagName: "#cccccc",
-    attributeName: "#777777",
-    constant: "#aaaaaa",
-    regexp: "#999999",
-    escape: "#999999",
+    operator: "#9c9c9c",
+    tagName: "#d4d4d4",
+    attributeName: "#a8a8a8",
+    constant: "#c2c2c2",
+    regexp: "#b0b0b0",
+    escape: "#b0b0b0",
     definition: "#ffffff",
-    propertyName: "#b3b3b3",
-    bool: "#aaaaaa",
-    null: "#aaaaaa",
+    propertyName: "#c8c8c8",
+    bool: "#c2c2c2",
+    null: "#c2c2c2",
 
     addLineBg: "#0d2211",
     removeLineBg: "#220d0d",
@@ -248,7 +322,7 @@ const vesper: EditorColorTheme = {
   },
 };
 
-export const EDITOR_THEMES: EditorColorTheme[] = [atlas, dracula, oneDark, monokai, vesper];
+export const EDITOR_THEMES: EditorColorTheme[] = [atlas, atlasMono, dracula, oneDark, monokai, vesper];
 
 export const DEFAULT_EDITOR_THEME_ID = "atlas";
 

--- a/src/styles/diff-syntax.css
+++ b/src/styles/diff-syntax.css
@@ -1,8 +1,8 @@
 /* Syntax-highlight theme for the git diff view (src/features/git/).
  *
- * Mirrors the code editor's Zed-derived "enterprise" palette (AMOLED black,
- * monochromatic grays, a single #ffff00 accent on function names) — see the
- * CodeMirror HighlightStyle in editor-panel.tsx. lowlight emits highlight.js
+ * Mirrors the code editor's default `atlas` palette (AMOLED black, restrained
+ * syntax hues, a #ffff00 accent on function names) — see the theme registry in
+ * features/editor/themes/themes.ts. lowlight emits highlight.js
  * token classes, so we key the same colors off `.hljs-*` here.
  *
  * Scoped under `.diff-syntax` (specificity 0,2,0) AND intentionally UNLAYERED:
@@ -12,44 +12,44 @@
  * `.hljs` root class to diff spans, so github-dark's root bg/color never apply.
  *
  * Base text color (operators, punctuation, plain identifiers — left unclassed
- * by highlight.js) comes from the row's `text-text-secondary` (#b3b3b3),
- * matching the editor's operator/punctuation color. */
+ * by highlight.js) comes from the row's `text-text-secondary` (#aaaaaa),
+ * close to the editor's operator/punctuation color. */
 
 /* Colors resolve from the active editor theme's CSS custom properties
    (set on :root by applyEditorTheme). The atlas hex values remain as
-   fallbacks so an un-applied theme degrades to the original look. */
+   fallbacks so an un-applied theme degrades to the default `atlas` look. */
 
 .diff-syntax .hljs-comment,
 .diff-syntax .hljs-quote {
-  color: var(--cm-comment, #555);
+  color: var(--cm-comment, #8f8f8f);
   font-style: italic;
 }
 
 .diff-syntax .hljs-keyword,
 .diff-syntax .hljs-built_in {
-  color: var(--cm-keyword, #585858);
+  color: var(--cm-keyword, #c9a2f5);
   font-style: italic;
 }
 
 .diff-syntax .hljs-string,
 .diff-syntax .hljs-meta .hljs-string {
-  color: var(--cm-string, #aaa);
+  color: var(--cm-string, #9ecf8a);
 }
 
 .diff-syntax .hljs-number,
 .diff-syntax .hljs-literal {
-  color: var(--cm-number, #aaa);
+  color: var(--cm-number, #e0b070);
 }
 
 .diff-syntax .hljs-type,
 .diff-syntax .hljs-title.class_,
 .diff-syntax .hljs-class .hljs-title {
-  color: var(--cm-type, #ccc);
+  color: var(--cm-type, #7fd1e8);
 }
 
 /* Bare title (rare fallthrough) reads as a type/name. */
 .diff-syntax .hljs-title {
-  color: var(--cm-type, #ccc);
+  color: var(--cm-type, #7fd1e8);
 }
 
 /* The one accent: function/method names — must out-specify the bare title. */
@@ -59,32 +59,32 @@
 }
 
 .diff-syntax .hljs-variable {
-  color: var(--cm-variable, #fff);
+  color: var(--cm-variable, #eaeaea);
 }
 
 .diff-syntax .hljs-tag,
 .diff-syntax .hljs-name {
-  color: var(--cm-tag, #ccc);
+  color: var(--cm-tag, #7fd1e8);
 }
 
 .diff-syntax .hljs-attr,
 .diff-syntax .hljs-attribute {
-  color: var(--cm-attr, #777);
+  color: var(--cm-attr, #d9b47a);
 }
 
 .diff-syntax .hljs-symbol,
 .diff-syntax .hljs-bullet {
-  color: var(--cm-constant, #aaa);
+  color: var(--cm-constant, #e0b070);
 }
 
 .diff-syntax .hljs-regexp {
-  color: var(--cm-regexp, #999);
+  color: var(--cm-regexp, #e59a72);
 }
 
 .diff-syntax .hljs-property {
-  color: var(--cm-property, #b3b3b3);
+  color: var(--cm-property, #c8c8c8);
 }
 
 .diff-syntax .hljs-meta {
-  color: var(--cm-meta, #777);
+  color: var(--cm-meta, #d9b47a);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -400,7 +400,7 @@
     border: none;
   }
   .cm-activeLineGutter {
-    color: var(--cm-active-gutter-fg, #777);
+    color: var(--cm-active-gutter-fg, #d4d4d4);
     background-color: transparent;
   }
   .cm-activeLine {
@@ -413,7 +413,7 @@
   }
   .cm-cursor,
   .cm-dropCursor {
-    border-left-color: var(--cm-caret, #b3b3b3);
+    border-left-color: var(--cm-caret, #d4d4d4);
     border-left-width: 2px;
   }
   .cm-matchingBracket {
@@ -423,7 +423,7 @@
   .cm-foldPlaceholder {
     background-color: var(--cm-fold-bg, #1a1a1a);
     border: 1px solid var(--cm-fold-border, #2a2a2a);
-    color: var(--cm-fold-fg, #555);
+    color: var(--cm-fold-fg, #8a8a8a);
   }
 
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -374,27 +374,29 @@
 
      These rules sit at the same specificity as the runtime injection so they
      always win when the runtime fails, and harmlessly co-exist when it
-     succeeds. Match colors with `atlasTheme` in editor-panel.tsx. */
+     succeeds. Every fallback hex mirrors the `atlas` theme in
+     `features/editor/themes/themes.ts` — keep the two in step. */
   .cm-editor {
     background-color: var(--cm-bg, #000);
-    color: var(--cm-fg, #b3b3b3);
+    color: var(--cm-fg, #d4d4d4);
     /* `font-size` + `line-height` live on the editor so both .cm-content
        and .cm-gutters measure the SAME row height — CodeMirror reads the
        computed line-height off the content via ResizeObserver to position
        the gutter elements; forcing different metrics on `.cm-content`
        alone desyncs the gutter, leaving line numbers stranded at the top
-       while text sits further down. Keep them at the editor root. */
+       while text sits further down. Keep them at the editor root, and in
+       step with the metrics in `themes/build-cm-theme.ts`. */
     font-family: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
-    font-size: 14px;
-    line-height: 18px;
+    font-size: 13px;
+    line-height: 20px;
   }
   .cm-content {
-    color: var(--cm-fg, #b3b3b3);
-    caret-color: var(--cm-caret, #b3b3b3);
+    color: var(--cm-fg, #d4d4d4);
+    caret-color: var(--cm-caret, #d4d4d4);
   }
   .cm-gutters {
     background-color: var(--cm-gutter-bg, #000);
-    color: var(--cm-gutter-fg, #222);
+    color: var(--cm-gutter-fg, #666);
     border: none;
   }
   .cm-activeLineGutter {


### PR DESCRIPTION
Closes #75.

The editor opened source files looking unhighlighted. There were two independent causes, plus a palette that was hard to read once highlighting did work.

## 1. Languages that claimed a grammar they never had

`editor-store.ts` mapped `.sh`/`.zsh`/`.bash`, `.rb`, `.swift` and `.kt` to language ids — `"shell"`, `"ruby"`, `"swift"`, `"kotlin"` — that the loader `switch` in `editor-panel.tsx` never handled. The buffer reported a language, CodeMirror got no grammar, and the file rendered as flat text.

The table and the loaders now live in one registry (`features/editor/lib/languages.ts`), where the extension map is typed against the loaders' own keys:

```ts
const LANGUAGE_LOADERS = { typescript: …, rust: … } satisfies Record<string, LanguageLoader>;
type LanguageId = keyof typeof LANGUAGE_LOADERS;
export const EXTENSION_LANGUAGE: Record<string, LanguageId | typeof PLAINTEXT> = { … };
```

Mapping an extension to a language with no loader is now a compile error:

```
src/features/editor/lib/languages.ts(184,3): error TS2322:
Type '"ruby"' is not assignable to type 'EditorLanguage'.
```

`bun run typecheck` is already a CI job, so that is the guard, and it needed no new tooling.

Extensions Atlas can't parse are **listed** as plaintext with the reason, rather than falling through silently — the distinction between a decision and an oversight is the whole bug.

**`.toml` note.** It previously resolved to `"toml"` and borrowed `@codemirror/lang-yaml`. That looks like a regression here, so I checked it rather than argued it: rendering a real `Cargo.toml` through `yaml()` is **pixel-identical** to rendering it as plaintext, comment lines included — the grammars disagree structurally (`[table]` is a YAML flow *sequence*; `k = v` is not a YAML mapping), so the parse fails and nothing gets tagged. Nothing is lost by labelling it honestly.

**Shell, Ruby, Swift, Kotlin and TOML can all highlight properly with `@codemirror/legacy-modes`** (a `StreamLanguage` grammar each, lazily imported). CONTRIBUTING asks that new top-level dependencies be agreed in the issue first, so I've left them degrading honestly instead of adding it unilaterally. **Happy to add it in this PR if you want it** — it's a one-file change now that the registry exists.

## 2. Markdown parsed fine and still rendered flat

`buildHighlightStyle` only mapped code tags. A `HighlightStyle` colors *only* the tags it names, so every prose tag `@codemirror/lang-markdown` emits — heading, strong, emphasis, link, inline code, quote, list — fell through to the plain foreground. A `.md` file was indistinguishable from one with no grammar at all. Those rules now exist. (I found this from the screenshot, not from reading the code.)

## 3. The default palette

Comments were `#555555` and keywords `#585858` on black: **2.82:1 and 2.95:1**, both under 3:1, and a shade apart from each other. Most other tokens sat bunched between 9:1 and 13:1 with no hue separation, so highlighted code read as grey text.

`atlas` is retuned so every syntax token clears **4.5:1** against the interface base, with token families far enough apart to actually read as highlighted code. The `#ffff00` function accent stays.

The previous monochrome look is preserved as a selectable **`atlas-mono`**, with its ramp spread over readable lightnesses instead of bunched at the bottom — so nobody who liked the old editor loses it.

**This is a UI change, and CONTRIBUTING asks for a design pass in the issue first.** I've built it so the decision is easy to reverse or re-aim: if you'd rather ship monochrome as the default, it's a one-line change to `DEFAULT_EDITOR_THEME_ID`, and the palettes are just data in `themes.ts`. Say the word and I'll adjust rather than defend it.

## 4. Type metrics

14px/18px → **13px/20px**. 13px is the `--text-base` step of the Atlas scale and matches the app's other CodeMirror surface (the chat composer, already 13px/1.55); 14px read a step oversized next to every panel around it. The metrics also move to the editor root, which is where CodeMirror measures line height for gutter alignment — `globals.css` already had a comment warning about exactly that.

## Tests

The repo gained vitest on `0.2.5`, so this is covered properly — 105 new assertions, no new dependencies:

| File | Covers |
|---|---|
| `lib/languages.test.ts` | every language id resolves to a real grammar at runtime; extension detection incl. dotfiles, dotted directories, compound names, case; explicit-plaintext entries |
| `themes/build-cm-theme.test.ts` | every code **and prose** tag resolves to a style, for all 6 themes — the regression in §2 |
| `themes/themes.test.ts` | WCAG contrast floors for every theme against every interface background |
| `themes/editor-theme-swap.test.ts` | a live theme change preserves document, undo history and selection |
| `themes/css-fallbacks.test.ts` | the stylesheet `var(--cm-…, #hex)` fallbacks match the theme registry |

Two of these were written after checking they actually fail on the old code — the contrast guard trips 5 tests when the old greys are restored, and the type guard produces the error quoted above.

`css-fallbacks.test.ts` earned its place immediately: the palette lives in three places, and three fallbacks had **already drifted** in my own first commit — including `--cm-fold-fg: #555`, 2.8:1, on the code path that renders when the runtime theme injection loses its race.

## What is *not* covered

There's no screenshot infrastructure in the repo, so the visual-regression half of the acceptance criteria is a manual matrix. I ran it against a real CodeMirror mount of this branch — before/after on the same file, TypeScript / Python / Rust / CSS / JSON / YAML / Markdown / unsupported-`.sh`, and all six themes. Happy to attach the screenshots to a comment.

## Verification

- `bun run typecheck` — passes
- `bun run test` — 472 passed
- `bun run build` — passes
- Reviewed against CONTRIBUTING and the issue's acceptance criteria by two independent passes; findings from both are addressed in the second commit.

**Not verified:** I don't have macOS, so I couldn't run `bun run dev:app` and use it in a real window as the checklist asks. Everything visual above was verified against a real CodeMirror mount of this branch in a browser, which is not the same thing. Worth a look in the app before merge.
