### PR TITLE
fix(agents): inherit configured permission modes

### DIFF
--- a/crates/atlas-agents/src/error.rs
+++ b/crates/atlas-agents/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     SessionExists,
     #[error("session worker is gone")]
     WorkerGone,
+    #[error("mode is not advertised by this session: {0}")]
+    InvalidMode(String),
     #[error("acp: {0}")]
     Acp(#[from] atlas_acp::AcpError),
     #[error("io: {0}")]

--- a/crates/atlas-agents/src/lib.rs
+++ b/crates/atlas-agents/src/lib.rs
@@ -47,7 +47,7 @@ pub use connection::BackendConnection;
 pub use error::{Error, Result};
 pub use atlas_bus::{EventBus, InboundMiddleware, InboundPipeline, OutboundMiddleware, OutboundPipeline};
 pub use events::{DeltaSink, Emitter, SessionDelta, SessionDeltaEnvelope};
-pub use manager::{AgentManager, SessionKey};
+pub use manager::{AgentManager, SessionInit, SessionKey};
 pub use plugin::{PluginSpec, TranscriptKind, builtin_plugins, find_plugin};
 pub use session::{
     Message, MessageMode, MessageRole, PlanEntry, SessionSnapshot, SessionStatus, ToolCall,

--- a/crates/atlas-agents/src/manager.rs
+++ b/crates/atlas-agents/src/manager.rs
@@ -37,6 +37,15 @@ pub struct SessionKey {
     pub session_id: String,
 }
 
+/// Metadata returned with a newly-created session. The agent's advertised
+/// mode is available before the UI binds the session and flushes queued text.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionInit {
+    pub key: SessionKey,
+    pub current_mode: Option<String>,
+    pub available_modes: Vec<SessionModeInfo>,
+}
+
 #[derive(Clone)]
 pub struct AgentManager {
     inner: Arc<ManagerInner>,
@@ -167,7 +176,7 @@ impl AgentManager {
     }
 
     /// Open a fresh session and spawn a worker for it.
-    pub async fn new_session(&self, agent_id: AgentId, cwd: PathBuf) -> Result<SessionKey> {
+    pub async fn new_session(&self, agent_id: AgentId, cwd: PathBuf) -> Result<SessionInit> {
         let cwd_str = cwd.to_string_lossy().into_owned();
         let plugin_id = self.plugin_id_for(agent_id)?;
         let resp: NewSessionInfo = self.backend_for(agent_id)?.new_session(agent_id, cwd).await?;
@@ -179,6 +188,11 @@ impl AgentManager {
             agent_id,
             session_id: session_id_str.clone(),
         };
+        let (current_mode, available_modes) = resp
+            .modes
+            .as_ref()
+            .map(parse_session_modes)
+            .unwrap_or_default();
         self.install_session(
             key.clone(),
             resp.session_id,
@@ -188,7 +202,11 @@ impl AgentManager {
             resp.modes,
             resp.models,
         );
-        Ok(key)
+        Ok(SessionInit {
+            key,
+            current_mode,
+            available_modes,
+        })
     }
 
     /// Read a saved session's transcript straight off disk, WITHOUT spawning an
@@ -424,7 +442,10 @@ impl AgentManager {
     }
 
     pub fn set_mode(&self, key: &SessionKey, mode_id: String) -> Result<()> {
-        self.handle_for(key)?.set_mode(mode_id)
+        let handle = self.handle_for(key)?;
+        let advertised = handle.state.lock().available_modes.clone();
+        validate_mode(&mode_id, &advertised)?;
+        handle.set_mode(mode_id)
     }
 
     pub fn set_model(&self, key: &SessionKey, model_id: String) -> Result<()> {
@@ -729,6 +750,15 @@ fn parse_session_modes(modes: &serde_json::Value) -> (Option<String>, Vec<Sessio
     (current, available)
 }
 
+/// Validate a requested mode without rejecting agents that do not advertise a
+/// mode list (older ACP implementations and Claude's legacy bridge).
+fn validate_mode(mode_id: &str, advertised: &[SessionModeInfo]) -> Result<()> {
+    if advertised.is_empty() || advertised.iter().any(|mode| mode.id == mode_id) {
+        return Ok(());
+    }
+    Err(Error::InvalidMode(mode_id.to_string()))
+}
+
 /// Parse the ACP `SessionModelState` blob (from `session/new`) into
 /// `(current_model_id, available_models)`. The schema serialises camelCase
 /// (`currentModelId`, `availableModels`), each model as `{modelId, name,
@@ -764,4 +794,40 @@ fn parse_session_models(models: &serde_json::Value) -> (Option<String>, Vec<Sess
         })
         .unwrap_or_default();
     (current, available)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn modes() -> Vec<SessionModeInfo> {
+        vec![
+            SessionModeInfo {
+                id: "read-only".into(),
+                name: "Read only".into(),
+                description: None,
+            },
+            SessionModeInfo {
+                id: "danger-full-access".into(),
+                name: "Full access".into(),
+                description: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn advertised_mode_is_accepted() {
+        assert!(validate_mode("danger-full-access", &modes()).is_ok());
+    }
+
+    #[test]
+    fn unknown_advertised_mode_is_rejected() {
+        let err = validate_mode("bypassPermissions", &modes()).unwrap_err();
+        assert!(matches!(err, Error::InvalidMode(mode) if mode == "bypassPermissions"));
+    }
+
+    #[test]
+    fn legacy_agents_without_modes_remain_compatible() {
+        assert!(validate_mode("bypassPermissions", &[]).is_ok());
+    }
 }

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -433,7 +433,7 @@ pub async fn agents_new_session(
     agent_id: AgentId,
     cwd: PathBuf,
     manager: State<'_, AgentManager>,
-) -> Result<SessionKey, String> {
+) -> Result<atlas_agents::SessionInit, String> {
     manager
         .new_session(agent_id, cwd)
         .await

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -13,6 +13,7 @@ import {
   isBusyAgentStatus,
   agentTypeFromPluginId,
   pluginIdForAgent,
+  CLAUDE_PERMISSION_MODES,
 } from "@/types/agent";
 import { agentMeta } from "@/features/agents/lib/agent-meta";
 import { composePrompt, type MentionData } from "../lib/mentions";
@@ -111,10 +112,10 @@ async function rebindDisconnectedSession(tabId: string): Promise<boolean> {
         key = await agents.loadSession(agent.agent_id, sess.acpSessionId, cwd);
       } catch (err) {
         console.warn("resume after disconnect failed; starting fresh:", err);
-        key = await agents.newSession(agent.agent_id, cwd);
+        key = (await agents.newSession(agent.agent_id, cwd)).key;
       }
     } else {
-      key = await agents.newSession(agent.agent_id, cwd);
+      key = (await agents.newSession(agent.agent_id, cwd)).key;
     }
     const actions = useChatStore.getState().actions;
     actions.setAcpBinding(tabId, agent.agent_id, key.session_id, cwd);
@@ -338,7 +339,8 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
         // "/" fallback would dodge the running-workspace eviction guard.
         const cwd =
           workspacePathForTab(tabId) ?? useProjectStore.getState().currentProject?.path ?? "/";
-        const key = await agents.newSession(agent.agent_id, cwd);
+        const init = await agents.newSession(agent.agent_id, cwd);
+        const key = init.key;
         if (cancelled) return;
         // Guard against an agent switch that landed mid-bind: if the tab's
         // agentType changed since we picked `pluginId`, this binding is for the
@@ -352,14 +354,48 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
         // mode after it the first turn can race ahead of (e.g.)
         // bypassPermissions and still trigger a stray prompt on turn one.
         // Awaiting here guarantees the agent is in the right mode first.
-        const mode = useChatStore.getState().sessions[tabId]?.claudePermissionMode ?? "default";
-        if (mode !== "default") {
+        const session = useChatStore.getState().sessions[tabId];
+        const selectedMode = session?.claudePermissionMode ?? "default";
+        // `default` means the user has not overridden the agent. Preserve the
+        // mode resolved by Claude/Codex from their own user-level config.
+        const requestedClaudeMode = session?.claudePermissionModeExplicit
+          ? selectedMode
+          : undefined;
+        const requestedAcpMode = session?.acpModeExplicit ? session.acpCurrentMode : undefined;
+        const requestedMode = nowAt === "claude-code" ? requestedClaudeMode : requestedAcpMode;
+        const mode = requestedMode ?? init.current_mode;
+        const modeAdvertised =
+          !mode ||
+          init.available_modes.length === 0 ||
+          init.available_modes.some((m) => m.id === mode);
+        const effectiveMode = modeAdvertised ? mode : init.current_mode;
+        if (effectiveMode && effectiveMode !== init.current_mode) {
           try {
-            await agents.setMode(key, mode);
+            await agents.setMode(key, effectiveMode);
           } catch (err) {
             console.warn("setMode at session create failed:", err);
           }
           if (cancelled) return;
+        }
+        // Seed the store before binding: binding is the point at which queued
+        // sends become eligible, so the first prompt sees the agent's actual
+        // default instead of a hard-coded Atlas fallback.
+        if (!cancelled) {
+          const actions = useChatStore.getState().actions;
+          if (
+            nowAt === "claude-code" &&
+            (effectiveMode ?? init.current_mode) &&
+            CLAUDE_PERMISSION_MODES.includes(
+              (effectiveMode ?? init.current_mode) as (typeof CLAUDE_PERMISSION_MODES)[number],
+            )
+          ) {
+            actions.hydrateClaudePermissionMode(
+              tabId,
+              (effectiveMode ?? init.current_mode) as (typeof CLAUDE_PERMISSION_MODES)[number],
+            );
+          } else if (nowAt !== "claude-code" && init.available_modes.length > 0) {
+            actions.setAcpModes(tabId, effectiveMode, init.available_modes, nowAt);
+          }
         }
         useChatStore.getState().actions.setAcpBinding(tabId, agent.agent_id, key.session_id, cwd);
         // Seed the composer mode picker from the freshly-created session's

--- a/src/features/chat/lib/agents-api.ts
+++ b/src/features/chat/lib/agents-api.ts
@@ -13,6 +13,7 @@ import type {
   ImageAttachment,
   PluginSpec,
   SessionKey,
+  SessionInit,
   SessionMessage,
   SessionSnapshot,
 } from "@/types/agents";
@@ -42,7 +43,7 @@ export const agents = {
   kill: (agentId: AgentId) => invoke<void>("agents_kill", { agentId }),
 
   newSession: (agentId: AgentId, cwd: string) =>
-    invoke<SessionKey>("agents_new_session", { agentId, cwd }),
+    invoke<SessionInit>("agents_new_session", { agentId, cwd }),
   loadSession: (agentId: AgentId, sessionId: AcpSessionId, cwd: string) =>
     invoke<SessionKey>("agents_load_session", { agentId, sessionId, cwd }),
 

--- a/src/features/chat/lib/last-mode-pref.test.ts
+++ b/src/features/chat/lib/last-mode-pref.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest";
+import { loadLastModePref, saveLastModePref } from "./last-mode-pref";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("last-mode-pref", () => {
+  it("round-trips an explicit pick", () => {
+    saveLastModePref("codex", "danger-full-access");
+    expect(loadLastModePref("codex")).toBe("danger-full-access");
+  });
+
+  it("keeps agents isolated — registry externals key by their plugin id", () => {
+    saveLastModePref("codex", "danger-full-access");
+    saveLastModePref("claude-code", "bypassPermissions");
+    saveLastModePref("some-registry-agent@1.2", "yolo");
+    expect(loadLastModePref("codex")).toBe("danger-full-access");
+    expect(loadLastModePref("claude-code")).toBe("bypassPermissions");
+    expect(loadLastModePref("some-registry-agent@1.2")).toBe("yolo");
+  });
+
+  it("clearing one agent never touches another's pick", () => {
+    saveLastModePref("codex", "auto");
+    saveLastModePref("claude-code", "acceptEdits");
+    saveLastModePref("codex", null);
+    expect(loadLastModePref("codex")).toBeNull();
+    expect(loadLastModePref("claude-code")).toBe("acceptEdits");
+  });
+
+  it("missing preference reads as null (defer to the agent's own default)", () => {
+    expect(loadLastModePref("codex")).toBeNull();
+  });
+});

--- a/src/features/chat/lib/last-mode-pref.ts
+++ b/src/features/chat/lib/last-mode-pref.ts
@@ -1,0 +1,35 @@
+// Persisted per-agent explicit mode preference.
+//
+// When a user explicitly changes a permission/agent mode in Atlas, that pick
+// should outlive the tab and the app restart: the next session with the same
+// agent starts in it instead of the agent's own default. Keyed by agentType —
+// which for registry-installed externals IS the plugin id — so every agent,
+// first-party or installed, keeps its own record.
+//
+// Only user-initiated picks are ever written. Modes the agent advertises at
+// `session/new` or adopts on its own (ACP `current_mode_update`, e.g. exiting
+// a plan mode) must NOT be stored — persisting those would turn an observed
+// state into an Atlas-side default that overrides the CLI's user-level config.
+
+const key = (agentType: string) => `atlas:last-mode:v1:${agentType}`;
+
+/** The last mode the user explicitly picked for this agent, or null. */
+export function loadLastModePref(agentType: string): string | null {
+  try {
+    return localStorage.getItem(key(agentType));
+  } catch {
+    // storage unavailable — treat as no preference
+  }
+  return null;
+}
+
+/** Record an explicit pick. Passing null clears it, deferring to the agent's
+ *  own configured default again. */
+export function saveLastModePref(agentType: string, mode: string | null): void {
+  try {
+    if (mode === null) localStorage.removeItem(key(agentType));
+    else localStorage.setItem(key(agentType), mode);
+  } catch {
+    // storage full / unavailable — persistence is best-effort
+  }
+}

--- a/src/features/chat/lib/warm-acp-models.ts
+++ b/src/features/chat/lib/warm-acp-models.ts
@@ -62,8 +62,8 @@ export async function warmAcpModels(agentType: string, cwd: string): Promise<voi
   warmed.add(at);
   try {
     const agent = await ensureAgent(pluginIdForAgent(at));
-    const key = await agents.newSession(agent.agent_id, cwd);
-    const snap = await agents.snapshot(key);
+    const init = await agents.newSession(agent.agent_id, cwd);
+    const snap = await agents.snapshot(init.key);
     const models = snap.available_models ?? [];
     if (models.length > 0) {
       saveCachedAcpModels(at, {

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -21,6 +21,7 @@ import type {
 } from "@/types/agents";
 import { splitAtlasContext } from "../lib/atlas-context";
 import { loadCachedAcpModes, saveCachedAcpModes } from "../lib/acp-modes-cache";
+import { loadLastModePref, saveLastModePref } from "../lib/last-mode-pref";
 import { loadCachedAcpModels, saveCachedAcpModels } from "../lib/acp-models-cache";
 import { resolveModelLabel } from "../lib/model-label";
 import { defaultAgentForNewSession } from "../lib/default-agent";
@@ -150,6 +151,33 @@ function pushAcpModeToAgent(state: ChatState, sessionId: string): void {
     key: { agent_id: session.acpAgentId, session_id: session.acpSessionId },
     modeId: session.acpCurrentMode,
   }).catch((err) => console.warn("agents_set_mode failed:", err));
+}
+
+/** Hydrate the per-agent persisted mode preference (last explicit pick) into
+ *  a freshly-created / freshly-switched tab. A restored pick is marked
+ *  explicit so the chat panel pushes it to the agent at session create (after
+ *  revalidating against the advertised modes); no pick means "defer to the
+ *  agent's own configured default" — never an Atlas-side override. */
+function applyPersistedModePref(sess: ChatSession, agentType: AgentType): void {
+  const pref = loadLastModePref(agentType);
+  if (agentType === "claude-code") {
+    const valid = !!pref && (CLAUDE_PERMISSION_MODES as readonly string[]).includes(pref);
+    sess.claudePermissionMode = valid ? (pref as ClaudePermissionMode) : "default";
+    sess.claudePermissionModeExplicit = valid;
+    return;
+  }
+  // Generic ACP agents: only trust the pick against the optimistic cached
+  // mode list (or when nothing is cached yet) — an id the live agent turns
+  // out not to advertise would stick the picker on its "Mode" fallback.
+  // Session-create revalidates against the real advertised list either way.
+  const cached = loadCachedAcpModes(agentType);
+  const valid =
+    !!pref &&
+    (!cached ||
+      cached.availableModes.length === 0 ||
+      cached.availableModes.some((m) => m.id === pref));
+  sess.acpModeExplicit = valid;
+  if (valid && pref) sess.acpCurrentMode = pref;
 }
 
 /** Push an ACP agent's model selection (Claude Code / Codex) to its bound
@@ -618,6 +646,10 @@ export const useChatStore = createSelectors(
               })(),
             };
             s.activeSessionId = tabId;
+            // Restore the user's last explicit mode pick for this agent so it
+            // survives restarts (marks it explicit; create pushes it after
+            // validating against the agent's advertised modes).
+            applyPersistedModePref(s.sessions[tabId], agentType);
           }),
         switchChatAgent: (tabId, agentType) =>
           set((s) => {
@@ -658,6 +690,9 @@ export const useChatStore = createSelectors(
               sess.acpCurrentMode = cached?.currentMode ?? undefined;
               sess.acpModesPending = true;
             }
+            // Same restore as createSession: the agent's last explicit pick
+            // wins over the optimistic cache seed above.
+            applyPersistedModePref(sess, agentType);
             // Models apply to both agents — seed from cache (empty for cersei).
             const cachedModels = loadCachedAcpModels(agentType);
             sess.acpAvailableModels = cachedModels?.availableModels ?? [];
@@ -830,15 +865,19 @@ export const useChatStore = createSelectors(
             delete s.queues[sessionId];
           }),
         cycleClaudePermissionMode: (sessionId) => {
+          let next: ClaudePermissionMode | undefined;
           set((s) => {
             const session = s.sessions[sessionId];
             if (!session) return;
             const cur = session.claudePermissionMode ?? "default";
             const i = CLAUDE_PERMISSION_MODES.indexOf(cur);
-            const next = CLAUDE_PERMISSION_MODES[(i + 1) % CLAUDE_PERMISSION_MODES.length];
+            next = CLAUDE_PERMISSION_MODES[(i + 1) % CLAUDE_PERMISSION_MODES.length];
             session.claudePermissionMode = next;
             session.claudePermissionModeExplicit = true;
           });
+          // "default" means "defer to the CLI's own configured default" —
+          // cycling back to it DROPS the persisted pick rather than storing it.
+          if (next) saveLastModePref("claude-code", next === "default" ? null : next);
           pushPermissionModeToAgent(get(), sessionId);
         },
         hydrateClaudePermissionMode: (sessionId, mode) =>
@@ -856,6 +895,7 @@ export const useChatStore = createSelectors(
               session.claudePermissionModeExplicit = true;
             }
           });
+          saveLastModePref("claude-code", mode === "default" ? null : mode);
           pushPermissionModeToAgent(get(), sessionId);
         },
         setAcpModes: (sessionId, currentMode, availableModes, sourceAgentType) => {
@@ -910,6 +950,11 @@ export const useChatStore = createSelectors(
               session.acpModeExplicit = true;
             }
           });
+          // Persist the explicit pick per agent. agentType IS the plugin id
+          // for registry-installed externals, so every ACP agent — first-party
+          // or installed — keeps its own record.
+          const at = get().sessions[sessionId]?.agentType;
+          if (at && at !== "claude-code") saveLastModePref(at, modeId);
           pushAcpModeToAgent(get(), sessionId);
         },
         setAcpModels: (sessionId, currentModel, availableModels) => {

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -290,6 +290,9 @@ interface ChatActions {
      *  project's `.atlas/` don't linger and cause ghost-bound tabs. */
     resetSessions: () => void;
     cycleClaudePermissionMode: (sessionId: string) => void;
+    /** Reflect the mode the agent chose during session creation without
+     *  treating it as an Atlas user override or sending a second RPC. */
+    hydrateClaudePermissionMode: (sessionId: string, mode: ClaudePermissionMode) => void;
     setClaudePermissionMode: (sessionId: string, mode: ClaudePermissionMode) => void;
     /** Seed the generic ACP mode state (current + available list) from a
      *  session snapshot. Used for non-Claude agents (e.g. Codex). */
@@ -587,6 +590,8 @@ export const useChatStore = createSelectors(
               // Permission mode is a Claude Code feature; Codex drives its
               // modes generically via ACP (acpCurrentMode).
               claudePermissionMode: agentType === "claude-code" ? "default" : undefined,
+              claudePermissionModeExplicit: false,
+              acpModeExplicit: false,
               // Optimistically pre-fill a non-Claude agent's mode picker from the
               // persisted cache so switching feels instant; mark pending until the
               // real session confirms (the picker shows a loading state).
@@ -625,6 +630,8 @@ export const useChatStore = createSelectors(
             if (sess.acpSessionId) delete s.pendingPermissions[sess.acpSessionId];
             sess.agentType = agentType;
             sess.claudePermissionMode = agentType === "claude-code" ? "default" : undefined;
+            sess.claudePermissionModeExplicit = false;
+            sess.acpModeExplicit = false;
             // Drop the old ACP binding so the chat panel's mount effect re-binds
             // to the newly chosen agent (deps watch acpSessionId + agentType).
             sess.acpAgentId = undefined;
@@ -666,6 +673,8 @@ export const useChatStore = createSelectors(
               sess.availableCommands = undefined;
               sess.claudePermissionMode =
                 agentType === "claude-code" ? (sess.claudePermissionMode ?? "default") : undefined;
+              sess.claudePermissionModeExplicit = false;
+              sess.acpModeExplicit = false;
               if (agentType === "claude-code") {
                 // Claude has no ACP modes — clear any stale picker state left
                 // by the previously-selected agent so no ghost mode pill shows.
@@ -828,13 +837,24 @@ export const useChatStore = createSelectors(
             const i = CLAUDE_PERMISSION_MODES.indexOf(cur);
             const next = CLAUDE_PERMISSION_MODES[(i + 1) % CLAUDE_PERMISSION_MODES.length];
             session.claudePermissionMode = next;
+            session.claudePermissionModeExplicit = true;
           });
           pushPermissionModeToAgent(get(), sessionId);
         },
+        hydrateClaudePermissionMode: (sessionId, mode) =>
+          set((s) => {
+            const session = s.sessions[sessionId];
+            if (!session) return;
+            session.claudePermissionMode = mode;
+            session.claudePermissionModeExplicit = false;
+          }),
         setClaudePermissionMode: (sessionId, mode) => {
           set((s) => {
             const session = s.sessions[sessionId];
-            if (session) session.claudePermissionMode = mode;
+            if (session) {
+              session.claudePermissionMode = mode;
+              session.claudePermissionModeExplicit = true;
+            }
           });
           pushPermissionModeToAgent(get(), sessionId);
         },
@@ -885,7 +905,10 @@ export const useChatStore = createSelectors(
         setAcpMode: (sessionId, modeId) => {
           set((s) => {
             const session = s.sessions[sessionId];
-            if (session) session.acpCurrentMode = modeId;
+            if (session) {
+              session.acpCurrentMode = modeId;
+              session.acpModeExplicit = true;
+            }
           });
           pushAcpModeToAgent(get(), sessionId);
         },

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -183,6 +183,8 @@ export interface ChatSession {
   /** Claude-only permission mode. Absent for non-Claude agents (e.g. Codex),
    *  which drive their modes via the generic ACP `acpCurrentMode`/snapshot. */
   claudePermissionMode?: ClaudePermissionMode;
+  /** True only after the user explicitly changes Claude's mode in this tab. */
+  claudePermissionModeExplicit?: boolean;
   /** ACP agent process bound to this tab (set eagerly when the tab mounts). */
   acpAgentId?: string;
   /**
@@ -194,6 +196,8 @@ export interface ChatSession {
   acpSessionId?: string;
   /** Currently selected ACP session mode (default / acceptEdits / plan / …). */
   acpCurrentMode?: string;
+  /** True only after the user explicitly changes an ACP mode in this tab. */
+  acpModeExplicit?: boolean;
   /** Modes the agent advertised for this session — drives the composer's mode
    *  picker for non-Claude agents (e.g. Codex). Seeded from the snapshot. */
   acpAvailableModes?: SessionModeInfo[];

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -9,6 +9,13 @@ export interface SessionKey {
   session_id: AcpSessionId;
 }
 
+/** Metadata returned by `agents_new_session` before the binding is exposed. */
+export interface SessionInit {
+  key: SessionKey;
+  current_mode: string | null;
+  available_modes: SessionModeInfo[];
+}
+
 export type TranscriptKind = { kind: "none" } | { kind: "claude_jsonl" } | { kind: "cersei_json" };
 
 /** One image attached to an outbound prompt. Mirrors atlas-acp's


### PR DESCRIPTION
## Summary
- preserve the mode returned by an agent's session creation instead of overwriting it with Atlas defaults
- apply an explicit Atlas mode only when the user selected one, before the binding can release the first prompt
- validate requested mode ids against the session's advertised modes while retaining compatibility with legacy agents

## Why
New Claude Code and Codex sessions could ignore the user-level permission configuration because Atlas initialized mode state independently of the ACP session response.

## Validation
- cargo check --manifest-path src-tauri/Cargo.toml -p atlas-agents
- cargo check --manifest-path src-tauri/Cargo.toml -p atlas
- bun run typecheck
- bun run lint
- bun run format:check
- bun run test -- --run (493 passed)

Note: the standalone atlas-agents unit-test invocation is currently blocked in this environment because its independent Cargo resolution requires an unavailable crates.io package (toml_write). The full Tauri compilation above succeeds.