### PR TITLE
Port 5 main-only fixes onto 0.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
             clippy: true
           - crate: atlas-codeindex
           - crate: atlas-embed
+          - crate: atlas-git
           - crate: atlas-gitdiff
           - crate: atlas-kb-server
           - crate: atlas-memory

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4",
         "@tauri-apps/cli": "^2.11.2",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1081,7 +1082,7 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
-    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -1251,7 +1252,7 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
-    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
 
@@ -2169,9 +2170,9 @@
 
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
-    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@types/estree-jsx/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 

--- a/crates/atlas-redact/src/credential.rs
+++ b/crates/atlas-redact/src/credential.rs
@@ -165,18 +165,25 @@ fn is_credential_key(key: &str) -> bool {
 fn segments(key: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut current = String::new();
+    let mut prev_upper = false;
     let mut prev_lower = false;
-    for ch in key.chars() {
+    let mut chars = key.chars().peekable();
+    while let Some(ch) = chars.next() {
         if matches!(ch, '_' | '-' | '.') {
             if !current.is_empty() {
                 out.push(std::mem::take(&mut current));
             }
+            prev_upper = false;
             prev_lower = false;
             continue;
         }
+        let next_lower = chars.peek().is_some_and(|nc| nc.is_ascii_lowercase());
         if ch.is_ascii_uppercase() && prev_lower && !current.is_empty() {
             out.push(std::mem::take(&mut current));
+        } else if ch.is_ascii_uppercase() && prev_upper && next_lower && !current.is_empty() {
+            out.push(std::mem::take(&mut current));
         }
+        prev_upper = ch.is_ascii_uppercase();
         prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
         current.push(ch.to_ascii_lowercase());
     }
@@ -415,6 +422,20 @@ mod tests {
         assert!(spans(r#"{"password": "[REDACTED]"}"#).is_empty());
         assert!(spans(r#"{"api_key": "<your-api-key>"}"#).is_empty());
         assert!(spans(r#"{"client_secret": "changeme"}"#).is_empty());
+    }
+
+    #[test]
+    fn caps_acronym_prefix_camel_keys_are_detected() {
+        for (input, expected) in [
+            ("APIToken=hunter2xyz", "hunter2xyz"),
+            ("APISecret=hunter2xyz", "hunter2xyz"),
+            ("JWTSecret=hunter2xyz", "hunter2xyz"),
+            ("JWTToken=hunter2xyz", "hunter2xyz"),
+            ("GCPSecret=hunter2xyz", "hunter2xyz"),
+            ("DBPassword=hunter2xyz", "hunter2xyz"),
+        ] {
+            assert_eq!(spans(input), vec![expected], "missed: {input}");
+        }
     }
 
     #[test]

--- a/crates/atlas-redact/src/credential.rs
+++ b/crates/atlas-redact/src/credential.rs
@@ -178,9 +178,8 @@ fn segments(key: &str) -> Vec<String> {
             continue;
         }
         let next_lower = chars.peek().is_some_and(|nc| nc.is_ascii_lowercase());
-        if ch.is_ascii_uppercase() && prev_lower && !current.is_empty() {
-            out.push(std::mem::take(&mut current));
-        } else if ch.is_ascii_uppercase() && prev_upper && next_lower && !current.is_empty() {
+        if ch.is_ascii_uppercase() && !current.is_empty() && (prev_lower || (prev_upper && next_lower))
+        {
             out.push(std::mem::take(&mut current));
         }
         prev_upper = ch.is_ascii_uppercase();

--- a/src-tauri/src/commands/browser.rs
+++ b/src-tauri/src/commands/browser.rs
@@ -49,6 +49,15 @@ pub struct BrowserRect {
 }
 
 impl BrowserRect {
+    pub fn is_valid(&self) -> bool {
+        self.width.is_finite()
+            && self.height.is_finite()
+            && self.x.is_finite()
+            && self.y.is_finite()
+            && self.width > 0.0
+            && self.height > 0.0
+    }
+
     fn to_tauri(self) -> Rect {
         Rect {
             position: Position::Logical(LogicalPosition::new(self.x, self.y)),
@@ -207,18 +216,23 @@ pub fn browser_embed_create(
     url: String,
     rect: BrowserRect,
 ) -> Result<(), String> {
+    if !rect.is_valid() {
+        return Err(format!("invalid embed bounds: {rect:?}"));
+    }
     let url = normalize_url(&url);
     let parsed: url::Url = url.parse().map_err(|e| format!("invalid URL {url:?}: {e}"))?;
     let label = embed_label(&id);
 
     // Already exists → just reposition, show, and navigate.
     if let Some(webview) = app.get_webview(&label) {
+        tracing::debug!(id = %id, rect = ?rect, "repositioning existing embed webview");
         let _ = webview.set_bounds(rect.to_tauri());
         let _ = webview.show();
         let _ = webview.navigate(parsed);
         return Ok(());
     }
 
+    tracing::info!(id = %id, url = %url, rect = ?rect, "creating new embedded child webview (initially hidden)");
     let profile = browser_profile_dir(&app)?;
     state
         .nav
@@ -258,13 +272,14 @@ pub fn browser_embed_create(
             }
         });
 
-    window
+    let webview = window
         .add_child(
             builder,
             Position::Logical(LogicalPosition::new(rect.x, rect.y)),
             Size::Logical(LogicalSize::new(rect.width.max(1.0), rect.height.max(1.0))),
         )
         .map_err(|e| format!("failed to embed browser webview: {e}"))?;
+    let _ = webview.hide();
 
     Ok(())
 }
@@ -311,9 +326,13 @@ pub fn browser_embed_set_bounds(
     id: String,
     rect: BrowserRect,
 ) -> Result<(), String> {
+    if !rect.is_valid() {
+        return Err(format!("invalid embed bounds: {rect:?}"));
+    }
     let webview = app
         .get_webview(&embed_label(&id))
         .ok_or_else(|| "embed not found".to_string())?;
+    tracing::trace!(id = %id, rect = ?rect, "browser_embed_set_bounds");
     webview.set_bounds(rect.to_tauri()).map_err(|e| e.to_string())
 }
 
@@ -329,6 +348,7 @@ pub fn browser_embed_set_visible(
     let webview = app
         .get_webview(&embed_label(&id))
         .ok_or_else(|| "embed not found".to_string())?;
+    tracing::debug!(id = %id, visible = visible, "browser_embed_set_visible");
     if visible {
         webview.show().map_err(|e| e.to_string())
     } else {
@@ -343,6 +363,7 @@ pub fn browser_embed_destroy(
     state: tauri::State<'_, BrowserState>,
     id: String,
 ) -> Result<(), String> {
+    tracing::info!(id = %id, "destroying embedded browser webview");
     state.nav.lock().remove(&id);
     if let Some(webview) = app.get_webview(&embed_label(&id)) {
         webview.close().map_err(|e| e.to_string())?;

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -388,6 +388,12 @@ pub struct AppSettings {
     /// check won't re-prompt for exactly this version. `None` = nothing ignored.
     #[serde(default)]
     pub updater_ignored_version: Option<String>,
+    /// Chat composer send gesture. Default ON: Enter sends, Shift+Enter inserts
+    /// a newline (Slack/Discord/ChatGPT convention). OFF: only Cmd/Ctrl+Enter
+    /// sends, matching Atlas's original behavior. Cmd/Ctrl+Enter always sends
+    /// regardless of this setting. See `src/features/chat/components/chat-input.tsx`.
+    #[serde(default = "default_true")]
+    pub enter_to_send: bool,
 }
 
 fn default_true() -> bool {
@@ -435,6 +441,7 @@ impl Default for AppSettings {
             git_blame_inline: true,
             auto_update: true,
             updater_ignored_version: None,
+            enter_to_send: true,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -541,7 +541,7 @@ export function App() {
         }
         if (permissionState !== "granted") return;
         sendNotification({
-          title: `Atlas — ${sessionProjectName(acpSessionId)}`,
+          title: `Atlas: ${sessionProjectName(acpSessionId)}`,
           body: "Agent task finished.",
         });
       } catch (e) {
@@ -564,7 +564,7 @@ export function App() {
         }
         if (permissionState !== "granted") return;
         sendNotification({
-          title: `Atlas — ${sessionProjectName(acpSessionId)} needs permission`,
+          title: `Atlas: ${sessionProjectName(acpSessionId)} needs permission`,
           body: `Approve "${toolTitle}" to continue.`,
         });
       } catch (e) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { LayoutSwitcher } from "@/features/layout/components/layout-switcher";
 import { SearchOverlay } from "@/components/search-overlay";
 import { useHotkeys } from "@/hooks/use-hotkey";
 import { useLayoutStore } from "@/features/layout/stores/layout-store";
+import { useTerminalStore } from "@/features/terminal/stores/terminal-store";
 import { useProjectStore, type AppStateWire } from "@/features/project/stores/project-store";
 import { useChatStore } from "@/features/chat/stores/chat-store";
 import { listenAgents, resetAgentByAgentId } from "@/features/chat/lib/agents-api";
@@ -346,11 +347,8 @@ export function App() {
     const groupTabs = st.tabs.filter((t) => groupOf(t) === g);
     const activeTab = st.tabs.find((t) => t.id === st.activeByGroup[g]);
 
-    const focusTerminalSoon = () => {
-      // Ask the active block terminal to focus once the tab is mounted/visible.
-      requestAnimationFrame(() => {
-        window.dispatchEvent(new CustomEvent("atlas:focus-terminal"));
-      });
+    const focusTerminalSoon = (tabId: string) => {
+      useTerminalStore.getState().actions.requestTerminalFocus(tabId);
     };
 
     if (activeTab?.type === "terminal") {
@@ -368,17 +366,18 @@ export function App() {
     const existing = groupTabs.find((t) => t.type === "terminal");
     if (existing) {
       setActiveTab(existing.id);
-      focusTerminalSoon();
+      focusTerminalSoon(existing.id);
     } else {
+      const newTabId = `terminal-${Date.now()}`;
       addTab({
-        id: `terminal-${Date.now()}`,
+        id: newTabId,
         type: "terminal",
         title: "Terminal",
         closable: true,
         dirty: false,
         data: {},
       });
-      focusTerminalSoon();
+      focusTerminalSoon(newTabId);
     }
   };
   const currentProject = useProjectStore.use.currentProject();

--- a/src/features/artifacts/components/session-chat-panel.tsx
+++ b/src/features/artifacts/components/session-chat-panel.tsx
@@ -34,6 +34,7 @@ import { AtlasIcon } from "@/components/atlas-icon";
 
 import { ChatInput, type ChatInputHandle } from "@/features/chat/components/chat-input";
 import { ProviderModelPills } from "@/features/chat/components/provider-model-pills";
+import { useProjectStore } from "@/features/project/stores/project-store";
 import { CHAT_PROVIDERS } from "@/features/settings/lib/providers";
 import { useByokStore } from "@/features/settings/stores/byok-store";
 import { cn } from "@/lib/utils";
@@ -510,6 +511,7 @@ function Composer({
 }) {
   const inputRef = useRef<ChatInputHandle>(null);
   const [hasText, setHasText] = useState(false);
+  const enterToSend = useProjectStore((s) => s.settings.enterToSend);
   const ready = !!thread.provider && !!thread.model;
 
   const submit = () => {
@@ -543,6 +545,7 @@ function Composer({
           placeholder="Ask about this session…"
           onChange={(v) => setHasText(v.trim().length > 0)}
           onSubmit={submit}
+          enterToSend={enterToSend}
         />
         <div className="flex items-center justify-between gap-2 px-2 pb-2 pt-1">
           {/* The agent composer's combo, not the Memory-Chat pair. It collapses

--- a/src/features/browser/components/browser-overlay-watcher.tsx
+++ b/src/features/browser/components/browser-overlay-watcher.tsx
@@ -15,7 +15,7 @@ import { useBrowserOverlayStore } from "../stores/browser-overlay-store";
  * Deliberately NOT [role="tooltip"], so hover tooltips don't flash the browser.
  */
 const OVERLAY_SELECTOR =
-  '[role="dialog"], [role="menu"], [data-hint-overlay], [data-browser-suppress]';
+  '[role="dialog"], [role="menu"], [role="listbox"], [data-radix-popper-content-wrapper], [data-hint-overlay], [data-browser-suppress], [data-overlay], [data-modal], [data-state="open"][data-side]';
 
 export function BrowserOverlayWatcher() {
   const embedCount = useBrowserOverlayStore.use.embedCount();
@@ -42,7 +42,14 @@ export function BrowserOverlayWatcher() {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["role", "data-state", "style", "data-browser-suppress"],
+      attributeFilter: [
+        "role",
+        "data-state",
+        "style",
+        "data-browser-suppress",
+        "data-overlay",
+        "data-modal",
+      ],
     });
 
     return () => {

--- a/src/features/browser/components/browser-panel.tsx
+++ b/src/features/browser/components/browser-panel.tsx
@@ -116,6 +116,9 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
 
   const lastRectRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const stableCountRef = useRef(0);
+  /** Last visibility we actually sent to Rust, so the per-frame sync can skip
+   *  the IPC when nothing changed. `null` = nothing sent yet. */
+  const lastVisibleRef = useRef<boolean | null>(null);
 
   // ── Live: geometry + lifecycle ──────────────────────────────────────────
 
@@ -164,7 +167,14 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
         stableCountRef.current = 1;
       }
       lastRectRef.current = rect;
-      invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
+      // Only cross the IPC boundary when the geometry actually moved. This
+      // runs from a per-frame rAF loop, and `browser_embed_set_bounds` does a
+      // native `webview.set_bounds` on the Rust side — issuing it every frame
+      // burns ~60 native repositions/sec per live embed forever, since the
+      // browser is a persistent module that stays mounted across tab switches.
+      if (!isStable) {
+        invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
+      }
     } else {
       stableCountRef.current = 0;
       lastRectRef.current = null;
@@ -173,7 +183,11 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     // Require stable geometry (at least 2 consecutive checks) before showing native webview
     const isGeometryStable = rect && stableCountRef.current >= 2;
     const visible = !!isGeometryStable && !overlayOpenRef.current;
-    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
+    // Same rationale: only tell Rust when the desired visibility flips.
+    if (lastVisibleRef.current !== visible) {
+      lastVisibleRef.current = visible;
+      invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
+    }
   }, [embedId, currentRect]);
 
   const ensureLive = useCallback(
@@ -200,6 +214,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
           });
         } else {
           await invoke("browser_embed_navigate", { id: embedId, url });
+          // A later successful navigation has to retire the fallback, or one
+          // transient failure pins the panel to the error UI for the rest of
+          // the tab's life even though the embed is working again.
+          setEmbedError(null);
         }
       } catch (e) {
         const errorMsg = String(e);
@@ -281,6 +299,10 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     if (mode === "live") {
       syncVisibility();
     } else {
+      // Keep the cache in step with what Rust was actually told, otherwise the
+      // per-frame sync would think `false` was already sent and skip the
+      // re-show when the user switches back to Live.
+      lastVisibleRef.current = false;
       invoke("browser_embed_set_visible", { id: embedId, visible: false }).catch(() => {});
     }
   }, [mode, embedId, syncVisibility]);

--- a/src/features/browser/components/browser-panel.tsx
+++ b/src/features/browser/components/browser-panel.tsx
@@ -43,6 +43,30 @@ interface BrowserNav {
 
 type BrowserMode = "live" | "reader";
 
+/** Window-relative rect the native child webview is positioned to. */
+interface EmbedRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Sub-pixel geometry churn isn't worth a native reposition. */
+const RECT_EPSILON = 0.5;
+
+function rectsMatch(a: EmbedRect, b: EmbedRect): boolean {
+  return (
+    Math.abs(a.x - b.x) < RECT_EPSILON &&
+    Math.abs(a.y - b.y) < RECT_EPSILON &&
+    Math.abs(a.width - b.width) < RECT_EPSILON &&
+    Math.abs(a.height - b.height) < RECT_EPSILON
+  );
+}
+
+/** Frames of stillness before the settle loop parks itself. ~200ms at 60Hz —
+ *  long enough to ride out a CSS transition's easing tail. */
+const SETTLE_FRAMES = 12;
+
 interface BrowserPanelProps {
   tabId?: string;
   initialUrl?: string;
@@ -114,11 +138,21 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   const contentRef = useRef<HTMLDivElement>(null);
   const currentProject = useProjectStore.use.currentProject();
 
-  const lastRectRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
+  /** Previous frame's rect — drives the "geometry has settled" counter only. */
+  const prevRectRef = useRef<EmbedRect | null>(null);
   const stableCountRef = useRef(0);
-  /** Last visibility we actually sent to Rust, so the per-frame sync can skip
-   *  the IPC when nothing changed. `null` = nothing sent yet. */
+  /** Last rect we told Rust about. Deliberately SEPARATE from `prevRectRef`:
+   *  bounds are diffed against what the native webview is actually parked at,
+   *  never against the previous frame. A transition moving <0.5px/frame reads
+   *  as "unchanged" every single frame, so a previous-frame diff would let the
+   *  placeholder drift arbitrarily far while the webview never moves.
+   *  `null` = nothing sent yet, or the last send failed — either way, re-send. */
+  const sentRectRef = useRef<EmbedRect | null>(null);
+  /** Last visibility we told Rust about; `null` = unknown, so re-send. */
   const lastVisibleRef = useRef<boolean | null>(null);
+  /** Handle for the settle loop (see `pump`), or null when parked. */
+  const rafRef = useRef<number | null>(null);
+  const idleFramesRef = useRef(0);
 
   // ── Live: geometry + lifecycle ──────────────────────────────────────────
 
@@ -147,48 +181,78 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   }, []);
 
   // Single source of truth for the native webview's visibility & bounds.
-  const syncVisibility = useCallback(() => {
-    if (modeRef.current !== "live" || !createdRef.current) return;
+  // Returns true while geometry is still moving, so the settle loop knows it
+  // can't park yet.
+  const syncVisibility = useCallback((): boolean => {
+    if (modeRef.current !== "live" || !createdRef.current) return false;
     const rect = currentRect();
-    const lastRect = lastRectRef.current;
+    const prevRect = prevRectRef.current;
+    const isStable = !!rect && !!prevRect && rectsMatch(rect, prevRect);
 
-    const isStable =
-      rect &&
-      lastRect &&
-      Math.abs(rect.x - lastRect.x) < 0.5 &&
-      Math.abs(rect.y - lastRect.y) < 0.5 &&
-      Math.abs(rect.width - lastRect.width) < 0.5 &&
-      Math.abs(rect.height - lastRect.height) < 0.5;
+    // Drives the settle loop. Starts as "did it move since last frame", but a
+    // reposition also counts: a drift slower than the epsilon reads as stable
+    // every frame, and without this the loop would park mid-transition and
+    // stop tracking a still-moving element.
+    let changed = !isStable;
 
     if (rect) {
-      if (isStable) {
-        stableCountRef.current += 1;
-      } else {
-        stableCountRef.current = 1;
-      }
-      lastRectRef.current = rect;
-      // Only cross the IPC boundary when the geometry actually moved. This
-      // runs from a per-frame rAF loop, and `browser_embed_set_bounds` does a
-      // native `webview.set_bounds` on the Rust side — issuing it every frame
-      // burns ~60 native repositions/sec per live embed forever, since the
-      // browser is a persistent module that stays mounted across tab switches.
-      if (!isStable) {
-        invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
+      stableCountRef.current = isStable ? stableCountRef.current + 1 : 1;
+      prevRectRef.current = rect;
+
+      // Diffed against the last SENT rect, not the previous frame — see
+      // `sentRectRef`. Cached optimistically and invalidated on failure so a
+      // rejected call retries on the next sync instead of stranding the
+      // webview at stale bounds forever.
+      const sent = sentRectRef.current;
+      if (!sent || !rectsMatch(rect, sent)) {
+        changed = true;
+        sentRectRef.current = rect;
+        invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {
+          sentRectRef.current = null;
+        });
       }
     } else {
       stableCountRef.current = 0;
-      lastRectRef.current = null;
+      prevRectRef.current = null;
     }
 
     // Require stable geometry (at least 2 consecutive checks) before showing native webview
     const isGeometryStable = rect && stableCountRef.current >= 2;
     const visible = !!isGeometryStable && !overlayOpenRef.current;
-    // Same rationale: only tell Rust when the desired visibility flips.
     if (lastVisibleRef.current !== visible) {
       lastVisibleRef.current = visible;
-      invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
+      invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {
+        // Same self-healing rationale as bounds: without this, one swallowed
+        // rejection leaves the pane natively hidden while the cache claims
+        // it's visible, and nothing ever retries.
+        lastVisibleRef.current = null;
+      });
     }
+
+    return changed;
   }, [embedId, currentRect]);
+
+  /**
+   * Kick a short rAF burst so a CSS transition (splitter drag, panel collapse)
+   * is tracked frame-by-frame, then park once the rect holds still for
+   * `SETTLE_FRAMES`. The previous shape ran rAF unconditionally for the life of
+   * the window — and since the browser is a persistent module that survives tab
+   * switches, that was a forced layout read every frame forever, per embed.
+   */
+  const pump = useCallback(() => {
+    idleFramesRef.current = 0;
+    if (rafRef.current !== null) return; // already running; the reset above extends it
+    const step = () => {
+      const moving = syncVisibility();
+      idleFramesRef.current = moving ? 0 : idleFramesRef.current + 1;
+      if (idleFramesRef.current >= SETTLE_FRAMES) {
+        rafRef.current = null;
+        return;
+      }
+      rafRef.current = requestAnimationFrame(step);
+    };
+    rafRef.current = requestAnimationFrame(step);
+  }, [syncVisibility]);
 
   const ensureLive = useCallback(
     async (url: string) => {
@@ -209,7 +273,7 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
           setEmbedError(null);
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
-              syncVisibility();
+              pump();
             });
           });
         } else {
@@ -231,7 +295,7 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
         });
       }
     },
-    [embedId, currentRect, registerEmbed, syncVisibility],
+    [embedId, currentRect, registerEmbed, pump],
   );
 
   // Listen for Rust-owned navigation deltas for this embed.
@@ -252,36 +316,37 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     };
   }, [embedId, groupId, tabId, focusThisGroup]);
 
-  // Track geometry + visibility continuously during layout changes & transitions.
+  // Track geometry + visibility across layout changes & transitions.
+  // `mode` is a dependency because the placeholder div only exists in Live
+  // mode — a Live→Reader→Live round-trip mounts a NEW node, and without the
+  // re-run the observer would stay attached to the detached one and silently
+  // stop reporting.
   useEffect(() => {
+    if (mode !== "live") return;
     const el = placeholderRef.current;
     if (!el) return;
 
-    let animFrame: number | null = null;
-    const loop = () => {
-      syncVisibility();
-      animFrame = requestAnimationFrame(loop);
-    };
-
-    const ro = new ResizeObserver(syncVisibility);
+    const ro = new ResizeObserver(pump);
     ro.observe(el);
-    window.addEventListener("resize", syncVisibility);
-    window.addEventListener("fullscreenchange", syncVisibility);
-
-    animFrame = requestAnimationFrame(loop);
+    window.addEventListener("resize", pump);
+    window.addEventListener("fullscreenchange", pump);
+    pump();
 
     return () => {
-      if (animFrame !== null) cancelAnimationFrame(animFrame);
       ro.disconnect();
-      window.removeEventListener("resize", syncVisibility);
-      window.removeEventListener("fullscreenchange", syncVisibility);
+      window.removeEventListener("resize", pump);
+      window.removeEventListener("fullscreenchange", pump);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
     };
-  }, [syncVisibility]);
+  }, [mode, pump]);
 
   // Hide/restore the moment a DOM overlay opens or closes.
   useEffect(() => {
-    syncVisibility();
-  }, [overlayOpen, syncVisibility]);
+    pump();
+  }, [overlayOpen, pump]);
 
   // Create the embed once we have an initial URL and the placeholder is laid out.
   useEffect(() => {
@@ -297,15 +362,20 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   useEffect(() => {
     if (!createdRef.current) return;
     if (mode === "live") {
-      syncVisibility();
+      pump();
     } else {
-      // Keep the cache in step with what Rust was actually told, otherwise the
-      // per-frame sync would think `false` was already sent and skip the
-      // re-show when the user switches back to Live.
+      // Reader mode tears the placeholder out of the tree, so the next Live
+      // pass starts from scratch: drop both caches or the re-show is skipped
+      // as "already sent" and the webview never comes back.
       lastVisibleRef.current = false;
-      invoke("browser_embed_set_visible", { id: embedId, visible: false }).catch(() => {});
+      sentRectRef.current = null;
+      prevRectRef.current = null;
+      stableCountRef.current = 0;
+      invoke("browser_embed_set_visible", { id: embedId, visible: false }).catch(() => {
+        lastVisibleRef.current = null;
+      });
     }
-  }, [mode, embedId, syncVisibility]);
+  }, [mode, embedId, pump]);
 
   // Destroy the native webview when the tab closes (panel unmounts).
   useEffect(() => {
@@ -630,11 +700,9 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
                     The embedded live browser could not be native-contained in this panel area. You
                     can view in Reader mode or open in a separate window:
                   </p>
-                  {embedError && (
-                    <p className="truncate pt-1 font-mono text-[10px] text-text-tertiary">
-                      {embedError}
-                    </p>
-                  )}
+                  <p className="truncate pt-1 font-mono text-[10px] text-text-tertiary">
+                    {embedError}
+                  </p>
                 </div>
                 <div className="flex flex-col gap-2 pt-1 w-full max-w-[280px]">
                   <button

--- a/src/features/browser/components/browser-panel.tsx
+++ b/src/features/browser/components/browser-panel.tsx
@@ -110,8 +110,12 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
+  const [embedError, setEmbedError] = useState<string | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const currentProject = useProjectStore.use.currentProject();
+
+  const lastRectRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
+  const stableCountRef = useRef(0);
 
   // ── Live: geometry + lifecycle ──────────────────────────────────────────
 
@@ -124,10 +128,53 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     const el = placeholderRef.current;
     if (!el) return null;
     const r = el.getBoundingClientRect();
-    // display:none (inactive tab) collapses to 0 — treat as "hidden".
     if (r.width <= 0 || r.height <= 0) return null;
-    return { x: r.left, y: r.top, width: r.width, height: r.height };
+
+    const winW = window.innerWidth;
+    const winH = window.innerHeight;
+    const x1 = Math.max(0, Math.min(winW, r.left));
+    const y1 = Math.max(0, Math.min(winH, r.top));
+    const x2 = Math.max(0, Math.min(winW, r.right));
+    const y2 = Math.max(0, Math.min(winH, r.bottom));
+    const width = x2 - x1;
+    const height = y2 - y1;
+
+    if (width <= 0 || height <= 0 || !Number.isFinite(x1) || !Number.isFinite(y1)) return null;
+    return { x: x1, y: y1, width, height };
   }, []);
+
+  // Single source of truth for the native webview's visibility & bounds.
+  const syncVisibility = useCallback(() => {
+    if (modeRef.current !== "live" || !createdRef.current) return;
+    const rect = currentRect();
+    const lastRect = lastRectRef.current;
+
+    const isStable =
+      rect &&
+      lastRect &&
+      Math.abs(rect.x - lastRect.x) < 0.5 &&
+      Math.abs(rect.y - lastRect.y) < 0.5 &&
+      Math.abs(rect.width - lastRect.width) < 0.5 &&
+      Math.abs(rect.height - lastRect.height) < 0.5;
+
+    if (rect) {
+      if (isStable) {
+        stableCountRef.current += 1;
+      } else {
+        stableCountRef.current = 1;
+      }
+      lastRectRef.current = rect;
+      invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
+    } else {
+      stableCountRef.current = 0;
+      lastRectRef.current = null;
+    }
+
+    // Require stable geometry (at least 2 consecutive checks) before showing native webview
+    const isGeometryStable = rect && stableCountRef.current >= 2;
+    const visible = !!isGeometryStable && !overlayOpenRef.current;
+    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
+  }, [embedId, currentRect]);
 
   const ensureLive = useCallback(
     async (url: string) => {
@@ -135,23 +182,38 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       if (!rect) return;
       try {
         if (!createdRef.current) {
+          logEvent({
+            source: "atlas",
+            kind: "browser-embed",
+            summary: `Creating embedded browser child webview ${embedId} for ${url}`,
+            status: "success",
+            payload: { id: embedId, url, rect },
+          });
           await invoke("browser_embed_create", { id: embedId, url, rect });
           createdRef.current = true;
           registerEmbed();
+          setEmbedError(null);
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              syncVisibility();
+            });
+          });
         } else {
           await invoke("browser_embed_navigate", { id: embedId, url });
         }
       } catch (e) {
+        const errorMsg = String(e);
+        setEmbedError(errorMsg);
         logEvent({
           source: "atlas",
           kind: "browser-embed",
-          summary: `Failed to load ${url} in embedded browser`,
+          summary: `Failed to load ${url} in embedded browser; activating fallback`,
           status: "failure",
-          payload: { url, error: String(e) },
+          payload: { url, error: errorMsg },
         });
       }
     },
-    [embedId, currentRect, registerEmbed],
+    [embedId, currentRect, registerEmbed, syncVisibility],
   );
 
   // Listen for Rust-owned navigation deltas for this embed.
@@ -172,32 +234,29 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
     };
   }, [embedId, groupId, tabId, focusThisGroup]);
 
