### PR TITLE
Show toast when embedding model download finishes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ import {
 import { useAuthStore } from "@/features/auth/stores/auth-store";
 import { ConnectDialog } from "@/features/auth/components/connect-dialog";
 import { clampScale, SCALE_STEP, DEFAULT_SCALE } from "@/features/settings/lib/ui-scale";
+import { useModelsStore } from "@/features/settings/stores/models-store";
 
 // Interface-zoom helpers (⌘+/⌘-/⌘0). They read + write the persisted
 // `uiScale` setting; `updateSettings` applies it to the native WebView zoom.
@@ -93,6 +94,12 @@ const zoomReset = () =>
   useProjectStore.getState().actions.updateSettings({ uiScale: DEFAULT_SCALE });
 
 export function App() {
+  // Own model download listeners at app scope so completion notifications are
+  // delivered even when Settings is closed.
+  useEffect(() => {
+    void useModelsStore.getState().actions.init();
+  }, []);
+
   // Probe Claude Code (installed? authed?) on mount. Drives the banner
   // above the message composer and the hard-disabled state of the input
   // when the CLI isn't ready. Fast — two parallel subprocesses, totals

--- a/src/features/settings/stores/models-store.test.ts
+++ b/src/features/settings/stores/models-store.test.ts
@@ -1,0 +1,85 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DownloadDone, DownloadProgress, ModelStatus } from "../lib/models-api";
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  progressHandler: undefined as ((progress: DownloadProgress) => void) | undefined,
+  doneHandler: undefined as ((done: DownloadDone) => void) | undefined,
+  changedHandler: undefined as (() => void) | undefined,
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: mocks.success, error: mocks.error } }));
+vi.mock("../lib/models-api", () => ({
+  models: {
+    list: mocks.list,
+    download: vi.fn(),
+    remove: vi.fn(),
+    select: vi.fn(),
+  },
+  listenModelProgress: vi.fn((handler: (progress: DownloadProgress) => void) => {
+    mocks.progressHandler = handler;
+    return Promise.resolve(vi.fn());
+  }),
+  listenModelDone: vi.fn((handler: (done: DownloadDone) => void) => {
+    mocks.doneHandler = handler;
+    return Promise.resolve(vi.fn());
+  }),
+  listenModelsChanged: vi.fn((handler: () => void) => {
+    mocks.changedHandler = handler;
+    return Promise.resolve(vi.fn());
+  }),
+}));
+
+const embeddingModel: ModelStatus = {
+  id: "all-MiniLM-L6-v2",
+  kind: "embedding",
+  name: "MiniLM-L6-v2",
+  repo: "sentence-transformers/all-MiniLM-L6-v2",
+  files: [],
+  dim: 384,
+  sizeMb: 90,
+  description: "Fast embeddings",
+  compatible: true,
+  downloaded: false,
+  selected: false,
+};
+
+let useModelsStore: typeof import("./models-store").useModelsStore;
+
+beforeAll(async () => {
+  mocks.list.mockResolvedValue([embeddingModel]);
+  ({ useModelsStore } = await import("./models-store"));
+  await useModelsStore.getState().actions.init();
+});
+
+beforeEach(() => {
+  mocks.success.mockClear();
+  mocks.error.mockClear();
+});
+
+describe("model download completion notifications", () => {
+  it("shows exactly one success toast for an embedding model", () => {
+    mocks.doneHandler?.({ id: embeddingModel.id, success: true, error: null });
+
+    expect(mocks.success).toHaveBeenCalledExactlyOnceWith("MiniLM-L6-v2 downloaded");
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("shows the download error for an embedding model", () => {
+    mocks.doneHandler?.({ id: embeddingModel.id, success: false, error: "network offline" });
+
+    expect(mocks.error).toHaveBeenCalledExactlyOnceWith("MiniLM-L6-v2 download failed", {
+      description: "network offline",
+    });
+    expect(mocks.success).not.toHaveBeenCalled();
+  });
+
+  it("does not notify for an event outside the embedding catalog", () => {
+    mocks.doneHandler?.({ id: "unknown-model", success: true, error: null });
+
+    expect(mocks.success).not.toHaveBeenCalled();
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/settings/stores/models-store.ts
+++ b/src/features/settings/stores/models-store.ts
@@ -4,6 +4,7 @@
 // Rust; this store is view state + orchestration only.
 
 import { create } from "zustand";
+import { toast } from "sonner";
 import { createSelectors } from "@/lib/create-selectors";
 import {
   models,
@@ -56,11 +57,21 @@ export const useModelsStore = createSelectors(
         );
         unlistens.push(
           await listenModelDone((d) => {
+            const model = get().list.find((entry) => entry.id === d.id);
             set((s) => {
               const next = { ...s.downloading };
               delete next[d.id];
               return { downloading: next };
             });
+            if (model) {
+              if (d.success) {
+                toast.success(`${model.name} downloaded`);
+              } else {
+                toast.error(`${model.name} download failed`, {
+                  description: d.error ?? undefined,
+                });
+              }
+            }
             void get().actions.refresh();
           }),
         );


### PR DESCRIPTION
### What?

- Initialize the local-model store at app scope so its download listeners remain active outside Settings.
- Show one Sonner success toast when a catalogued embedding model finishes downloading.
- Show a failure toast with the backend error when the completion event reports failure.
- Add focused tests for success, failure, and unrelated model events.

### Why?

Embedding-model downloads can take several minutes. Previously the listener was initialized only by the Settings model manager, leaving users without completion feedback after navigating away.

### How?

The existing `atlas:model-download:done` subscription remains owned by the singleton Zustand store. The app initializes that store on mount, and the handler resolves the event ID against the embedding-model catalog before notifying. This preserves exactly one listener and ignores unrelated IDs.

Fixes #168

## Checklist

- [x] Targets the current version branch, unless it is a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [ ] I have run the app and used the change in a window (toolchain was not installed on this machine; full frontend checks pass)

Validation: `bun run format:check`, `bun run lint`, `bun run typecheck`, and `bun run test` (557 tests). No dependencies or telemetry changes.