### PR TITLE
fix(atlas-redact): collapse identical if/else-if branches (clippy)

### DIFF
--- a/crates/atlas-redact/src/credential.rs
+++ b/crates/atlas-redact/src/credential.rs
@@ -178,9 +178,13 @@ fn segments(key: &str) -> Vec<String> {
             continue;
         }
         let next_lower = chars.peek().is_some_and(|nc| nc.is_ascii_lowercase());
-        if ch.is_ascii_uppercase() && prev_lower && !current.is_empty() {
-            out.push(std::mem::take(&mut current));
-        } else if ch.is_ascii_uppercase() && prev_upper && next_lower && !current.is_empty() {
+        // Word boundary before an uppercase letter: either a lower→upper
+        // transition ("my|Key"), or the start of a new word at the tail of an
+        // uppercase run ("HTTP|Server").
+        let at_boundary = ch.is_ascii_uppercase()
+            && !current.is_empty()
+            && (prev_lower || (prev_upper && next_lower));
+        if at_boundary {
             out.push(std::mem::take(&mut current));
         }
         prev_upper = ch.is_ascii_uppercase();


### PR DESCRIPTION
There's a function that splits keys like myAPIKey into words (my, api, key). It had two separate if checks for "is this the start of a new word?" and when either one was true, they both did the exact same thing. Rust's linter (clippy) flags that as a mistake ("why write it twice?"), and CI treats linter warnings as hard failures, so the build was red.

Fix: combined the two checks into one if (with an "or") since they led to the same action anyway. No behavior change, verified against the existing 65+ test suite.