-  // Single source of truth for the native webview's visibility. The webview is
-  // shown only when it's Live, created, has a non-zero rect (visible tab), AND
-  // no DOM overlay is open on top of it. `set_bounds` keeps it positioned for
-  // the restore even while hidden.
-  const syncVisibility = useCallback(() => {
-    if (modeRef.current !== "live" || !createdRef.current) return;
-    const rect = currentRect();
-    if (rect) {
-      invoke("browser_embed_set_bounds", { id: embedId, rect }).catch(() => {});
-    }
-    const visible = !!rect && !overlayOpenRef.current;
-    invoke("browser_embed_set_visible", { id: embedId, visible }).catch(() => {});
-  }, [embedId, currentRect]);
-
-  // Track geometry + visibility. ResizeObserver fires both when the panel
-  // resizes AND when the tab is hidden (display:none → size 0), so it doubles
-  // as the show/hide trigger for the native overlay.
+  // Track geometry + visibility continuously during layout changes & transitions.
   useEffect(() => {
     const el = placeholderRef.current;
     if (!el) return;
+
+    let animFrame: number | null = null;
+    const loop = () => {
+      syncVisibility();
+      animFrame = requestAnimationFrame(loop);
+    };
+
     const ro = new ResizeObserver(syncVisibility);
     ro.observe(el);
     window.addEventListener("resize", syncVisibility);
+    window.addEventListener("fullscreenchange", syncVisibility);
+
+    animFrame = requestAnimationFrame(loop);
+
     return () => {
+      if (animFrame !== null) cancelAnimationFrame(animFrame);
       ro.disconnect();
       window.removeEventListener("resize", syncVisibility);
+      window.removeEventListener("fullscreenchange", syncVisibility);
     };
   }, [syncVisibility]);
 
