### PR TITLE
chore: disable dependabot version updates for the bun ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,39 +1,42 @@
 version: 2
 updates:
+  # Version updates are OFF for this ecosystem. `open-pull-requests-limit: 0`
+  # is the documented way to disable them for a single package manager;
+  # security update PRs are exempt from the limit and still arrive, which is
+  # the only part we actually need to be automatic.
+  #
+  # This is a workaround for a real defect, not a statement that JS deps do not
+  # matter. The wildcard `version-update:semver-major` ignore below does not
+  # hold for the bun ecosystem. On 2026-08-10 it let through vite 6 -> 8,
+  # typescript 5 -> 7, @vitejs/plugin-react 4 -> 6, immer 10 -> 11 and
+  # lucide-react 0.468 -> 1.30; after those five were closed and the ignore was
+  # made explicit per package, the very next run opened react-resizable-panels
+  # 2 -> 4 (#146). Six majors through this entry against zero through 38 Cargo
+  # PRs on the same config. Naming packages individually cannot work, because
+  # the next major is always a package nobody has listed yet.
+  #
+  # It matters more here than it would elsewhere because JS breakage in this
+  # repo is invisible to CI. Per the `dedupe` note in vite.config.ts, a
+  # duplicated @codemirror/* or pdfjs-dist in the production bundle silently
+  # breaks editor theming and PDF rendering while lint, typecheck, `bun run
+  # build` and `bun run dev` all stay green. An unattended bot PR cannot attest
+  # to the one thing that would catch it: `bun run build:app` and a real
+  # window. Frontend deps therefore move deliberately, in their own PRs.
+  #
+  # Revisit if Dependabot's bun support starts honouring ignore.update-types —
+  # at that point restore the limit and the group below and delete this note.
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     groups:
-      # One PR for the whole JS dependency set rather than one per package.
-      # The frontend is only meaningfully verifiable as a whole anyway — a
-      # bundler or plugin bump is judged by whether the packaged app still
-      # renders, not by whether one package resolved.
       javascript:
         patterns: ["*"]
         update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      # Belt and braces. The wildcard semver-major ignore above did not hold
-      # for this ecosystem on the 2026-08-10 run — it opened vite 6 -> 8,
-      # typescript 5 -> 7, @vitejs/plugin-react 4 -> 6, immer 10 -> 11 and
-      # lucide-react 0.468 -> 1.30. The four below are named explicitly so that
-      # a repeat is impossible regardless of why the wildcard was skipped.
-      #
-      # lucide-react is deliberately not pinned here: an icon rename fails as a
-      # red typecheck, so CI catches it and the update is worth taking. The
-      # four below are the ones whose breakage is invisible to CI. Per the
-      # `dedupe` note in vite.config.ts, a duplicated @codemirror/* or
-      # pdfjs-dist in the production bundle silently breaks editor theming and
-      # PDF rendering while lint, typecheck, `bun run build` and `bun run dev`
-      # all stay green. A major on any of these needs `bun run build:app` and a
-      # real window, so it should never arrive as an unattended bot PR.
-      - dependency-name: "vite"
-      - dependency-name: "@vitejs/plugin-react"
-      - dependency-name: "typescript"
-      - dependency-name: "immer"
 
   # Every crates/* crate is a standalone package with its own Cargo.lock, not a
   # workspace member. Dependabot sees 16 unrelated projects that happen to share


### PR DESCRIPTION
## The defect

The wildcard `version-update:semver-major` ignore **does not hold for the `bun` ecosystem**.

#145 named `vite`, `@vitejs/plugin-react`, `typescript` and `immer` explicitly after the 2026-08-10 run let those majors through. The very next run, against the merged config, opened **#146 — `react-resizable-panels` 2.1.9 → 4.12.2** (manifest spec is `^2`).

| ecosystem | PRs on this config | semver-major leaked |
|---|---|---|
| `bun` | 6 | **6** |
| `cargo` | 38 | 0 |

Same `ignore` block on both entries. Zero leaked through Cargo, all six through bun — so the wildcard isn't being *applied* here rather than being mis-specified. I don't have the Dependabot job logs to confirm the mechanism, and the fix doesn't depend on it.

Naming packages individually can't work: the next major is always a package nobody has listed yet.

## The fix

`open-pull-requests-limit: 0` on the bun entry. Per the [options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference), this is the documented way to disable version updates for one package manager, and **security update PRs are exempt from the limit** — so vulnerability fixes still arrive automatically. Only routine version bumps stop.

The `groups` and `ignore` blocks are left in place, unused, so this is a one-line revert once bun support honours `ignore.update-types`.

Cargo and github-actions are untouched.

## Why this is the right trade here specifically

JS breakage in this repo is invisible to CI. Per the `dedupe` note in `vite.config.ts` and CLAUDE.md, a duplicated `@codemirror/*` or `pdfjs-dist` in the production bundle silently breaks editor theming and PDF rendering while lint, typecheck, `bun run build` and `bun run dev` all stay green. The only check that catches it is `bun run build:app` and a real window — which no unattended bot PR can attest to.

So the frontend was never going to be safely auto-updatable in this repo regardless of the bug. Losing routine JS bump PRs costs little; being unable to stop majors costs a maintainer closing them by hand every month.

**The tradeoff, stated plainly:** JS minor/patch updates will now drift until someone bumps them deliberately. That's the real cost, and it's accepted knowingly.

## Meanwhile, the Cargo grouping from #145 works

The two grouped PRs the new config produced:

- **#148** — tokio across **10** `Cargo.lock` files in one PR (previously 6 separate PRs)
- **#147** — agent-client-protocol across **5** crates in one PR

Dependabot names a grouped PR after its first directory, so the titles read `in /crates/atlas-acp` while the diffs span every affected crate.

## Verification

- [x] Parses as valid YAML
- [x] Validates against the official SchemaStore Dependabot v2 schema (`ajv`), and `open-pull-requests-limit` is a schema-known key rather than silently tolerated
- [ ] Confirmed by the next scheduled run — config changes can't be tested before merge