### PR TITLE
Auto-acquire the built-in ACP agents, and let users turn them off

### DIFF
--- a/crates/atlas-acp/src/lib.rs
+++ b/crates/atlas-acp/src/lib.rs
@@ -19,7 +19,8 @@ pub use driver::AuthMethodWire;
 pub use error::{AcpError, ErrorClass, Result, classify_message};
 pub use events::{AcpEvent, EventSink};
 pub use registry::{
-    AgentId, AgentInfo, AgentRegistry, AgentSpec, ImageAttachment, PermissionDecision, SpecSource,
+    AUTO_MANAGED_BUILTIN_IDS, AgentId, AgentInfo, AgentRegistry, AgentSpec, ImageAttachment,
+    PermissionDecision, SpecSource, builtin_login_args,
 };
 pub use schema::NewSessionInfo;
 pub use spawn::{managed_node_bin, register_managed_node_bin, sanitize_host_env};

--- a/crates/atlas-acp/src/registry.rs
+++ b/crates/atlas-acp/src/registry.rs
@@ -65,6 +65,41 @@ pub trait SpecSource: Send + Sync {
     fn extra_specs(&self) -> Vec<AgentSpec>;
 }
 
+/// Built-in agents whose adapter is a plain CLI binary rather than an npm
+/// package. Claude and Codex spawn through `npx -y …`, so npm fetches their
+/// adapter on first run and they work on a machine that never installed
+/// anything by hand; these three do not, and their bare commands
+/// (`cursor-agent acp`, `opencode acp`, `kilo acp`) simply ENOENT there.
+///
+/// `atlas-registry` closes that gap by downloading each one's official binary
+/// from the ACP registry manifest and offering it as a dynamic spec. For these
+/// ids ONLY, that dynamic spec's command REPLACES the bare command below (see
+/// [`AgentRegistry::known_specs`]) — every other id keeps first-party
+/// precedence, so a registry install can never shadow a built-in agent.
+pub const AUTO_MANAGED_BUILTIN_IDS: &[&str] = &["cursor", "opencode", "kilo"];
+
+/// The CLI argv that signs a user in to an auto-managed built-in, appended to
+/// its managed binary.
+///
+/// These three adapters advertise an `authMethod` but ship NO
+/// `_meta.terminal-auth` block, so there is nothing for the host's terminal-auth
+/// runner to execute — and because Atlas downloads their binary into its own
+/// app-data dir, the user has no CLI on `PATH` to run by hand either. Without
+/// this table "sign in" is simply impossible from inside Atlas: the agent
+/// answers every prompt with `Authentication required` forever.
+///
+/// Verified against the downloaded binaries (`--help`): cursor exposes a
+/// top-level `login`; opencode (and its Kilo fork) nest it under `auth login`.
+/// Each opens the browser and prints the URL on stdout, which the auth runner
+/// already streams to the UI.
+pub fn builtin_login_args(spec_id: &str) -> Option<&'static [&'static str]> {
+    match spec_id {
+        "cursor" => Some(&["login"]),
+        "opencode" | "kilo" => Some(&["auth", "login"]),
+        _ => None,
+    }
+}
+
 impl AgentSpec {
     pub fn claude_code_ts() -> Self {
         Self {
@@ -242,12 +277,24 @@ impl AgentRegistry {
     /// First-party specs ∪ dynamic (registry-installed) specs. First-party
     /// wins on a spec-id collision — a registry install must never shadow a
     /// built-in agent.
+    ///
+    /// The one exception is [`AUTO_MANAGED_BUILTIN_IDS`]: those built-ins have
+    /// no npx distribution, so the registry's downloaded binary is strictly
+    /// better than their bare-CLI command and takes over the `command` field
+    /// IN PLACE — same id, same slot, same display name, never a second entry
+    /// for one agent (the plugin catalog keys off `spec_id`). When no binary
+    /// has been acquired the dynamic spec is simply absent and the bare
+    /// command stands, which is the pre-existing behaviour.
     pub fn known_specs(&self) -> Vec<AgentSpec> {
         let mut specs = AgentSpec::all_known();
         if let Some(source) = &self.dynamic {
             for spec in source.extra_specs() {
-                if !specs.iter().any(|s| s.spec_id == spec.spec_id) {
-                    specs.push(spec);
+                match specs.iter().position(|s| s.spec_id == spec.spec_id) {
+                    Some(i) if AUTO_MANAGED_BUILTIN_IDS.contains(&spec.spec_id.as_str()) => {
+                        specs[i].command = spec.command;
+                    }
+                    Some(_) => {}
+                    None => specs.push(spec),
                 }
             }
         }
@@ -806,11 +853,36 @@ mod spec_source_tests {
     fn first_party_wins_on_spec_id_collision() {
         // A registry install must never shadow a built-in agent's command.
         let registry = AgentRegistry::with_spec_source(Arc::new(FakeSource(vec![
-            external("opencode"),
+            external("codex"),
         ])));
         let specs = registry.known_specs();
-        let opencode: Vec<&AgentSpec> = specs.iter().filter(|s| s.spec_id == "opencode").collect();
-        assert_eq!(opencode.len(), 1);
-        assert_eq!(opencode[0].command, "opencode acp");
+        let codex: Vec<&AgentSpec> = specs.iter().filter(|s| s.spec_id == "codex").collect();
+        assert_eq!(codex.len(), 1);
+        assert_eq!(codex[0].command, AgentSpec::codex().command);
+    }
+
+    #[test]
+    fn auto_managed_builtin_takes_the_dynamic_command_in_place() {
+        // cursor/opencode/kilo have no npx distribution, so the registry's
+        // downloaded binary replaces the bare CLI — but stays ONE entry with
+        // the built-in's own display name.
+        let registry = AgentRegistry::with_spec_source(Arc::new(FakeSource(vec![
+            external("cursor"),
+        ])));
+        let specs = registry.known_specs();
+        let cursor: Vec<&AgentSpec> = specs.iter().filter(|s| s.spec_id == "cursor").collect();
+        assert_eq!(cursor.len(), 1);
+        assert_eq!(cursor[0].command, "npx -y cursor");
+        assert_eq!(cursor[0].display_name, AgentSpec::cursor().display_name);
+        assert_eq!(specs.len(), AgentSpec::all_known().len());
+    }
+
+    #[test]
+    fn auto_managed_builtin_keeps_bare_command_without_a_dynamic_spec() {
+        // Nothing acquired (offline / no manifest) → pre-existing behaviour.
+        let registry = AgentRegistry::with_spec_source(Arc::new(FakeSource(vec![])));
+        let specs = registry.known_specs();
+        let cursor = specs.iter().find(|s| s.spec_id == "cursor").unwrap();
+        assert_eq!(cursor.command, "cursor-agent acp");
     }
 }

--- a/crates/atlas-acp/src/spawn.rs
+++ b/crates/atlas-acp/src/spawn.rs
@@ -228,16 +228,23 @@ pub(crate) fn explain_spawn_failure(spec: &AgentSpec, err: AcpError) -> AcpError
         "Node.js (which provides `npx`) was not found. Install Node.js \
          (https://nodejs.org) and relaunch Atlas. If it is installed, make sure \
          it is on your login shell's PATH."
+    // The three auto-managed built-ins (AUTO_MANAGED_BUILTIN_IDS). Reaching
+    // this branch means the managed download did NOT happen — Atlas normally
+    // fetches these itself at spawn, so the actionable advice is "check your
+    // connection", not "go install it" (though installing the CLI by hand
+    // still works: a PATH binary is used when no managed one is available).
     } else if program == "opencode" {
-        "the OpenCode CLI was not found. Install it from https://opencode.ai \
-         (then optionally run `opencode auth login`) and relaunch Atlas."
+        "OpenCode could not be set up. Atlas downloads it automatically — check \
+         your internet connection and try again. You can also install it \
+         yourself from https://opencode.ai. Sign in with `opencode auth login`."
     } else if program == "cursor-agent" {
-        "the Cursor CLI was not found. Install it from https://cursor.com/cli \
-         and run `cursor-agent login`, then relaunch Atlas."
+        "Cursor could not be set up. Atlas downloads it automatically — check \
+         your internet connection and try again. You can also install the CLI \
+         yourself from https://cursor.com/cli. Sign in with `cursor-agent login`."
     } else if program == "kilo" {
-        "the Kilo Code CLI was not found. Install it with \
-         `npm install -g @kilocode/cli` (or `brew install Kilo-Org/tap/kilo`) \
-         and run `kilo auth login`, then relaunch Atlas."
+        "Kilo Code could not be set up. Atlas downloads it automatically — check \
+         your internet connection and try again. You can also install it with \
+         `npm install -g @kilocode/cli`. Sign in with `kilo auth login`."
     } else if program == "uvx" {
         "uv (which provides `uvx`) was not found. Install uv \
          (https://docs.astral.sh/uv) and relaunch Atlas."

--- a/crates/atlas-registry/src/store.rs
+++ b/crates/atlas-registry/src/store.rs
@@ -37,6 +37,13 @@ struct StoreInner {
     /// Serializes concurrent downloads of the same agent (two windows
     /// installing / self-healing at once).
     download_locks: DashMap<String, Arc<tokio::sync::Mutex<()>>>,
+    /// Auto-acquired binaries for the built-ins with no npx distribution
+    /// (`atlas_acp::AUTO_MANAGED_BUILTIN_IDS`), keyed by id. Deliberately NOT
+    /// persisted: these are not installs, so they never touch
+    /// `installed.json`. The on-disk extract under `binaries_root` is the real
+    /// cache — this map is just the resolved entry point, refilled from that
+    /// extract (no download) by the first `ensure_builtin` after launch.
+    builtin_binaries: DashMap<String, install_store::ResolvedBinary>,
 }
 
 /// One agent as the marketplace sees it.
@@ -83,6 +90,7 @@ impl RegistryStore {
                 install_path,
                 binaries_root: app_data_dir.join("external-agents"),
                 download_locks: DashMap::new(),
+                builtin_binaries: DashMap::new(),
             }),
         }
     }
@@ -245,6 +253,95 @@ impl RegistryStore {
         Ok(())
     }
 
+    /// Acquire the managed binary for a built-in agent that has no npx
+    /// distribution — cursor / opencode / kilo, i.e.
+    /// `atlas_acp::AUTO_MANAGED_BUILTIN_IDS`. Claude and Codex spawn via
+    /// `npx -y …`, so npm fetches their adapter on first run; these three are
+    /// plain CLIs, and on a machine that never installed them by hand they
+    /// cannot spawn at all. This closes that gap the way Zed does: the
+    /// official per-platform archive from the registry manifest, downloaded
+    /// on demand and cached.
+    ///
+    /// Cache-first — a completed extract is reused (no network), otherwise the
+    /// archive is downloaded and extracted NOW, so the caller must expect this
+    /// to be slow on a cold cache. sha256 is verified whenever the manifest
+    /// publishes one (kilo/opencode do; cursor does not, so it installs
+    /// unverified — same as Zed).
+    ///
+    /// **Never fails a spawn.** Manifest not fetched yet, no binary for this
+    /// platform, offline, checksum mismatch — every failure just leaves the
+    /// built-in's bare-CLI command in place, which is exactly the behaviour
+    /// that existed before (spawn then fails with `explain_spawn_failure`'s
+    /// install hint). Returns whether a managed binary is now available.
+    pub async fn ensure_builtin(&self, id: &str, progress: Option<&ProgressFn>) -> bool {
+        if !atlas_acp::AUTO_MANAGED_BUILTIN_IDS.contains(&id) {
+            return false;
+        }
+        if self.inner.builtin_binaries.contains_key(id) {
+            return true;
+        }
+        let Some(agent) = self.inner.cache.agent(id) else {
+            tracing::debug!(
+                target: "atlas_registry",
+                "built-in {id}: no manifest entry (yet) — using its PATH command"
+            );
+            return false;
+        };
+        let Some(target) = platform_binary(&agent.distribution) else {
+            tracing::debug!(
+                target: "atlas_registry",
+                "built-in {id}: no binary published for {} — using its PATH command",
+                platform_key()
+            );
+            return false;
+        };
+        let _guard = self.download_lock(id).lock_owned().await;
+        // Re-check under the lock: a concurrent spawn may have just finished
+        // the same download.
+        if self.inner.builtin_binaries.contains_key(id) {
+            return true;
+        }
+        match binary::ensure_binary(
+            &self.inner.binaries_root,
+            id,
+            &agent.version,
+            target,
+            progress,
+        )
+        .await
+        {
+            Ok(resolved) => {
+                self.inner.builtin_binaries.insert(id.to_string(), resolved);
+                true
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "atlas_registry",
+                    "built-in {id}: managed binary unavailable ({e}) — falling back to its PATH command"
+                );
+                false
+            }
+        }
+    }
+
+    /// Whether `id`'s managed built-in binary is acquired and ready to spawn.
+    pub fn builtin_ready(&self, id: &str) -> bool {
+        self.inner.builtin_binaries.contains_key(id)
+    }
+
+    /// Absolute path to `id`'s managed built-in executable, once acquired.
+    ///
+    /// Exists so the host can run the agent's OWN CLI for side flows the ACP
+    /// session can't cover — signing in, above all. These binaries live in
+    /// Atlas's app-data dir and never land on `PATH`, so this is the only way
+    /// anything outside the spawn path can reach them.
+    pub fn builtin_binary_path(&self, id: &str) -> Option<String> {
+        self.inner
+            .builtin_binaries
+            .get(id)
+            .map(|r| r.entry_cmd.clone())
+    }
+
     pub fn is_installed(&self, id: &str) -> bool {
         self.inner
             .installs
@@ -263,6 +360,23 @@ impl RegistryStore {
             .values()
             .filter(|i| i.is_active())
             .filter_map(|inst| self.spec_for(inst))
+            .collect()
+    }
+
+    /// Specs carrying the acquired binary command for auto-managed built-ins.
+    /// Only `command` is consumed downstream — `AgentRegistry::known_specs`
+    /// grafts it onto the built-in's existing entry and keeps Atlas's own
+    /// display name, so these placeholder names are never shown.
+    fn builtin_specs(&self) -> Vec<atlas_acp::AgentSpec> {
+        self.inner
+            .builtin_binaries
+            .iter()
+            .map(|e| atlas_acp::AgentSpec {
+                spec_id: e.key().clone(),
+                display_name: e.key().clone(),
+                command: binary_command(e.key(), e.value()),
+                help_url: None,
+            })
             .collect()
     }
 
@@ -330,8 +444,17 @@ impl RegistryStore {
 }
 
 impl atlas_acp::SpecSource for RegistryStore {
+    /// Installed externals first, auto-managed built-ins LAST — deliberately.
+    /// One id can have both (a machine that installed OpenCode from the
+    /// marketplace before it shipped as a built-in still carries that install
+    /// record), and `known_specs` applies these in order, so the last write
+    /// wins. The managed built-in is the one that tracks the current manifest
+    /// version; an install record is frozen at install time and would pin a
+    /// stale binary.
     fn extra_specs(&self) -> Vec<atlas_acp::AgentSpec> {
-        self.installed_specs()
+        let mut specs = self.installed_specs();
+        specs.extend(self.builtin_specs());
+        specs
     }
 }
 
@@ -400,12 +523,7 @@ fn synthesize_command(binaries_root: &std::path::Path, inst: &InstalledAgent) ->
                 env: target.env.clone(),
             },
         };
-        let program = if resolved.entry_cmd == "node" {
-            atlas_acp::resolve_program("node").unwrap_or_else(|| "node".to_string())
-        } else {
-            resolved.entry_cmd.clone()
-        };
-        return Some(json_stdio_spec(&inst.id, &program, &resolved.args, &resolved.env));
+        return Some(binary_command(&inst.id, &resolved));
     }
     if let Some(pkg) = &inst.distribution.npx {
         return Some(package_command("npx -y", &pkg.package, &pkg.args, &pkg.env, &inst.id));
@@ -414,6 +532,18 @@ fn synthesize_command(binaries_root: &std::path::Path, inst: &InstalledAgent) ->
         return Some(package_command("uvx", &pkg.package, &pkg.args, &pkg.env, &inst.id));
     }
     None
