### PR TITLE
feat(editor): add Tokyo Night color theme

### DIFF
--- a/src/features/editor/themes/themes.ts
+++ b/src/features/editor/themes/themes.ts
@@ -3,7 +3,7 @@ import type { EditorColorTheme, EditorThemeColors } from "./types";
 /**
  * Built-in editor color themes. `atlas` is the default; `atlas-mono` keeps the
  * historical monochrome look for anyone who prefers it. The others are the
- * standard dark palettes (Dracula, One Dark, Monokai, Vesper).
+ * standard dark palettes (Dracula, One Dark, Monokai, Tokyo Night, Vesper).
  *
  * Every theme renders on the interface base surface (see `resolveEditorColors`),
  * which is AMOLED black or near it in all three Atlas interface themes. Syntax
@@ -274,6 +274,54 @@ const monokai: EditorColorTheme = {
   },
 };
 
+const tokyoNight: EditorColorTheme = {
+  id: "tokyo-night",
+  name: "Tokyo Night",
+  description: "Cool midnight blue with vivid purple, cyan, and coral syntax.",
+  dark: true,
+  colors: {
+    bg: "#1a1b26",
+    fg: "#c0caf5",
+    caret: "#c0caf5",
+    gutterBg: "#1a1b26",
+    gutterFg: "#565f89",
+    activeLineGutterFg: "#a9b1d6",
+    activeLineBg: "#ffffff0a",
+    selectionBg: "#33467c",
+    matchBracketBg: "#292e42",
+    matchBracketOutline: "#7aa2f7",
+    foldBg: "#16161e",
+    foldBorder: "#292e42",
+    foldFg: "#565f89",
+
+    comment: "#565f89",
+    keyword: "#bb9af7",
+    string: "#9ece6a",
+    number: "#ff9e64",
+    type: "#2ac3de",
+    func: "#7aa2f7",
+    variable: "#c0caf5",
+    operator: "#89ddff",
+    tagName: "#f7768e",
+    attributeName: "#73daca",
+    constant: "#ff9e64",
+    regexp: "#b4f9f8",
+    escape: "#bb9af7",
+    definition: "#7aa2f7",
+    propertyName: "#7dcfff",
+    bool: "#ff9e64",
+    null: "#ff9e64",
+
+    addLineBg: "#1b3328",
+    removeLineBg: "#3b202b",
+    contextBg: "#16161e",
+    addSideBg: "rgba(158,206,106,0.13)",
+    removeSideBg: "rgba(247,118,142,0.13)",
+    emphAddBg: "rgba(158,206,106,0.30)",
+    emphRemoveBg: "rgba(247,118,142,0.30)",
+  },
+};
+
 const vesper: EditorColorTheme = {
   id: "vesper",
   name: "Vesper",
@@ -328,6 +376,7 @@ export const EDITOR_THEMES: EditorColorTheme[] = [
   dracula,
   oneDark,
   monokai,
+  tokyoNight,
   vesper,
 ];
 


### PR DESCRIPTION
### What?

Adds Tokyo Night as a built-in editor color theme with complete editor chrome, syntax, and diff tokens.

### Why?

Expands the editor theme selection with a recognizable cool-toned palette while keeping every syntax color above the repository's contrast floor across all Atlas interface backgrounds.

### How?

Registers a complete `EditorColorTheme` entry in `EDITOR_THEMES`. The existing shared theme pipeline applies it to CodeMirror and exposes its syntax and diff tokens to the diff viewer and source-control views.

Fixes #170

## Verification

- `git diff --check`
- Static contrast calculation across all interface bases (minimum: 3.23:1; required: 3:1)
- Confirmed the registry feeds CodeMirror via `editorThemeExtensions`
- Confirmed the CSS variable mapping feeds diff and source-control views
- Bun checks were not run locally because Bun is not installed in the provided environment; PR CI will run the full suite

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; the existing parameterized theme suites automatically cover every registry entry
- [ ] You've run the app and used the change in a window (not possible in the provided environment)
