### PR TITLE
Slash picker on ACP advertisement, retire inline skill mentions, converge skills store

### DIFF
--- a/src-tauri/src/commands/compose_prompt.rs
+++ b/src-tauri/src/commands/compose_prompt.rs
@@ -58,23 +58,10 @@ pub enum MentionSpec {
         #[serde(default)]
         inline_body: Option<String>,
     },
-    /// A reusable procedure invoked with `#skill:<name>`. The body is the
-    /// `SKILL.md` minus its frontmatter — inlined as a context block so it
-    /// rides the same delivery rail as every other mention and reaches any
-    /// ACP agent (no native-skills folder required). Mirrors `Knowledge`:
-    /// the frontend pre-fills `inline_body` via `skills_read` (already
-    /// frontmatter-stripped); `file_path` is the read fallback.
-    Skill {
-        id: String,
-        display_name: String,
-        file_path: String,
-        #[serde(default)]
-        inline_body: Option<String>,
-    },
     /// A pack-delivered component invoked with `#<kind>:<name>` — `command`,
-    /// `agent`, or `rule`. Like `Skill`, its body (frontmatter stripped) is
-    /// inlined as a context block so it reaches any ACP agent. The frontend
-    /// pre-fills `inline_body`; `file_path` is the read fallback.
+    /// `agent`, or `rule`. Its body (frontmatter stripped) is inlined as a
+    /// context block so it reaches any ACP agent. The frontend pre-fills
+    /// `inline_body`; `file_path` is the read fallback.
     Component {
         id: String,
         display_name: String,
@@ -117,8 +104,8 @@ pub enum MentionSpec {
     },
     /// A whole past agent session's transcript, referenced with
     /// `@session:<title>`. The frontend pre-reads + formats the JSONL
-    /// transcript into `inline_body` (like `Skill`); there is no Rust read
-    /// fallback since formatting a transcript lives on the JS side.
+    /// transcript into `inline_body` (like `Component`); there is no Rust
+    /// read fallback since formatting a transcript lives on the JS side.
     PastSession {
         id: String,
         display_name: String,
@@ -135,7 +122,6 @@ impl MentionSpec {
             | MentionSpec::Folder { id, .. }
             | MentionSpec::Symbol { id, .. }
             | MentionSpec::Knowledge { id, .. }
-            | MentionSpec::Skill { id, .. }
             | MentionSpec::Component { id, .. }
             | MentionSpec::Repo { id, .. }
             | MentionSpec::Workspace { id, .. }
@@ -152,7 +138,6 @@ impl MentionSpec {
             MentionSpec::Folder { display_name, .. } => format!("@folder:{display_name}"),
             MentionSpec::Symbol { display_name, .. } => format!("@symbol:{display_name}"),
             MentionSpec::Knowledge { id, .. } => format!("@note:{id}"),
-            MentionSpec::Skill { display_name, .. } => format!("#skill:{display_name}"),
             MentionSpec::Component {
                 component_kind,
                 display_name,
@@ -295,40 +280,18 @@ fn render_block(m: &MentionSpec) -> Option<String> {
                 body = clip_body(&body),
             ))
         }
-        MentionSpec::Skill {
-            file_path,
-            inline_body,
-            ..
-        } => {
-            // The frontend pre-fills `inline_body` from `skills_read` (already
-            // frontmatter-stripped). Fall back to reading the `SKILL.md` and
-            // stripping its frontmatter so the agent sees only the procedure.
-            let body = match inline_body.as_deref() {
-                Some(b) if !b.is_empty() => b.to_string(),
-                _ => read_skill_body(file_path),
-            };
-            // Lead with the frontmatter `description:` — the rich "what/when to
-            // use" text Claude Code / Codex read natively from the SKILL.md
-            // header. The inline body alone drops it, and some skills ship only a
-            // thin discovery stub as their body, so without this the agent has
-            // nothing to act on but "go find the skill".
-            Some(format!(
-                "## {sf}\n\n{lead}{body}",
-                sf = m.short_form(),
-                lead = describe_lead(file_path),
-                body = clip_body(&body),
-            ))
-        }
         MentionSpec::Component {
             file_path,
             inline_body,
             ..
         } => {
-            // Same rail as Skill: inline the component body (a command/agent/rule
-            // markdown, frontmatter stripped) so any ACP agent receives it.
+            // Inline the component body (a command/agent/rule markdown,
+            // frontmatter stripped) so any ACP agent receives it. The
+            // frontend pre-fills `inline_body`; fall back to reading the
+            // file and stripping its frontmatter otherwise.
             let body = match inline_body.as_deref() {
                 Some(b) if !b.is_empty() => b.to_string(),
-                _ => read_skill_body(file_path),
+                _ => read_component_body(file_path),
             };
             Some(format!(
                 "## {sf}\n\n{lead}{body}",
@@ -393,19 +356,19 @@ fn render_block(m: &MentionSpec) -> Option<String> {
     }
 }
 
-/// Read a `SKILL.md` and return just the procedure body, stripping a leading
-/// `---` frontmatter block. The frontend normally pre-fills the already-parsed
-/// body, so this is only the fallback path; it intentionally mirrors the
-/// minimal frontmatter handling in `commands::skills::parse_frontmatter`
-/// without depending on it.
-fn read_skill_body(path: &str) -> String {
+/// Read a component markdown file (`command`/`agent`/`rule`) and return just
+/// its body, stripping a leading `---` frontmatter block. The frontend
+/// normally pre-fills the already-parsed body, so this is only the fallback
+/// path; it intentionally mirrors the minimal frontmatter handling in
+/// `commands::skills::parse_frontmatter` without depending on it.
+fn read_component_body(path: &str) -> String {
     let Ok(raw) = std::fs::read_to_string(path) else {
-        return "(unable to read skill)".to_string();
+        return "(unable to read component)".to_string();
     };
     strip_frontmatter(&raw)
 }
 
-/// Build the optional one-line lead (the skill/component `description:`, in
+/// Build the optional one-line lead (the component `description:`, in
 /// italics) prepended to an inlined body, or empty when there's no description.
 fn describe_lead(file_path: &str) -> String {
     match std::fs::read_to_string(file_path) {
@@ -507,54 +470,11 @@ mod tests {
     }
 
     #[test]
-    fn skill_short_form_and_block_use_hash_prefix() {
-        let m = MentionSpec::Skill {
-            id: "global:review-rust-diff".into(),
-            display_name: "review-rust-diff".into(),
-            file_path: "/nonexistent/SKILL.md".into(),
-            inline_body: Some("Review the diff the way I like.".into()),
-        };
-        assert_eq!(m.short_form(), "#skill:review-rust-diff");
-        let block = render_block(&m).expect("skill renders a block");
-        // No readable file → no description lead, block is body-only.
-        assert_eq!(
-            block,
-            "## #skill:review-rust-diff\n\nReview the diff the way I like."
-        );
-    }
-
-    #[test]
     fn frontmatter_description_reads_single_line_field() {
         let raw = "---\nname: x\ndescription: \"Does a thing\"\n---\n\nbody";
         assert_eq!(frontmatter_description(raw), "Does a thing");
         assert_eq!(frontmatter_description("no frontmatter here"), "");
         assert_eq!(frontmatter_description("---\nname: x\n---\nbody"), "");
-    }
-
-    #[test]
-    fn skill_block_leads_with_description_when_file_has_one() {
-        // A stub-bodied skill (like agent-browser): the useful "what/when" text
-        // lives in the frontmatter description, which must reach the agent.
-        let dir = std::env::temp_dir().join(format!("atlas-skill-lead-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("SKILL.md");
-        std::fs::write(
-            &path,
-            "---\nname: stubby\ndescription: Use for X and Y\n---\n\nThis is a discovery stub.",
-        )
-        .unwrap();
-        let m = MentionSpec::Skill {
-            id: "global:stubby".into(),
-            display_name: "stubby".into(),
-            file_path: path.to_string_lossy().into_owned(),
-            inline_body: Some("This is a discovery stub.".into()),
-        };
-        let block = render_block(&m).expect("skill renders a block");
-        assert_eq!(
-            block,
-            "## #skill:stubby\n\n_Use for X and Y_\n\nThis is a discovery stub."
-        );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 

--- a/src-tauri/src/commands/shared_memory.rs
+++ b/src-tauri/src/commands/shared_memory.rs
@@ -58,10 +58,17 @@ pub enum EventKind {
     SessionEnd,
     TodoAdded,
     TodoDone,
-    /// A `#skill:<name>` was applied in a sent message. Recorded so cross-agent
-    /// memory reflects "this session used skill X", but intentionally invisible
-    /// — no view projection (it's a lightweight audit breadcrumb, not state).
-    SkillUsed,
+    /// Catches any kind string this build doesn't recognize — e.g. a retired
+    /// kind (like the old `skill_used`) still sitting in an existing
+    /// project's `events.jsonl`. Without this, `serde_json::from_str` fails
+    /// the WHOLE line on an unknown `kind`, `filter_map(..).ok()` drops it
+    /// silently, and if it happened to be the log's last event, the derived
+    /// `last_seq` regresses behind the true file tail — the next appended
+    /// event then reuses a `seq` still on disk. Folding this into no view
+    /// bucket (below) makes it inert either way, but at least `seq` stays
+    /// continuous across the upgrade.
+    #[serde(other)]
+    Unknown,
 }
 
 /// A new event as handed to [`SharedMemoryStore::append_event`]. `seq`/`ts` are
@@ -274,11 +281,11 @@ impl SharedState {
                 self.session_agents
                     .insert(ev.session_id.clone(), ev.agent.clone());
             }
-            EventKind::SessionEnd
-            | EventKind::TodoAdded
-            | EventKind::TodoDone
-            | EventKind::SkillUsed => {
+            EventKind::SessionEnd | EventKind::TodoAdded | EventKind::TodoDone => {
                 // Recorded in the log for audit; no view projection in MVP.
+            }
+            EventKind::Unknown => {
+                // Kept only to advance `last_seq`; no view projection.
             }
         }
     }
@@ -664,22 +671,6 @@ mod tests {
             key: key.into(),
             payload,
         }
-    }
-
-    #[test]
-    fn skill_used_is_recorded_but_not_projected() {
-        // Invisible by design: the seq advances (it's in the log) but it never
-        // surfaces in any compiled view.
-        let s = fold_events(vec![ev(
-            1,
-            EventKind::SkillUsed,
-            "",
-            serde_json::json!({ "skills": ["review-rust-diff"] }),
-        )]);
-        assert_eq!(s.last_seq, 1);
-        assert!(s.active_plan.is_none());
-        assert!(s.decisions.is_empty());
-        assert!(s.recent_changes.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1,29 +1,45 @@
 //! Skills feature — Phase 1 backend (on-disk authoring + multi-agent enable).
 //!
-//! Atlas manages agent "skills" the same way the `skills` CLI does: a single
-//! **canonical store** holds the authored `SKILL.md`, and each agent that should
-//! "see" the skill gets a **symlink** into its own skills directory. Disk *is*
-//! the state — there is no separate enable/disable file.
+//! Atlas manages agent "skills" the same way the `skills` CLI and Zed do: a
+//! single **canonical store** — `~/.agents/skills` (global) / `<project>/.agents/skills`
+//! (project) — holds the authored `SKILL.md`, and each agent that should "see"
+//! the skill gets a **symlink** into its own skills directory. Disk *is* the
+//! state — there is no separate enable/disable file. See
+//! `docs/adr/0003-agents-skills-is-the-canonical-store-acp-advertisement-is-the-picker.md`:
+//! Atlas does not run its own second store anymore, it reads/writes the same
+//! `.agents/skills` tree skills.sh and Zed already use.
 //!
 //! ```text
 //! canonical (= installed, managed by Atlas):
-//!   <root>/.atlas/skills/<name>/SKILL.md
+//!   <root>/.agents/skills/<name>/SKILL.md
 //! enablement (= symlink present, what the agent reads):
-//!   <root>/.claude/skills/<name> -> ../../.atlas/skills/<name>
+//!   <root>/.claude/skills/<name> -> ../../.agents/skills/<name>
 //! ```
 //!
 //! `<root>` is the home dir (global scope) or the project path (project scope).
 //! The agent registry is a static table for v1 (Claude Code + Codex); detection
-//! is "does the agent's config dir exist under `<root>`?".
+//! is "does the agent's config dir exist under `<root>`?". Note Codex's own
+//! *project*-scope skills dir was already `.agents/skills` before this store
+//! converged onto the same path — see [`project`]'s native-location guard.
 //!
-//! Discovery also surfaces **external** skills: real directories that live
-//! directly in an agent's skills dir (e.g. `~/.claude/skills/<name>/SKILL.md`)
-//! that Atlas did not author. These are `managed = false`; the "Make for all
-//! agents" (adopt) command copies them into the canonical store and fans them
-//! out to every detected agent via symlink.
+//! Discovery also surfaces **external** skills: real directories (or symlinks
+//! to directories, e.g. a skills.sh/Zed projection) that live directly in an
+//! agent's skills dir (e.g. `~/.claude/skills/<name>/SKILL.md`) and are not the
+//! canonical store's own entries. These are `managed = false`; the "Make for
+//! all agents" (adopt) command copies them into the canonical store and fans
+//! them out to every detected agent via symlink.
+//!
+//! A pre-convergence Atlas install may still have content sitting in the old
+//! `.atlas/skills` store; [`migrate_legacy_skills`] moves it into the new
+//! canonical store the first time it's discovered.
+//!
+//! A fourth, read-only discovery channel — [`list_plugin_skills`] — surfaces
+//! Claude Code plugin marketplace skills (`~/.claude/plugins/marketplaces/*/skills/`)
+//! purely for the Skills UI's browsing surface; they are never installable or
+//! projectable through Atlas (ADR 0003).
 //!
 //! Security: skill names are sanitized and every resolved path is verified to
-//! stay inside `<root>/.atlas/skills` so a crafted name can't escape via `..`.
+//! stay inside `<root>/.agents/skills` so a crafted name can't escape via `..`.
 //!
 //! Mirrors conventions from `byok.rs` (`#[tauri::command]` + `Result<T,String>`),
 //! `shared_memory.rs` (atomic tmp+rename writes), and `agent_memory.rs`
@@ -54,13 +70,15 @@ pub struct SkillMeta {
     pub path: String,
     /// Capability tier from the registry (default `"native-dir"`).
     pub delivery: String,
-    /// `true` when this skill exists in Atlas's canonical `.atlas/skills` store
-    /// (Atlas authored/adopted it). `false` for external skills that only exist
+    /// `true` when this skill exists in the canonical `.agents/skills` store
+    /// (Atlas authored/adopted it, or it was placed there by skills.sh/Zed/another
+    /// tool — the store is shared). `false` for external skills that only exist
     /// as a real directory inside one or more agent skills dirs.
     pub managed: bool,
     /// When this skill is *provided by an installed pack* (rather than authored
     /// in the canonical store), the originating pack name. `None` for authored
-    /// or external skills. Pack-provided skills are still `#skill:`-invokable.
+    /// or external skills. Pack-provided skills are still invokable — the
+    /// bound agent advertises them over ACP like any other skill.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pack: Option<String>,
 }
@@ -387,7 +405,7 @@ const TOOL_REGISTRY: &[ToolDef] = &[
         display_name: "Atlas",
         // The native in-process "Atlas" (cersei) agent. Enabled skills are
         // symlinked into a DEDICATED dir that only the in-process `AtlasSkillTool`
-        // reads — kept separate from `.atlas/skills` (the canonical store) so this
+        // reads — kept separate from `.agents/skills` (the canonical store) so this
         // toggle is the exclusive gate (no `~/.claude`/bundled-skill leakage). Same
         // path at both scopes (`~/.atlas/agent-skills`, `<root>/.atlas/agent-skills`).
         global_skills_dir: ".atlas/agent-skills",
@@ -452,7 +470,7 @@ fn root_for(scope: &str, project_path: Option<&str>) -> Result<PathBuf, String> 
             let path = PathBuf::from(p);
             // Lexically reject parent-dir traversal. The project root may not
             // exist yet, so we cannot canonicalize; instead refuse any `..`
-            // segment so a crafted path can't escape `.atlas/skills` later.
+            // segment so a crafted path can't escape `.agents/skills` later.
             if path.components().any(|c| matches!(c, Component::ParentDir)) {
                 return Err(
                     "invalid projectPath: parent-directory segments are not allowed".to_string(),
@@ -470,9 +488,84 @@ fn home_dir() -> Option<PathBuf> {
     dirs::home_dir().or_else(|| std::env::var_os("HOME").map(PathBuf::from))
 }
 
-/// `<root>/.atlas/skills` — the canonical (Atlas-managed) store base.
+/// `<root>/.agents/skills` — the canonical store base. This is the same
+/// `.agents/skills` layout skills.sh and Zed already read/write (ADR 0003);
+/// Atlas does not keep a separate store.
 fn skills_base(root: &Path) -> PathBuf {
+    root.join(".agents").join("skills")
+}
+
+/// `<root>/.atlas/skills` — the pre-convergence canonical store. Superseded by
+/// [`skills_base`]; only consulted by [`migrate_legacy_skills`] to move any
+/// leftover content from an Atlas install that predates the store convergence.
+fn legacy_skills_base(root: &Path) -> PathBuf {
     root.join(".atlas").join("skills")
+}
+
+/// One-time migration of anything still sitting in the pre-convergence
+/// `.atlas/skills` store into the new canonical `.agents/skills` store.
+/// Best-effort and idempotent: called on every discovery pass, but becomes a
+/// no-op as soon as the legacy dir is empty (no sentinel file needed) — on the
+/// maintainer's machine this never had content, but other users who installed
+/// skills through Atlas before the convergence do. A skill name already present
+/// in the new store wins; the legacy copy is left in place rather than
+/// clobbered. Renames when possible (same volume), copies as a fallback.
+fn migrate_legacy_skills(root: &Path) {
+    let legacy = legacy_skills_base(root);
+    let Ok(entries) = fs::read_dir(&legacy) else {
+        return;
+    };
+    let new_base = skills_base(root);
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue; // e.g. the legacy `.projections.json` ledger file
+        }
+        if !entry.path().join("SKILL.md").is_file() {
+            continue;
+        }
+        let Some(raw_name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Ok(safe_name) = sanitize_name(&raw_name) else {
+            continue;
+        };
+        let Ok(dst) = canonical_skill_dir(&new_base, &safe_name) else {
+            continue;
+        };
+        if dst.exists() {
+            continue; // new store already has this skill — don't clobber
+        }
+        if let Some(parent) = dst.parent() {
+            if fs::create_dir_all(parent).is_err() {
+                continue;
+            }
+        }
+        let src = entry.path();
+        if fs::rename(&src, &dst).is_ok() {
+            eprintln!(
+                "skills: migrated legacy skill '{safe_name}' from {} to {}",
+                src.display(),
+                dst.display()
+            );
+        } else if copy_dir_all(&src, &dst).is_ok() {
+            // Cross-device rename failed — fall back to copy, leaving the
+            // legacy copy in place (best-effort, not fatal to discovery).
+            eprintln!(
+                "skills: copied legacy skill '{safe_name}' from {} to {} (legacy copy left in place)",
+                src.display(),
+                dst.display()
+            );
+        } else {
+            // Both rename and copy failed (permissions, disk full, …) — not
+            // fatal to discovery, but worth a trace instead of vanishing
+            // silently; the skill stays in the legacy dir and migration
+            // retries on the next discovery pass.
+            eprintln!(
+                "skills: failed to migrate legacy skill '{safe_name}' from {} — left in place, will retry",
+                src.display()
+            );
+        }
+    }
 }
 
 /// Sanitize a skill name into a safe single path segment.
@@ -511,7 +604,7 @@ fn sanitize_name(name: &str) -> Result<String, String> {
 }
 
 /// Resolve the canonical skill directory for a sanitized name and verify it
-/// stays inside `<root>/.atlas/skills` (no `..` escape).
+/// stays inside `<root>/.agents/skills` (no `..` escape).
 fn canonical_skill_dir(base: &Path, safe_name: &str) -> Result<PathBuf, String> {
     let dir = base.join(safe_name);
     // The only non-base component must be exactly `safe_name`.
@@ -610,12 +703,12 @@ fn tool_has_entry(root: &Path, def: &ToolDef, scope: &str, safe_name: &str) -> b
 }
 
 /// Compute the relative symlink target from a tool's skills dir up to the
-/// canonical `<root>/.atlas/skills/<name>`. Used only for `<root>`-relative dirs
+/// canonical `<root>/.agents/skills/<name>`. Used only for `<root>`-relative dirs
 /// (the common case). For env-relocated absolute dirs we fall back to an absolute
 /// target via [`canonical_symlink_target`].
 fn relative_symlink_target(skills_dir_rel: &Path, safe_name: &str) -> PathBuf {
     let up = "../".repeat(skills_dir_rel.components().count());
-    PathBuf::from(format!("{up}.atlas/skills/{safe_name}"))
+    PathBuf::from(format!("{up}.agents/skills/{safe_name}"))
 }
 
 /// Best symlink target for a projection: relative when the tool dir is under
@@ -768,7 +861,8 @@ fn collect_files(base: &Path, dir: &Path, out: &mut Vec<(String, PathBuf)>) {
 /// the canonical hash at push time (for drift detection on copies).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct LedgerEntry {
-    /// `"symlink"` | `"copy"`.
+    /// `"symlink"` | `"copy"` | `"native"` (the tool's own skills dir IS the
+    /// canonical store at this scope — see [`project`]'s native-location guard).
     mode: String,
     /// Canonical content hash at the moment of projection.
     hash: String,
@@ -785,7 +879,7 @@ fn is_skill_kind(kind: &ComponentKind) -> bool {
     *kind == ComponentKind::Skill
 }
 
-/// `<root>/.atlas/skills/.projections.json` — one ledger per root (home for
+/// `<root>/.agents/skills/.projections.json` — one ledger per root (home for
 /// global, project for project). Map: skill → toolId → entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Ledger {
@@ -855,7 +949,7 @@ fn ledger_remove(ledger: &mut Ledger, safe_name: &str, tool_id: &str) {
 //
 // Packs own their own projection ledger (`.atlas/packs/.pack-projections.json`).
 // The Skills subsystem reads it one-directionally — never writes it — so that a
-// pack-delivered skill is a first-class, `#skill:`-invokable skill and so the
+// pack-delivered skill is a first-class skill in every listing and so the
 // Skills side never silently clobbers a projection a pack owns.
 
 /// Every skill shipped by an installed pack, as `(pack_name, safe_skill_name,
@@ -937,9 +1031,21 @@ fn project(
         return Err(format!("canonical skill not found: {safe_name}"));
     }
 
+    let link = tool_link_path(root, def, scope, safe_name);
+
+    // Store convergence (ADR 0003): Codex's own *project*-scope skills dir was
+    // already `.agents/skills`, the same path the canonical store now uses, so
+    // for that (tool, scope) pair `link` and `canonical` are the same directory.
+    // The skill already lives where the tool reads it — nothing to symlink/copy,
+    // just record it as projected.
+    if link == canonical {
+        let mut ledger = read_ledger(root);
+        ledger_record(&mut ledger, safe_name, def.id, "native", &canonical_hash);
+        return write_ledger(root, &ledger);
+    }
+
     // Non-destructive guard: if a real (non-symlink) dir already sits at the
     // target, only overwrite when the caller forces it.
-    let link = tool_link_path(root, def, scope, safe_name);
     if !force {
         if let Ok(meta) = link.symlink_metadata() {
             if !meta.file_type().is_symlink() && meta.is_dir() {
@@ -983,8 +1089,18 @@ fn project(
     write_ledger(root, &ledger)
 }
 
-/// Remove a projection (symlink or copy) and drop its ledger entry.
+/// Remove a projection (symlink or copy) and drop its ledger entry. Refuses to
+/// act on a native-location pair (see [`project`]) — `clear_entry` would delete
+/// the canonical skill itself rather than a projection of it.
 fn unproject(root: &Path, def: &ToolDef, scope: &str, safe_name: &str) -> Result<(), String> {
+    let canonical = canonical_skill_dir(&skills_base(root), safe_name)?;
+    let link = tool_link_path(root, def, scope, safe_name);
+    if link == canonical {
+        return Err(format!(
+            "cannot disable {} for '{safe_name}': its {scope}-scope skills dir is the canonical store itself",
+            def.id
+        ));
+    }
     remove_symlink(root, def, scope, safe_name)?;
     let mut ledger = read_ledger(root);
     ledger_remove(&mut ledger, safe_name, def.id);
@@ -994,10 +1110,14 @@ fn unproject(root: &Path, def: &ToolDef, scope: &str, safe_name: &str) -> Result
 // ── Core (testable, no Tauri) ──────────────────────────────────────────────────
 
 fn list_skills(root: &Path, scope: &str) -> Result<Vec<SkillMeta>, String> {
+    // One-time move of anything left in the pre-convergence `.atlas/skills`
+    // store into the new canonical `.agents/skills` store. No-op once migrated.
+    migrate_legacy_skills(root);
+
     // Keyed by the sanitized skill name so canonical + external entries dedupe.
     let mut by_name: BTreeMap<String, SkillMeta> = BTreeMap::new();
 
-    // ── 1. Canonical (managed) skills under `<root>/.atlas/skills/*`. ──────────
+    // ── 1. Canonical (managed) skills under `<root>/.agents/skills/*`. ─────────
     let base = skills_base(root);
     if let Ok(entries) = fs::read_dir(&base) {
         for entry in entries.flatten() {
@@ -1040,22 +1160,22 @@ fn list_skills(root: &Path, scope: &str) -> Result<Vec<SkillMeta>, String> {
     }
 
     // ── 2. External (unmanaged) skills living directly in each tool dir. ───────
-    // A top-level entry that is a *real directory* with its own `SKILL.md` and
-    // is NOT one of our canonical skills is an external tool skill. Symlinks
-    // resolving into the canonical store are already accounted for above, so we
-    // skip them here. Container dirs without a top-level `SKILL.md` (e.g.
-    // `~/.claude/skills/ecc/`) are skipped — no recursion (v1).
+    // A top-level entry — real directory OR symlink to one — with its own
+    // `SKILL.md` and NOT one of our canonical skills is an external tool skill.
+    // Symlinks are followed rather than rejected (ADR 0003): most of them are
+    // exactly the `.agents/skills` projections skills.sh/Zed/Atlas itself write,
+    // and those resolving into our own canonical store are already accounted for
+    // above (the `by_name.contains_key` check below skips them). Container dirs
+    // without a top-level `SKILL.md` (e.g. `~/.claude/skills/ecc/`) are skipped —
+    // no recursion (v1).
     for def in TOOL_REGISTRY {
         let dir = tool_skills_dir(def, scope, root);
         let Ok(entries) = fs::read_dir(&dir) else {
             continue;
         };
         for entry in entries.flatten() {
-            // Only real directories — skip symlinks (managed) and files.
-            let Ok(meta) = entry.path().symlink_metadata() else {
-                continue;
-            };
-            if meta.file_type().is_symlink() || !meta.is_dir() {
+            // Follow symlinks: only reject non-directories (files, broken links).
+            if !entry.path().is_dir() {
                 continue;
             }
             let skill_md = entry.path().join("SKILL.md");
@@ -1094,10 +1214,10 @@ fn list_skills(root: &Path, scope: &str) -> Result<Vec<SkillMeta>, String> {
     }
 
     // ── 3. Pack-provided skills (installed packs' `Skill` components). ─────────
-    // A skill shipped by an installed pack is a first-class, `#skill:`-invokable
-    // skill even before it is projected into a tool. Surface it here (badged with
-    // its pack) so both My Skills and the `#skill:` picker see it. An authored or
-    // external skill of the same name wins — don't downgrade it.
+    // A skill shipped by an installed pack is a first-class skill even before
+    // it is projected into a tool. Surface it here (badged with its pack) so
+    // My Skills sees it. An authored or external skill of the same name
+    // wins — don't downgrade it.
     for (pack_name, safe_name, skill_md) in pack_provided_skills(root) {
         if by_name.contains_key(&safe_name) {
             continue;
@@ -1139,7 +1259,7 @@ fn read_skill(root: &Path, name: &str) -> Result<SkillContent, String> {
     let raw = match fs::read_to_string(&skill_md) {
         Ok(raw) => raw,
         // Not in the canonical store — fall back to an installed pack that ships
-        // a skill of this name, so pack-provided skills are `#skill:`-readable.
+        // a skill of this name, so pack-provided skills are readable too.
         Err(_) => pack_skill_md(root, &safe)
             .and_then(|p| fs::read_to_string(&p).ok())
             .ok_or_else(|| format!("skill not found: {safe}"))?,
@@ -1437,6 +1557,10 @@ pub struct ReconcileView {
 /// Build the reconciled matrix for `scope`. `home` is always needed for global
 /// detection facts even when reconciling a project scope.
 fn reconcile(root: &Path, scope: &str, home: &Path) -> Result<ReconcileView, String> {
+    // Same one-time legacy migration as `list_skills` — reconcile is a discovery
+    // entry point too and is called independently of the list view.
+    migrate_legacy_skills(root);
+
     let tools: Vec<ToolInfo> = TOOL_REGISTRY
         .iter()
         .map(|def| ToolInfo {
@@ -1489,6 +1613,7 @@ fn reconcile(root: &Path, scope: &str, home: &Path) -> Result<ReconcileView, Str
     }
 
     // Pre-scan external/real dirs per tool (name → (display, desc, hash)).
+    // Follows symlinks (ADR 0003) same as `list_skills`'s external scan.
     let mut external: BTreeMap<String, BTreeMap<String, (String, String, String)>> =
         BTreeMap::new();
     for def in TOOL_REGISTRY {
@@ -1497,10 +1622,7 @@ fn reconcile(root: &Path, scope: &str, home: &Path) -> Result<ReconcileView, Str
             continue;
         };
         for entry in entries.flatten() {
-            let Ok(meta) = entry.path().symlink_metadata() else {
-                continue;
-            };
-            if meta.file_type().is_symlink() || !meta.is_dir() {
+            if !entry.path().is_dir() {
                 continue;
             }
             if !entry.path().join("SKILL.md").is_file() {
@@ -1671,7 +1793,7 @@ fn reconcile(root: &Path, scope: &str, home: &Path) -> Result<ReconcileView, Str
 // ── Freeze (CP.3 uninstall safety) ───────────────────────────────────────────────
 
 /// Convert every Atlas-authored *symlink* projection in the ledger into a real
-/// copy, so removing `~/.atlas/skills` leaves each tool with a working,
+/// copy, so removing `~/.agents/skills` leaves each tool with a working,
 /// self-contained skill dir. Idempotent (copies are left as-is).
 fn freeze(root: &Path, scope: &str) -> Result<(), String> {
     let mut ledger = read_ledger(root);
@@ -1699,8 +1821,8 @@ fn freeze(root: &Path, scope: &str) -> Result<(), String> {
 
 // ── Promote (CP.4 scenario 4) ────────────────────────────────────────────────────
 
-/// Promote a project skill to global: copy `<proj>/.atlas/skills/<name>` →
-/// `~/.atlas/skills/<name>`, then re-project into every detected tool at global
+/// Promote a project skill to global: copy `<proj>/.agents/skills/<name>` →
+/// `~/.agents/skills/<name>`, then re-project into every detected tool at global
 /// scope. The project copy is kept (the repo still travels with it).
 fn promote(project_root: &Path, home: &Path, name: &str) -> Result<SkillMeta, String> {
     let safe = sanitize_name(name)?;
@@ -1738,6 +1860,90 @@ fn promote(project_root: &Path, home: &Path, name: &str) -> Result<SkillMeta, St
         managed: true,
         pack: None,
     })
+}
+
+// ── Plugin skills (read-only fourth discovery channel, ADR 0003) ─────────────────
+//
+// Claude Code plugin marketplaces ship their own bundled skills under
+// `~/.claude/plugins/marketplaces/<marketplace>/skills/<name>/SKILL.md`. These
+// are a genuinely foreign channel: never installable, projectable, or
+// uninstallable through Atlas. They already reach the picker because the
+// *agent* advertises them over ACP — Atlas only needs to find them so the
+// Skills UI's browsing surface can show they exist. Not merged into
+// `SkillMeta`/`list_skills`: that type's `managed`/`enabled_agents` fields
+// describe things Atlas can toggle, which is exactly what these are not.
+
+/// Metadata for one read-only plugin-bundled skill.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginSkillMeta {
+    pub name: String,
+    pub description: String,
+    /// Which plugin host this came from, e.g. `"claude-code"`.
+    pub source: String,
+    /// The marketplace (or equivalent grouping) this skill was bundled in.
+    pub marketplace: String,
+    /// Absolute path to the plugin's `SKILL.md`, for display only — never
+    /// written to, never used as a projection source.
+    pub path: String,
+}
+
+/// `~/.claude/plugins/marketplaces` — each child dir is one installed
+/// marketplace; each marketplace may have a `skills/` dir of its own.
+fn claude_plugin_marketplaces_dir(home: &Path) -> PathBuf {
+    home.join(".claude").join("plugins").join("marketplaces")
+}
+
+/// Scan Claude Code's plugin marketplaces for bundled skills. Best-effort and
+/// read-only: a marketplace or skill dir that can't be read is silently
+/// skipped, never an error (this channel is informational, not authoritative).
+fn list_claude_plugin_skills(home: &Path) -> Vec<PluginSkillMeta> {
+    let mut out = Vec::new();
+    let Ok(marketplaces) = fs::read_dir(claude_plugin_marketplaces_dir(home)) else {
+        return out;
+    };
+    for marketplace_entry in marketplaces.flatten() {
+        if !marketplace_entry.path().is_dir() {
+            continue;
+        }
+        let marketplace = marketplace_entry.file_name().to_string_lossy().to_string();
+        let skills_dir = marketplace_entry.path().join("skills");
+        let Ok(entries) = fs::read_dir(&skills_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let skill_md = entry.path().join("SKILL.md");
+            let Ok(raw) = fs::read_to_string(&skill_md) else {
+                continue;
+            };
+            let (fm, _body) = parse_frontmatter(&raw);
+            let raw_name = entry.file_name().to_string_lossy().to_string();
+            out.push(PluginSkillMeta {
+                name: fm.name.unwrap_or(raw_name),
+                description: fm.description.unwrap_or_default(),
+                source: "claude-code".to_string(),
+                marketplace: marketplace.clone(),
+                path: skill_md.to_string_lossy().to_string(),
+            });
+        }
+    }
+    out.sort_by(|a, b| (&a.marketplace, &a.name).cmp(&(&b.marketplace, &b.name)));
+    out
+}
+
+// TODO(codex plugin skills): Codex's plugin directory layout is unverified —
+// `~/.codex/plugins/` exists on the maintainer's machine but contains only a
+// `cache/` dir, not a `marketplaces/*/skills` tree like Claude Code's. Add a
+// `list_codex_plugin_skills(home)` here (same read-only pattern, folded into
+// `list_plugin_skills` below) once a real Codex plugin install reveals the
+// actual layout — don't guess at a path that might be wrong.
+
+/// All plugin-bundled skills across every supported host.
+fn list_plugin_skills(home: &Path) -> Vec<PluginSkillMeta> {
+    list_claude_plugin_skills(home)
 }
 
 // ── Tauri commands ─────────────────────────────────────────────────────────────
@@ -1850,6 +2056,19 @@ pub async fn agents_list_skill_targets(
     let root = root_for(&scope, project_path.as_deref())?;
     Ok(
         tokio::task::spawn_blocking(move || list_targets(&root, &scope))
+            .await
+            .map_err(|e| e.to_string())?,
+    )
+}
+
+/// List read-only plugin-bundled skills (Claude Code plugin marketplaces today;
+/// Codex TODO) for the Skills UI's browsing surface. Never installable or
+/// projectable through Atlas — see the "Plugin skills" module section.
+#[tauri::command]
+pub async fn skills_list_plugins() -> Result<Vec<PluginSkillMeta>, String> {
+    let home = home_dir().ok_or_else(|| "could not resolve home directory".to_string())?;
+    Ok(
+        tokio::task::spawn_blocking(move || list_plugin_skills(&home))
             .await
             .map_err(|e| e.to_string())?,
     )
@@ -2683,13 +2902,29 @@ fn install_skill_from_dir(
     }
     copy_dir_all(&src_dir, &dst)?;
 
+    // Project immediately into every currently-detected agent, the way
+    // `npx skills add` does (ADR 0003) — a freshly installed skill must be
+    // visible right away, not stuck until the user finds the per-agent toggles
+    // in another tab. Same fan-out `adopt_skill`/`promote` use; the per-agent
+    // toggles remain for changing your mind later.
+    let mut enabled_agents = Vec::new();
+    for def in TOOL_REGISTRY {
+        if !tool_detected(root, def) || def.delivery == "inject-only" {
+            continue;
+        }
+        project(root, def, scope, &safe, false)?;
+        enabled_agents.push(def.id.to_string());
+    }
+    enabled_agents.sort();
+    enabled_agents.dedup();
+
     let raw = fs::read_to_string(dst.join("SKILL.md")).map_err(|e| e.to_string())?;
     let (fm, _b) = parse_frontmatter(&raw);
     Ok(SkillMeta {
         name: fm.name.unwrap_or_else(|| safe.clone()),
         description: fm.description.unwrap_or_default(),
         scope: scope.to_string(),
-        enabled_agents: Vec::new(), // not projected yet — user toggles per agent
+        enabled_agents,
         path: dst.join("SKILL.md").to_string_lossy().to_string(),
         delivery: "native-dir".to_string(),
         managed: true,
@@ -3634,15 +3869,19 @@ mod tests {
         let s = &listed[0];
         assert_eq!(s.name, "pdf-extract");
         assert_eq!(s.description, "Pull text out of PDFs");
-        assert_eq!(s.enabled_agents, vec!["claude-code".to_string()]);
+        // codex is auto-included: its project-scope skills dir IS the canonical
+        // store post-convergence (ADR 0003), so any canonical skill is already
+        // there — no explicit projection needed.
+        assert_eq!(
+            s.enabled_agents,
+            vec!["claude-code".to_string(), "codex".to_string()]
+        );
 
-        // Canonical SKILL.md exists, symlink exists for claude-code only.
-        assert!(root.join(".atlas/skills/pdf-extract/SKILL.md").is_file());
+        // Canonical SKILL.md exists, symlink exists for claude-code.
+        assert!(root.join(".agents/skills/pdf-extract/SKILL.md").is_file());
         assert!(root.join(".claude/skills/pdf-extract").symlink_metadata().is_ok());
-        assert!(root
-            .join(".agents/skills/pdf-extract")
-            .symlink_metadata()
-            .is_err());
+        // `.agents/skills/pdf-extract` IS the canonical dir above, not a separate
+        // codex projection — same path, no symlink involved.
 
         // Round-trip the body via read_skill.
         let content = read_skill(&root, "pdf-extract").unwrap();
@@ -3659,7 +3898,7 @@ mod tests {
         let link = root.join(".claude/skills/demo");
         // Following the link reaches the canonical SKILL.md.
         let resolved = fs::canonicalize(link.join("SKILL.md")).unwrap();
-        let expected = fs::canonicalize(root.join(".atlas/skills/demo/SKILL.md")).unwrap();
+        let expected = fs::canonicalize(root.join(".agents/skills/demo/SKILL.md")).unwrap();
         assert_eq!(resolved, expected);
         fs::remove_dir_all(&root).ok();
     }
@@ -3668,14 +3907,27 @@ mod tests {
     fn set_enabled_toggles_symlink() {
         let root = tmp_root();
         create_skill(&root, "project", "demo", "d", "b", &[]).unwrap();
-        let link = root.join(".agents/skills/demo");
-        assert!(link.symlink_metadata().is_err());
 
+        // claude-code has its own dir — a real toggleable symlink projection.
+        let claude_link = root.join(".claude/skills/demo");
+        assert!(claude_link.symlink_metadata().is_err());
+        set_enabled(&root, "project", "demo", "claude-code", true).unwrap();
+        assert!(claude_link.symlink_metadata().is_ok());
+        set_enabled(&root, "project", "demo", "claude-code", false).unwrap();
+        assert!(claude_link.symlink_metadata().is_err());
+
+        // codex's project-scope skills dir IS the canonical store post-
+        // convergence (ADR 0003): already "enabled" the moment the skill
+        // exists, enabling again is a no-op, and disabling is refused rather
+        // than deleting the canonical skill.
+        let codex_path = root.join(".agents/skills/demo");
+        assert!(codex_path.symlink_metadata().is_ok());
         set_enabled(&root, "project", "demo", "codex", true).unwrap();
-        assert!(link.symlink_metadata().is_ok());
-
-        set_enabled(&root, "project", "demo", "codex", false).unwrap();
-        assert!(link.symlink_metadata().is_err());
+        assert!(set_enabled(&root, "project", "demo", "codex", false).is_err());
+        assert!(
+            codex_path.join("SKILL.md").is_file(),
+            "disabling codex must not delete the canonical skill"
+        );
 
         // Toggling for an unknown agent errors.
         assert!(set_enabled(&root, "project", "demo", "nope", true).is_err());
@@ -3694,14 +3946,14 @@ mod tests {
             &["claude-code".to_string(), "codex".to_string()],
         )
         .unwrap();
-        assert!(root.join(".atlas/skills/demo").is_dir());
+        // `.agents/skills/demo` is both the canonical dir AND codex's project
+        // skills dir post-convergence (ADR 0003) — same path.
+        assert!(root.join(".agents/skills/demo").is_dir());
         assert!(root.join(".claude/skills/demo").symlink_metadata().is_ok());
-        assert!(root.join(".agents/skills/demo").symlink_metadata().is_ok());
 
         delete_skill(&root, "project", "demo").unwrap();
-        assert!(!root.join(".atlas/skills/demo").exists());
+        assert!(!root.join(".agents/skills/demo").exists());
         assert!(root.join(".claude/skills/demo").symlink_metadata().is_err());
-        assert!(root.join(".agents/skills/demo").symlink_metadata().is_err());
 
         // Listing is now empty.
         assert!(list_skills(&root, "project").unwrap().is_empty());
@@ -3734,7 +3986,7 @@ mod tests {
     fn hash_is_stable_and_detects_change() {
         let root = tmp_root();
         create_skill(&root, "project", "h", "d", "body one", &[]).unwrap();
-        let dir = root.join(".atlas/skills/h");
+        let dir = root.join(".agents/skills/h");
         let a = hash_skill_dir(&dir);
         assert_eq!(a, hash_skill_dir(&dir), "hash must be stable");
         create_skill(&root, "project", "h", "d", "body two", &[]).unwrap();
@@ -3762,11 +4014,17 @@ mod tests {
     #[test]
     fn reconcile_reports_synced_external_and_absent() {
         let root = tmp_root();
-        // Canonical skill projected into claude-code → synced; codex → absent.
+        // Canonical skill projected into claude-code → synced. codex's
+        // project-scope skills dir IS the canonical store post-convergence
+        // (ADR 0003), so it reads synced too without an explicit projection;
+        // atlas's dedicated dir is untouched → absent.
         create_skill(&root, "project", "owned", "d", "b", &[]).unwrap();
         project(&root, tool_def("claude-code").unwrap(), "project", "owned", false).unwrap();
-        // A hand-authored skill living only in codex's project dir → external.
-        plant_external(&root, ".agents/skills", "wild", "External wild");
+        // A hand-authored skill living only in claude-code's project dir →
+        // external. (Planting one in codex's project dir is no longer a
+        // distinct "external" case — that dir IS the canonical store now, so
+        // anything placed there is ordinary discovery, not reconciliation.)
+        plant_external(&root, ".claude/skills", "wild", "External wild");
 
         let view = reconcile(&root, "project", &root).unwrap();
         assert_eq!(view.tools.len(), 3); // claude-code, codex, atlas
@@ -3779,13 +4037,17 @@ mod tests {
         );
         assert_eq!(
             owned.cells.iter().find(|c| c.tool == "codex").unwrap().status,
+            "synced"
+        );
+        assert_eq!(
+            owned.cells.iter().find(|c| c.tool == "atlas").unwrap().status,
             "absent"
         );
 
         let wild = view.skills.iter().find(|s| s.name == "wild").unwrap();
         assert!(!wild.managed);
         assert_eq!(
-            wild.cells.iter().find(|c| c.tool == "codex").unwrap().status,
+            wild.cells.iter().find(|c| c.tool == "claude-code").unwrap().status,
             "external"
         );
         fs::remove_dir_all(&root).ok();
@@ -3814,7 +4076,7 @@ mod tests {
 
         let meta = promote(&proj, &home, "pr").unwrap();
         assert_eq!(meta.name, "pr");
-        assert!(home.join(".atlas/skills/pr/SKILL.md").is_file());
+        assert!(home.join(".agents/skills/pr/SKILL.md").is_file());
         fs::remove_dir_all(&home).ok();
         fs::remove_dir_all(&proj).ok();
     }
@@ -3829,13 +4091,13 @@ mod tests {
     }
 
     #[test]
-    fn canonical_base_is_under_dot_atlas() {
+    fn canonical_base_is_under_dot_agents() {
         let root = tmp_root();
-        assert_eq!(skills_base(&root), root.join(".atlas/skills"));
+        assert_eq!(skills_base(&root), root.join(".agents/skills"));
         let meta = create_skill(&root, "project", "demo", "d", "b", &[]).unwrap();
-        assert!(meta.path.contains("/.atlas/skills/demo/"));
+        assert!(meta.path.contains("/.agents/skills/demo/"));
         assert!(meta.managed);
-        assert!(root.join(".atlas/skills/demo/SKILL.md").is_file());
+        assert!(root.join(".agents/skills/demo/SKILL.md").is_file());
         fs::remove_dir_all(&root).ok();
     }
 
@@ -3906,7 +4168,7 @@ mod tests {
         );
 
         // Canonical copy now exists.
-        assert!(root.join(".atlas/skills/foo/SKILL.md").is_file());
+        assert!(root.join(".agents/skills/foo/SKILL.md").is_file());
         // The original real dir was replaced by a symlink into canonical.
         let claude_link = root.join(".claude/skills/foo");
         assert!(claude_link.symlink_metadata().unwrap().file_type().is_symlink());
@@ -3914,7 +4176,7 @@ mod tests {
         let codex_link = root.join(".codex/skills/foo");
         assert!(codex_link.symlink_metadata().unwrap().file_type().is_symlink());
         // Both resolve to the canonical SKILL.md.
-        let expected = fs::canonicalize(root.join(".atlas/skills/foo/SKILL.md")).unwrap();
+        let expected = fs::canonicalize(root.join(".agents/skills/foo/SKILL.md")).unwrap();
         assert_eq!(
             fs::canonicalize(claude_link.join("SKILL.md")).unwrap(),
             expected
@@ -3937,6 +4199,164 @@ mod tests {
             ]
         );
         fs::remove_dir_all(&root).ok();
+    }
+
+    // ── Store convergence (ADR 0003) ──────────────────────────────────────────
+
+    /// Plant a real skill dir at `real_rel`, then symlink it into an agent's
+    /// skills dir at `link_rel` — mirrors what a skills.sh/Zed projection into
+    /// `.claude/skills` looks like from Atlas's point of view.
+    fn plant_symlinked_external(root: &Path, real_rel: &str, link_rel: &str, name: &str) {
+        let real_dir = root.join(real_rel).join(name);
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::write(
+            real_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: symlinked\n---\n\nbody\n"),
+        )
+        .unwrap();
+        let link_parent = root.join(link_rel);
+        fs::create_dir_all(&link_parent).unwrap();
+        symlink(&real_dir, &link_parent.join(name)).unwrap();
+    }
+
+    #[test]
+    fn external_scan_follows_symlinked_skill_dirs() {
+        let root = tmp_root();
+        // A skill dir that lives outside both the canonical store and any
+        // registry tool dir, symlinked into claude-code's skills dir — e.g. a
+        // skills.sh/Zed-style projection Atlas didn't create itself.
+        plant_symlinked_external(&root, "elsewhere", ".claude/skills", "linked");
+
+        let listed = list_skills(&root, "global").unwrap();
+        let s = listed.iter().find(|s| s.name == "linked").expect(
+            "symlinked external skill dir must be discovered, not skipped as a managed marker",
+        );
+        assert!(!s.managed);
+        assert_eq!(s.enabled_agents, vec!["claude-code".to_string()]);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn migrate_legacy_skills_moves_pre_convergence_store_content() {
+        let root = tmp_root();
+        // Simulate a pre-convergence Atlas install: a skill sitting in the old
+        // `.atlas/skills` store, never touched by the new `.agents/skills` one.
+        let legacy_dir = legacy_skills_base(&root).join("legacy-demo");
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(
+            legacy_dir.join("SKILL.md"),
+            "---\nname: legacy-demo\ndescription: from before convergence\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let listed = list_skills(&root, "global").unwrap();
+        let s = listed
+            .iter()
+            .find(|s| s.name == "legacy-demo")
+            .expect("legacy skill must be migrated and then discovered");
+        assert!(s.managed);
+        assert_eq!(s.description, "from before convergence");
+        assert!(root.join(".agents/skills/legacy-demo/SKILL.md").is_file());
+        assert!(
+            !legacy_dir.exists(),
+            "legacy copy should be moved, not left behind, when the rename succeeds"
+        );
+
+        // Idempotent: a second discovery pass is a no-op (nothing left to migrate).
+        let listed_again = list_skills(&root, "global").unwrap();
+        assert_eq!(listed_again.len(), 1);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn migrate_legacy_skills_does_not_clobber_existing_new_store_entry() {
+        let root = tmp_root();
+        // New store already has `demo`, with different content than the legacy
+        // copy — the legacy copy must be left alone, not overwrite it.
+        create_skill(&root, "global", "demo", "new content wins", "b", &[]).unwrap();
+        let legacy_dir = legacy_skills_base(&root).join("demo");
+        fs::create_dir_all(&legacy_dir).unwrap();
+        fs::write(
+            legacy_dir.join("SKILL.md"),
+            "---\nname: demo\ndescription: stale legacy content\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let listed = list_skills(&root, "global").unwrap();
+        let s = listed.iter().find(|s| s.name == "demo").unwrap();
+        assert_eq!(s.description, "new content wins");
+        assert!(legacy_dir.exists(), "legacy copy is left in place, not deleted");
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn codex_project_scope_is_native_location_not_a_projection() {
+        let root = tmp_root();
+        let def = tool_def("codex").unwrap();
+        create_skill(&root, "project", "native", "d", "b", &[]).unwrap();
+
+        // Projecting is a no-op success recorded as "native" in the ledger —
+        // there is nothing to symlink, the skill already lives where codex reads.
+        project(&root, def, "project", "native", false).unwrap();
+        assert_eq!(read_ledger(&root).projections["native"]["codex"].mode, "native");
+        assert!(
+            root.join(".agents/skills/native")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_dir(),
+            "must stay a real dir, never become a self-referential symlink"
+        );
+
+        // Unprojecting must refuse rather than delete the canonical skill.
+        assert!(unproject(&root, def, "project", "native").is_err());
+        assert!(root.join(".agents/skills/native/SKILL.md").is_file());
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn install_skill_projects_to_detected_agents_immediately() {
+        let root = tmp_root(); // both .claude and .codex detected
+        let src = make_src_pack("v1");
+        let meta = install_skill_from_dir(&root, "project", &src, "foo").unwrap();
+        fs::remove_dir_all(&src).ok();
+
+        // Installed skill is immediately visible to every detected agent, not
+        // left with empty `enabled_agents` until a separate per-agent toggle.
+        assert!(meta.enabled_agents.contains(&"claude-code".to_string()));
+        assert!(meta.enabled_agents.contains(&"codex".to_string()));
+        assert!(root.join(".claude/skills/foo").symlink_metadata().is_ok());
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn list_plugin_skills_discovers_claude_marketplace_skills() {
+        let home = tmp_root();
+        let skill_dir = claude_plugin_marketplaces_dir(&home)
+            .join("some-marketplace")
+            .join("skills")
+            .join("bundled-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: bundled-skill\ndescription: ships with the plugin\n---\n\nbody\n",
+        )
+        .unwrap();
+
+        let found = list_plugin_skills(&home);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "bundled-skill");
+        assert_eq!(found[0].description, "ships with the plugin");
+        assert_eq!(found[0].source, "claude-code");
+        assert_eq!(found[0].marketplace, "some-marketplace");
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn list_plugin_skills_empty_when_no_marketplaces_dir() {
+        let home = tmp_root();
+        assert!(list_plugin_skills(&home).is_empty());
+        fs::remove_dir_all(&home).ok();
     }
 
     // ── Phase 0: pack model + tool homes ─────────────────────────────────────
@@ -4654,7 +5074,7 @@ mod tests {
     fn read_skill_resolves_pack_provided_skill() {
         let root = root_with_installed_pack();
         // `foo` lives only in the pack store, not the canonical store.
-        assert!(!root.join(".atlas/skills/foo").exists());
+        assert!(!root.join(".agents/skills/foo").exists());
         let content = read_skill(&root, "foo").unwrap();
         assert_eq!(content.body.trim(), "body");
         fs::remove_dir_all(&root).ok();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -647,6 +647,7 @@ pub fn run() {
             commands::skills::skills_path,
             commands::skills::skills_adopt,
             commands::skills::agents_list_skill_targets,
+            commands::skills::skills_list_plugins,
             commands::skills::tools_list,
             commands::skills::skills_reconcile,
             commands::skills::skills_project,

--- a/src/features/chat/components/chat-input.tsx
+++ b/src/features/chat/components/chat-input.tsx
@@ -95,10 +95,6 @@ interface ChatInputProps {
    * picker is open and routes accordingly.
    */
   keyInterceptor?: MentionKeyInterceptor | null;
-  /** When false, the `#` skill mention picker is disabled (the active agent
-   *  has no skill integration). Read live so switching agents takes effect
-   *  without remounting the view. Defaults to true. */
-  allowSkillMention?: boolean;
   /** Offered clipboard image files BEFORE the default file-paste handling.
    *  Return true to consume them (e.g. stage as inline attachments); false
    *  falls through to the path-paste path. Read live via ref. */
@@ -121,7 +117,6 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     onMentionTrigger,
     onSlashTrigger,
     keyInterceptor,
-    allowSkillMention = true,
     onPasteImages,
     extraExtensions,
     minHeight = 44,
@@ -149,8 +144,6 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     keyInterceptor,
   );
   keyInterceptorRef.current = keyInterceptor;
-  const allowSkillRef = useRef(allowSkillMention);
-  allowSkillRef.current = allowSkillMention;
   const onPasteImagesRef = useRef(onPasteImages);
   onPasteImagesRef.current = onPasteImages;
 
@@ -367,10 +360,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
             },
           }),
           ...mentionExtension,
-          mentionTriggerPlugin(
-            (t) => onMentionTriggerRef.current?.(t),
-            () => allowSkillRef.current,
-          ),
+          mentionTriggerPlugin((t) => onMentionTriggerRef.current?.(t)),
           slashTriggerPlugin((t) => onSlashTriggerRef.current?.(t)),
           // Prec.highest puts the picker keymap above lang-markdown's
           // Enter binding (which would otherwise continue a bullet) and

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -16,8 +16,7 @@ import {
   AGENT_LABEL,
   type SwitchableAgent,
 } from "@/types/agent";
-import { composePrompt, type MentionData, type MentionSkill } from "../lib/mentions";
-import { sharedMemory } from "@/features/memory/lib/shared-memory-api";
+import { composePrompt, type MentionData } from "../lib/mentions";
 import { usePaneFind } from "../lib/use-pane-find";
 import { useDefaultAgentType } from "../hooks/use-default-agent";
 import { MessageInput } from "./message-input";
@@ -754,19 +753,6 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     // directive + the block are stripped from the thread. Gated on the setting.
     if (useProjectStore.getState().settings.adaptiveSuggestions !== "off") {
       wirePrompt = appendNextStepsDirective(wirePrompt);
-    }
-
-    // Best-effort, invisible: record that this turn applied one or more skills
-    // so cross-agent shared memory reflects it (no view projection — see
-    // EventKind::SkillUsed). Fire-and-forget; must never block or break send.
-    const usedSkills = mentions.filter((m): m is MentionSkill => m.kind === "skill");
-    const memoryProject = useProjectStore.getState().currentProject?.path ?? null;
-    if (usedSkills.length > 0 && memoryProject) {
-      void sharedMemory
-        .appendEvent(memoryProject, bound.acpAgentId, bound.acpSessionId, "skill_used", null, {
-          skills: usedSkills.map((m) => m.skillName),
-        })
-        .catch(() => {});
     }
 
     // Non-blocking send: returns the instant the prompt is queued onto the

--- a/src/features/chat/components/composer-add-menu.tsx
+++ b/src/features/chat/components/composer-add-menu.tsx
@@ -1,7 +1,7 @@
 // The composer's "+" attach menu. Presentation only: the file dialogs,
 // image-vs-path routing, GitHub clone, and session referencing all live in the
-// parent (`message-input.tsx`). Skill/session lists reuse the `#`/`@` rails'
-// search sources so the menu and rails cannot drift.
+// parent (`message-input.tsx`). The session list reuses the `@` rail's
+// search source so the menu and rail cannot drift.
 //
 // The two searchable submenus (GitHub, Sessions) embed a text <input> inside a
 // Radix `SubContent` and stop keydown propagation so Radix's typeahead doesn't
@@ -26,7 +26,6 @@ import {
   Paperclip,
   Plus,
   Search,
-  SquareSlash,
   Star,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -37,15 +36,14 @@ import type { GithubRepo, ClonedRepo } from "@/features/github/types";
 import {
   searchMentions,
   listPastSessions,
-  type MentionSkill,
   type MentionWorkspace,
   type PastSessionRef,
 } from "../lib/mentions";
 
 interface ComposerAddMenuProps {
   disabled?: boolean;
-  /** Project root — scopes skills/sessions to this project, and is the clone
-   *  destination root for GitHub repos (`<project>/.atlas/repos`). */
+  /** Project root — scopes sessions/workspaces to this project, and is the
+   *  clone destination root for GitHub repos (`<project>/.atlas/repos`). */
   projectPath: string | null;
   /** Skill-registry agent id (e.g. "claude-code" | "codex" | "cersei"). */
   agentId?: string;
@@ -54,7 +52,6 @@ interface ComposerAddMenuProps {
   onAddFilesOrPhotos: () => void;
   onAttachMedia: () => void;
   onTakeScreenshot: (mode: "region" | "full") => void;
-  onPickSkill: (skill: MentionSkill) => void;
   onCloneRepo: (repo: GithubRepo) => void;
   onPickSession: (session: PastSessionRef) => void;
   /** Reference another project in the active org — inserts a `@workspace`
@@ -121,7 +118,6 @@ export function ComposerAddMenu({
   onAddFilesOrPhotos,
   onAttachMedia,
   onTakeScreenshot,
-  onPickSkill,
   onCloneRepo,
   onPickSession,
   onPickWorkspace,
@@ -129,28 +125,6 @@ export function ComposerAddMenu({
   onSwitchAgent,
 }: ComposerAddMenuProps) {
   const [open, setOpen] = useState(false);
-  // null = not loaded yet (spinner on first open); [] = loaded, none found.
-  const [skills, setSkills] = useState<MentionSkill[] | null>(null);
-  const [skillsError, setSkillsError] = useState(false);
-
-  // Lazy-load skills the first time the menu opens.
-  useEffect(() => {
-    if (!open || skills !== null) return;
-    let cancelled = false;
-    searchMentions("", "skill", { projectPath, agentId })
-      .then((found) => {
-        if (cancelled) return;
-        setSkills(found.filter((m): m is MentionSkill => m.kind === "skill"));
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setSkills([]);
-        setSkillsError(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, skills, projectPath, agentId]);
 
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
@@ -164,7 +138,7 @@ export function ComposerAddMenu({
               ? "opacity-50 cursor-default"
               : "hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] cursor-pointer",
           )}
-          title="Attach files, media, repos, skills, or a past session"
+          title="Attach files, media, repos, or a past session"
         >
           <Plus size={13} />
         </button>
@@ -215,61 +189,6 @@ export function ComposerAddMenu({
           <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-default)]" />
 
           <GithubSubmenu projectPath={projectPath} onCloneRepo={onCloneRepo} />
-
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger className={ITEM_CLASS}>
-              <SquareSlash size={11} />
-              <span>Skills</span>
-              <ChevronRight size={11} className="ml-auto text-[var(--text-tertiary)]" />
-            </DropdownMenu.SubTrigger>
-            <DropdownMenu.Portal>
-              <DropdownMenu.SubContent
-                sideOffset={6}
-                className={cn(
-                  CONTENT_CLASS,
-                  "min-w-[220px] max-w-[280px] max-h-[320px] overflow-y-auto",
-                )}
-                style={{ zIndex: 9999 }}
-              >
-                {skills === null ? (
-                  <div className="flex items-center gap-2 px-3 h-[26px] text-[11px] text-[var(--text-tertiary)]">
-                    <Loader2 size={11} className="animate-spin" />
-                    Loading skills…
-                  </div>
-                ) : skills.length === 0 ? (
-                  <div className="px-3 py-1.5 text-[11px] text-[var(--text-tertiary)]">
-                    {skillsError ? "Couldn't load skills." : "No skills installed"}
-                  </div>
-                ) : (
-                  skills.map((skill) => (
-                    <DropdownMenu.Item
-                      key={skill.id}
-                      className={cn(ITEM_CLASS, "h-auto items-start py-1.5")}
-                      onSelect={() => onPickSkill(skill)}
-                    >
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-1.5">
-                          <span className="truncate text-[var(--text-primary)]">
-                            {skill.displayName}
-                          </span>
-                          {skill.scope === "project" && (
-                            <span className="shrink-0 rounded px-1 text-[9px] leading-4 border border-[var(--border-default)] text-[var(--text-tertiary)]">
-                              project
-                            </span>
-                          )}
-                        </div>
-                        {skill.description && (
-                          <div className="text-[10px] text-[var(--text-tertiary)] line-clamp-2">
-                            {skill.description}
-                          </div>
-                        )}
-                      </div>
-                    </DropdownMenu.Item>
-                  ))
-                )}
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Portal>
-          </DropdownMenu.Sub>
 
           <SessionsSubmenu
             projectPath={projectPath}

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -63,7 +63,6 @@ import { imageMimeFromPath } from "@/features/model-chat/lib/model-capabilities"
 import type { ImageAttachment } from "@/types/agents";
 import type {
   MentionFile,
-  MentionSkill,
   MentionWorkspace,
   MentionRepo,
   MentionPastSession,
@@ -72,6 +71,7 @@ import type {
 import { toast } from "sonner";
 import { useComposerFileDrop } from "../hooks/use-composer-file-drop";
 import { useProjectStore } from "@/features/project/stores/project-store";
+import { openSettingsSection } from "@/features/settings/lib/open-settings";
 import { useClaudeSetupStore } from "@/features/claude-setup/stores/claude-setup-store";
 import type { MentionTrigger } from "../lib/cm-mention-extension";
 import type { SlashTrigger } from "../lib/cm-slash-extension";
@@ -608,7 +608,7 @@ export function MessageInput({
   // only re-renders composers, not the whole settings surface.
   const enterToSend = useProjectStore((s) => s.settings.enterToSend);
   // `agentType` widened to a SwitchableAgent (drops "custom") for the composer
-  // sub-components (skill/session scope, agent switcher) + the label lookup.
+  // sub-components (session scope, agent switcher) + the label lookup.
   const switchableAgent: SwitchableAgent =
     agentType === "codex" ||
     agentType === "opencode" ||
@@ -672,11 +672,14 @@ export function MessageInput({
   // ACP-reported slash commands for this session. Both adapters advertise
   // their real command list via `available_commands_update` — Codex's arrives
   // with the binding, Claude's a few seconds after session/new (the SDK
-  // discovers skills/plugins/MCP prompts first), so Claude falls back to the
-  // curated catalogue until the live list lands. The native agent has no
-  // slash commands; its trigger is suppressed at the wiring site below.
+  // discovers skills/plugins/MCP prompts first). Per ADR 0003 there is no
+  // fallback catalogue: the picker shows a loading state (see
+  // `slashCommandsLoading` below) during that gap instead. The native agent
+  // has no slash commands; its trigger is suppressed at the wiring site
+  // below.
   const availableCommands = useChatStore((s) => s.sessions[tabId]?.availableCommands);
-  const agentSlashCommands = useMemo<SlashCommand[] | undefined>(() => {
+  const slashCommandsLoading = availableCommands === undefined;
+  const agentSlashCommands = useMemo<SlashCommand[]>(() => {
     if (
       agentType !== "codex" &&
       agentType !== "claude-code" &&
@@ -684,7 +687,7 @@ export function MessageInput({
       agentType !== "cursor" &&
       agentType !== "kilo"
     )
-      return undefined;
+      return [];
     const fromAgent: SlashCommand[] = (availableCommands ?? [])
       .map((c) => {
         const o = (c ?? {}) as {
@@ -702,16 +705,11 @@ export function MessageInput({
         };
       })
       .filter((c) => c.name && c.name !== "login");
-    // Claude: until the ACP list arrives, `undefined` selects the picker's
-    // curated fallback (which carries its own `/login`).
-    if (agentType === "claude-code" && fromAgent.length === 0) return undefined;
-    // OpenCode / Cursor / Kilo auth is terminal-only — no host dialog, so no
-    // synthetic `/login`; the composer's auth pill covers them.
-    if (agentType === "opencode" || agentType === "cursor" || agentType === "kilo")
-      return fromAgent;
     // `/login` is Atlas-handled, not advertised by either adapter: it opens
-    // the host sign-in dialog for the bound agent.
-    const login: SlashCommand =
+    // the host sign-in dialog for the bound agent. OpenCode / Cursor / Kilo
+    // auth is terminal-only — no host dialog, so no synthetic `/login`;
+    // the composer's auth pill covers them.
+    const login: SlashCommand | null =
       agentType === "codex"
         ? {
             name: "login",
@@ -719,13 +717,47 @@ export function MessageInput({
             description: "Sign in to Codex (ChatGPT or API key).",
             handler: "codex-login" as const,
           }
-        : {
-            name: "login",
-            signature: "/login",
-            description: "Sign in to your Anthropic account.",
-            handler: "atlas-login" as const,
-          };
-    return [login, ...fromAgent];
+        : agentType === "claude-code"
+          ? {
+              name: "login",
+              signature: "/login",
+              description: "Sign in to your Anthropic account.",
+              handler: "atlas-login" as const,
+            }
+          : null;
+    // Host-handled guard rows, merged in alongside whatever the agent
+    // advertises. `/skills` opens Settings for any supported agent.
+    // `/clear`/`/logout` are dimmed for Claude Code specifically — the ACP
+    // adapter blocklists both from `available_commands_update`, so without
+    // these rows selecting the typed name would silently do nothing; with
+    // them the picker explains why and points at the TUI instead.
+    const guards: SlashCommand[] = [
+      {
+        name: "skills",
+        signature: "/skills",
+        description: "Open Skills settings.",
+        handler: "open-settings",
+      },
+      ...(agentType === "claude-code"
+        ? [
+            {
+              name: "clear",
+              signature: "/clear",
+              description: "Not available in Atlas — use the Claude Code TUI.",
+              handler: "unavailable" as const,
+            },
+            {
+              name: "logout",
+              signature: "/logout",
+              description: "Not available in Atlas — use the Claude Code TUI.",
+              handler: "unavailable" as const,
+            },
+          ]
+        : []),
+    ];
+    const guardNames = new Set(guards.map((g) => g.name));
+    const deduped = fromAgent.filter((c) => !guardNames.has(c.name));
+    return [...(login ? [login] : []), ...guards, ...deduped];
   }, [agentType, availableCommands]);
   const queue = useChatStore((s) => s.queues[tabId] ?? EMPTY_QUEUE);
 
@@ -946,11 +978,6 @@ export function MessageInput({
     }
   }, [imageSupported, handleDropFiles]);
 
-  const handlePickSkill = useCallback((skill: MentionSkill) => {
-    inputRef.current?.insertMention(skill);
-    requestAnimationFrame(() => inputRef.current?.focus());
-  }, []);
-
   const handlePickWorkspace = useCallback((workspace: MentionWorkspace) => {
     inputRef.current?.insertMention(workspace);
     requestAnimationFrame(() => inputRef.current?.focus());
@@ -1122,6 +1149,13 @@ export function MessageInput({
     [imageSupported],
   );
 
+  // `submit` (below) is defined after `handleSlashSelect` but the latter
+  // needs to invoke it — routed through a ref (set right after `submit` is
+  // declared) rather than a direct reference, since a `useCallback` deps
+  // array is evaluated eagerly on every render and would otherwise read
+  // `submit` before its `const` initializes.
+  const submitRef = useRef<() => void>(() => {});
+
   const handleSlashSelect = useCallback(
     (cmd: SlashCommand) => {
       const t = slashTriggerRef.current;
@@ -1135,6 +1169,24 @@ export function MessageInput({
         setSlashTrigger(null);
         if (cmd.handler === "codex-login") setCodexLoginOpen(true);
         else openLoginDialog();
+        inputRef.current?.focus();
+        return;
+      }
+
+      if (cmd.handler === "open-settings") {
+        clearSlashRange(view, t.from, t.to);
+        setSlashTrigger(null);
+        openSettingsSection("skills");
+        inputRef.current?.focus();
+        return;
+      }
+
+      if (cmd.handler === "unavailable") {
+        // Host-handled guard row — the agent doesn't support this command
+        // (or the ACP adapter blocklists it from advertisement). Nothing to
+        // run; just close the picker and drop the typed token.
+        clearSlashRange(view, t.from, t.to);
+        setSlashTrigger(null);
         inputRef.current?.focus();
         return;
       }
@@ -1168,72 +1220,111 @@ export function MessageInput({
         return;
       }
 
-      // No required args — fire and forget. Clear the composer (the
-      // user's `/query` doesn't need to linger) and dispatch via the
-      // panel's normal send path.
-      clearSlashRange(view, t.from, t.to);
-      inputRef.current?.clear();
-      setValue("");
+      // No required args — commit the full command name in place of the
+      // typed token (the query may be a prefix, e.g. "he" → "help"), then
+      // run the normal submit path so trim/mentions/queueing behave exactly
+      // like pressing Enter on typed text. Since the trigger can now sit
+      // mid-message, this preserves any surrounding text instead of wiping
+      // the whole composer.
+      const insertText = `/${cmd.name}`;
+      view.dispatch({
+        changes: { from: t.from, to: t.to, insert: insertText },
+        selection: { anchor: t.from + insertText.length },
+      });
       setSlashTrigger(null);
-      onSend(`/${cmd.name}`, []);
+      submitRef.current();
     },
-    [openLoginDialog, onSend, disabled],
+    [openLoginDialog, disabled],
   );
 
-  // Forward Up/Down/Enter/Esc/Backspace from CodeMirror to whichever
+  // Forward Up/Down/Enter/Esc/Backspace/Tab from CodeMirror to whichever
   // picker is open. Slash and mention pickers are mutually exclusive in
   // practice (slash only fires at line start of an otherwise-empty
   // composer), but we still route deterministically.
-  const keyInterceptor = useCallback((key: "Up" | "Down" | "Enter" | "Escape" | "Backspace") => {
-    // Slash takes precedence when both happen to be open.
-    const sp = slashPickerRef.current;
-    const st = slashTriggerRef.current;
-    if (st && sp) {
+  const keyInterceptor = useCallback(
+    (key: "Up" | "Down" | "Enter" | "Escape" | "Backspace" | "Tab") => {
+      // Slash takes precedence when both happen to be open.
+      const sp = slashPickerRef.current;
+      const st = slashTriggerRef.current;
+      if (st && sp) {
+        switch (key) {
+          case "Up":
+            sp.moveUp();
+            return true;
+          case "Down":
+            sp.moveDown();
+            return true;
+          case "Enter":
+            return sp.commit();
+          case "Escape":
+            setSlashTrigger(null);
+            return true;
+          case "Backspace":
+            // Let CM delete a query char or the `/` itself (which closes
+            // the picker via the trigger detector).
+            return false;
+          case "Tab": {
+            const active = sp.activeCommand();
+            if (!active) return true;
+            // Only real passthrough commands get "complete without sending"
+            // — that's for filling in args before Enter. Host-handled rows
+            // (login, open-settings, unavailable guards) take no args, so
+            // completing them into plain text would let a guard row like
+            // dimmed `/clear` slip past its own handler on the next Enter
+            // and get sent to the agent as literal passthrough text — the
+            // exact silent no-op these guard rows exist to prevent. Those
+            // run through the normal commit path instead, same as Enter.
+            if (active.handler !== "passthrough") {
+              return sp.commit();
+            }
+            // Complete to the full command name (never sends). The caret
+            // lands right after a trailing space, which the trigger
+            // detector reads as "hit whitespace" and closes the picker on
+            // its own — same as if the user had typed the space by hand.
+            const view = inputRef.current?.view();
+            if (!view) return true;
+            const insertText = `/${active.name} `;
+            view.dispatch({
+              changes: { from: st.from, to: st.to, insert: insertText },
+              selection: { anchor: st.from + insertText.length },
+            });
+            return true;
+          }
+        }
+      }
+
+      const p = pickerRef.current;
+      const t = triggerRef.current;
+      if (!t || !p) return false;
       switch (key) {
         case "Up":
-          sp.moveUp();
+          p.moveUp();
           return true;
         case "Down":
-          sp.moveDown();
+          p.moveDown();
           return true;
         case "Enter":
-          return sp.commit();
+          return p.commit();
         case "Escape":
-          setSlashTrigger(null);
+          // At a sublevel, Esc pops back. At the top level, it closes.
+          if (p.goBack()) return true;
+          setTrigger(null);
           return true;
         case "Backspace":
-          // Let CM delete a query char or the `/` itself (which closes
-          // the picker via the trigger detector).
+          // Only consume Backspace when at a sublevel AND the query is
+          // empty — otherwise let CM delete a character in the query (or
+          // the `@` itself, which closes the picker via the trigger
+          // detector).
+          if (t.query === "" && p.goBack()) return true;
+          return false;
+        case "Tab":
+          // Not handled for the mention picker — fall through to CM's
+          // default Tab handling (list indent / outdent).
           return false;
       }
-    }
-
-    const p = pickerRef.current;
-    const t = triggerRef.current;
-    if (!t || !p) return false;
-    switch (key) {
-      case "Up":
-        p.moveUp();
-        return true;
-      case "Down":
-        p.moveDown();
-        return true;
-      case "Enter":
-        return p.commit();
-      case "Escape":
-        // At a sublevel, Esc pops back. At the top level, it closes.
-        if (p.goBack()) return true;
-        setTrigger(null);
-        return true;
-      case "Backspace":
-        // Only consume Backspace when at a sublevel AND the query is
-        // empty — otherwise let CM delete a character in the query (or
-        // the `@` itself, which closes the picker via the trigger
-        // detector).
-        if (t.query === "" && p.goBack()) return true;
-        return false;
-    }
-  }, []);
+    },
+    [],
+  );
 
   // Auto-focus the composer whenever this panel mounts (tab switch back into
   // chat). If the CodeMirror chunk hasn't resolved yet, the next re-render
@@ -1364,6 +1455,7 @@ export function MessageInput({
     stagedImages,
     githubSyncing,
   ]);
+  submitRef.current = submit;
 
   const trimmed = value.trim();
   // Tri-state button:
@@ -1513,11 +1605,6 @@ export function MessageInput({
                 onSlashTrigger={agentType === "cersei" ? undefined : setSlashTrigger}
                 onPasteImages={handlePasteImages}
                 keyInterceptor={keyInterceptor}
-                // All agents (incl. the native Atlas/cersei agent) support skills
-                // now — the `#` rail inlines a skill body via compose_prompt, and the
-                // native agent additionally loads Atlas-enabled skills via its Skill
-                // tool. (`agentType` retained for other per-agent gating above.)
-                allowSkillMention={true}
               />
             ) : (
               // Same-height empty slot so the panel layout doesn't reflow when
@@ -1536,7 +1623,6 @@ export function MessageInput({
                 onAddFilesOrPhotos={() => void pickFilesOrPhotos()}
                 onAttachMedia={() => void pickMedia()}
                 onTakeScreenshot={(mode) => void handleTakeScreenshot(mode)}
-                onPickSkill={handlePickSkill}
                 onCloneRepo={(repo) => void handleCloneRepo(repo)}
                 onPickSession={handlePickSession}
                 onPickWorkspace={handlePickWorkspace}
@@ -1636,8 +1722,9 @@ export function MessageInput({
           anchor={trigger?.anchor ?? null}
           initialScope={trigger?.scope ?? null}
           projectPath={projectPath}
-          // Per-agent skill gating: the `#` rail only lists skills enabled for
-          // the active agent (registry ids "claude-code" / "codex" match agentType).
+          // Per-agent component gating: pack components (command/agent/rule)
+          // only list ones enabled for the active agent (registry ids
+          // "claude-code" / "codex" match agentType).
           agentId={agentType}
           onSelect={handleMentionSelect}
           onClose={() => setTrigger(null)}
@@ -1652,6 +1739,7 @@ export function MessageInput({
           onSelect={handleSlashSelect}
           onClose={() => setSlashTrigger(null)}
           commands={agentSlashCommands}
+          loading={slashCommandsLoading}
           footerLabel={
             agentType === "codex"
               ? "Codex commands"
@@ -1659,7 +1747,7 @@ export function MessageInput({
                 ? "OpenCode commands"
                 : agentType === "cursor"
                   ? "Cursor commands"
-                  : agentType === "claude-code" && agentSlashCommands
+                  : agentType === "claude-code"
                     ? "Claude Code commands"
                     : undefined
           }

--- a/src/features/chat/components/slash-command-picker.tsx
+++ b/src/features/chat/components/slash-command-picker.tsx
@@ -1,11 +1,13 @@
 // Floating slash-command picker. Same architecture as `mention-picker.tsx`:
 // portal-anchored, imperative handle, no DOM focus. Opens when the trigger
-// plugin (`cm-slash-extension.ts`) reports a `/` at the start of the line.
+// plugin (`cm-slash-extension.ts`) reports a `/` preceded by whitespace or
+// start-of-line, anywhere in the composer.
 //
-// Phase 1 wires only `/login` as an Atlas-handled command (opens the
-// existing `ClaudeLoginDialog`). Every other command in the catalogue is
-// marked `unsupported` and renders greyed out — the picker is primarily a
-// discoverability surface for now.
+// Per ADR 0003, the bound agent's own ACP `available_commands_update` is the
+// only source of commands — there is no local catalogue. `message-input.tsx`
+// merges in a few host-handled guard rows (`/login`, `/skills`, and
+// `/clear`/`/logout` dimmed-unavailable rows) alongside whatever the agent
+// advertises.
 
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -15,15 +17,25 @@ import { cn } from "@/lib/utils";
 
 /** Where the command is dispatched.
  *
- * - `atlas-login` — opens Atlas's own `ClaudeLoginDialog` (the adapter
- *   filters `/login` from its slash list, so sending it as text is a
- *   no-op; we drive a host-side OAuth flow instead).
+ * - `atlas-login` / `codex-login` — opens Atlas's own sign-in dialog for the
+ *   bound agent (the ACP adapter filters `/login` from its slash list, so
+ *   sending it as text is a no-op; we drive a host-side OAuth flow instead).
+ * - `open-settings` — host-handled, opens Settings on a fixed section
+ *   (currently only `/skills`).
+ * - `unavailable` — host-handled guard row for a command the agent doesn't
+ *   support (e.g. `/clear`/`/logout`, blocklisted by the ACP adapter).
+ *   Selecting it just closes the picker.
  * - `passthrough` — sent verbatim as the user's next prompt. The agent
  *   (claude-agent-acp's SDK) processes it locally and emits the response
  *   as `<local-command-stdout>…</local-command-stdout>` blocks which flow
  *   through the normal `agent_message_chunk` pipeline and render in the
  *   chat thread alongside regular assistant output. */
-export type SlashCommandHandler = "atlas-login" | "codex-login" | "passthrough";
+export type SlashCommandHandler =
+  | "atlas-login"
+  | "codex-login"
+  | "open-settings"
+  | "unavailable"
+  | "passthrough";
 
 export interface SlashCommand {
   /** Unique slug used both as the visible command name and matched query. */
@@ -46,6 +58,9 @@ export interface SlashCommandPickerHandle {
   moveUp(): void;
   commit(): boolean;
   goBack(): boolean;
+  /** The currently-highlighted row, if any. Used by Tab-to-complete, which
+   *  needs the full command name without sending. */
+  activeCommand(): SlashCommand | null;
 }
 
 export interface SlashCommandPickerProps {
@@ -54,180 +69,34 @@ export interface SlashCommandPickerProps {
   anchor: { x: number; y: number } | null;
   onSelect: (cmd: SlashCommand) => void;
   onClose: () => void;
-  /** Override the catalogue (e.g. Codex's ACP-reported commands). When absent
-   *  the curated Claude Code list is used. */
-  commands?: SlashCommand[];
+  /** The bound agent's ACP-advertised commands, plus any host-handled guard
+   *  rows the caller merges in. ADR 0003: there is no local fallback
+   *  catalogue — ACP advertisement is the only source. */
+  commands: SlashCommand[];
+  /** True between session start and the first `available_commands_update` —
+   *  renders a loading message instead of "no commands match". */
+  loading?: boolean;
   /** Footer label (e.g. "Codex commands"). */
   footerLabel?: string;
 }
 
-// ── Command catalogue ──────────────────────────────────────────────────────
-//
-// Curated from the Claude Code CLI command list. `/login` is the only
-// host-handled command (opens Atlas's sign-in dialog); everything else is
-// `passthrough` — the picker drops the command text into the composer
-// and either auto-sends it (no args) or waits for the user to fill in
-// arguments before pressing Enter. The agent (claude-agent-acp) handles
-// the actual command logic and emits the response into the chat thread.
-
-export const SLASH_COMMANDS: SlashCommand[] = [
-  {
-    name: "login",
-    signature: "/login",
-    description: "Sign in to your Anthropic account.",
-    handler: "atlas-login",
-  },
-  {
-    name: "logout",
-    signature: "/logout",
-    description: "Sign out from your Anthropic account.",
-    handler: "passthrough",
-  },
-  {
-    name: "agents",
-    signature: "/agents",
-    description: "Manage agent configurations.",
-    handler: "passthrough",
-  },
-  {
-    name: "add-dir",
-    signature: "/add-dir <path>",
-    description: "Add a working directory for file access in this session.",
-    handler: "passthrough",
-  },
-  {
-    name: "clear",
-    signature: "/clear [name]",
-    description: "Start a new conversation with empty context.",
-    handler: "passthrough",
-  },
-  {
-    name: "compact",
-    signature: "/compact",
-    description: "Summarize the conversation to free up context.",
-    handler: "passthrough",
-  },
-  {
-    name: "model",
-    signature: "/model [model]",
-    description: "Set the AI model for the current session.",
-    handler: "passthrough",
-  },
-  {
-    name: "effort",
-    signature: "/effort [level]",
-    description: "Set the model effort level (low/medium/high/xhigh/max).",
-    handler: "passthrough",
-  },
-  {
-    name: "context",
-    signature: "/context",
-    description: "Visualize current context usage.",
-    handler: "passthrough",
-  },
-  {
-    name: "memory",
-    signature: "/memory",
-    description: "Edit CLAUDE.md memory files and auto-memory entries.",
-    handler: "passthrough",
-  },
-  {
-    name: "resume",
-    signature: "/resume [session]",
-    description: "Resume a previous conversation.",
-    handler: "passthrough",
-  },
-  {
-    name: "rewind",
-    signature: "/rewind",
-    description: "Rewind the conversation or code to a previous point.",
-    handler: "passthrough",
-  },
-  {
-    name: "diff",
-    signature: "/diff",
-    description: "Open an interactive diff viewer for uncommitted changes.",
-    handler: "passthrough",
-  },
-  {
-    name: "permissions",
-    signature: "/permissions",
-    description: "Manage allow / ask / deny rules for tool permissions.",
-    handler: "passthrough",
-  },
-  {
-    name: "config",
-    signature: "/config",
-    description: "Open the Settings interface.",
-    handler: "passthrough",
-  },
-  {
-    name: "status",
-    signature: "/status",
-    description: "Show version, model, account, and connectivity.",
-    handler: "passthrough",
-  },
-  {
-    name: "usage",
-    signature: "/usage",
-    description: "Show session cost, plan usage limits, and activity stats.",
-    handler: "passthrough",
-  },
-  {
-    name: "doctor",
-    signature: "/doctor",
-    description: "Diagnose and verify your Claude Code installation.",
-    handler: "passthrough",
-  },
-  {
-    name: "mcp",
-    signature: "/mcp",
-    description: "Manage MCP server connections and OAuth.",
-    handler: "passthrough",
-  },
-  {
-    name: "hooks",
-    signature: "/hooks",
-    description: "View hook configurations for tool events.",
-    handler: "passthrough",
-  },
-  {
-    name: "ide",
-    signature: "/ide",
-    description: "Manage IDE integrations and show status.",
-    handler: "passthrough",
-  },
-  {
-    name: "init",
-    signature: "/init",
-    description: "Initialize project with a CLAUDE.md guide.",
-    handler: "passthrough",
-  },
-  {
-    name: "review",
-    signature: "/review [PR]",
-    description: "Review a pull request locally in the current session.",
-    handler: "passthrough",
-  },
-  {
-    name: "security-review",
-    signature: "/security-review",
-    description: "Analyze pending changes for security vulnerabilities.",
-    handler: "passthrough",
-  },
-  {
-    name: "feedback",
-    signature: "/feedback",
-    description: "Submit feedback, report a bug, or share the conversation.",
-    handler: "passthrough",
-  },
-  {
-    name: "help",
-    signature: "/help",
-    description: "Show help and available commands.",
-    handler: "passthrough",
-  },
-];
+/** Highlight every case-insensitive occurrence of `query` in `text`. */
+function highlightMatches(text: string, query: string) {
+  const q = query.trim();
+  if (!q) return text;
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+  if (parts.length === 1) return text;
+  return parts.map((part, i) =>
+    i % 2 === 1 ? (
+      <mark key={i} className="bg-[var(--bg-selected)] text-[var(--text-primary)] rounded-[2px]">
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  );
+}
 
 // ── Component ───────────────────────────────────────────────────────────────
 
@@ -236,7 +105,7 @@ const GAP = 6;
 
 export const SlashCommandPicker = forwardRef<SlashCommandPickerHandle, SlashCommandPickerProps>(
   function SlashCommandPicker(
-    { open, query, anchor, onSelect, onClose, commands, footerLabel },
+    { open, query, anchor, onSelect, onClose, commands, loading, footerLabel },
     ref,
   ) {
     const [active, setActive] = useState(0);
@@ -245,17 +114,27 @@ export const SlashCommandPicker = forwardRef<SlashCommandPickerHandle, SlashComm
       if (open) setActive(0);
     }, [open, query]);
 
-    // The agent's own commands when provided (Codex), else the curated Claude list.
-    const catalogue = commands ?? SLASH_COMMANDS;
-
-    // Filter by query against name + description. Cheap linear scan.
+    // Tiered sort: exact name match, then name prefix, then name substring,
+    // then description substring. Alphabetical within each tier. Unmatched
+    // rows are dropped rather than kept in catalogue order, so a query
+    // narrows the list instead of just reordering it.
     const rows = useMemo(() => {
       const q = query.trim().toLowerCase();
-      if (!q) return catalogue;
-      return catalogue.filter(
-        (c) => c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
-      );
-    }, [query, catalogue]);
+      if (!q) return commands;
+      const tierOf = (c: SlashCommand): number => {
+        const name = c.name.toLowerCase();
+        if (name === q) return 0;
+        if (name.startsWith(q)) return 1;
+        if (name.includes(q)) return 2;
+        if (c.description.toLowerCase().includes(q)) return 3;
+        return -1;
+      };
+      return commands
+        .map((c) => ({ c, tier: tierOf(c) }))
+        .filter((x) => x.tier >= 0)
+        .sort((a, b) => a.tier - b.tier || a.c.name.localeCompare(b.c.name))
+        .map((x) => x.c);
+    }, [query, commands]);
 
     useEffect(() => {
       if (active >= rows.length) setActive(0);
@@ -285,6 +164,7 @@ export const SlashCommandPicker = forwardRef<SlashCommandPickerHandle, SlashComm
           return true;
         },
         goBack: () => false,
+        activeCommand: () => activeRow ?? null,
       }),
       [activeRow, rows.length],
     );
@@ -331,12 +211,13 @@ export const SlashCommandPicker = forwardRef<SlashCommandPickerHandle, SlashComm
         <div className="flex-1 overflow-y-auto py-1">
           {rows.length === 0 ? (
             <div className="px-3 py-6 text-center text-[11px] text-[var(--text-tertiary)] leading-snug">
-              No commands match &ldquo;/{query}&rdquo;.
+              {loading ? "Loading commands…" : `No commands match "/${query}".`}
             </div>
           ) : (
             rows.map((cmd, i) => {
               const isActive = i === active;
               const needsArgs = commandRequiresArgs(cmd);
+              const unavailable = cmd.handler === "unavailable";
               return (
                 <button
                   key={cmd.name}
@@ -347,17 +228,19 @@ export const SlashCommandPicker = forwardRef<SlashCommandPickerHandle, SlashComm
                   }}
                   className={cn(
                     "w-full text-left px-3 h-[26px] flex items-center gap-2 text-[11.5px]",
-                    isActive
-                      ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
-                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]",
+                    unavailable
+                      ? "opacity-50"
+                      : isActive
+                        ? "bg-[var(--bg-selected)] text-[var(--text-primary)]"
+                        : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]",
                   )}
                   title={cmd.description}
                 >
                   <span className="font-mono text-[var(--text-primary)] shrink-0 min-w-[80px]">
-                    /{cmd.name}
+                    /{highlightMatches(cmd.name, query)}
                   </span>
                   <span className="truncate text-[10.5px] text-[var(--text-tertiary)] min-w-0 flex-1">
-                    {cmd.description}
+                    {highlightMatches(cmd.description, query)}
                   </span>
                   {needsArgs && (
                     <span

--- a/src/features/chat/lib/cm-mention-extension.ts
+++ b/src/features/chat/lib/cm-mention-extension.ts
@@ -212,20 +212,17 @@ export interface MentionTrigger {
  *  runs after the view finishes committing. */
 export function mentionTriggerPlugin(
   onChange: (trigger: MentionTrigger | null) => void,
-  // Returns whether the `#` skill picker is enabled. Read live so the active
-  // agent (e.g. Cersei, which has no skills) can toggle it without remounting.
-  allowSkill: () => boolean = () => true,
 ): ViewPlugin<{ last: MentionTrigger | null; pending: number }> {
   return ViewPlugin.define((view) => {
     const state = {
       last: null as MentionTrigger | null,
       pending: 0,
     };
-    schedule(view, state, onChange, allowSkill);
+    schedule(view, state, onChange);
     return {
       update(u: ViewUpdate) {
         if (!u.docChanged && !u.selectionSet && !u.viewportChanged) return;
-        schedule(u.view, state, onChange, allowSkill);
+        schedule(u.view, state, onChange);
       },
     };
   });
@@ -235,13 +232,12 @@ function schedule(
   view: EditorView,
   state: { last: MentionTrigger | null; pending: number },
   onChange: (t: MentionTrigger | null) => void,
-  allowSkill: () => boolean,
 ): void {
   const ticket = ++state.pending;
   queueMicrotask(() => {
     // Drop the stale schedule if another update has fired since.
     if (ticket !== state.pending) return;
-    recompute(view, state, onChange, allowSkill);
+    recompute(view, state, onChange);
   });
 }
 
@@ -249,12 +245,11 @@ function recompute(
   view: EditorView,
   state: { last: MentionTrigger | null; pending: number },
   onChange: (t: MentionTrigger | null) => void,
-  allowSkill: () => boolean,
 ): void {
   // The view may have been destroyed between the queueMicrotask schedule
   // and its callback firing (e.g. component unmount inside the same tick).
   if (!view.dom.isConnected) return;
-  const trig = detectTrigger(view, allowSkill);
+  const trig = detectTrigger(view);
   if (sameTrigger(state.last, trig)) return;
   state.last = trig;
   onChange(trig);
@@ -273,7 +268,7 @@ function sameTrigger(a: MentionTrigger | null, b: MentionTrigger | null): boolea
   );
 }
 
-function detectTrigger(view: EditorView, allowSkill: () => boolean): MentionTrigger | null {
+function detectTrigger(view: EditorView): MentionTrigger | null {
   const sel = view.state.selection.main;
   if (!sel.empty) return null;
   const caret = sel.head;
@@ -285,10 +280,11 @@ function detectTrigger(view: EditorView, allowSkill: () => boolean): MentionTrig
   for (let i = lineBefore.length - 1; i >= 0; i--) {
     const ch = lineBefore[i];
     // `@` → unscoped picker; `~` → knowledge-only (mirrors the Tiptap KB
-    // editor's `~` shortcut so chat and notes behave the same); `#` →
-    // skills-only (the `#skill:` invoke rail). The whitespace-precedence
-    // guard below keeps `C#`, `issue#3`, `a@b` from opening the picker.
-    if (ch === "@" || ch === "~" || (ch === "#" && allowSkill())) {
+    // editor's `~` shortcut so chat and notes behave the same). `#`
+    // (skills-only invoke) was retired — skills are invoked through the `/`
+    // picker's passthrough now (ADR 0001). The whitespace-precedence guard
+    // below keeps `C#`, `issue#3`, `a@b` from opening the picker.
+    if (ch === "@" || ch === "~") {
       const prev = i > 0 ? lineBefore[i - 1] : "";
       if (prev && !/\s/.test(prev) && prev !== "(" && prev !== "[") {
         return null;
@@ -309,7 +305,7 @@ function detectTrigger(view: EditorView, allowSkill: () => boolean): MentionTrig
         to: caret,
         query,
         anchor: { x: coords.left, y: coords.top },
-        scope: ch === "~" ? "knowledge" : ch === "#" ? "skill" : null,
+        scope: ch === "~" ? "knowledge" : null,
       };
     }
     if (/\s/.test(ch)) {
@@ -324,7 +320,7 @@ function detectTrigger(view: EditorView, allowSkill: () => boolean): MentionTrig
 /** A key passes through this when the picker is open. The interceptor is a
  *  mutable ref the parent sets; CodeMirror's keymap looks it up live so we
  *  don't have to reconfigure the view every time the picker opens. */
-export type MentionKey = "Up" | "Down" | "Enter" | "Escape" | "Backspace";
+export type MentionKey = "Up" | "Down" | "Enter" | "Escape" | "Backspace" | "Tab";
 export type MentionKeyInterceptor = (key: MentionKey) => boolean;
 
 export const mentionKeymap = (getInterceptor: () => MentionKeyInterceptor | null) => {
@@ -342,6 +338,10 @@ export const mentionKeymap = (getInterceptor: () => MentionKeyInterceptor | null
     // The interceptor returns false to let CM's default delete handler run
     // when there's nothing to back-navigate to.
     { key: "Backspace", run: tryIntercept("Backspace") },
+    // Tab-to-complete for the slash picker only — the mention picker's
+    // interceptor returns false for "Tab" so list-indent Tab keeps working
+    // when a mention/knowledge picker happens to be open.
+    { key: "Tab", run: tryIntercept("Tab") },
   ];
 };
 
@@ -493,8 +493,8 @@ const ICON_GIT_BRANCH = lucideSvg(
 const ICON_MESSAGE_SQUARE = lucideSvg(
   `<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>`,
 );
-// Lucide "zap" — skill mentions (the `#skill:` invoke rail). Keep in sync
-// with the `Zap` icon used in mention-picker.tsx's CategoryIcon.
+// Lucide "zap" — pack-component mentions. Keep in sync with the `Zap` icon
+// used in mention-picker.tsx's CategoryIcon.
 const ICON_ZAP = lucideSvg(`<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>`);
 
 function kindGlyph(kind: MentionKind): string {
@@ -507,8 +507,6 @@ function kindGlyph(kind: MentionKind): string {
       return ICON_HASH;
     case "knowledge":
       return ICON_BOOK_OPEN;
-    case "skill":
-      return ICON_ZAP;
     case "component":
       return ICON_ZAP;
     case "repo":
@@ -536,8 +534,6 @@ function chipTitle(m: MentionData): string {
       return `${m.symbolKind} · ${m.filePath}:${m.line}`;
     case "knowledge":
       return `${m.source} · ${m.filePath}`;
-    case "skill":
-      return m.description || m.displayName;
     case "component":
       return m.description || m.displayName;
     case "repo":

--- a/src/features/chat/lib/cm-slash-extension.ts
+++ b/src/features/chat/lib/cm-slash-extension.ts
@@ -3,9 +3,10 @@
 // `message-input.tsx` can wire it identically.
 //
 // Differences vs mentions:
-//   - Triggers ONLY when `/` sits at the start of the line (after optional
-//     whitespace). Slash commands replace the message; `foo /bar` mid-line
-//     shouldn't open a picker.
+//   - `detectTrigger` below scans backward from the caret for a `/`
+//     preceded by whitespace or start-of-line, same as the mention
+//     extension's `@`/`~` scan — so a slash command can sit anywhere in the
+//     message, not just at the very start.
 //   - There is no document-level state field — selecting a command
 //     either runs an app-level handler (e.g. `/login` opens a dialog) or
 //     leaves the literal `/foo` text in place for passthrough commands.
@@ -86,25 +87,35 @@ function detectTrigger(view: EditorView): SlashTrigger | null {
   const sel = view.state.selection.main;
   if (!sel.empty) return null;
   const caret = sel.head;
-  // Only the FIRST line of the document can host a slash command — the
-  // composer is single-message and slash commands replace the message,
-  // so multi-line input with a `/` somewhere makes no sense.
-  if (view.state.doc.lines > 1) return null;
   const line = view.state.doc.lineAt(caret);
-  const before = view.state.doc.sliceString(line.from, caret);
-  const match = before.match(/^(\s*)\/([^\s/]*)$/);
-  if (!match) return null;
-  const leading = match[1].length;
-  const from = line.from + leading;
-  const query = match[2];
-  const coords = view.coordsAtPos(from);
-  if (!coords) return null;
-  return {
-    from,
-    to: caret,
-    query,
-    anchor: { x: coords.left, y: coords.top },
-  };
+  // Scan backward from the caret for the most recent `/` on this line,
+  // stopping (no trigger) at the first whitespace encountered first. This
+  // means the `/` must be part of the token currently being typed, mirroring
+  // `cm-mention-extension.ts`'s `@`/`~` scan.
+  const lineBefore = view.state.doc.sliceString(line.from, caret);
+  for (let i = lineBefore.length - 1; i >= 0; i--) {
+    const ch = lineBefore[i];
+    if (ch === "/") {
+      const prev = i > 0 ? lineBefore[i - 1] : "";
+      if (prev && !/\s/.test(prev) && prev !== "(" && prev !== "[") {
+        return null;
+      }
+      const from = line.from + i;
+      const query = lineBefore.slice(i + 1);
+      const coords = view.coordsAtPos(from);
+      if (!coords) return null;
+      return {
+        from,
+        to: caret,
+        query,
+        anchor: { x: coords.left, y: coords.top },
+      };
+    }
+    if (/\s/.test(ch)) {
+      return null;
+    }
+  }
+  return null;
 }
 
 // `clearSlashRange` used to live here. It moved to `./cm-clear-range` — it

--- a/src/features/chat/lib/mentions.ts
+++ b/src/features/chat/lib/mentions.ts
@@ -19,6 +19,10 @@ import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store"
 import { useOrgStore } from "@/features/organisations/stores/org-store";
 import { skills } from "@/features/skills/lib/skills-api";
 import type { PackComponentKind } from "@/features/skills/lib/types";
+// NOTE: skills are no longer a mention kind — inlining a skill body into the
+// prompt was retired (see docs/adr/0001-slash-tokens-pass-through-skills-are-not-inlined.md).
+// Skill invocation goes through the agent-advertised `/` passthrough now.
+// Pack-delivered components (command/agent/rule) are unrelated and stay.
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -27,7 +31,6 @@ export type MentionKind =
   | "folder"
   | "symbol"
   | "knowledge"
-  | "skill"
   | "component"
   | "repo"
   | "workspace"
@@ -73,21 +76,6 @@ export interface MentionKnowledge {
    *  Surfaces the user's "spaces" — nested subfolders under
    *  `.atlas/knowledge/`. Null for top-level entries. */
   folder: string | null;
-}
-
-export interface MentionSkill {
-  kind: "skill";
-  /** `${scope}:${name}` — dedupe key across scopes. */
-  id: string;
-  displayName: string; // skill name (the `#skill:<name>` token)
-  description: string;
-  scope: "global" | "project";
-  /** Sanitized on-disk name, passed to `skills_read` at compose time. */
-  skillName: string;
-  /** Project root for project-scope reads; null for global. */
-  projectPath: string | null;
-  /** Absolute path to the canonical `SKILL.md` (Rust read fallback). */
-  filePath: string;
 }
 
 export interface MentionComponent {
@@ -164,7 +152,6 @@ export type MentionData =
   | MentionFolder
   | MentionSymbol
   | MentionKnowledge
-  | MentionSkill
   | MentionComponent
   | MentionRepo
   | MentionWorkspace
@@ -189,7 +176,6 @@ export const MENTION_CATEGORIES: readonly MentionCategory[] = [
   { kind: "folder", label: "Folders", aliases: ["folder", "dir", "d/"], weight: 0.95 },
   { kind: "symbol", label: "Symbols", aliases: ["symbol", "sym", "s/"], weight: 0.85 },
   { kind: "knowledge", label: "Knowledge", aliases: ["note", "knowledge", "k/"], weight: 0.85 },
-  { kind: "skill", label: "Skills", aliases: ["skill", "sk/"], weight: 0.9 },
   {
     kind: "component",
     label: "Pack Components",
@@ -221,9 +207,10 @@ export interface MentionContext {
   /** Project root (cwd for the chat). Required by per-project sources. */
   projectPath: string | null;
   /** Active chat agent's skill-registry id (e.g. "claude-code" | "codex").
-   *  When set, the `#` skill rail only offers skills enabled for this agent,
-   *  so disabling a skill/pack for an agent removes it from that agent's chat.
-   *  Undefined = no agent filter (legacy callers). */
+   *  When set, pack-component mentions (command/agent/rule) only offer ones
+   *  enabled for this agent, so disabling a pack for an agent removes its
+   *  components from that agent's chat. Undefined = no agent filter (legacy
+   *  callers). */
   agentId?: string;
 }
 
@@ -339,8 +326,6 @@ export function toShortForm(m: MentionData): string {
       return `@symbol:${m.displayName}`;
     case "knowledge":
       return `@note:${m.id}`;
-    case "skill":
-      return `#skill:${m.displayName}`;
     case "component":
       return `#${m.componentKind}:${m.displayName}`;
     case "repo":
@@ -398,21 +383,11 @@ export async function searchMentions(
         filePath: s.filePath,
       }));
   }
-  // Skills take the cheaper path: list the canonical store(s) and
-  // substring-filter JS-side (no Rust `mention_search` change needed). They
-  // also join the unscoped `@` blend below, capped so they never crowd files.
-  // The `#` rail (scope locked to "skill") invokes skills AND pack-delivered
-  // components (command/agent/rule) — both inline their body at send time.
-  if (scope === "skill") {
-    const q = stripCategoryAlias(query, "skill");
-    const [sk, comps] = await Promise.all([searchSkills(q, ctx), searchPackComponents(q, ctx)]);
-    return [...sk, ...comps];
-  }
   if (scope === "component") {
     return searchPackComponents(stripCategoryAlias(query, "component"), ctx);
   }
-  // Workspaces live in a JS store — resolve them JS-side (like skills), so an
-  // agent in one project can be handed another project's path via @workspace.
+  // Workspaces live in a JS store — resolve them JS-side, so an agent in one
+  // project can be handed another project's path via @workspace.
   if (scope === "workspace") {
     return searchWorkspaces(stripCategoryAlias(query, "workspace"), ctx);
   }
@@ -429,29 +404,19 @@ export async function searchMentions(
   }
   try {
     const stripped = stripCategoryAlias(query, scope ?? "file");
-    // Unscoped `@`: blend the JS-owned kinds (workspaces, skills) alongside
-    // the Rust-ranked kinds so ONE search reaches everything — files, folders,
-    // notes, repos, branches, papers, symbols, workspaces, skills. The JS
-    // kinds are small lists; they're appended after the Rust results and the
-    // picker groups the flat list into per-kind sections for display.
+    // Unscoped `@`: blend the JS-owned kinds (workspaces) alongside the
+    // Rust-ranked kinds so ONE search reaches everything — files, folders,
+    // notes, repos, branches, papers, symbols, workspaces. The JS kinds are
+    // small lists; they're appended after the Rust results and the picker
+    // groups the flat list into per-kind sections for display.
     if (scope === null) {
-      const [results, skillMatches] = await Promise.all([
-        invoke<MentionData[]>("mention_search", {
-          query: stripped,
-          scope,
-          projectPath: ctx.projectPath,
-          workspaceId: activeWorkspaceId(),
-        }),
-        searchSkills(stripped, ctx).catch(() => [] as MentionSkill[]),
-      ]);
-      const q = stripped.trim();
-      return [
-        ...results,
-        ...searchWorkspaces(stripped, ctx),
-        // Zero-query overview keeps skills to a taster; a real query shows
-        // every matching skill (still bounded by the store size).
-        ...skillMatches.slice(0, q ? 10 : 3),
-      ];
+      const results = await invoke<MentionData[]>("mention_search", {
+        query: stripped,
+        scope,
+        projectPath: ctx.projectPath,
+        workspaceId: activeWorkspaceId(),
+      });
+      return [...results, ...searchWorkspaces(stripped, ctx)];
     }
     return await invoke<MentionData[]>("mention_search", {
       query: stripped,
@@ -489,69 +454,9 @@ function searchWorkspaces(query: string, ctx: MentionContext): MentionWorkspace[
     }));
 }
 
-/** Skill search for the `#skill:` rail. Lists the canonical store for global
- *  and (when a project is open) project scope, then substring-filters by name
- *  or description. Project skills sort first (more specific), then alpha.
- *  Reuses the existing `skills_list` IPC — no new backend command. */
-async function searchSkills(query: string, ctx: MentionContext): Promise<MentionSkill[]> {
-  const q = query.trim().toLowerCase();
-  const sources: { scope: "global" | "project"; projectPath: string | null }[] = [
-    { scope: "global", projectPath: null },
-  ];
-  if (ctx.projectPath) {
-    sources.push({ scope: "project", projectPath: ctx.projectPath });
-  }
-
-  const lists = await Promise.all(
-    sources.map(async (s) => {
-      try {
-        const metas = await skills.list(s.scope, s.projectPath);
-        return metas.map((meta) => ({ meta, source: s }));
-      } catch (e) {
-        console.warn(`skills_list (${s.scope}) failed:`, e);
-        return [];
-      }
-    }),
-  );
-
-  const seen = new Set<string>();
-  const out: MentionSkill[] = [];
-  for (const { meta, source } of lists.flat()) {
-    const id = `${source.scope}:${meta.name}`;
-    if (seen.has(id)) continue;
-    // NOTE: we intentionally do NOT gate by per-agent enablement here. Selecting
-    // a skill in the picker inlines its SKILL.md body into the prompt (see
-    // compose_prompt), which works for ANY agent regardless of whether the skill
-    // is symlinked into that agent's native skills dir. The old `enabledAgents`
-    // gate hid freshly installed skills (not yet projected to any agent →
-    // `enabledAgents` empty) — which read as "skills not indexed yet". Every
-    // installed skill in scope is a valid mention target, so we show them all.
-    if (q && !meta.name.toLowerCase().includes(q) && !meta.description.toLowerCase().includes(q)) {
-      continue;
-    }
-    seen.add(id);
-    out.push({
-      kind: "skill",
-      id,
-      displayName: meta.name,
-      description: meta.description,
-      scope: source.scope,
-      skillName: meta.name,
-      projectPath: source.projectPath,
-      filePath: meta.path,
-    });
-  }
-
-  out.sort((a, b) => {
-    if (a.scope !== b.scope) return a.scope === "project" ? -1 : 1;
-    return a.displayName.localeCompare(b.displayName);
-  });
-  return out;
-}
-
-/** Pack-component search for the `#` rail — lists installed-pack commands,
- *  agents, and rules (via `pack_components_list`) and substring-filters by name,
- *  description, or kind. Grouped by kind, then alpha. Mirrors `searchSkills`. */
+/** Pack-component search — lists installed-pack commands, agents, and rules
+ *  (via `pack_components_list`) and substring-filters by name, description,
+ *  or kind. Grouped by kind, then alpha. */
 async function searchPackComponents(
   query: string,
   ctx: MentionContext,
@@ -582,7 +487,7 @@ async function searchPackComponents(
     const id = `${source.scope}:${meta.kind}:${meta.pack}:${meta.name}`;
     if (seen.has(id)) continue;
     // Per-agent gating: only offer pack components (command/agent/rule) that the
-    // pack has projected to the active agent. Mirrors the skill filter above.
+    // pack has projected to the active agent.
     if (ctx.agentId && !meta.enabledAgents.includes(ctx.agentId)) {
       continue;
     }
@@ -714,22 +619,10 @@ export async function composePrompt(
             useKnowledgeStore.getState().entries.find((e) => e.id === m.id)?.content ?? null,
         };
       }
-      // Skills have no in-memory store, so read the frontmatter-stripped body
-      // now (one cheap IPC per mentioned skill). Rust falls back to reading
-      // `filePath` if this is null.
-      if (m.kind === "skill") {
-        let inlineBody: string | null = null;
-        try {
-          inlineBody = (await skills.read(m.scope, m.skillName, m.projectPath)).body;
-        } catch (e) {
-          console.warn("skills.read for compose failed:", e);
-        }
-        return { ...m, inlineBody };
-      }
       // Past session: read the JSONL transcript now and format it into a
       // plain-text conversation the agent can reference. Kept lightweight in
       // the chip (just filePath); the (potentially large) body only
-      // materializes here, at send time — same lazy pattern skills use.
+      // materializes here, at send time.
       if (m.kind === "past_session") {
         let inlineBody: string | null = null;
         try {

--- a/src/features/memory/lib/shared-memory-api.ts
+++ b/src/features/memory/lib/shared-memory-api.ts
@@ -14,8 +14,7 @@ export type EventKind =
   | "session_start"
   | "session_end"
   | "todo_added"
-  | "todo_done"
-  | "skill_used";
+  | "todo_done";
 
 export interface MemoryEvent {
   seq: number;

--- a/src/features/mentions/components/mention-picker.tsx
+++ b/src/features/mentions/components/mention-picker.tsx
@@ -8,8 +8,8 @@
 //     the ranked results surface them. Empty query shows a zero-query
 //     overview (recents + a slice of each kind) with a "Browse" category
 //     tail as an escape hatch for explicit scoping + past messages.
-//   • Scope locked (category pick, `~`, `#`, or an alias like `@note `):
-//     results from that kind only.
+//   • Scope locked (category pick, `~`, or an alias like `@note `): results
+//     from that kind only.
 //
 // Keyboard contract: the parent component forwards Up/Down/Enter/Esc via
 // the imperative handle so CM's focus stays put — the picker never has
@@ -91,8 +91,8 @@ export interface MentionPickerProps {
   anchor: { x: number; y: number } | null;
   /** Active project root — required for project-scoped sources. */
   projectPath: string | null;
-  /** Active chat agent's skill-registry id. When set, the `#` skill rail only
-   *  lists skills enabled for this agent (per-agent skill/pack gating). */
+  /** Active chat agent's skill-registry id. When set, pack-component
+   *  mentions (command/agent/rule) only list ones enabled for this agent. */
   agentId?: string;
   /** A mention was picked. Parent inserts the chip. */
   onSelect: (mention: MentionData) => void;
@@ -296,9 +296,9 @@ export const MentionPicker = forwardRef<MentionPickerHandle, MentionPickerProps>
       };
     }, [open]);
 
-    // Re-run the search when skills/packs change on disk (install, projection,
-    // adopt, …) so a freshly installed skill/component shows up without the
-    // user reopening the picker. Mirrors the file-index refresh above.
+    // Re-run the search when packs change on disk (install, projection,
+    // adopt, …) so a freshly installed component shows up without the user
+    // reopening the picker. Mirrors the file-index refresh above.
     useEffect(() => {
       if (!open) return;
       const onChanged = () => setIndexNonce((n) => n + 1);
@@ -336,18 +336,9 @@ export const MentionPicker = forwardRef<MentionPickerHandle, MentionPickerProps>
       }
       if (scope) {
         // Group results under per-kind sub-headers. Homogeneous scopes collapse
-        // to a single header (unchanged); the `#` rail (skills + pack components)
-        // splits into Skills / Commands / Agents / Rules.
+        // to a single header (unchanged); the "component" scope (pack-delivered
+        // commands/agents/rules) splits into Commands / Agents / Rules.
         const groupOf = (m: MentionData): { key: string; label: string } => {
-          // Skills can be installed globally or per-workspace — segment them so
-          // the user sees which scope a skill came from.
-          if (m.kind === "skill") {
-            const ws = m.scope === "project";
-            return {
-              key: `skill:${m.scope}`,
-              label: ws ? "Workspace Skills" : "Global Skills",
-            };
-          }
           if (m.kind === "component") {
             const label =
               m.componentKind === "command"
@@ -872,8 +863,6 @@ function CategoryIcon({ kind }: { kind: MentionKind }) {
       return <Hash size={size} />;
     case "knowledge":
       return <BookOpen size={size} />;
-    case "skill":
-      return <Zap size={size} />;
     case "component":
       return <Zap size={size} />;
     case "repo":
@@ -913,8 +902,6 @@ function secondaryLabel(m: MentionData): string {
       return `${m.symbolKind} · ${shortPath(m.filePath)}`;
     case "knowledge":
       return m.folder ? `${m.folder} · ${m.source}` : m.source;
-    case "skill":
-      return m.scope === "project" ? `${m.description} · project` : m.description;
     case "component":
       return `${m.componentKind} · pack: ${m.pack}`;
     case "repo":
@@ -980,8 +967,6 @@ function mentionTitle(m: MentionData): string {
       return `${m.filePath}:${m.line}`;
     case "knowledge":
       return m.filePath;
-    case "skill":
-      return m.description || m.filePath;
     case "component":
       return m.description || m.filePath;
     case "repo":

--- a/src/features/model-chat/components/model-chat-panel.tsx
+++ b/src/features/model-chat/components/model-chat-panel.tsx
@@ -461,28 +461,34 @@ function Composer({
     inputRef.current?.insertMention(mention, t.from, t.to);
   }, []);
 
-  const keyInterceptor = useCallback((key: "Up" | "Down" | "Enter" | "Escape" | "Backspace") => {
-    const p = pickerRef.current;
-    const t = triggerRef.current;
-    if (!t || !p) return false;
-    switch (key) {
-      case "Up":
-        p.moveUp();
-        return true;
-      case "Down":
-        p.moveDown();
-        return true;
-      case "Enter":
-        return p.commit();
-      case "Escape":
-        if (p.goBack()) return true;
-        setTrigger(null);
-        return true;
-      case "Backspace":
-        if (t.query === "" && p.goBack()) return true;
-        return false;
-    }
-  }, []);
+  const keyInterceptor = useCallback(
+    (key: "Up" | "Down" | "Enter" | "Escape" | "Backspace" | "Tab") => {
+      const p = pickerRef.current;
+      const t = triggerRef.current;
+      if (!t || !p) return false;
+      switch (key) {
+        case "Up":
+          p.moveUp();
+          return true;
+        case "Down":
+          p.moveDown();
+          return true;
+        case "Enter":
+          return p.commit();
+        case "Escape":
+          if (p.goBack()) return true;
+          setTrigger(null);
+          return true;
+        case "Backspace":
+          if (t.query === "" && p.goBack()) return true;
+          return false;
+        case "Tab":
+          // No slash picker on this composer — Tab is never intercepted.
+          return false;
+      }
+    },
+    [],
+  );
 
   const submit = () => {
     if (running) {


### PR DESCRIPTION
## Summary

Two related changes, landing together:

- **Composer**: the `/` slash-command picker now sources its list purely from the bound agent's ACP-advertised commands instead of a hardcoded catalogue — it stays in sync with what the agent actually supports, shows a loading state during the startup gap instead of stale/wrong entries, opens mid-message instead of only at line-start, ranks and highlights matches instead of just filtering, and completes via Tab without ever sending. Host-handled guard rows (`/skills` → opens Settings; dimmed `/clear`/`/logout` → the ACP adapter blocklists these from advertisement, so without a guard row selecting them silently no-ops) round out the picker.
- **Skills**: skill invocation moves entirely onto that `/` passthrough path — the `#` mention rail and its `compose_prompt.rs` body-splicing are retired (inlining could never carry `$ARGUMENTS` and always missed a skill's bundled reference files). The canonical skill store moves from `.atlas/skills` to `~/.agents/skills` + `<project>/.agents/skills`, the format skills.sh and Zed already use — discovery follows the symlink projections other tooling already writes there instead of rejecting them, install projects a skill to every detected agent immediately instead of leaving it invisible until per-agent toggles are found in Settings, anything left in the old store migrates in automatically, and Claude's plugin-bundled skill directories are scanned as a fourth, read-only channel.

Relates to #86 — that issue's scope predates this design (it assumed the picker needed its own registry) and should be reconciled/closed separately rather than auto-closed by this PR.

## Known follow-ups (not fixed here, flagging rather than hiding)

- `skills_list_plugins` (the new Claude-plugin discovery channel) has no Settings UI consumer yet — the backend capability is there and tested, nothing surfaces it to the user yet.
- Install's per-agent projection fan-out (`install_skill_from_dir`) has no rollback if projection fails partway through multiple agents — this mirrors the identical pre-existing pattern in `adopt_skill`/`promote`, so fixing it well means touching all three consistently, out of scope here.
- Codex's own plugin-skill directory layout is unverified (`~/.codex/plugins/` only has `cache/` on hand) — left as a marked TODO rather than guessing at a path.

## Test plan

- [x] `bun run lint` / `bun run format:check` / `bunx tsc --noEmit` — clean
- [x] `cd src-tauri && cargo check` — clean
- [x] `cargo test --lib commands::skills::` — 58 passed
- [x] `cargo test --lib commands::compose_prompt::` — 5 passed
- [x] `cargo test --lib commands::shared_memory::` — 8 passed
- [x] `bun run test` (Vitest incl. IPC-contract check) — 476 passed
- [x] Independent Standards + Spec review and a second-opinion Codex pass — findings fixed: a Tab-complete bug that let the dimmed `/clear` guard row bypass its own handler, a backward-compat gap in the removed `skill_used` event breaking `last_seq` continuity on upgrade, and a silent failure path in legacy-store migration
- [ ] Manual pass in `bun run dev:app` — no frontend test runner covers picker UI interaction directly; needs a real window