### PR TITLE
Add copy actions to Log panel and Mission Control

### DIFF
--- a/src/features/log/components/log-panel.tsx
+++ b/src/features/log/components/log-panel.tsx
@@ -14,6 +14,7 @@ import {
   Pin,
   PinOff,
   Copy,
+  ClipboardCopy,
   Check,
   Trash2,
   ListFilter,
@@ -21,7 +22,9 @@ import {
   ChevronDown,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { copyText } from "@/lib/clipboard";
 import { timeAgo } from "@/lib/time-ago";
 import { useLogStore, type LogEntry, type LogSource } from "../stores/log-store";
 import { useProjectStore } from "@/features/project/stores/project-store";
@@ -109,6 +112,7 @@ export function LogPanel() {
   const [showPinnedOnly, setShowPinnedOnly] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copiedLineId, setCopiedLineId] = useState<string | null>(null);
 
   // Keyed on the Organisation, not just on `ready`: the panel can mount before
   // the org store has hydrated (pins then load as empty), and an org switch has
@@ -167,12 +171,19 @@ export function LogPanel() {
   };
 
   const handleCopy = async (e: LogEntry) => {
-    try {
-      await navigator.clipboard.writeText(JSON.stringify(e, null, 2));
+    const ok = await copyText(JSON.stringify(e, null, 2));
+    if (ok) {
       setCopiedId(e.id);
       setTimeout(() => setCopiedId(null), 1200);
-    } catch {
-      // ignore
+    }
+  };
+
+  const handleCopyLine = async (e: LogEntry) => {
+    const ok = await copyText(`[${e.source}] ${e.kind} — ${e.summary}`);
+    if (ok) {
+      setCopiedLineId(e.id);
+      toast.success("Copied");
+      setTimeout(() => setCopiedLineId(null), 1200);
     }
   };
 
@@ -294,13 +305,23 @@ export function LogPanel() {
               >
                 {copiedId === e.id ? <Check size={11} /> : <Copy size={11} />}
               </button>
+              <button
+                onClick={(ev) => {
+                  ev.stopPropagation();
+                  handleCopyLine(e);
+                }}
+                className="p-1 rounded hover:bg-[var(--bg-hover)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] cursor-pointer transition-colors opacity-0 group-hover:opacity-100"
+                title="Copy line"
+              >
+                {copiedLineId === e.id ? <Check size={11} /> : <ClipboardCopy size={11} />}
+              </button>
             </div>
           );
         },
-        size: 60,
+        size: 84,
       },
     ],
-    [expanded, copiedId, pin, unpin],
+    [expanded, copiedId, copiedLineId, pin, unpin],
   );
 
   const table = useReactTable<LogEntry>({
@@ -425,7 +446,7 @@ export function LogPanel() {
                   <div
                     onClick={() => toggleExpanded(row.original.id)}
                     className={cn(
-                      "flex items-center px-3 cursor-pointer border-b border-[var(--border-subtle)] hover:bg-bg-hover",
+                      "group flex items-center px-3 cursor-pointer border-b border-[var(--border-subtle)] hover:bg-bg-hover",
                       isExpanded && "bg-[var(--bg-elevated)]/40",
                     )}
                     style={{ height: 32 }}

--- a/src/features/mission-control/components/dashboard/dashboard-header.tsx
+++ b/src/features/mission-control/components/dashboard/dashboard-header.tsx
@@ -6,6 +6,7 @@ import {
   FileType2,
   RefreshCw,
   ChevronDown,
+  Copy,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AtlasIcon } from "@/components/atlas-icon";
@@ -22,7 +23,7 @@ export function DashboardHeader({
 }: {
   range: TimeRange;
   onRange: (r: TimeRange) => void;
-  onExport: (kind: "pdf" | "jpeg" | "markdown") => void;
+  onExport: (kind: "pdf" | "jpeg" | "markdown" | "copy-markdown") => void;
   onRefresh: () => void;
   loading: boolean;
 }) {
@@ -88,6 +89,11 @@ export function DashboardHeader({
               icon={<FileText size={13} />}
               label="Markdown report"
               onSelect={() => onExport("markdown")}
+            />
+            <Item
+              icon={<Copy size={13} />}
+              label="Copy as Markdown"
+              onSelect={() => onExport("copy-markdown")}
             />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>

--- a/src/features/mission-control/components/dashboard/mission-control-dashboard.tsx
+++ b/src/features/mission-control/components/dashboard/mission-control-dashboard.tsx
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { useWorkspaceStore } from "@/features/workspaces/stores/workspace-store";
 import { useMissionControlStore } from "../../stores/mission-control-store";
 import { RANGE_DAYS } from "../../types";
-import { exportJpeg, exportMarkdown, exportPdf } from "../../lib/export";
+import { copyMarkdownReport, exportJpeg, exportMarkdown, exportPdf } from "../../lib/export";
 import { DashboardHeader } from "./dashboard-header";
 import { StatCards } from "./stat-cards";
 import { UsageAreaChart } from "./usage-area-chart";
@@ -31,9 +31,15 @@ export function MissionControlDashboard() {
 
   const rangeDays = RANGE_DAYS[range];
 
-  const onExport = async (kind: "pdf" | "jpeg" | "markdown") => {
+  const onExport = async (kind: "pdf" | "jpeg" | "markdown" | "copy-markdown") => {
     if (!data) return;
     try {
+      if (kind === "copy-markdown") {
+        const ok = await copyMarkdownReport(data);
+        if (!ok) throw new Error("clipboard write failed");
+        toast.success("Copied Markdown report");
+        return;
+      }
       if (kind === "markdown") await exportMarkdown(data);
       else if (captureRef.current) {
         if (kind === "pdf") await exportPdf(captureRef.current);

--- a/src/features/mission-control/lib/export.ts
+++ b/src/features/mission-control/lib/export.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { fmtTokens, fmtCost } from "@/features/monitor/lib/usage-format";
+import { copyText } from "@/lib/clipboard";
 import type { MissionControlUsage } from "../types";
 
 // Lazy-load the heavy libs only when an export is actually triggered.
@@ -96,6 +97,11 @@ export async function exportMarkdown(data: MissionControlUsage): Promise<void> {
   const target = await pickSave(`atlas-console-${stamp()}.md`, "md");
   if (!target) return;
   await invoke("mission_control_export_markdown", { targetPath: target, markdown: md });
+}
+
+/** Copy the same Markdown report used for file export straight to the clipboard. */
+export async function copyMarkdownReport(data: MissionControlUsage): Promise<boolean> {
+  return copyText(buildMarkdown(data));
 }
 
 function buildMarkdown(data: MissionControlUsage): string {


### PR DESCRIPTION
## Summary
- Log panel: adds a hover-revealed "copy line" button per row that copies a readable one-liner (`[source] kind — summary`), and fixes the existing "Copy JSON" button to use the app's native-first clipboard helper instead of a raw `navigator.clipboard` call.
- Mission Control: adds a "Copy as Markdown" export action that copies the same report Markdown used for file export straight to the clipboard.

Closes #179
Closes #175

## Test plan
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`
- [ ] Manually verify in `bun run dev:app`: hover a Log panel row, copy the line, paste to confirm format; open Mission Control export menu, "Copy as Markdown", paste to confirm report content