+}
+
+/// A downloaded binary's entry point → the JSON stdio spec the SDK spawns.
+/// `"node"` entries resolve through the (possibly Atlas-managed) toolchain;
+/// anything else is already an absolute path inside the extract dir.
+fn binary_command(id: &str, resolved: &install_store::ResolvedBinary) -> String {
+    let program = if resolved.entry_cmd == "node" {
+        atlas_acp::resolve_program("node").unwrap_or_else(|| "node".to_string())
+    } else {
+        resolved.entry_cmd.clone()
+    };
+    json_stdio_spec(id, &program, &resolved.args, &resolved.env)
 }
 
 fn package_command(
@@ -482,7 +612,7 @@ fn json_stdio_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manifest::{BinaryTarget, PackageTarget};
+    use crate::manifest::{BinaryTarget, PackageTarget, RegistryManifest};
 
     fn installed(dist: Distribution) -> InstalledAgent {
         InstalledAgent {
@@ -539,5 +669,143 @@ mod tests {
         assert_eq!(spec["type"], "stdio");
         assert!(spec["command"].as_str().unwrap().ends_with("/agent"));
         assert!(spec["env"].as_array().unwrap().iter().any(|e| e["name"] == "FOO"));
+    }
+
+    fn empty_store() -> (RegistryStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        (RegistryStore::new(dir.path().to_path_buf()), dir)
+    }
+
+    #[tokio::test]
+    async fn ensure_builtin_ignores_agents_that_are_not_auto_managed() {
+        // Claude/Codex ship via npx and must never take this path; neither may
+        // an arbitrary registry id.
+        let (store, _dir) = empty_store();
+        assert!(!store.ensure_builtin("claude-code-ts", None).await);
+        assert!(!store.ensure_builtin("codex", None).await);
+        assert!(!store.ensure_builtin("amp-acp", None).await);
+    }
+
+    #[tokio::test]
+    async fn ensure_builtin_falls_back_when_no_manifest_is_cached() {
+        // Offline first launch: no manifest → no managed binary, no error, and
+        // the built-in keeps its bare PATH command.
+        let (store, _dir) = empty_store();
+        for id in atlas_acp::AUTO_MANAGED_BUILTIN_IDS {
+            assert!(!store.ensure_builtin(id, None).await, "{id} must not resolve");
+            assert!(!store.builtin_ready(id));
+        }
+        assert!(<RegistryStore as atlas_acp::SpecSource>::extra_specs(&store).is_empty());
+    }
+
+    #[tokio::test]
+    async fn ensure_builtin_falls_back_when_the_platform_has_no_binary() {
+        // The manifest knows cursor, but publishes nothing runnable here —
+        // no download is attempted and the bare PATH command stands.
+        let (store, _dir) = empty_store();
+        store.inner.cache.set_manifest_for_tests(RegistryManifest {
+            version: "1.0.0".into(),
+            agents: vec![RegistryAgent {
+                id: "cursor".into(),
+                name: "Cursor".into(),
+                version: "2026.08.11".into(),
+                description: None,
+                repository: None,
+                website: None,
+                authors: None,
+                license: None,
+                icon: None,
+                distribution: Distribution {
+                    // Deliberately a platform we are not running on.
+                    binary: Some(HashMap::from([(
+                        "some-other-platform".to_string(),
+                        BinaryTarget {
+                            archive: "https://example.invalid/x.tar.gz".into(),
+                            cmd: "./cursor-agent".into(),
+                            args: vec!["acp".into()],
+                            env: HashMap::new(),
+                            sha256: None,
+                        },
+                    )])),
+                    npx: None,
+                    uvx: None,
+                },
+            }],
+        });
+        assert!(!store.ensure_builtin("cursor", None).await);
+        assert!(!store.builtin_ready("cursor"));
+    }
+
+    #[test]
+    fn acquired_builtin_is_offered_as_a_spec_carrying_the_binary_command() {
+        let (store, _dir) = empty_store();
+        store.inner.builtin_binaries.insert(
+            "cursor".to_string(),
+            install_store::ResolvedBinary {
+                cache_dir: "/tmp/root/cursor/v1".into(),
+                entry_cmd: "/tmp/root/cursor/v1/dist-package/cursor-agent".into(),
+                args: vec!["acp".into()],
+                env: HashMap::new(),
+            },
+        );
+        let specs = <RegistryStore as atlas_acp::SpecSource>::extra_specs(&store);
+        let cursor = specs.iter().find(|s| s.spec_id == "cursor").unwrap();
+        let spec: serde_json::Value = serde_json::from_str(&cursor.command).unwrap();
+        assert_eq!(spec["command"], "/tmp/root/cursor/v1/dist-package/cursor-agent");
+        assert_eq!(spec["args"][0], "acp");
+    }
+
+    #[test]
+    fn managed_builtin_binary_outranks_a_stale_install_record() {
+        // Seen live: a machine that installed OpenCode from the marketplace
+        // before it shipped as a built-in has BOTH an install record and a
+        // managed binary. The managed one tracks the current manifest version
+        // and must be the command that survives into `known_specs`.
+        let (store, _dir) = empty_store();
+        let mut binaries = HashMap::new();
+        binaries.insert(
+            platform_key().to_string(),
+            BinaryTarget {
+                archive: "https://x/opencode-old.zip".into(),
+                cmd: "./opencode".into(),
+                args: vec!["acp".into()],
+                env: HashMap::new(),
+                sha256: None,
+            },
+        );
+        let mut stale = installed(Distribution {
+            binary: Some(binaries),
+            npx: None,
+            uvx: None,
+        });
+        stale.id = "opencode".into();
+        stale.resolved_binary = Some(install_store::ResolvedBinary {
+            cache_dir: "/stale".into(),
+            entry_cmd: "/stale/opencode".into(),
+            args: vec!["acp".into()],
+            env: HashMap::new(),
+        });
+        store
+            .inner
+            .installs
+            .write()
+            .installed
+            .insert("opencode".into(), stale);
+        store.inner.builtin_binaries.insert(
+            "opencode".to_string(),
+            install_store::ResolvedBinary {
+                cache_dir: "/fresh".into(),
+                entry_cmd: "/fresh/opencode".into(),
+                args: vec!["acp".into()],
+                env: HashMap::new(),
+            },
+        );
+
+        let acp = atlas_acp::AgentRegistry::with_spec_source(Arc::new(store));
+        let specs = acp.known_specs();
+        let opencode: Vec<_> = specs.iter().filter(|s| s.spec_id == "opencode").collect();
+        assert_eq!(opencode.len(), 1, "one entry per agent");
+        let cmd: serde_json::Value = serde_json::from_str(&opencode[0].command).unwrap();
+        assert_eq!(cmd["command"], "/fresh/opencode");
     }
 }

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -408,18 +408,110 @@ pub fn agents_list_running(manager: State<'_, AgentManager>) -> Vec<AgentInfo> {
     manager.list_agents()
 }
 
+/// Byte progress for a built-in agent's managed-binary download, emitted while
+/// a spawn waits on it. Deliberately its OWN event rather than reusing
+/// `atlas:registry-install:*`: this is a spawn-time acquisition, not an
+/// install, and the marketplace only clears its progress map from the install
+/// flow — feeding it entries from here would leak them.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AcquireProgress {
+    agent_id: String,
+    received: u64,
+    total: Option<u64>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AcquireDone {
+    agent_id: String,
+    /// Whether a managed binary is now in place. `false` means the spawn falls
+    /// back to the agent's bare CLI command (which may still succeed).
+    ready: bool,
+}
+
+/// Whole-percent to emit for a download chunk, or `None` to skip this one.
+///
+/// `ensure_binary` invokes its progress callback once PER HTTP CHUNK — ~56k
+/// times for Cursor's 77 MB archive. Emitting a Tauri event each time would
+/// flood the IPC bridge and jank the UI, so a percent is emitted only when it
+/// actually changes (~101 events for a whole download). Chunks with no
+/// content-length are skipped entirely — there is no percent to show.
+fn acquire_pct_to_emit(
+    received: u64,
+    total: Option<u64>,
+    last: &std::sync::atomic::AtomicU64,
+) -> Option<u64> {
+    let total = total.filter(|t| *t > 0)?;
+    let pct = received.saturating_mul(100) / total;
+    (last.swap(pct, std::sync::atomic::Ordering::Relaxed) != pct).then_some(pct)
+}
+
 #[tauri::command]
 pub async fn agents_spawn(
     plugin_id: String,
+    app: AppHandle,
     manager: State<'_, AgentManager>,
     registry: State<'_, atlas_registry::RegistryStore>,
+    app_state: State<'_, crate::state::AppStateHandle>,
 ) -> Result<AgentInfo, String> {
+    // The user turned this built-in off in Settings → Agents. The UI already
+    // hides it from the picker; this is the authority behind that — it also
+    // covers paths the picker doesn't gate, notably resuming an old session
+    // that was recorded against the agent before it was switched off.
+    // Deliberately BEFORE any acquisition work: a disabled agent must never
+    // trigger a download.
+    if app_state.lock().settings.builtin_disabled(&plugin_id) {
+        let name = atlas_acp::AgentSpec::all_known()
+            .into_iter()
+            .find(|s| s.spec_id == plugin_id)
+            .map(|s| s.display_name)
+            .unwrap_or_else(|| plugin_id.clone());
+        return Err(format!(
+            "{name} is turned off. Turn it back on in Settings → Agents."
+        ));
+    }
     // Self-heal for registry-installed externals: re-download a binary payload
     // that went missing (killed mid-install, cache purge). No-op otherwise.
     registry
         .ensure_ready(&plugin_id)
         .await
         .map_err(|e| e.to_string())?;
+    // Built-ins with no npx distribution (cursor / opencode / kilo): acquire
+    // their official binary from the registry so they spawn with zero manual
+    // setup, the way `npx -y` already handles Claude/Codex. Deliberately not
+    // fatal — on failure the bare-CLI command still runs, which is the
+    // behaviour that existed before. Cold cache means a real download here,
+    // so the composer gets progress to show instead of a silent 20 s stall.
+    if atlas_acp::AUTO_MANAGED_BUILTIN_IDS.contains(&plugin_id.as_str()) {
+        let progress_app = app.clone();
+        let progress_id = plugin_id.clone();
+        let last_pct = std::sync::atomic::AtomicU64::new(u64::MAX);
+        let progress = move |received: u64, total: Option<u64>| {
+            // Throttled — see `acquire_pct_to_emit`.
+            if acquire_pct_to_emit(received, total, &last_pct).is_none() {
+                return;
+            }
+            let _ = progress_app.emit(
+                "atlas:agent-acquire:progress",
+                AcquireProgress {
+                    agent_id: progress_id.clone(),
+                    received,
+                    total,
+                },
+            );
+        };
+        let ready = registry.ensure_builtin(&plugin_id, Some(&progress)).await;
+        // Always emitted (cache hit, download, or failure) so the composer can
+        // clear its "Setting up…" pill on every path.
+        let _ = app.emit(
+            "atlas:agent-acquire:done",
+            AcquireDone {
+                agent_id: plugin_id.clone(),
+                ready,
+            },
+        );
+    }
     manager.spawn(&plugin_id).await.map_err(|e| e.to_string())
 }
 
@@ -791,12 +883,61 @@ pub fn agents_respond_permission(
 // localhost-loopback OAuth flow, opens the browser, catches the callback,
 // writes credentials. The host's only job is to spawn the spec.
 
+/// Fill in a runnable terminal-auth spec for the auto-managed built-ins.
+///
+/// Cursor / OpenCode / Kilo advertise an auth method but no
+/// `_meta.terminal-auth`, so `terminal_command` arrives `None` and the whole
+/// sign-in path dead-ends: `agents_run_auth_method` rejects the method, the UI
+/// has no command to offer, and the user can't fall back to a shell either
+/// because Atlas downloaded the CLI into its own app-data dir instead of onto
+/// `PATH`. Pairing the managed binary with the agent's documented login argv
+/// (`atlas_acp::builtin_login_args`) makes the existing runner work unchanged.
+///
+/// A spec the adapter DID supply always wins — this only fills a hole.
+fn enrich_auth_methods(
+    plugin_id: Option<&str>,
+    methods: Vec<AuthMethodWire>,
+    registry: &atlas_registry::RegistryStore,
+) -> Vec<AuthMethodWire> {
+    let Some(plugin_id) = plugin_id else {
+        return methods;
+    };
+    let Some(login_args) = atlas_acp::builtin_login_args(plugin_id) else {
+        return methods;
+    };
+    // Absent when nothing has been downloaded yet (the user is on a PATH
+    // install, or acquisition failed) — leave the methods untouched rather
+    // than inventing a command that isn't there.
+    let Some(binary) = registry.builtin_binary_path(plugin_id) else {
+        return methods;
+    };
+    methods
+        .into_iter()
+        .map(|mut m| {
+            if m.terminal_command.is_none() {
+                m.terminal_command = Some(binary.clone());
+                m.terminal_args = Some(login_args.iter().map(|s| s.to_string()).collect());
+                if m.terminal_label.is_none() {
+                    m.terminal_label = Some(m.name.clone());
+                }
+            }
+            m
+        })
+        .collect()
+}
+
 #[tauri::command]
 pub fn agents_list_auth_methods(
     agent_id: AgentId,
     manager: State<'_, AgentManager>,
+    registry: State<'_, atlas_registry::RegistryStore>,
 ) -> Result<Vec<AuthMethodWire>, String> {
-    manager.auth_methods(agent_id).map_err(|e| e.to_string())
+    let methods = manager.auth_methods(agent_id).map_err(|e| e.to_string())?;
+    Ok(enrich_auth_methods(
+        manager.plugin_id_for_agent(agent_id).as_deref(),
+        methods,
+        &registry,
+    ))
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -813,7 +954,15 @@ pub async fn agents_run_auth_method(
     app: AppHandle,
 ) -> Result<(), String> {
     let manager: State<'_, AgentManager> = app.state();
+    let registry: State<'_, atlas_registry::RegistryStore> = app.state();
     let methods = manager.auth_methods(agent_id).map_err(|e| e.to_string())?;
+    // Same enrichment the list command applies, so what the UI offers is
+    // exactly what runs here.
+    let methods = enrich_auth_methods(
+        manager.plugin_id_for_agent(agent_id).as_deref(),
+        methods,
+        &registry,
+    );
     let method = methods
         .into_iter()
         .find(|m| m.id == method_id)
@@ -894,4 +1043,123 @@ pub async fn agents_run_auth_method(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod acquire_progress_tests {
+    use super::acquire_pct_to_emit;
+    use std::sync::atomic::AtomicU64;
+
+    /// Replays a download the way `ensure_binary` drives the callback (one call
+    /// per HTTP chunk) and counts how many events would reach the UI.
+    fn emits_for(total: u64, chunk: u64) -> Vec<u64> {
+        let last = AtomicU64::new(u64::MAX);
+        let mut out = Vec::new();
+        let mut received = 0;
+        while received < total {
+            received = (received + chunk).min(total);
+            if let Some(pct) = acquire_pct_to_emit(received, Some(total), &last) {
+                out.push(pct);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn collapses_a_per_chunk_flood_into_one_event_per_percent() {
+        // Cursor's real archive: 77_650_670 bytes in ~1.4 KB chunks = ~56k
+        // callbacks. Unthrottled that many IPC emits would jank the UI.
+        let emits = emits_for(77_650_670, 1_369);
+        assert_eq!(emits.len(), 101, "0..=100 inclusive, once each");
+        assert_eq!(emits.first(), Some(&0));
+        assert_eq!(emits.last(), Some(&100), "always finishes at 100%");
+        assert!(emits.windows(2).all(|w| w[1] > w[0]), "monotonic, no repeats");
+    }
+
+    #[test]
+    fn a_tiny_download_still_reports_completion() {
+        // Fewer chunks than percents: every chunk is a new percent, and the
+        // pill must still reach 100 so the UI can settle.
+        let emits = emits_for(300, 100);
+        assert_eq!(emits, vec![33, 66, 100]);
+    }
+
+    #[test]
+    fn without_a_content_length_nothing_is_emitted() {
+        // No total → no percent to render; the pill falls back to its
+        // indeterminate "Setting up X…" text instead of showing a bogus 0%.
+        let last = AtomicU64::new(u64::MAX);
+        assert_eq!(acquire_pct_to_emit(1_024, None, &last), None);
+        assert_eq!(acquire_pct_to_emit(2_048, Some(0), &last), None);
+    }
+}
+
+#[cfg(test)]
+mod auth_enrichment_tests {
+    use super::enrich_auth_methods;
+    use atlas_agents::AuthMethodWire;
+
+    /// Exactly what `cursor-agent acp` returns from `initialize` — captured
+    /// live: an auth method with NO `_meta.terminal-auth`, which is why the
+    /// sign-in path dead-ended before this enrichment existed.
+    fn cursor_method() -> AuthMethodWire {
+        AuthMethodWire {
+            id: "cursor_login".into(),
+            name: "Cursor Login".into(),
+            description: Some("Authenticate using existing Cursor login credentials.".into()),
+            terminal_command: None,
+            terminal_args: None,
+            terminal_label: None,
+        }
+    }
+
+    fn store() -> atlas_registry::RegistryStore {
+        atlas_registry::RegistryStore::new(std::env::temp_dir().join("atlas-auth-test"))
+    }
+
+    #[test]
+    fn without_an_acquired_binary_nothing_is_invented() {
+        // Nothing downloaded → leave the method exactly as the adapter sent it,
+        // rather than pointing the runner at a path that doesn't exist.
+        let out = enrich_auth_methods(Some("cursor"), vec![cursor_method()], &store());
+        assert!(out[0].terminal_command.is_none());
+    }
+
+    #[test]
+    fn agents_that_are_not_auto_managed_are_untouched() {
+        for id in ["claude-code-ts", "codex", "cersei", "amp-acp"] {
+            let out = enrich_auth_methods(Some(id), vec![cursor_method()], &store());
+            assert!(out[0].terminal_command.is_none(), "{id} must not be enriched");
+        }
+        // …and an unknown agent (no plugin id resolved) too.
+        let out = enrich_auth_methods(None, vec![cursor_method()], &store());
+        assert!(out[0].terminal_command.is_none());
+    }
+
+    #[test]
+    fn an_adapter_supplied_spec_always_wins() {
+        let mut m = cursor_method();
+        m.terminal_command = Some("/adapter/own/node".into());
+        m.terminal_args = Some(vec!["--cli".into(), "auth".into()]);
+        let out = enrich_auth_methods(Some("cursor"), vec![m], &store());
+        assert_eq!(out[0].terminal_command.as_deref(), Some("/adapter/own/node"));
+        assert_eq!(out[0].terminal_args.as_ref().unwrap(), &["--cli", "auth"]);
+    }
+
+    #[test]
+    fn login_argv_matches_each_cli() {
+        // Verified against the downloaded binaries' `--help`: cursor exposes a
+        // top-level `login`; opencode/kilo nest it under `auth login`.
+        assert_eq!(atlas_acp::builtin_login_args("cursor"), Some(&["login"][..]));
+        assert_eq!(
+            atlas_acp::builtin_login_args("opencode"),
+            Some(&["auth", "login"][..])
+        );
+        assert_eq!(
+            atlas_acp::builtin_login_args("kilo"),
+            Some(&["auth", "login"][..])
+        );
+        assert_eq!(atlas_acp::builtin_login_args("codex"), None);
+        assert_eq!(atlas_acp::builtin_login_args("claude-code-ts"), None);
+    }
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -394,6 +394,30 @@ pub struct AppSettings {
     /// regardless of this setting. See `src/features/chat/components/chat-input.tsx`.
     #[serde(default = "default_true")]
     pub enter_to_send: bool,
+    /// Built-in agents the user has turned OFF — plugin ids drawn from
+    /// `atlas_acp::AUTO_MANAGED_BUILTIN_IDS` (cursor / opencode / kilo).
+    /// Empty by default: every built-in ships enabled.
+    ///
+    /// Only those three are optional. Claude, Codex and Cersei are the agents
+    /// Atlas is built around and are always available, so an entry naming one
+    /// is ignored rather than honoured — see [`AppSettings::builtin_disabled`].
+    #[serde(default)]
+    pub disabled_builtin_agents: Vec<String>,
+}
+
+impl AppSettings {
+    /// Whether `plugin_id` is a built-in the user turned off.
+    ///
+    /// The membership test against `AUTO_MANAGED_BUILTIN_IDS` is the guard that
+    /// makes this safe to call from the spawn path: a hand-edited `state.json`
+    /// listing `claude-code-ts` cannot disable Claude.
+    pub fn builtin_disabled(&self, plugin_id: &str) -> bool {
+        atlas_acp::AUTO_MANAGED_BUILTIN_IDS.contains(&plugin_id)
+            && self
+                .disabled_builtin_agents
+                .iter()
+                .any(|id| id == plugin_id)
+    }
 }
 
 fn default_true() -> bool {
@@ -442,6 +466,7 @@ impl Default for AppSettings {
             auto_update: true,
             updater_ignored_version: None,
             enter_to_send: true,
+            disabled_builtin_agents: Vec::new(),
         }
     }
 }
@@ -568,5 +593,70 @@ mod tests {
         state.apply_patch(patch);
         assert_eq!(state.telemetry_anon_id.as_deref(), Some("keep-me"));
         assert_eq!(state.version, SCHEMA_VERSION);
+    }
+
+    fn settings_disabling(ids: &[&str]) -> AppSettings {
+        AppSettings {
+            disabled_builtin_agents: ids.iter().map(|s| s.to_string()).collect(),
+            ..AppSettings::default()
+        }
+    }
+
+    #[test]
+    fn every_builtin_is_enabled_by_default() {
+        let s = AppSettings::default();
+        assert!(s.disabled_builtin_agents.is_empty());
+        for id in atlas_acp::AUTO_MANAGED_BUILTIN_IDS {
+            assert!(!s.builtin_disabled(id), "{id} must ship enabled");
+        }
+    }
+
+    #[test]
+    fn a_disabled_builtin_is_reported_disabled() {
+        let s = settings_disabling(&["cursor"]);
+        assert!(s.builtin_disabled("cursor"));
+        // ...and only that one.
+        assert!(!s.builtin_disabled("kilo"));
+        assert!(!s.builtin_disabled("opencode"));
+    }
+
+    #[test]
+    fn the_core_agents_can_never_be_disabled() {
+        // A hand-edited state.json naming Claude/Codex/Cersei must not be able
+        // to switch off the agents Atlas is built around — the spawn path calls
+        // straight into this.
+        let s = settings_disabling(&["claude-code-ts", "claude-code-rs", "codex", "cersei"]);
+        for id in ["claude-code-ts", "claude-code-rs", "codex", "cersei"] {
+            assert!(!s.builtin_disabled(id), "{id} must stay available");
+        }
+    }
+
+    #[test]
+    fn an_unknown_id_is_not_disabled() {
+        // External/registry agents are uninstalled, never "disabled" — this
+        // setting has no say over them.
+        assert!(!settings_disabling(&["amp-acp"]).builtin_disabled("amp-acp"));
+    }
+
+    #[test]
+    fn the_toggle_survives_a_settings_round_trip() {
+        // The frontend sends `settings` wholesale, so the field has to make it
+        // through `apply_patch` — otherwise the switch silently forgets itself
+        // on the next save, which is exactly how `adaptiveSuggestions` is lost.
+        let patch: AppStatePatch = serde_json::from_value(serde_json::json!({
+            "settings": { "disabledBuiltinAgents": ["kilo", "opencode"] }
+        }))
+        .expect("patch parses");
+        let mut state = AppState::default();
+        state.apply_patch(patch);
+        assert!(state.settings.builtin_disabled("kilo"));
+        assert!(state.settings.builtin_disabled("opencode"));
+        assert!(!state.settings.builtin_disabled("cursor"));
+
+        // And a payload from an OLDER frontend (no such key) leaves everything on.
+        let old: AppStatePatch =
+            serde_json::from_value(serde_json::json!({ "settings": {} })).expect("old patch");
+        state.apply_patch(old);
+        assert!(!state.settings.builtin_disabled("kilo"));
     }
 }

--- a/src/features/agents/lib/agent-meta.test.ts
+++ b/src/features/agents/lib/agent-meta.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// agent-meta reaches into two zustand stores. Stub both so the module under
+// test is exercised without a Tauri runtime or a React tree.
+const registryState = {
+  plugins: [] as { plugin_id: string; external: boolean }[],
+  registryEntries: [],
+};
+const projectState = { settings: { disabledBuiltinAgents: [] as string[] } };
+
+vi.mock("../stores/agent-registry-store", () => ({
+  useAgentRegistryStore: Object.assign(() => undefined, { getState: () => registryState }),
+}));
+vi.mock("@/features/project/stores/project-store", () => ({
+  useProjectStore: Object.assign(() => undefined, { getState: () => projectState }),
+}));
+
+const { switchableAgentIds, isAgentDisabled } = await import("./agent-meta");
+
+beforeEach(() => {
+  registryState.plugins = [];
+  projectState.settings.disabledBuiltinAgents = [];
+});
+
+describe("isAgentDisabled", () => {
+  it("is false for everything by default", () => {
+    for (const id of ["cursor", "opencode", "kilo", "claude-code", "codex", "cersei"]) {
+      expect(isAgentDisabled(id)).toBe(false);
+    }
+  });
+
+  it("reports an optional built-in the user turned off", () => {
+    projectState.settings.disabledBuiltinAgents = ["cursor"];
+    expect(isAgentDisabled("cursor")).toBe(true);
+    expect(isAgentDisabled("kilo")).toBe(false);
+  });
+
+  it("refuses to disable the agents Atlas is built around", () => {
+    // Mirrors the Rust guard: a stale/hand-edited list naming these is ignored
+    // rather than honoured, so Claude can never be switched off.
+    projectState.settings.disabledBuiltinAgents = ["claude-code", "codex", "cersei"];
+    expect(isAgentDisabled("claude-code")).toBe(false);
+    expect(isAgentDisabled("codex")).toBe(false);
+    expect(isAgentDisabled("cersei")).toBe(false);
+  });
+
+  it("has no say over external agents", () => {
+    projectState.settings.disabledBuiltinAgents = ["amp-acp"];
+    expect(isAgentDisabled("amp-acp")).toBe(false);
+  });
+});
+
+describe("switchableAgentIds", () => {
+  it("lists every built-in when nothing is turned off", () => {
+    expect(switchableAgentIds()).toEqual([
+      "claude-code",
+      "codex",
+      "opencode",
+      "cursor",
+      "kilo",
+      "cersei",
+    ]);
+  });
+
+  it("drops the agents the user turned off, keeping the rest in order", () => {
+    projectState.settings.disabledBuiltinAgents = ["opencode", "kilo"];
+    expect(switchableAgentIds()).toEqual(["claude-code", "codex", "cursor", "cersei"]);
+  });
+
+  it("still lists installed externals alongside the enabled built-ins", () => {
+    registryState.plugins = [{ plugin_id: "amp-acp", external: true }];
+    projectState.settings.disabledBuiltinAgents = ["cursor", "opencode", "kilo"];
+    expect(switchableAgentIds()).toEqual(["claude-code", "codex", "cersei", "amp-acp"]);
+  });
+});

--- a/src/features/agents/lib/agent-meta.ts
+++ b/src/features/agents/lib/agent-meta.ts
@@ -8,9 +8,11 @@ import {
   AGENT_LABEL,
   PLUGIN_ID_BY_AGENT,
   SWITCHABLE_AGENTS,
+  isOptionalBuiltinAgent,
   type AgentType,
   type FirstPartyAgent,
 } from "@/types/agent";
+import { useProjectStore } from "@/features/project/stores/project-store";
 import { useAgentRegistryStore } from "../stores/agent-registry-store";
 
 export interface AgentMeta {
@@ -84,21 +86,33 @@ function prettifyId(id: string): string {
     .join(" ");
 }
 
+/** Whether the user turned this optional built-in off in Settings → Agents.
+ *  Always false for Claude / Codex / Cersei and for external agents (which are
+ *  uninstalled rather than disabled). Rust enforces the same rule at spawn —
+ *  see `AppSettings::builtin_disabled`. */
+export function isAgentDisabled(agentTypeOrPluginId: string): boolean {
+  if (!isOptionalBuiltinAgent(agentTypeOrPluginId)) return false;
+  return useProjectStore.getState().settings.disabledBuiltinAgents.includes(agentTypeOrPluginId);
+}
+
 /** The dynamic switch list: first-party agents in their fixed order, then
  *  installed external plugin ids sorted by label. Drives option+/ cycling and
- *  the composer "+" agent picker. */
+ *  the composer "+" agent picker. Agents the user turned off are omitted —
+ *  that is what "off" means everywhere the user picks an agent. */
 export function switchableAgentIds(): string[] {
   const { plugins } = useAgentRegistryStore.getState();
   const externals = plugins
     .filter((p) => p.external)
     .map((p) => p.plugin_id)
     .sort((a, b) => agentMeta(a).label.localeCompare(agentMeta(b).label));
-  return [...SWITCHABLE_AGENTS, ...externals];
+  return [...SWITCHABLE_AGENTS, ...externals].filter((id) => !isAgentDisabled(id));
 }
 
 /** Reactive variant for components that must re-render when agents are
- *  installed/uninstalled. Subscribes to the primitive signature only. */
+ *  installed/uninstalled — or turned on/off, hence the settings subscription
+ *  alongside the registry signature. */
 export function useSwitchableAgents(): string[] {
   useAgentRegistryStore((s) => s.signature);
+  useProjectStore((s) => s.settings.disabledBuiltinAgents);
   return switchableAgentIds();
 }

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -14,7 +14,14 @@ import {
   agentTypeFromPluginId,
   pluginIdForAgent,
 } from "@/types/agent";
-import { agentMeta } from "@/features/agents/lib/agent-meta";
+import { agentMeta, isAgentDisabled } from "@/features/agents/lib/agent-meta";
+import { canSignIn, isAuthError, promptSignIn } from "../lib/agent-signin";
+import { toast } from "sonner";
+
+/** Tab+agent pairs whose bind failure has already been surfaced, so the
+ *  focus-triggered retry doesn't re-toast the same error on every focus.
+ *  Cleared for a pair once its bind finally succeeds. */
+const reportedBindFailures = new Set<string>();
 import { composePrompt, type MentionData } from "../lib/mentions";
 import { usePaneFind } from "../lib/use-pane-find";
 import { useDefaultAgentType } from "../hooks/use-default-agent";
@@ -362,6 +369,10 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
           if (cancelled) return;
         }
         useChatStore.getState().actions.setAcpBinding(tabId, agent.agent_id, key.session_id, cwd);
+        // Bound successfully — re-arm the failure toast so a LATER breakage
+        // (agent crashes, gets uninstalled) is reported again rather than
+        // swallowed by the earlier dedupe.
+        reportedBindFailures.delete(`${tabId}:${pluginId}`);
         // Seed the composer mode picker from the freshly-created session's
         // advertised modes (Codex: read-only / auto / full-access). The modes
         // are seeded into the Rust SessionState by `new_session`, so the
@@ -406,9 +417,32 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
         }
       } catch (err) {
         console.warn("Agent session creation failed:", err);
-        // Bind failed (agent not installed / spawn error) — clear the spinner so
-        // the picker doesn't hang in a loading state forever.
-        if (!cancelled) useChatStore.getState().actions.setAcpModesPending(tabId, false);
+        // Bind failed (couldn't set the agent up / spawn error). This used to
+        // be console-only, so a user whose agent wouldn't start just saw a dead
+        // composer with no reason given. The backend's message is the useful
+        // one — `explain_spawn_failure` names the agent and the fix (check your
+        // connection, or sign in with `cursor-agent login`). Deduped per
+        // tab+agent because the focus handler retries this bind.
+        if (!cancelled) {
+          useChatStore.getState().actions.setAcpModesPending(tabId, false);
+          const at = useChatStore.getState().sessions[tabId]?.agentType;
+          const key = `${tabId}:${pluginIdForAgent(at)}`;
+          if (!reportedBindFailures.has(key)) {
+            reportedBindFailures.add(key);
+            // Cursor (and friends) reject `session/new` when signed out, so the
+            // "you need to sign in" case lands HERE, not on the turn-failure
+            // route that raises `atlas:auth-required`. Offer the one-click fix
+            // instead of dumping a raw protocol error, and rebind once it lands.
+            if (at && canSignIn(at) && isAuthError(err)) {
+              promptSignIn(at, () => {
+                reportedBindFailures.delete(key);
+                void ensureBound();
+              });
+            } else {
+              toast.error(String((err as Error)?.message ?? err));
+            }
+          }
+        }
       } finally {
         pending = false;
       }
@@ -560,6 +594,7 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     const timers: ReturnType<typeof setTimeout>[] = [];
     (["codex", "opencode", "cursor", "kilo"] as const).forEach((at, i) => {
       if (!loadCachedAcpModes(at)) return; // never used → skip
+      if (isAgentDisabled(at)) return; // turned off → never spawn, even to pre-warm
       timers.push(
         setTimeout(
           () => {

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -19,9 +19,12 @@ import { agents } from "../lib/agents-api";
 import {
   CLAUDE_PERMISSION_MODE_LABEL,
   agentTypeFromPluginId,
+  pluginIdForAgent,
   type SwitchableAgent,
 } from "@/types/agent";
 import { agentMeta } from "@/features/agents/lib/agent-meta";
+import { useAgentAcquire, acquirePercent } from "../lib/agent-acquire";
+import { canSignIn, promptSignIn } from "../lib/agent-signin";
 import {
   cycleChatAgent,
   nextAgentForTab,
@@ -313,6 +316,8 @@ function AcpModePicker({ tabId }: { tabId: string }) {
   const currentMode = useChatStore((s) => s.sessions[tabId]?.acpCurrentMode);
   const availableModes = useChatStore((s) => s.sessions[tabId]?.acpAvailableModes);
   const pending = useChatStore((s) => s.sessions[tabId]?.acpModesPending ?? false);
+  const agentType = useChatStore((s) => s.sessions[tabId]?.agentType);
+  const acquiring = useAgentAcquire(pluginIdForAgent(agentType));
   const { setAcpMode } = useChatStore.use.actions();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -327,6 +332,24 @@ function AcpModePicker({ tabId }: { tabId: string }) {
   }, [open]);
 
   const hasModes = !!availableModes && availableModes.length > 0;
+
+  // Atlas is downloading this agent's binary (first-ever use of Cursor /
+  // OpenCode / Kilo — tens of MB, ~20 s). Takes priority over everything
+  // else here, cached modes included: nothing can start until it lands, and a
+  // silent stall is exactly what this pill exists to prevent.
+  if (acquiring) {
+    const pct = acquirePercent(acquiring);
+    const label = agentMeta(agentType ?? "").label;
+    return (
+      <span
+        className="flex items-center gap-1.5 px-2 h-6.5 rounded-full border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[10px] leading-none font-medium text-[var(--text-tertiary)] select-none tabular-nums"
+        title={`Downloading ${label} — this happens once.`}
+      >
+        <Loader2 size={11} className="shrink-0 animate-spin" />
+        {pct !== null ? `Setting up ${label}… ${pct}%` : `Setting up ${label}…`}
+      </span>
+    );
+  }
 
   // Still booting the session with nothing cached to show — a pure loading
   // pill so the user sees the agent coming up instead of an empty composer.
@@ -853,14 +876,22 @@ export function MessageInput({
 
   // An auth-classified turn failure routes to the sign-in flow (P15) instead
   // of dying as a generic banner. Claude sessions open the login dialog; the
-  // Codex sign-in pill is handled in ChatComposer (it owns that probe state).
+  // Codex sign-in pill is handled in ChatComposer (it owns that probe state);
+  // the auto-managed built-ins get an actionable toast — they have no bespoke
+  // surface, and without one their `Authentication required` error was a dead
+  // end the user could not act on (their CLI isn't on PATH to log in by hand).
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ sessionId?: string; agentType?: string }>).detail;
-      if (detail?.agentType !== "claude-code") return;
+      const at = detail?.agentType;
+      if (!at) return;
       const sess = useChatStore.getState().sessions[tabId];
       if (!sess?.acpSessionId || sess.acpSessionId !== detail.sessionId) return;
-      openLoginDialog();
+      if (at === "claude-code") {
+        openLoginDialog();
+        return;
+      }
+      if (canSignIn(at)) promptSignIn(at);
     };
     window.addEventListener("atlas:auth-required", handler);
     return () => window.removeEventListener("atlas:auth-required", handler);

--- a/src/features/chat/lib/agent-acquire.test.ts
+++ b/src/features/chat/lib/agent-acquire.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/** Captures the handlers `agent-acquire.ts` registers so tests can drive the
+ *  backend's events without a Tauri runtime. */
+const handlers = new Map<string, (e: { payload: unknown }) => void>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (name: string, cb: (e: { payload: unknown }) => void) => {
+    handlers.set(name, cb);
+    return Promise.resolve(() => handlers.delete(name));
+  },
+}));
+
+const { acquirePercent, __testing } = await import("./agent-acquire");
+
+function emitProgress(agentId: string, received: number, total: number | null) {
+  handlers.get("atlas:agent-acquire:progress")?.({
+    payload: { agentId, received, total },
+  });
+}
+function emitDone(agentId: string, ready: boolean) {
+  handlers.get("atlas:agent-acquire:done")?.({ payload: { agentId, ready } });
+}
+
+describe("acquirePercent", () => {
+  it("renders whole percents from the byte counts", () => {
+    expect(acquirePercent({ agentId: "cursor", received: 0, total: 200 })).toBe(0);
+    expect(acquirePercent({ agentId: "cursor", received: 50, total: 200 })).toBe(25);
+    expect(acquirePercent({ agentId: "cursor", received: 200, total: 200 })).toBe(100);
+  });
+
+  it("is null without a content-length, so the pill stays indeterminate", () => {
+    expect(acquirePercent(null)).toBeNull();
+    expect(acquirePercent({ agentId: "cursor", received: 10, total: null })).toBeNull();
+  });
+
+  it("never exceeds 100 if the server under-reports the total", () => {
+    expect(acquirePercent({ agentId: "cursor", received: 300, total: 200 })).toBe(100);
+  });
+});
+
+describe("acquire progress tracking", () => {
+  beforeEach(() => {
+    __testing.reset();
+    __testing.subscribe(() => {});
+  });
+
+  it("tracks progress per agent and clears it on done", () => {
+    emitProgress("cursor", 40, 100);
+    expect(__testing.get("cursor")).toEqual({ agentId: "cursor", received: 40, total: 100 });
+    // A second agent downloading concurrently must not clobber the first.
+    emitProgress("kilo", 10, 100);
+    expect(__testing.get("cursor")?.received).toBe(40);
+    expect(__testing.get("kilo")?.received).toBe(10);
+
+    emitDone("cursor", true);
+    expect(__testing.get("cursor")).toBeNull();
+    expect(__testing.get("kilo")?.received).toBe(10);
+  });
+
+  it("clears the pill even when acquisition FAILED", () => {
+    // ready:false means we fell back to the PATH command — the download is
+    // over either way, so a stuck "Setting up…" pill would be a lie.
+    emitProgress("opencode", 90, 100);
+    emitDone("opencode", false);
+    expect(__testing.get("opencode")).toBeNull();
+  });
+
+  it("reports nothing for agents that are not being acquired", () => {
+    expect(__testing.get("claude-code-ts")).toBeNull();
+  });
+
+  it("notifies subscribers so the composer re-renders", () => {
+    const seen: number[] = [];
+    __testing.subscribe(() => seen.push(1));
+    emitProgress("cursor", 1, 100);
+    emitProgress("cursor", 2, 100);
+    emitDone("cursor", true);
+    expect(seen.length).toBe(3);
+  });
+});

--- a/src/features/chat/lib/agent-acquire.ts
+++ b/src/features/chat/lib/agent-acquire.ts
@@ -1,0 +1,88 @@
+// Download progress for a built-in agent's managed binary (cursor / opencode /
+// kilo — `atlas_acp::AUTO_MANAGED_BUILTIN_IDS`).
+//
+// Claude and Codex ship through `npx -y`, so npm fetches them on first run.
+// These three are plain CLIs that Atlas downloads itself at spawn time
+// (`RegistryStore::ensure_builtin`), which on a cold cache is a real ~20 s,
+// tens-of-MB download. Without this the composer just sat there looking hung;
+// with it the boot pill reads "Setting up Cursor… 42%".
+//
+// State lives at MODULE scope behind `useSyncExternalStore` (same shape as the
+// agents marketplace) so an unmount mid-download — switching tabs while Cursor
+// installs — doesn't lose the progress.
+
+import { useSyncExternalStore } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export interface AgentAcquireProgress {
+  agentId: string;
+  received: number;
+  total: number | null;
+}
+
+interface AgentAcquireDone {
+  agentId: string;
+  ready: boolean;
+}
+
+const progressByPlugin = new Map<string, AgentAcquireProgress>();
+let version = 0;
+const subs = new Set<() => void>();
+
+function notify() {
+  version++;
+  subs.forEach((f) => f());
+}
+
+/** One process-wide listener pair, started on the first subscriber and kept
+ *  for the app's lifetime — the download outlives any single component. */
+let listeners: Promise<UnlistenFn[]> | null = null;
+function ensureListeners() {
+  if (listeners) return;
+  listeners = Promise.all([
+    listen<AgentAcquireProgress>("atlas:agent-acquire:progress", (e) => {
+      progressByPlugin.set(e.payload.agentId, e.payload);
+      notify();
+    }),
+    // Fires on every path — cache hit, finished download, and failure — so the
+    // pill can never stick at 99%.
+    listen<AgentAcquireDone>("atlas:agent-acquire:done", (e) => {
+      if (progressByPlugin.delete(e.payload.agentId)) notify();
+    }),
+  ]);
+}
+
+function subscribe(cb: () => void) {
+  ensureListeners();
+  subs.add(cb);
+  return () => {
+    subs.delete(cb);
+  };
+}
+
+/** Live download progress for `pluginId`, or `null` when nothing is being
+ *  acquired for it (the overwhelmingly common case: warm cache or an npx
+ *  agent). */
+export function useAgentAcquire(pluginId: string | undefined): AgentAcquireProgress | null {
+  useSyncExternalStore(subscribe, () => version);
+  if (!pluginId) return null;
+  return progressByPlugin.get(pluginId) ?? null;
+}
+
+/** Whole-percent for a progress record, or `null` when the server sent no
+ *  content-length. */
+export function acquirePercent(p: AgentAcquireProgress | null): number | null {
+  if (!p || !p.total) return null;
+  return Math.min(100, Math.round((p.received / p.total) * 100));
+}
+
+/** Test seam — the module's state is process-wide by design, so the suite
+ *  needs a way to drive and reset it without a React tree. */
+export const __testing = {
+  subscribe,
+  get: (pluginId: string) => progressByPlugin.get(pluginId) ?? null,
+  reset: () => {
+    progressByPlugin.clear();
+    subs.clear();
+  },
+};

--- a/src/features/chat/lib/agent-signin.test.ts
+++ b/src/features/chat/lib/agent-signin.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The module pulls in Tauri IPC + zustand stores at import time; none of that
+// is needed for the pure classifiers under test.
+vi.mock("sonner", () => ({
+  toast: Object.assign(() => {}, {
+    error: () => {},
+    success: () => {},
+    loading: () => {},
+    dismiss: () => {},
+  }),
+}));
+vi.mock("./agents-api", () => ({
+  agents: {},
+  ensureAgent: () => {},
+  listenAuthRunDone: () => Promise.resolve(() => {}),
+}));
+vi.mock("@/features/agents/lib/agent-meta", () => ({ agentMeta: (id: string) => ({ label: id }) }));
+
+const { isAuthError, canSignIn } = await import("./agent-signin");
+
+describe("isAuthError", () => {
+  it("recognises the error Cursor actually returns from session/new", () => {
+    // Captured verbatim from `cursor-agent acp` while signed out. This arrives
+    // at BIND time, not during a turn, which is the whole reason the bind
+    // catch has to classify it instead of relying on the turn-failure route.
+    const real =
+      'acp: acp protocol error: Error { code: -32000, message: "Authentication required", ' +
+      'data: Some(Object {"message": String("Authentication required. Please run \'agent login\' ' +
+      "first, then call authenticate() with methodId 'cursor_login'.\")}) }";
+    expect(isAuthError(new Error(real))).toBe(true);
+    expect(isAuthError(real)).toBe(true);
+  });
+
+  it("covers the other shapes agents use for the same thing", () => {
+    for (const m of [
+      "Unauthorized",
+      "not authenticated",
+      "auth required",
+      "HTTP 401 from provider",
+      "http 403",
+    ]) {
+      expect(isAuthError(new Error(m))).toBe(true);
+    }
+  });
+
+  it("does not swallow unrelated failures", () => {
+    // These must keep showing their real message rather than a sign-in prompt.
+    for (const m of [
+      "spawn ENOENT",
+      "Could not start Cursor: `cursor-agent` is not available",
+      "prompt is too long",
+      "Cursor is turned off. Turn it back on in Settings → Agents.",
+    ]) {
+      expect(isAuthError(new Error(m))).toBe(false);
+    }
+  });
+});
+
+describe("canSignIn", () => {
+  it("is true for the agents Atlas can drive a CLI login for", () => {
+    expect(canSignIn("cursor")).toBe(true);
+    expect(canSignIn("opencode")).toBe(true);
+    expect(canSignIn("kilo")).toBe(true);
+  });
+
+  it("is false for agents that own their sign-in elsewhere", () => {
+    // Claude has its login dialog, Codex its pill; cersei is in-process, and
+    // externals aren't ours to log in.
+    expect(canSignIn("claude-code")).toBe(false);
+    expect(canSignIn("codex")).toBe(false);
+    expect(canSignIn("cersei")).toBe(false);
+    expect(canSignIn("amp-acp")).toBe(false);
+    expect(canSignIn(undefined)).toBe(false);
+  });
+});

--- a/src/features/chat/lib/agent-signin.ts
+++ b/src/features/chat/lib/agent-signin.ts
@@ -1,0 +1,111 @@
+// Sign-in for the auto-managed built-ins (cursor / opencode / kilo).
+//
+// Claude and Codex each own a bespoke sign-in surface (the login dialog and the
+// Codex pill). These three had none: an unauthenticated agent answered every
+// prompt with a raw `Authentication required` protocol error and there was no
+// way to act on it — their CLI lives in Atlas's app-data dir, not on PATH, so
+// "run `cursor-agent login`" was advice the user could not follow.
+//
+// The flow mirrors what the adapters ask for: run the CLI's own login (opens
+// the browser, streamed through `atlas:auth-run:*`), then call ACP
+// `authenticate()` on the live agent so the already-running session picks the
+// new credentials up without a respawn.
+
+import { toast } from "sonner";
+
+import { agents, ensureAgent, listenAuthRunDone } from "./agents-api";
+import { isOptionalBuiltinAgent, pluginIdForAgent } from "@/types/agent";
+import { agentMeta } from "@/features/agents/lib/agent-meta";
+
+/** Resolves when the login subprocess exits. `agents.runAuthMethod` returns as
+ *  soon as the process is spawned — completion arrives as an event. */
+function awaitAuthRun(
+  timeoutMs = 5 * 60 * 1000,
+): Promise<{ success: boolean; message: string | null }> {
+  return new Promise((resolve) => {
+    let unlisten: (() => void) | undefined;
+    const timer = setTimeout(() => {
+      unlisten?.();
+      resolve({ success: false, message: "Timed out waiting for sign-in to finish." });
+    }, timeoutMs);
+    void listenAuthRunDone((p) => {
+      clearTimeout(timer);
+      unlisten?.();
+      resolve({ success: p.success, message: p.message });
+    }).then((fn) => {
+      unlisten = fn;
+    });
+  });
+}
+
+/** Run the agent's browser sign-in end to end. Throws with a user-facing
+ *  message on any failure. */
+export async function signInToAgent(agentType: string): Promise<void> {
+  const label = agentMeta(agentType).label;
+  const agent = await ensureAgent(pluginIdForAgent(agentType));
+  const methods = await agents.listAuthMethods(agent.agent_id);
+  const method = methods[0];
+  if (!method) throw new Error(`${label} didn't offer a sign-in method.`);
+  if (!method.terminalCommand) {
+    throw new Error(
+      `${label} can't be signed in from Atlas yet — its adapter offered no login command.`,
+    );
+  }
+  const done = awaitAuthRun();
+  await agents.runAuthMethod(agent.agent_id, method.id);
+  const result = await done;
+  if (!result.success) {
+    throw new Error(result.message ?? `Signing in to ${label} failed.`);
+  }
+  // The adapters explicitly want this after the CLI login ("then call
+  // authenticate() with methodId …"): it re-reads the credentials the login
+  // just wrote, so the live session stops failing without a restart.
+  await agents.authenticate(agent.agent_id, method.id);
+}
+
+/** Whether a failure means "this agent has no credentials".
+ *
+ *  Cursor rejects **`session/new`**, not the prompt — verified live against the
+ *  CLI — so an unauthenticated agent dies at BIND time, before any turn exists.
+ *  That path never emits the `atlas:auth-required` delta the turn-failure route
+ *  relies on, which is why the bind catch has to recognise it on its own.
+ *  Kept in sync with `atlas_acp::classify_message`'s AUTH bucket. */
+export function isAuthError(err: unknown): boolean {
+  const m = String((err as Error)?.message ?? err).toLowerCase();
+  return (
+    m.includes("authentication") ||
+    m.includes("unauthorized") ||
+    m.includes("not authenticated") ||
+    m.includes("auth required") ||
+    m.includes("http 401") ||
+    m.includes("http 403")
+  );
+}
+
+/** True when `agentType` is one Atlas can drive a sign-in for. */
+export function canSignIn(agentType: string | undefined): boolean {
+  return !!agentType && isOptionalBuiltinAgent(agentType);
+}
+
+/** The actionable "you need to sign in" toast, shared by the bind-failure and
+ *  turn-failure paths so both offer the same one-click recovery.
+ *  `onSignedIn` lets the caller retry whatever failed (a bind, typically). */
+export function promptSignIn(agentType: string, onSignedIn?: () => void): void {
+  const label = agentMeta(agentType).label;
+  toast.error(`Sign in to ${label} to continue.`, {
+    duration: 15000,
+    action: {
+      label: "Sign in",
+      onClick: () => {
+        const pending = toast.loading(`Opening your browser to sign in to ${label}…`);
+        void signInToAgent(agentType)
+          .then(() => {
+            toast.success(`Signed in to ${label}.`);
+            onSignedIn?.();
+          })
+          .catch((err) => toast.error(String((err as Error)?.message ?? err)))
+          .finally(() => toast.dismiss(pending));
+      },
+    },
+  });
+}

--- a/src/features/chat/lib/warm-acp-models.ts
+++ b/src/features/chat/lib/warm-acp-models.ts
@@ -17,6 +17,7 @@
 
 import { agents, ensureAgent } from "./agents-api";
 import { ACP_AGENTS, pluginIdForAgent, type SwitchableAgent } from "@/types/agent";
+import { isAgentDisabled } from "@/features/agents/lib/agent-meta";
 import {
   loadCachedAcpModels,
   saveCachedAcpModels,
@@ -35,10 +36,15 @@ function asAcpAgent(agentType: string): SwitchableAgent | null {
 
 /** The ACP agents to prefetch when `agentType` is active: every other ACP
  *  agent the user has used before (has a persisted model cache). Warming
- *  never-touched agents would spawn CLIs the user may not even have installed. */
+ *  never-touched agents would spawn CLIs the user may not even have installed.
+ *  Agents the user turned off are skipped too — a disabled agent must not be
+ *  spawned in the background (and a previously-used one still has a cache, so
+ *  the `loadCachedAcpModels` test alone would let it through). */
 export function otherAcpAgents(agentType: string): SwitchableAgent[] {
   if (!asAcpAgent(agentType)) return [];
-  return ACP_AGENTS.filter((a) => a !== agentType && loadCachedAcpModels(a) !== null);
+  return ACP_AGENTS.filter(
+    (a) => a !== agentType && !isAgentDisabled(a) && loadCachedAcpModels(a) !== null,
+  );
 }
 
 // Warm at most once per agent per app session (a model list is static per
@@ -53,6 +59,10 @@ const warmed = new Set<string>();
 export async function warmAcpModels(agentType: string, cwd: string): Promise<void> {
   const at = asAcpAgent(agentType);
   if (!at) return;
+  // Turned off in Settings → Agents: never spawn it, not even for a throwaway
+  // model-harvest session. (Also guarded in Rust — this just avoids the
+  // pointless round-trip and its rejection.)
+  if (isAgentDisabled(at)) return;
   if (warmed.has(at)) return;
   // TTL gate: if we already have a fresh cached list, DON'T spawn a throwaway
   // session to re-fetch a static catalog — the cache drives the picker and any

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -90,6 +90,13 @@ export interface AppSettings {
    *  Cmd/Ctrl+Enter sends, bare Enter always inserts a newline (the old
    *  default). Cmd/Ctrl+Enter always sends regardless of this setting. */
   enterToSend: boolean;
+  /** Built-in agents the user turned off, by plugin id. Only the optional
+   *  built-ins can appear here (`cursor` / `opencode` / `kilo` — the ones
+   *  Atlas downloads on demand); Claude, Codex and Cersei are always on.
+   *  Empty by default. Mirrors `AppSettings::disabled_builtin_agents` in Rust,
+   *  which is the authority — the spawn command rejects a disabled agent even
+   *  if some UI path forgets to hide it. */
+  disabledBuiltinAgents: string[];
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -108,6 +115,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   autoUpdate: true,
   updaterIgnoredVersion: null,
   enterToSend: true,
+  disabledBuiltinAgents: [],
 };
 
 /**

--- a/src/features/settings/components/agents-marketplace/agents-marketplace.tsx
+++ b/src/features/settings/components/agents-marketplace/agents-marketplace.tsx
@@ -23,6 +23,9 @@ import {
   type RegistryInstallProgress,
 } from "@/features/agents/lib/agent-registry-api";
 import { hydrateAgentRegistry } from "@/features/agents/stores/agent-registry-store";
+import { useProjectStore } from "@/features/project/stores/project-store";
+import { isOptionalBuiltinAgent } from "@/types/agent";
+import { Toggle } from "../settings-panel";
 import { downloadTrend, fmtDownloads } from "@/features/agents/lib/download-trends";
 import { TrendSparkline } from "@/components/trend-sparkline";
 
@@ -340,6 +343,42 @@ function AgentCard({
   );
 }
 
+/** On/off switch for an optional built-in (cursor / opencode / kilo).
+ *
+ *  "Off" means hidden from every agent picker and never spawned — including
+ *  the background pre-warms, and including a resume of an old session recorded
+ *  against it (Rust rejects that spawn). Chat history is untouched either way,
+ *  and turning it back on reuses the already-downloaded binary. */
+function BuiltinToggle({ entry }: { entry: AcpRegistryEntry }) {
+  const disabledIds = useProjectStore((s) => s.settings.disabledBuiltinAgents);
+  const { updateSettings } = useProjectStore.use.actions();
+  const enabled = !disabledIds.includes(entry.id);
+  return (
+    <span
+      className="flex items-center gap-2"
+      title={
+        enabled
+          ? `${entry.name} is available in the agent picker. Turn it off to hide it.`
+          : `${entry.name} is hidden. Your chat history with it is kept.`
+      }
+    >
+      <span className="text-[10.5px] font-medium text-[var(--text-tertiary)] w-5 text-right">
+        {enabled ? "On" : "Off"}
+      </span>
+      <Toggle
+        checked={enabled}
+        onChange={(next) =>
+          updateSettings({
+            disabledBuiltinAgents: next
+              ? disabledIds.filter((id) => id !== entry.id)
+              : [...disabledIds, entry.id],
+          })
+        }
+      />
+    </span>
+  );
+}
+
 function CardAction({
   entry,
   installing,
@@ -354,6 +393,10 @@ function CardAction({
   onUninstall: () => void;
 }) {
   if (entry.builtin) {
+    // Cursor / OpenCode / Kilo are optional built-ins: they ship with Atlas but
+    // the user can hide them. Claude and Codex are what Atlas is built around
+    // and only ever show the badge — there is nothing to switch off.
+    if (isOptionalBuiltinAgent(entry.id)) return <BuiltinToggle entry={entry} />;
     return (
       <span
         className="flex items-center gap-1 h-6 px-2 rounded-md text-[10.5px] font-medium text-[var(--text-tertiary)] border border-[var(--border-default)]"

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -767,7 +767,7 @@ function SettingRow({
  * owns the state and `onChange` is fired on click; otherwise we keep
  * internal state seeded by `defaultChecked` (original behavior).
  */
-function Toggle({
+export function Toggle({
   defaultChecked = false,
   checked,
   onChange,

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -66,6 +66,17 @@ export function pluginIdForAgent(agentType: AgentType | undefined): string {
  *  that care use the dynamic registry, not this constant. */
 export const ACP_AGENTS: FirstPartyAgent[] = ["claude-code", "codex", "opencode", "cursor", "kilo"];
 
+/** The built-ins a user may turn off in Settings → Agents: the three with no
+ *  npx distribution, which Atlas downloads on demand. Mirrors
+ *  `atlas_acp::AUTO_MANAGED_BUILTIN_IDS` (their agentType and plugin id are
+ *  the same string). Claude, Codex and Cersei are the agents Atlas is built
+ *  around — they are always available and never appear here. */
+export const OPTIONAL_BUILTIN_AGENTS: FirstPartyAgent[] = ["cursor", "opencode", "kilo"];
+
+export function isOptionalBuiltinAgent(id: string): boolean {
+  return (OPTIONAL_BUILTIN_AGENTS as string[]).includes(id);
+}
+
 /** Derive the display agent type from a spawnable plugin id. Unknown ids pass
  *  through unchanged — an external agent's identity is its plugin id, and
  *  collapsing it (the old `"custom"` fallback) lost it forever. */


### PR DESCRIPTION
Fixes #160.

Cursor, OpenCode and Kilo were shown as "Built-in" while Atlas bundled nothing and offered no way to install them. Their specs shell out to bare CLIs (`cursor-agent acp`, `opencode acp`, `kilo acp`); on a machine without those, the spawn failed, the error was swallowed, and the only visible symptom was a chat with no model picker. Claude and Codex were fine because `npx -y` self-installs their adapter.

This makes Atlas do for those three what npx already does for the other two — then lets you turn them off if you don't want them.

## Acquisition — cache-first, the model Zed uses

`RegistryStore::ensure_builtin` downloads the official per-platform binary from the ACP registry manifest on first use and caches it, reusing the existing versioned-cache / sha256 / prune machinery rather than adding a parallel one. It hangs off the pre-flight `agents_spawn` already ran for registry externals.

**Never fatal.** No manifest yet, unsupported platform, offline, bad checksum — every failure falls back to the bare PATH command, which is exactly today's behaviour. sha256 is verified where the manifest publishes one (kilo, opencode); Cursor ships none upstream, so it installs unverified, as it does in Zed.

`AUTO_MANAGED_BUILTIN_IDS` marks the three, and `known_specs` lets an acquired binary replace the bare command **in place** — same id, same slot, same display name — so the plugin catalogue never sees two entries for one agent. Built-in specs are emitted after installed ones, so a manifest-current binary outranks a frozen install record; a machine that installed OpenCode from the marketplace before it shipped built-in has both, and that case has a test.

## First-use progress

The composer's boot pill reads **"Setting up Cursor… 42%"** instead of stalling silently through a 77 MB download.

Progress is throttled to whole-percent changes. The registry's callback fires once per HTTP chunk — ~56k times for Cursor's archive — and one IPC event each would flood the bridge and jank the UI. `acquire_pct_to_emit` collapses that to 101 events, pinned by a test that replays the real byte/chunk counts.

These get their own `atlas:agent-acquire:*` events rather than reusing the marketplace's install events: only the install flow clears that progress map, so feeding it from here would leak entries, and the built-in cards short-circuit to the "Built-in" badge before the progress branch anyway.

## Sign-in

These adapters advertise an auth method but ship no `_meta.terminal-auth`, so Atlas's existing terminal-auth runner had nothing to execute — and since the CLI now lives in Atlas's app-data dir rather than on PATH, "run `cursor-agent login`" was advice a user could not follow. `enrich_auth_methods` synthesises the missing spec from the managed binary for both the list and run commands, so what the UI offers is exactly what executes. An adapter-supplied spec always wins.

Worth knowing for future work: **Cursor rejects `session/new`, not the prompt.** An unauthenticated agent therefore dies at bind time and never reaches the turn-failure route that raises `atlas:auth-required`. Both paths now offer the same one-click "Sign in", and the bind path retries itself once credentials land. Bind failures were previously a bare `console.warn`, so they are now actually reported.

## Turning them off

`AppSettings::disabled_builtin_agents`, with a switch on the three built-in marketplace cards. Off means hidden from the picker and never spawned — including both background pre-warms and a resume of an older session recorded against that agent.

The Rust guard is the authority and hard-filters against `AUTO_MANAGED_BUILTIN_IDS`, so a hand-edited `state.json` cannot switch off Claude, Codex or Cersei. Chat history is never hidden.

## Verification

Verified against the real binaries, not just mocks:

- Cursor cold-downloaded (77 MB, ~19 s), extracted, and answered an ACP `initialize` with protocol v1 and the `cursor_login` auth method — i.e. it now spawns on a machine with no Cursor CLI.
- Each agent's login argv was read off its own `--help` (`cursor login`; `opencode`/`kilo auth login`), not assumed.
- The `-32000 Authentication required` response was reproduced against the CLI and is pinned verbatim in a regression test.

Automated: 512 frontend tests, 230 Rust app tests, 14 atlas-acp, 12 atlas-registry; typecheck and lint clean.

## Not covered

- **The full sign-in loop is unverified end to end** — browser → `authenticate()` → rebind needs a real account.
- **OpenCode and Kilo will hang on the "Sign in" button.** Their `auth login` is an interactive TUI (provider picker, then an API-key prompt) and the auth runner spawns with stdin closed. Cursor is unaffected (browser OAuth). Setting a key works today via the CLI in a terminal, or via the provider env vars the binary reads (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`). The clean follow-up is to inject Atlas's existing BYOK keys into those agents' env at spawn.
- Separately noticed and left alone: `adaptiveSuggestions` exists in the frontend `AppSettings` but has no field in the Rust struct, so serde drops it on every save and it does not survive a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
