### PR TITLE
fix(explorer): polish file-tree git status indicators

### DIFF
--- a/src/features/explorer/components/file-tree.tsx
+++ b/src/features/explorer/components/file-tree.tsx
@@ -21,6 +21,11 @@ import { useFileTreeDragDrop, ROOT_DROP } from "../hooks/use-file-tree-drag-drop
 import { useExternalFileDrop } from "../hooks/use-external-file-drop";
 import { ROW_HEIGHT } from "../lib/tree-constants";
 import {
+  gitStatusPresentation,
+  moreProminentGitStatus,
+  type GitStatusPresentation,
+} from "../lib/git-status-presentation";
+import {
   ContextMenu,
   ContextMenuTrigger,
   ContextMenuContent,
@@ -43,24 +48,6 @@ interface FlatRow {
 /** Tab types whose `data.filePath` points at a file on disk — these must be
  *  re-pointed/closed when that file is renamed or deleted. */
 const FILE_TAB_TYPES = new Set(["editor", "media", "svg", "pdf", "unsupported"]);
-
-/** Map a git porcelain status char to a gutter-dot color, matching the
- *  Source Control panel's convention (`changes-view.tsx:statusBadge`). */
-function gitStatusColor(status: string): string {
-  switch (status) {
-    case "?": // untracked
-    case "A": // added
-      return "var(--status-success)";
-    case "D": // deleted
-    case "U": // unmerged / conflict
-      return "var(--status-error)";
-    case "R": // renamed
-    case "C": // copied
-      return "var(--status-info)";
-    default: // M and everything else → modified
-      return "var(--status-warning)";
-  }
-}
 
 export function FileTree() {
   const tree = useExplorerStore.use.tree();
@@ -150,18 +137,18 @@ export function FileTree() {
   const gitRepoPath = useGitStore.use.repoPath();
   const { fileColors, dirtyDirs } = useMemo(() => {
     const fileColors = new Map<string, string>();
-    const dirtyDirs = new Set<string>();
+    const dirtyDirs = new Map<string, GitStatusPresentation>();
     const root = gitRepoPath ?? rootPath;
     if (!root) return { fileColors, dirtyDirs };
     for (const f of gitFiles) {
       const abs = `${root}/${f.path}`;
-      fileColors.set(abs, gitStatusColor(f.status));
+      const presentation = gitStatusPresentation(f.status);
+      fileColors.set(abs, presentation.color);
       // Walk ancestors up to (and excluding) the root so each enclosing
       // folder knows it contains a change.
       let dir = abs.slice(0, abs.lastIndexOf("/"));
       while (dir.length > root.length) {
-        if (dirtyDirs.has(dir)) break; // ancestors already recorded
-        dirtyDirs.add(dir);
+        dirtyDirs.set(dir, moreProminentGitStatus(dirtyDirs.get(dir), presentation));
         dir = dir.slice(0, dir.lastIndexOf("/"));
       }
     }
@@ -757,8 +744,8 @@ export function FileTree() {
                   // marker when it contains a change (expanded dirs let their
                   // children carry the signal instead, to avoid double-marking).
                   const gitColor = isDir
-                    ? !node.expanded && dirtyDirs.has(node.entry.path)
-                      ? "var(--status-warning)"
+                    ? !node.expanded
+                      ? (dirtyDirs.get(node.entry.path)?.color ?? null)
                       : null
                     : (fileColors.get(node.entry.path) ?? null);
                   const isSelected = selectedPaths.includes(node.entry.path);

--- a/src/features/explorer/components/tree-row.tsx
+++ b/src/features/explorer/components/tree-row.tsx
@@ -50,8 +50,8 @@ interface TreeRowProps {
   isDropTarget?: boolean;
   /** Dim this row while it's the active drag source. */
   isDragging?: boolean;
-  /** When set, paints a small git-status dot in the left gutter (e.g. a
-   *  modified/added/untracked marker). Pass a CSS color string. */
+  /** When set, paints a small git-status dot at the trailing edge. File names
+   *  use the same color; folders retain their neutral typography. */
   gitColor?: string | null;
 }
 
@@ -182,16 +182,10 @@ export function TreeRow({
         ...style,
       }}
     >
-      {/* Left slot: chevron (folders) / spacer (files), OR a git-status dot.
-          A COLLAPSED folder with changes shows the dot IN PLACE of its right
-          chevron (so the dot never overlaps the arrow); expanding restores the
-          down chevron (its children then carry their own dots). A changed file
-          shows the dot in its (otherwise empty) gutter slot. */}
-      {!isEditing && gitColor && (!isDir || !isExpanded) ? (
-        <span className="w-3 shrink-0 flex items-center justify-center" aria-hidden>
-          <span className="rounded-full" style={{ width: 6, height: 6, background: gitColor }} />
-        </span>
-      ) : isDir ? (
+      {/* The left slot is intentionally stable: a folder always owns its
+          chevron and a file always owns its spacer. Git state lives beside the
+          filename at the row's trailing edge, where it cannot displace either. */}
+      {isDir ? (
         <ChevronRight
           size={12}
           className={cn(
@@ -244,20 +238,30 @@ export function TreeRow({
             else onCancel?.();
           }}
           className={cn(
-            "flex-1 min-w-0 font-mono text-[12px] leading-none bg-bg-input border border-border-default rounded px-1 py-0.5",
+            "flex-1 min-w-0 font-mono text-[11px] leading-4 bg-bg-input border border-border-default rounded px-1 py-0.5",
             "text-text-primary outline-none focus:border-border-focus",
           )}
         />
       ) : (
         <span
           className={cn(
-            "truncate font-mono text-[12px] leading-none flex-1 min-w-0",
+            "truncate font-mono text-[11px] leading-4 flex-1 min-w-0",
             isDir && "text-text-primary",
           )}
+          style={!isDir && gitColor ? { color: gitColor } : undefined}
         >
           {name}
         </span>
       )}
+
+      {!isEditing && gitColor ? (
+        <span
+          className="ml-auto grid h-3 w-3 shrink-0 place-items-center"
+          aria-label={isDir ? "Contains changed files" : "Git status changed"}
+        >
+          <span className="h-1.5 w-1.5 rounded-full" style={{ background: gitColor }} />
+        </span>
+      ) : null}
 
       {trailing && !isEditing ? (
         <span className="shrink-0 flex items-center gap-0.5">{trailing}</span>

--- a/src/features/explorer/lib/git-status-presentation.test.ts
+++ b/src/features/explorer/lib/git-status-presentation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { gitStatusPresentation, moreProminentGitStatus } from "./git-status-presentation";
+
+describe("gitStatusPresentation", () => {
+  it("uses warning for modified files and info blue for untracked files", () => {
+    expect(gitStatusPresentation("M").color).toBe("var(--status-warning)");
+    expect(gitStatusPresentation("?").color).toBe("var(--status-info)");
+  });
+
+  it("retains distinct semantic colors for added, deleted, renamed, and conflicted files", () => {
+    expect(gitStatusPresentation("A").color).toBe("var(--status-success)");
+    expect(gitStatusPresentation("D").color).toBe("var(--status-error)");
+    expect(gitStatusPresentation("R").color).toBe("var(--status-info)");
+    expect(gitStatusPresentation("U").color).toBe("var(--status-error)");
+  });
+
+  it("keeps the most prominent descendant status on collapsed folders", () => {
+    const untracked = gitStatusPresentation("?");
+    const modified = gitStatusPresentation("M");
+    const conflicted = gitStatusPresentation("U");
+
+    expect(moreProminentGitStatus(undefined, untracked)).toBe(untracked);
+    expect(moreProminentGitStatus(untracked, modified)).toBe(modified);
+    expect(moreProminentGitStatus(modified, conflicted)).toBe(conflicted);
+  });
+});

--- a/src/features/explorer/lib/git-status-presentation.ts
+++ b/src/features/explorer/lib/git-status-presentation.ts
@@ -1,0 +1,32 @@
+/**
+ * Visual treatment for the short status codes returned by `git status
+ * --porcelain`. Keeping this separate from the tree lets files and collapsed
+ * folders share the same semantic colors, and gives the mapping direct tests.
+ */
+export type GitStatusPresentation = {
+  color: string;
+  priority: number;
+};
+
+const PRESENTATIONS: Record<string, GitStatusPresentation> = {
+  M: { color: "var(--status-warning)", priority: 3 },
+  D: { color: "var(--status-error)", priority: 4 },
+  U: { color: "var(--status-error)", priority: 4 },
+  R: { color: "var(--status-info)", priority: 2 },
+  C: { color: "var(--status-info)", priority: 2 },
+  A: { color: "var(--status-success)", priority: 1 },
+  "?": { color: "var(--status-info)", priority: 2 },
+};
+
+/** Returns the status color and its severity for files and collapsed folders. */
+export function gitStatusPresentation(status: string): GitStatusPresentation {
+  return PRESENTATIONS[status] ?? PRESENTATIONS.M;
+}
+
+/** Prefer the strongest descendant state for a collapsed folder marker. */
+export function moreProminentGitStatus(
+  current: GitStatusPresentation | undefined,
+  next: GitStatusPresentation,
+): GitStatusPresentation {
+  return !current || next.priority > current.priority ? next : current;
+}


### PR DESCRIPTION
## Summary

- make file-tree typography compact while preserving line height for descenders at zoom
- move Git markers to the trailing edge and tint changed file names with the same semantic color
- use blue for untracked files and preserve meaningful colors for added, deleted, renamed/copied, and conflicted states
- retain collapsed-folder markers, prioritizing the strongest descendant status

Closes #65.

## Validation

- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (488 passing)
- `git diff --check`