### PR TITLE
Fix the Vitest dirname deprecation warning

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ import path from "path";
 export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
Replaces `__dirname` with `import.meta.dirname` in `vitest.config.ts`. The config is ESM, so this removes the warning without changing where the `@` alias resolves.

Closes #164

Tested locally:

- `bun run test`: 493 tests passed with no `__dirname` warning
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`