### PR TITLE
Unify the home-path shorteners

### DIFF
--- a/src/features/chat/lib/turn-rows.ts
+++ b/src/features/chat/lib/turn-rows.ts
@@ -23,6 +23,7 @@ import {
 } from "./tool-files";
 import { splitAtlasContext } from "./atlas-context";
 import { stripNextSteps } from "./next-steps";
+import { shortPath } from "@/lib/paths";
 
 // ── Row kinds ──────────────────────────────────────────────────────────────
 
@@ -191,13 +192,6 @@ function isInternalTool(tc: ToolCallDisplay): boolean {
 }
 
 // ── Marker labelling ───────────────────────────────────────────────────────
-
-/** Trim a path to something that reads in one line without the eye scanning. */
-function shortPath(p: string): string {
-  const parts = p.split("/").filter(Boolean);
-  if (parts.length <= 2) return parts.join("/");
-  return parts.slice(-2).join("/");
-}
 
 /**
  * One tool call → one marker. Codex shows a single line with the command

--- a/src/features/mentions/components/mention-picker.tsx
+++ b/src/features/mentions/components/mention-picker.tsx
@@ -44,6 +44,7 @@ import {
   Zap,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { shortPath } from "@/lib/paths";
 import { Kbd } from "@/ui/kbd";
 
 import {
@@ -917,11 +918,6 @@ function secondaryLabel(m: MentionData): string {
 function basenameOf(rel: string): string {
   const idx = rel.lastIndexOf("/");
   return idx >= 0 ? rel.slice(idx + 1) : rel;
-}
-
-function shortPath(p: string): string {
-  const parts = p.split("/");
-  return parts.slice(-2).join("/");
 }
 
 function emptyStateCopy(args: {

--- a/src/features/settings/components/providers-settings.tsx
+++ b/src/features/settings/components/providers-settings.tsx
@@ -18,6 +18,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { SecretInput } from "@/ui/secret-input";
 import { cn } from "@/lib/utils";
 import { copyText } from "@/lib/clipboard";
+import { tildePath } from "@/lib/paths";
 import { AtlasLoader } from "@/components/atlas-loader";
 import { ProviderLogo } from "@/components/provider-logo";
 import {
@@ -60,12 +61,6 @@ const COL = {
 } as const;
 
 const TABLE_MIN_W = 200 + 200 + 120 + 100 + 200 + 32; // 852
-
-/** `/Users/x/.zshrc` → `~/.zshrc`, for a path that fits in a table cell. */
-function tildePath(p: string): string {
-  const m = /^\/(?:Users|home)\/[^/]+\/(.*)$/.exec(p);
-  return m ? `~/${m[1]}` : p;
-}
 
 export function ProvidersSettings() {
   const entries = useByokStore.use.entries();

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { shortPath, tildePath } from "./paths";
+
+describe("tildePath", () => {
+  it.each([
+    ["macOS home", "/Users/alice/projects/atlas/src/foo.ts", "~/projects/atlas/src/foo.ts"],
+    ["Linux home", "/home/alice/.zshrc", "~/.zshrc"],
+    ["macOS home root file", "/Users/alice/.bashrc", "~/.bashrc"],
+  ])("rewrites a %s path to ~/...", (_label, input, expected) => {
+    expect(tildePath(input)).toBe(expected);
+  });
+
+  it.each([
+    ["a relative path", "src/lib/paths.ts"],
+    ["a non-home absolute path", "/etc/profile"],
+    ["a bare home directory with nothing after it", "/Users/alice"],
+  ])("leaves %s unchanged", (_label, input) => {
+    expect(tildePath(input)).toBe(input);
+  });
+});
+
+describe("shortPath", () => {
+  it("keeps only the last two segments of a long path", () => {
+    expect(shortPath("/Users/alice/projects/atlas/src/foo.ts")).toBe("src/foo.ts");
+  });
+
+  it("returns both segments unchanged when there are exactly two", () => {
+    expect(shortPath("src/foo.ts")).toBe("src/foo.ts");
+  });
+
+  it("returns a single segment unchanged, without a leading slash", () => {
+    expect(shortPath("foo.ts")).toBe("foo.ts");
+  });
+
+  it("ignores a trailing slash", () => {
+    expect(shortPath("/Users/alice/projects/atlas/src/")).toBe("atlas/src");
+  });
+
+  it("ignores a leading slash on an otherwise two-segment path", () => {
+    expect(shortPath("/src/foo.ts")).toBe("src/foo.ts");
+  });
+});

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,12 @@
+/** Rewrites a macOS/Linux home-directory prefix to `~/`. Any other path is returned unchanged. */
+export function tildePath(p: string): string {
+  const m = /^\/(?:Users|home)\/[^/]+\/(.*)$/.exec(p);
+  return m ? `~/${m[1]}` : p;
+}
+
+/** Truncates a path to its last two segments, e.g. for compact breadcrumb display. */
+export function shortPath(p: string): string {
+  const parts = p.split("/").filter(Boolean);
+  if (parts.length <= 2) return parts.join("/");
+  return parts.slice(-2).join("/");
+}


### PR DESCRIPTION
## Summary
- Closes #178. Extracts one shared `src/lib/paths.ts` with `tildePath` (macOS/Linux home → `~/`) and `shortPath` (last-two-segments truncation), replacing three local duplicates in `providers-settings.tsx`, `mention-picker.tsx`, and `turn-rows.ts`.
- The two `shortPath` locals weren't identical: kept the `turn-rows.ts` version as canonical since it filters empty segments (trailing slash) and guards the ≤2-segment case to avoid a stray leading slash.
- No behavior changes at any of the 8 call sites.

## Test plan
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`
- [x] `bun run test` (554 passed, including new `src/lib/paths.test.ts` covering macOS/Linux home shapes and non-home passthrough for `tildePath`, and segment-count/slash edge cases for `shortPath`)