### PR TITLE
Add Reveal action to API key save toast

### DIFF
--- a/src/features/settings/components/providers-settings.tsx
+++ b/src/features/settings/components/providers-settings.tsx
@@ -14,7 +14,7 @@ import {
   EyeOff,
   Lock,
 } from "lucide-react";
-import { openUrl } from "@tauri-apps/plugin-opener";
+import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 import { SecretInput } from "@/ui/secret-input";
 import { cn } from "@/lib/utils";
 import { copyText } from "@/lib/clipboard";
@@ -337,7 +337,18 @@ function ProviderEditor({
       const file = await save(envVar, draft);
       setDraft("");
       setRevealed(null);
-      toast.success(`${provider.name} key written to ${tildePath(file)}`);
+      toast.success(`${provider.name} key written to ${tildePath(file)}`, {
+        action: {
+          label: "Reveal",
+          onClick: () => {
+            revealItemInDir(file).catch((err) => {
+              toast.error(
+                `Couldn't reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+          },
+        },
+      });
     } catch (e) {
       toast.error(`Couldn't save key: ${e instanceof Error ? e.message : String(e)}`);
     }


### PR DESCRIPTION
## Summary
- Saving a provider API key now shows a "Reveal" action on the success toast that opens the shell profile file's enclosing folder in Finder, via the opener plugin's `revealItemInDir`.
- Reveal failures surface a `toast.error`, matching the existing pattern in `turn-summary-card.tsx`.

Closes #180

## Test plan
- [ ] `bunx tsc --noEmit`, `bun run lint`, `bun run format:check` all pass
- [ ] Save a provider key in Settings → API Keys, confirm the toast shows a "Reveal" action
- [ ] Click Reveal, confirm Finder opens at the correct profile file