### PR TITLE
Add a repository-wide Rust test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,7 @@ bun run lint                       # oxlint on src/
 bun run format:check               # oxfmt --check on src/
 bun run typecheck                  # frontend typecheck (app + test code)
 bun run test                       # frontend and cross-cutting tests
+bun run test:rust                  # every standalone Rust crate + src-tauri --lib
 cd src-tauri && cargo check        # Rust typecheck, including every crates/* dependency
 ```
 
@@ -173,6 +174,8 @@ cd crates/atlas-acp && cargo run --example smoke          # ACP transport smoke 
 ```
 
 Run `cargo test` from inside the directory of any crate you touched.
+Run `bun run test:rust` from the repository root to test every standalone crate
+and the Tauri library in one pass; it stops at the first failure.
 
 Frontend tests run under Vitest:
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
     "test": "vitest run",
+    "test:rust": "bash scripts/test-rust.sh",
     "test:watch": "vitest",
     "acp:test": "SDKROOT=\"$(xcrun --show-sdk-path)\" cargo run --manifest-path crates/atlas-agents/Cargo.toml --example backend_suite",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.test.json",

--- a/scripts/test-rust.sh
+++ b/scripts/test-rust.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# apple-sys needs the active macOS SDK while compiling native dependencies.
+# Respect an explicitly selected SDK, otherwise use Xcode's current default.
+if [[ "$(uname -s)" == "Darwin" && -z "${SDKROOT:-}" ]]; then
+  export SDKROOT="$(xcrun --show-sdk-path)"
+fi
+
+for crate_dir in "$repo_root"/crates/*; do
+  [[ -f "$crate_dir/Cargo.toml" ]] || continue
+  echo "==> Testing crates/$(basename "$crate_dir")"
+  (cd "$crate_dir" && cargo test)
+done
+
+echo "==> Testing src-tauri --lib"
+(cd "$repo_root/src-tauri" && cargo test --lib)


### PR DESCRIPTION
Adds `bun run test:rust` at the repo root. The script runs `cargo test` in each standalone crate, then `cargo test --lib` in `src-tauri`, and stops at the first failure. On macOS it fills in `SDKROOT` only when the caller has not set it.

The new command is also documented in `CONTRIBUTING.md`.

Closes #176

Tested locally:

- `bun run test:rust`: all 15 standalone crates and 218 Tauri library tests passed
- `bun run test`: 493 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`