### PR TITLE
chore: group dependabot updates and stop major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,148 +3,61 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      # One PR for the whole JS dependency set rather than one per package.
+      # The frontend is only meaningfully verifiable as a whole anyway — a
+      # bundler or plugin bump is judged by whether the packaged app still
+      # renders, not by whether one package resolved.
+      javascript:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Belt and braces. The wildcard semver-major ignore above did not hold
+      # for this ecosystem on the 2026-08-10 run — it opened vite 6 -> 8,
+      # typescript 5 -> 7, @vitejs/plugin-react 4 -> 6, immer 10 -> 11 and
+      # lucide-react 0.468 -> 1.30. The four below are named explicitly so that
+      # a repeat is impossible regardless of why the wildcard was skipped.
+      #
+      # lucide-react is deliberately not pinned here: an icon rename fails as a
+      # red typecheck, so CI catches it and the update is worth taking. The
+      # four below are the ones whose breakage is invisible to CI. Per the
+      # `dedupe` note in vite.config.ts, a duplicated @codemirror/* or
+      # pdfjs-dist in the production bundle silently breaks editor theming and
+      # PDF rendering while lint, typecheck, `bun run build` and `bun run dev`
+      # all stay green. A major on any of these needs `bun run build:app` and a
+      # real window, so it should never arrive as an unattended bot PR.
+      - dependency-name: "vite"
+      - dependency-name: "@vitejs/plugin-react"
+      - dependency-name: "typescript"
+      - dependency-name: "immer"
 
   # Every crates/* crate is a standalone package with its own Cargo.lock, not a
-  # workspace member — Dependabot doesn't discover them recursively from
-  # src-tauri, so each one needs its own entry. Limit kept low per-directory
-  # since a shared dep bump (e.g. a cersei-* pin) can fire across several of
-  # these at once.
+  # workspace member. Dependabot sees 16 unrelated projects that happen to share
+  # dependencies, so before grouping, one tokio release meant six near-identical
+  # PRs — the 2026-08-10 run opened 36 Cargo PRs covering 13 distinct crates.
+  #
+  # `directories` (plural) takes a glob where `directory` does not, so the whole
+  # tree is one entry instead of sixteen, and new crates are picked up without a
+  # config edit. atlas-git had already been missed by the old per-crate list.
+  #
+  # `group-by: dependency-name` is what collapses the fan-out: one PR per
+  # dependency spanning every crate that uses it, which also keeps shared pins
+  # in lockstep instead of letting crates drift apart between merges.
   - package-ecosystem: "cargo"
-    directory: "/src-tauri"
+    directories:
+      - "/src-tauri"
+      - "/crates/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-acp"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-agentkit"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-agents"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-bus"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-cersei"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-checkpoint"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-codeindex"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-embed"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-gitdiff"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-kb-server"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-memory"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-redact"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-review"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "cargo"
-    directory: "/crates/atlas-terminal"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
+    groups:
+      rust:
+        group-by: dependency-name
+        update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -152,7 +65,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## What

Dependabot's first scheduled run (2026-08-10) opened **41 PRs and 41 branches** in one go, burying the five open human PRs (#91, #95, #96, #97, #98). This collapses the config from **17 update entries to 3**.

## Why it happened

**Fan-out.** `crates/*` are standalone packages with their own `Cargo.lock`, not workspace members, so the config listed each one separately. Dependabot sees 16 unrelated projects that happen to share dependencies. One tokio release became six PRs:

| dependency | PRs opened |
|---|---|
| tokio 1.52.3 → 1.53.1 | 6 |
| serde 1.0.228 → 1.0.229 | 6 |
| serde_json 1.0.150 → 1.0.151 | 4 |
| async-trait 0.1.89 → 0.1.91 | 4 |
| anyhow 1.0.102 → 1.0.104 | 3 |

23 of the 41 were five dependencies replayed per crate. Ten of the seventeen directories also hit their PR limit exactly, so more were queued behind them.

**The major-version ignore didn't hold for `bun`.** All 36 Cargo PRs were patch/minor as configured, but the JS entry let through `vite` 6 → 8 (#104), `typescript` 5 → 7 (#122), `@vitejs/plugin-react` 4 → 6 (#113), `immer` 10 → 11 (#109) and `lucide-react` 0.468 → 1.30 (#106). I don't have the Dependabot job logs, so I can't say why the wildcard was skipped for that one ecosystem — the fix doesn't depend on knowing.

## Changes

- **One Cargo entry instead of sixteen**, using `directories` with a glob (`directory` doesn't support globbing). Picks up `atlas-git`, which the hand-maintained list had missed.
- **`group-by: dependency-name`** so one dependency is one PR spanning every crate that uses it. Also keeps shared pins in lockstep instead of letting crates drift between merges.
- **Grouped** the bun and github-actions entries the same way.
- **Monthly** instead of weekly on all three.
- **Four packages named explicitly in `ignore`** — `vite`, `@vitejs/plugin-react`, `typescript`, `immer` — so a major can't arrive unattended regardless of why the wildcard was skipped.

`lucide-react` is deliberately *not* pinned: an icon rename fails as a red typecheck, so CI catches it and the update is worth taking.

## Why those four

They're the ones whose breakage is invisible to CI. Per the `dedupe` note in `vite.config.ts` and CLAUDE.md, a duplicated `@codemirror/*` or `pdfjs-dist` in the production bundle silently breaks editor theming and PDF rendering while lint, typecheck, `bun run build` and `bun run dev` all stay green. A bundler major is exactly what perturbs module resolution and chunk splitting. Those need `bun run build:app` and a real window, which is not something a bot PR can attest to.

`vite` and `@vitejs/plugin-react` are additionally coupled — they have to move together, and each PR is green in isolation while the pair may not be.

## Base branch

Targets `main` rather than `0.2.6`. Dependabot only reads `dependabot.yml` from the default branch, so on a version branch this would have no effect until release — and the noise continues until then. Small standalone fix per the `CONTRIBUTING.md` carve-out.

## Effect

Next run: at most 3 + 5 + 3 PRs, most months far fewer, and no unattended majors.

## Verification

- [x] `dependabot.yml` parses as valid YAML (`js-yaml`), 3 entries resolve as intended
- [ ] Confirmed by the next scheduled run — config changes can't be tested before merge