### PR TITLE
feat(theme): add Rosé Pine interface theme

### DIFF
--- a/src/features/theme/themes.ts
+++ b/src/features/theme/themes.ts
@@ -136,6 +136,33 @@ export const ATLAS_THEMES: AtlasTheme[] = [
       accentForeground: "#090a12",
     },
   },
+  {
+    // AMOLED near-black + Rosé Pine's signature rose — soft, focused.
+    id: "rose-pine",
+    name: "Rosé Pine",
+    description: "AMOLED near-black with a soft rose accent — calm, focused.",
+    spec: {
+      // Keep the recognizable Rosé Pine warmth while pulling its surfaces
+      // toward black for OLED displays and preserving Atlas's depth ladder.
+      base: "#08070a",
+      panel: "#100e14",
+      elevated: "#18151e",
+      overlay: "#24202c",
+      input: "#0d0b10",
+      tabActive: "#1e1a25",
+      textPrimary: "#e0def4",
+      textSecondary: "#aaa6c2",
+      textTertiary: "#7a7692",
+      textGhost: "#292532",
+      textMuted: "#56516a",
+      borderDefault: "#302a39",
+      borderSubtle: "#1b1721",
+      borderStrong: "#51485f",
+      accent: "#eb6f92",
+      accentHover: "#f08ba7",
+      accentForeground: "#16090e",
+    },
+  },
 ];
 
 /** Look up a theme by id, falling back to the Atlas Black default. */


### PR DESCRIPTION
### What?

Adds a Rosé Pine-inspired interface palette with an AMOLED near-black base, a restrained surface ladder, and accessible rose accents.

### Why?

This expands Atlas's dark interface theme selection with a warmer OLED-friendly option. The palette is registered through the existing `ATLAS_THEMES` path, so it appears in Settings → Appearance, applies live, and persists through the existing `settings.atlasTheme` hydration flow.

No dependencies or telemetry changes.

### How?

Adds one `ThemeSpec` registry entry using the existing CSS-variable token structure. Primary, secondary, tertiary, accent, hover, and accent-foreground pairs were checked at 4.5:1 contrast or higher. `git diff --check` passes.

Local Bun checks and an app-window smoke test were not run because this checkout has no installed JavaScript dependencies or Bun, per the requested no-setup workflow; CI will run the repository checks.

Fixes #169

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [ ] New behaviour has a test; a bug fix has a test that fails without it
- [ ] You've run the app and used the change in a window
