### PR TITLE
feat(terminal): add visible stop and force-kill process control (#36)

### DIFF
--- a/crates/atlas-terminal/Cargo.lock
+++ b/crates/atlas-terminal/Cargo.lock
@@ -13,6 +13,7 @@ name = "atlas-terminal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "libc",
  "portable-pty",
  "serde",
  "tokio",

--- a/crates/atlas-terminal/Cargo.toml
+++ b/crates/atlas-terminal/Cargo.toml
@@ -9,3 +9,6 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/atlas-terminal/src/lib.rs
+++ b/crates/atlas-terminal/src/lib.rs
@@ -164,6 +164,43 @@ impl TerminalManager {
         Ok(())
     }
 
+    /// Kill the PTY's foreground job without killing the login shell. Returns
+    /// false when the shell already owns the foreground (the job exited, or the
+    /// terminal is idle), which also makes a late force-stop click race-safe.
+    pub fn kill_foreground(&self, id: &str) -> anyhow::Result<bool> {
+        let session = self
+            .sessions
+            .get(id)
+            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {}", id))?;
+
+        #[cfg(unix)]
+        {
+            let foreground = session
+                .master
+                .lock()
+                .map_err(|_| anyhow::anyhow!("terminal master mutex poisoned"))?
+                .process_group_leader();
+            let Some(pgid) = foreground_job_pgid(session.pid, foreground) else {
+                return Ok(false);
+            };
+            let result = unsafe { libc::kill(-pgid, libc::SIGKILL) };
+            if result == 0 {
+                return Ok(true);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(false);
+            }
+            return Err(error.into());
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = session;
+            anyhow::bail!("Force stopping foreground terminal jobs is unsupported on this platform")
+        }
+    }
+
     pub fn close(&mut self, id: &str) {
         self.sessions.remove(id);
     }
@@ -171,6 +208,25 @@ impl TerminalManager {
     /// PID of the session's login shell (for `cwd_of_pid`).
     pub fn pid(&self, id: &str) -> Option<u32> {
         self.sessions.get(id)?.pid
+    }
+}
+
+#[cfg(unix)]
+fn foreground_job_pgid(shell_pid: Option<u32>, foreground_pgid: Option<i32>) -> Option<i32> {
+    let pgid = foreground_pgid.filter(|pid| *pid > 0)?;
+    (shell_pid != Some(pgid as u32)).then_some(pgid)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::foreground_job_pgid;
+
+    #[test]
+    fn foreground_job_excludes_the_login_shell() {
+        assert_eq!(foreground_job_pgid(Some(42), Some(42)), None);
+        assert_eq!(foreground_job_pgid(Some(42), Some(84)), Some(84));
+        assert_eq!(foreground_job_pgid(Some(42), None), None);
+        assert_eq!(foreground_job_pgid(Some(42), Some(0)), None);
     }
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -568,6 +568,7 @@ name = "atlas-terminal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "libc",
  "portable-pty",
  "serde",
  "tokio",

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -160,6 +160,15 @@ pub async fn terminal_resize(
 }
 
 #[tauri::command]
+pub async fn terminal_kill_foreground(
+    state: State<'_, TerminalState>,
+    id: String,
+) -> Result<bool, String> {
+    let manager = state.manager.lock().await;
+    manager.kill_foreground(&id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn terminal_close(
     state: State<'_, TerminalState>,
     id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -322,6 +322,7 @@ pub fn run() {
             commands::terminal::terminal_zsh_dir,
             commands::terminal::terminal_write,
             commands::terminal::terminal_resize,
+            commands::terminal::terminal_kill_foreground,
             commands::terminal::terminal_close,
             commands::terminal::terminal_ack,
             commands::terminal::terminal_resolve_path,

--- a/src/features/terminal/components/block-terminal.tsx
+++ b/src/features/terminal/components/block-terminal.tsx
@@ -29,6 +29,7 @@ import { createTerminalKeymap } from "../lib/terminal-keymap";
 import { createPathLinkProvider } from "../lib/path-link-provider";
 import { BlockStreamParser, type TerminalBlock } from "../lib/block-parser";
 import { CommandInput, type CommandInputHandle } from "./command-input";
+import { TerminalStopControl } from "./terminal-stop-control";
 import { useTerminalStore } from "../stores/terminal-store";
 
 /** Compact git status for the input-area badge. */
@@ -486,6 +487,21 @@ export function BlockTerminal({
     if (id) void invoke("terminal_write", { id, data: [0x03] }).catch(() => {});
   }, []);
 
+  const forceStop = useCallback(async () => {
+    const id = ptyRef.current;
+    if (!id) return false;
+    return invoke<boolean>("terminal_kill_foreground", { id });
+  }, []);
+
+  const restoreBlockSurface = useCallback(() => {
+    if (!parserRef.current?.altScreen) return;
+    // A SIGKILL gives the app no chance to emit its alternate-screen leave
+    // sequence. Apply it locally so the shell prompt is visible again.
+    const leaveAltScreen = "\x1b[?1049l";
+    xtermRef.current?.write(leaveAltScreen);
+    parserRef.current.push(leaveAltScreen);
+  }, []);
+
   // Forward raw bytes to the PTY — used by the composer to feed nav keys to a
   // running interactive prompt (arrows / Tab / Esc).
   const writeRaw = useCallback((data: number[]) => {
@@ -558,7 +574,9 @@ export function BlockTerminal({
       {/* Interactive surface — overlays the block list while an alt-screen app runs. */}
       <div
         ref={xtermHostRef}
-        className="absolute inset-0 z-10 bg-[#000] px-1 py-1"
+        // Keep Atlas's footer outside the app-controlled terminal viewport so
+        // the stop control never covers top/htop clocks, menus, or editor UI.
+        className="absolute inset-x-0 top-0 bottom-[29px] z-10 bg-[#000] px-1 py-1"
         style={{
           visibility: altScreen ? "visible" : "hidden",
           pointerEvents: altScreen ? "auto" : "none",
@@ -628,22 +646,26 @@ export function BlockTerminal({
         ))}
       </div>
 
-      {/* Command input (hidden while an interactive app owns the screen).
-          min-h-[28px] + items-center matches the neighbouring panel footers /
-          the terminal pane header so the top borders line up. */}
-      {!altScreen && (
-        <div className="flex min-h-[28px] items-center gap-2 border-t border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-[5px]">
-          {busy ? (
-            <Loader2
-              size={13}
-              className="shrink-0 animate-spin text-[var(--accent-primary)]"
-            />
-          ) : (
-            <ChevronRight
-              size={13}
-              className="shrink-0 text-[var(--accent-primary)]"
-            />
-          )}
+      {/* Atlas-owned footer stays visible below both block and alternate-screen
+          modes. Keeping process controls outside the PTY viewport prevents them
+          from obscuring application content. */}
+      <div className="relative z-20 flex min-h-[29px] items-center gap-2 border-t border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-[5px]">
+        {busy || altScreen ? (
+          <Loader2
+            size={13}
+            className="shrink-0 animate-spin text-[var(--accent-primary)]"
+          />
+        ) : (
+          <ChevronRight
+            size={13}
+            className="shrink-0 text-[var(--accent-primary)]"
+          />
+        )}
+        {altScreen ? (
+          <span className="min-w-0 flex-1 truncate text-[11px] text-[var(--text-tertiary)]">
+            Interactive process
+          </span>
+        ) : (
           <CommandInput
             ref={commandInputRef}
             onSubmit={runCommand}
@@ -652,9 +674,15 @@ export function BlockTerminal({
             busy={busy}
             writeRaw={writeRaw}
           />
-          <StatusBadge cwd={cwd} git={git} />
-        </div>
-      )}
+        )}
+        <TerminalStopControl
+          active={busy || altScreen}
+          onInterrupt={interrupt}
+          onForceStop={forceStop}
+          onForceStopped={restoreBlockSurface}
+        />
+        {!altScreen && <StatusBadge cwd={cwd} git={git} />}
+      </div>
     </div>
   );
 }

--- a/src/features/terminal/components/terminal-stop-control.test.tsx
+++ b/src/features/terminal/components/terminal-stop-control.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { TerminalStopControl } from "./terminal-stop-control";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("TerminalStopControl", () => {
+  it("stays hidden without an active process", () => {
+    render(
+      <TerminalStopControl
+        active={false}
+        onInterrupt={vi.fn()}
+        onForceStop={vi.fn()}
+        onForceStopped={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("interrupts first, then offers force stop after the grace period", () => {
+    vi.useFakeTimers();
+    const onInterrupt = vi.fn();
+    render(
+      <TerminalStopControl
+        active
+        onInterrupt={onInterrupt}
+        onForceStop={vi.fn()}
+        onForceStopped={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stop process (Ctrl+C)" }),
+    );
+    expect(onInterrupt).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("button", { name: "Waiting for process to stop" }),
+    ).toBeDisabled();
+
+    act(() => vi.advanceTimersByTime(1500));
+    expect(
+      screen.getByRole("button", { name: "Force stop process" }),
+    ).toBeEnabled();
+  });
+
+  it("runs post-kill cleanup only when a foreground process was killed", async () => {
+    vi.useFakeTimers();
+    const onForceStop = vi.fn().mockResolvedValue(true);
+    const onForceStopped = vi.fn();
+    render(
+      <TerminalStopControl
+        active
+        onInterrupt={vi.fn()}
+        onForceStop={onForceStop}
+        onForceStopped={onForceStopped}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stop process (Ctrl+C)" }),
+    );
+    act(() => vi.advanceTimersByTime(1500));
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Force stop process" }),
+      );
+    });
+
+    expect(onForceStop).toHaveBeenCalledOnce();
+    expect(onForceStopped).toHaveBeenCalledOnce();
+  });
+
+  it("resets when the process exits during the interrupt grace period", () => {
+    vi.useFakeTimers();
+    const props = {
+      onInterrupt: vi.fn(),
+      onForceStop: vi.fn(),
+      onForceStopped: vi.fn(),
+    };
+    const { rerender } = render(<TerminalStopControl active {...props} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stop process (Ctrl+C)" }),
+    );
+    rerender(<TerminalStopControl active={false} {...props} />);
+    act(() => vi.advanceTimersByTime(1500));
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(props.onForceStop).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/terminal/components/terminal-stop-control.tsx
+++ b/src/features/terminal/components/terminal-stop-control.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { Loader2, OctagonX, Square } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const FORCE_STOP_DELAY_MS = 1500;
+
+type StopPhase = "ready" | "waiting" | "force" | "killing";
+
+interface TerminalStopControlProps {
+  active: boolean;
+  onInterrupt: () => void;
+  onForceStop: () => Promise<boolean>;
+  onForceStopped: () => void;
+  className?: string;
+}
+
+export function TerminalStopControl({
+  active,
+  onInterrupt,
+  onForceStop,
+  onForceStopped,
+  className,
+}: TerminalStopControlProps) {
+  const [phase, setPhase] = useState<StopPhase>("ready");
+
+  useEffect(() => {
+    if (!active) {
+      setPhase("ready");
+      return;
+    }
+    if (phase !== "waiting") return;
+    const timer = window.setTimeout(
+      () => setPhase("force"),
+      FORCE_STOP_DELAY_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [active, phase]);
+
+  if (!active) return null;
+
+  const force = phase === "force";
+  const pending = phase === "waiting" || phase === "killing";
+  const label =
+    phase === "waiting"
+      ? "Waiting for process to stop"
+      : phase === "killing"
+        ? "Force stopping process"
+        : force
+          ? "Force stop process"
+          : "Stop process (Ctrl+C)";
+
+  const stop = async () => {
+    if (!force) {
+      setPhase("waiting");
+      onInterrupt();
+      return;
+    }
+    setPhase("killing");
+    try {
+      if (await onForceStop()) onForceStopped();
+      else setPhase("ready");
+    } catch {
+      setPhase("ready");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => void stop()}
+      disabled={pending}
+      title={label}
+      aria-label={label}
+      className={cn(
+        "flex h-5 w-5 shrink-0 items-center justify-center rounded transition-colors",
+        force
+          ? "text-[var(--status-error)] hover:bg-[var(--status-error)]/10"
+          : "text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]",
+        pending && "cursor-wait",
+        className,
+      )}
+    >
+      {pending ? (
+        <Loader2 size={11} className="animate-spin" />
+      ) : force ? (
+        <OctagonX size={12} />
+      ) : (
+        <Square size={9} strokeWidth={3} fill="currentColor" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
### Summary
Closes #36

Adds a visible terminal process stop control integrated into the terminal footer, featuring two-stage escalation (soft stop `Ctrl+C` / `SIGINT` -> force kill `SIGKILL`).

### Key Changes
- **Footer UI Component (`TerminalStopControl`)**: Placed inside the terminal footer bar to avoid overlaying full-screen terminal tools (`top`, `htop`, `vim`, `less`).
- **Two-Stage Escalation**: 
  - Stage 1: Soft interrupt (`0x03` / `SIGINT`).
  - Stage 2: Automatic/click escalation to `terminal_kill_foreground` command targeting process group.
- **Backend Safety**: Rust implementation (`tcgetpgrp`) ensures child process group is terminated without killing the login shell.
- **Automated Tests**: Added component unit tests (`terminal-stop-control.test.tsx`) and verified Tauri IPC registration contract.