@@ -216,8 +275,7 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
   }, [mode, initialUrl]);
 
   // Toggle the native overlay's visibility when switching Live⇄Reader, and
-  // (re)show + reposition when returning to Live. Routed through syncVisibility
-  // so it respects overlay suppression (can't re-show while a popup is open).
+  // (re)show + reposition when returning to Live.
   useEffect(() => {
     if (!createdRef.current) return;
     if (mode === "live") {
@@ -537,6 +595,51 @@ export function BrowserPanel({ tabId, initialUrl, groupId }: BrowserPanelProps) 
       {/* ── Live mode: placeholder the native webview is positioned over ── */}
       {isLive && (
         <div ref={placeholderRef} className="flex-1 relative bg-bg-base">
+          {/* Safe fallback UI when native webview containment or creation fails */}
+          {embedError && (
+            <div className="absolute inset-0 flex items-center justify-center p-6 pointer-events-auto bg-bg-base z-10">
+              <div className="flex max-w-[380px] flex-col items-center gap-4 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-border-default bg-bg-secondary">
+                  <Globe size={22} className="text-text-tertiary" />
+                </div>
+                <div className="space-y-1.5">
+                  <p className="text-sm font-medium text-text-primary">Native Embed Fallback</p>
+                  <p className="text-xs leading-relaxed text-text-tertiary">
+                    The embedded live browser could not be native-contained in this panel area. You
+                    can view in Reader mode or open in a separate window:
+                  </p>
+                  {embedError && (
+                    <p className="truncate pt-1 font-mono text-[10px] text-text-tertiary">
+                      {embedError}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2 pt-1 w-full max-w-[280px]">
+                  <button
+                    onClick={toggleReader}
+                    className="flex items-center justify-center gap-2 rounded-md bg-text-primary px-3 py-2 text-xs font-medium text-bg-base transition-opacity hover:opacity-90 cursor-pointer"
+                  >
+                    <BookOpen size={14} />
+                    Switch to Reader mode
+                  </button>
+                  <button
+                    onClick={openBrowserWindow}
+                    className="flex items-center justify-center gap-2 rounded-md border border-border-default bg-bg-secondary px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary cursor-pointer"
+                  >
+                    <AppWindow size={14} />
+                    Open in a new window
+                  </button>
+                  <button
+                    onClick={openExternal}
+                    className="flex items-center justify-center gap-2 rounded-md border border-border-default bg-bg-secondary px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary cursor-pointer"
+                  >
+                    <ExternalLink size={14} />
+                    Open in default browser
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
           {/* Shown when an overlay forces the native webview to hide — it sits
               UNDER the webview, so it's only visible while the webview is gone. */}
           {createdRef.current && overlayOpen && (

--- a/src/features/chat/components/chat-input.tsx
+++ b/src/features/chat/components/chat-input.tsx
@@ -72,8 +72,15 @@ interface ChatInputProps {
   placeholder?: string;
   /** Fires on every doc change. Receives the plain text body. */
   onChange?: (value: string) => void;
-  /** Fires on Cmd/Ctrl+Enter — the submit gesture. */
+  /** Fires on Cmd/Ctrl+Enter — the submit gesture. Also fires on bare Enter
+   *  when `enterToSend` is true. */
   onSubmit?: () => void;
+  /** When true (default), bare Enter submits and Shift+Enter inserts a
+   *  newline — the Slack/Discord/ChatGPT convention. When false, Enter
+   *  always inserts a newline and only Cmd/Ctrl+Enter submits (the old
+   *  default). Read live via ref so toggling the setting takes effect
+   *  without remounting the view. */
+  enterToSend?: boolean;
   /** Fires whenever the `@` trigger range changes (open or close). */
   onMentionTrigger?: (trigger: MentionTrigger | null) => void;
   /** Fires whenever the `/` trigger range changes (open or close). */
@@ -110,6 +117,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     placeholder = "Message Atlas... (@ to mention, / for commands)",
     onChange,
     onSubmit,
+    enterToSend = true,
     onMentionTrigger,
     onSlashTrigger,
     keyInterceptor,
@@ -131,6 +139,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
   onChangeRef.current = onChange;
   const onSubmitRef = useRef(onSubmit);
   onSubmitRef.current = onSubmit;
+  const enterToSendRef = useRef(enterToSend);
+  enterToSendRef.current = enterToSend;
   const onMentionTriggerRef = useRef(onMentionTrigger);
   onMentionTriggerRef.current = onMentionTrigger;
   const onSlashTriggerRef = useRef(onSlashTrigger);
@@ -246,6 +256,24 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
       },
     ]);
 
+    // Enter-to-send. `Prec.high` places this above lang-markdown's Enter
+    // (which would otherwise continue a bullet) but below the pickers'
+    // `Prec.highest` keymap, so Enter still confirms an open @ / # / slash
+    // selection instead of firing a send. Declaring no `shift` handler
+    // leaves Shift+Enter to fall through to plain newline insertion.
+    const enterSubmitKeymap = Prec.high(
+      keymap.of([
+        {
+          key: "Enter",
+          run: () => {
+            if (!enterToSendRef.current) return false;
+            onSubmitRef.current?.();
+            return true;
+          },
+        },
+      ]),
+    );
+
     const view = new EditorView({
       parent,
       state: EditorState.create({
@@ -269,6 +297,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
           // Soft wrap so the composer feels like a textarea.
           EditorView.lineWrapping,
           submitKeymap,
+          enterSubmitKeymap,
           keymap.of([...historyKeymap, ...defaultKeymap]),
           cmPlaceholder(placeholder),
           theme,

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -604,6 +604,9 @@ export function MessageInput({
   // sits inside the active chat panel.
   const permissionMode = useChatStore((s) => s.sessions[tabId]?.claudePermissionMode ?? "default");
   const agentType = useChatStore((s) => s.sessions[tabId]?.agentType ?? "claude-code");
+  // Settings → General → "Enter to send". Narrow selector so a toggle flip
+  // only re-renders composers, not the whole settings surface.
+  const enterToSend = useProjectStore((s) => s.settings.enterToSend);
   // `agentType` widened to a SwitchableAgent (drops "custom") for the composer
   // sub-components (skill/session scope, agent switcher) + the label lookup.
   const switchableAgent: SwitchableAgent =
@@ -1502,6 +1505,7 @@ export function MessageInput({
                 placeholder={effectivePlaceholder}
                 onChange={setValue}
                 onSubmit={submit}
+                enterToSend={enterToSend}
                 onMentionTrigger={setTrigger}
                 // The native agent has no slash commands — suppressing the
                 // trigger here (rather than showing an empty picker) keeps "/"
@@ -1606,7 +1610,7 @@ export function MessageInput({
                       : "Stop generation"
                     : mode === "queue"
                       ? "Queue message (sends after current finishes)"
-                      : "Send to agent (⌘↵)"
+                      : `Send to agent (${enterToSend ? "↵" : "⌘↵"})`
                 }
               >
                 {mode === "stop" ? (

--- a/src/features/memory/components/memory-chat-view.tsx
+++ b/src/features/memory/components/memory-chat-view.tsx
@@ -549,6 +549,7 @@ function Composer({
 
   const inputRef = useRef<ChatInputHandle>(null);
   const [hasText, setHasText] = useState(false);
+  const enterToSend = useProjectStore((s) => s.settings.enterToSend);
 
   // Local selected but model not ready → offer install instead of send.
   const needsInstall = mode === "local" && phase !== "ready";
@@ -595,6 +596,7 @@ function Composer({
             }
             onChange={(v) => setHasText(v.trim().length > 0)}
             onSubmit={submit}
+            enterToSend={enterToSend}
           />
           <div className="flex items-center justify-between gap-2 px-2 pb-2 pt-1">
             <div className="flex min-w-0 items-center gap-1.5">

--- a/src/features/model-chat/components/model-chat-panel.tsx
+++ b/src/features/model-chat/components/model-chat-panel.tsx
@@ -378,6 +378,7 @@ function Composer({
   const session = useModelChatStore((s) => s.sessions[sessionId]);
   const { setProvider, setModel } = useModelChatStore.use.actions();
   const projectPath = useProjectStore((s) => s.currentProject?.path ?? null);
+  const enterToSend = useProjectStore((s) => s.settings.enterToSend);
   const provider = session?.provider ?? "";
   const model = session?.model ?? "";
   const providerLocked = (session?.messages.length ?? 0) > 0;
@@ -510,6 +511,7 @@ function Composer({
           placeholder="Ask anything…  (@ to reference, ~ for notes)"
           onChange={(v) => setHasText(v.trim().length > 0)}
           onSubmit={submit}
+          enterToSend={enterToSend}
           onMentionTrigger={setTrigger}
           keyInterceptor={keyInterceptor}
         />

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -85,6 +85,11 @@ export interface AppSettings {
   /** A version the user chose to "Ignore" in the update prompt; the startup
    *  check won't re-prompt for exactly this version. */
   updaterIgnoredVersion: string | null;
+  /** Chat composer send gesture. true (default) = Enter sends, Shift+Enter
+   *  inserts a newline (Slack/Discord/ChatGPT convention). false = only
+   *  Cmd/Ctrl+Enter sends, bare Enter always inserts a newline (the old
+   *  default). Cmd/Ctrl+Enter always sends regardless of this setting. */
+  enterToSend: boolean;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -102,6 +107,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   gitBlameInline: true,
   autoUpdate: true,
   updaterIgnoredVersion: null,
+  enterToSend: true,
 };
 
 /**

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -247,6 +247,15 @@ function GeneralSettings() {
     <div className="space-y-6">
       <SectionTitle title="General" subtitle="Application preferences" />
       <SettingRow
+        label="Enter to send"
+        description="Enter sends your message; Shift+Enter inserts a newline — the Slack/Discord/ChatGPT convention. Turn off to restore the old behavior, where only ⌘/Ctrl+Enter sends and Enter always inserts a newline. ⌘/Ctrl+Enter always sends either way."
+      >
+        <Toggle
+          checked={settings.enterToSend}
+          onChange={(next) => updateSettings({ enterToSend: next })}
+        />
+      </SettingRow>
+      <SettingRow
         label="Auto-add .atlas to .gitignore"
         description="When you open a git-tracked project, Atlas adds `.atlas/` to the project's .gitignore (creating one if needed). Atlas keeps its caches and state in `.atlas/` — keeping it out of version control is almost always what you want. No-op on non-git projects."
       >
@@ -562,6 +571,7 @@ function UpdatesSettings() {
 }
 
 function KeybindingsSettings() {
+  const settings = useProjectStore.use.settings();
   const groups: Array<{
     title: string;
     bindings: Array<{ action: string; keys: string }>;
@@ -616,7 +626,7 @@ function KeybindingsSettings() {
       title: "Chat",
       bindings: [
         { action: "Find in chat", keys: "⌘F" },
-        { action: "Send message", keys: "⌘↵" },
+        { action: "Send message", keys: settings.enterToSend ? "↵" : "⌘↵" },
         { action: "Cycle permission mode", keys: "⇧⇥" },
       ],
     },

--- a/src/features/terminal/components/block-terminal.tsx
+++ b/src/features/terminal/components/block-terminal.tsx
@@ -90,6 +90,9 @@ function renderHL(text: string, query: string): ReactNode {
 interface BlockTerminalProps {
   isActive: boolean;
   onFocus: () => void;
+  /** The terminal tab id (layout/terminal store), used to bind pending focus
+   *  requests to the correct terminal tab. */
+  tabId: string;
   /** The layout terminal id (terminal-store), used to report busy state to the
    *  tab strip. Distinct from the internal PTY session id. */
   terminalKey: string;
@@ -132,10 +135,11 @@ const XTERM_THEME = {
  * The React command input sends lines to the shell; when an alt-screen app is
  * running, keystrokes go to xterm instead.
  */
-export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalProps) {
+export function BlockTerminal({ isActive, onFocus, tabId, terminalKey }: BlockTerminalProps) {
   const [blocks, setBlocks] = useState<TerminalBlock[]>([]);
   const [altScreen, setAltScreen] = useState(false);
   const [cwd, setCwd] = useState<string>("");
+  const [surfaceReady, setSurfaceReady] = useState(false);
   const [git, setGit] = useState<TermGit | null>(null);
   const [search, setSearch] = useState({ open: false, query: "" });
   const [matchCount, setMatchCount] = useState(0);
@@ -145,6 +149,7 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
   const parserRef = useRef<BlockStreamParser | null>(null);
   const decoderRef = useRef(new TextDecoder());
   const ptyRef = useRef<string | null>(null);
+  const focusPendingRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const commandInputRef = useRef<CommandInputHandle>(null);
   // zsh integration ZDOTDIR (for relaunching root shells with integration).
@@ -161,6 +166,9 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
   const xtermRef = useRef<import("@xterm/xterm").Terminal | null>(null);
   const fitRef = useRef<import("@xterm/addon-fit").FitAddon | null>(null);
   const xtermHostRef = useRef<HTMLDivElement>(null);
+
+  const pendingFocus = useTerminalStore((s) => s.pendingFocus);
+  const { clearPendingTerminalFocus } = useTerminalStore.use.actions();
 
   useEffect(() => {
     let disposed = false;
@@ -218,6 +226,7 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
       }
       xtermRef.current = term;
       fitRef.current = fit;
+      setSurfaceReady(true);
 
       let cols = 80;
       let rows = 24;
@@ -372,23 +381,35 @@ export function BlockTerminal({ isActive, onFocus, terminalKey }: BlockTerminalP
     if (el && !altScreen && pinnedRef.current) el.scrollTop = el.scrollHeight;
   }, [blocks, altScreen]);
 
+  const focusTerminalSurface = useCallback(() => {
+    if (!isActive) return;
+    onFocus();
+    if (altScreen) {
+      if (!surfaceReady) return;
+      xtermRef.current?.focus();
+    } else {
+      commandInputRef.current?.focus();
+    }
+  }, [altScreen, isActive, onFocus, surfaceReady]);
   // Focus the right surface: xterm while an alt-screen app runs, else the input.
   useEffect(() => {
     if (!isActive) return;
-    if (altScreen) xtermRef.current?.focus();
-    else commandInputRef.current?.focus();
-  }, [isActive, altScreen]);
+    focusTerminalSurface();
+  }, [isActive, altScreen, surfaceReady, focusTerminalSurface]);
 
   // External focus request (⌘J / focus-terminal shortcut).
   useEffect(() => {
-    const handler = () => {
-      if (!isActive) return;
-      if (parserRef.current?.altScreen) xtermRef.current?.focus();
-      else commandInputRef.current?.focus();
-    };
-    window.addEventListener("atlas:focus-terminal", handler);
-    return () => window.removeEventListener("atlas:focus-terminal", handler);
-  }, [isActive]);
+    if (!pendingFocus || pendingFocus.tabId !== tabId || !isActive) return;
+    focusPendingRef.current = true;
+  }, [isActive, pendingFocus, tabId]);
+
+  useEffect(() => {
+    if (!focusPendingRef.current) return;
+    if (!isActive || !surfaceReady) return;
+    focusTerminalSurface();
+    focusPendingRef.current = false;
+    clearPendingTerminalFocus();
+  }, [altScreen, clearPendingTerminalFocus, focusTerminalSurface, isActive, surfaceReady]);
 
   // A command is running when the live (last) block is still open. Surface it
   // as a spinner in the footer and report it to the tab strip via the store.

--- a/src/features/terminal/components/terminal-panel.tsx
+++ b/src/features/terminal/components/terminal-panel.tsx
@@ -223,6 +223,7 @@ export function TerminalPanel({ tabId }: TerminalPanelProps) {
               <BlockTerminal
                 isActive={isActiveInPane && isPaneActive}
                 terminalKey={ptyId}
+                tabId={tabId}
                 onFocus={() => {
                   setActiveTerminalInPane(tabId, pane.id, ptyId);
                   setActivePane(tabId, pane.id);

--- a/src/features/terminal/stores/terminal-store.ts
+++ b/src/features/terminal/stores/terminal-store.ts
@@ -25,11 +25,17 @@ export interface TerminalTabState {
   activePaneId: string | null;
 }
 
+interface PendingTerminalFocus {
+  tabId: string;
+  requestId: number;
+}
+
 interface TerminalState {
   tabs: Record<string, TerminalTabState>;
   /** Per-terminal "a command is running" flag, keyed by the layout terminal id.
    *  Surfaced as a spinner on the tab strip; the BlockTerminal reports it. */
   busy: Record<string, boolean>;
+  pendingFocus: PendingTerminalFocus | null;
 }
 
 interface TerminalActions {
@@ -42,6 +48,8 @@ interface TerminalActions {
     setActiveTerminalInPane: (tabId: string, paneId: string, ptyId: string) => void;
     setActivePane: (tabId: string, paneId: string) => void;
     setTerminalBusy: (ptyId: string, busy: boolean) => void;
+    requestTerminalFocus: (tabId: string) => void;
+    clearPendingTerminalFocus: () => void;
     /** Drop several terminal tabs (used when a workspace is DISCARDED). PTYs
      *  are already closed by the BlockTerminal unmount; this frees the trees. */
     removeTabs: (tabIds: string[]) => void;
@@ -108,6 +116,7 @@ export const useTerminalStore = createSelectors(
     immer((set, get) => ({
       tabs: {},
       busy: {},
+      pendingFocus: null,
       actions: {
         initTab: (tabId) => {
           if (get().tabs[tabId]) return;
@@ -225,6 +234,17 @@ export const useTerminalStore = createSelectors(
           });
         },
 
+        requestTerminalFocus: (tabId) => {
+          set((s) => {
+            s.pendingFocus = { tabId, requestId: (s.pendingFocus?.requestId ?? 0) + 1 };
+          });
+        },
+
+        clearPendingTerminalFocus: () => {
+          set((s) => {
+            s.pendingFocus = null;
+          });
+        },
         removeTabs: (tabIds) =>
           set((s) => {
             for (const id of tabIds) delete s.tabs[id];


### PR DESCRIPTION
## Summary

Ports 5 commits that landed on `main` as standalone PRs but never made it onto `0.2.5`, which has diverged significantly (80+ commits) since. This closes that gap so the eventual `0.2.5` → `main` release merge doesn't drop or conflict on them.

- `500c12c` → credential all-caps acronym detection (clean port)
- `7a99051` → avoid em dashes in notification titles (hand-adapted to `0.2.5`'s `sessionProjectName` refactor)
- `9130c35` → enforce native webview containment and geometry stability (adapted; also fixes a real latent bug — `WebviewBuilder::visible()` doesn't exist in tauri 2.11.1, replaced with `.hide()` on the created `Webview` handle)
- `563dfdc` → deterministic focus mechanism for terminals instead of a race
- `ce8bcdd` → configurable chat send keybinding

Plus 2 follow-up commits from an internal review pass on the port itself, both fixing bugs the port introduced in `browser-panel.tsx` (not pre-existing on either `main` or `0.2.5`):
- an unconditional per-frame native IPC loop (~120 calls/sec per open browser tab)
- two correctness bugs in that first fix: diffing against the wrong cached rect, and caches not invalidating on a failed `invoke()`

**Deliberately left out:** PRs #88 (right-align chat messages) and #89 (loading indicator while chat starts) — both are chat-rendering changes, and `0.2.5` has had significant, deliberate performance rework in that area since. Porting old logic in risked clobbering that work for cosmetic gain.

**Known accepted issue, not introduced by this branch:** the browser webview containment fix does not fully resolve webview-renders-outside-panel in practice. Confirmed this is pre-existing — `0.2.5`'s base had zero containment logic before this port, so nothing here is a regression. Tracked as follow-up, not blocking.

This branch was also rebased onto `0.2.5`'s latest 3 commits (chat composer/opencode fix, opencode path enrichment, new `atlas-git` crate) after those landed mid-port; one conflict in `message-input.tsx` (disabled-state wrapper vs. the new `enterToSend` prop) resolved by keeping both.

## Test plan

- [x] `bun run lint` / `bun run format:check` / `bunx tsc --noEmit` / `cd src-tauri && cargo check` all pass
- [x] Independent Standards + Spec review of the full diff against `0.2.5` (no correctness regressions found; minor cleanup opportunities noted, not blocking)
- [x] Manual verification of credential redaction, notification titles, terminal focus, and chat send keybinding across all 4 chat surfaces
- [ ] Browser containment remains known-broken (webview can render outside its panel) — pre-existing, tracked separately