### PR TITLE
Remove orphaned artifacts_sessions command

### DIFF
--- a/src-tauri/src/commands/capture.rs
+++ b/src-tauri/src/commands/capture.rs
@@ -1191,29 +1191,6 @@ fn off_health(summary: &str) -> atlas_checkpoint::CaptureHealth {
     }
 }
 
-/// Every Session captured in this Workspace, newest first.
-///
-/// The whole point of the recorder. Reading is safe from any window — the
-/// writer lock guards writes only — so this deliberately does not check
-/// `is_writer`: a second Atlas window cannot record, but it can still read back
-/// what the first one did.
-#[tauri::command]
-pub async fn artifacts_sessions(
-    project_path: String,
-    workspace_id: Option<String>,
-) -> Result<Vec<atlas_checkpoint::SessionSummary>, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        let Some(store) = open_reader(&project_path)? else {
-            return Ok(Vec::new());
-        };
-        let workspace_id = workspace_id
-            .unwrap_or_else(|| workspace_id_for(std::path::Path::new(&project_path)));
-        atlas_checkpoint::session_summaries(&store, &workspace_id).map_err(|e| e.to_string())
-    })
-    .await
-    .map_err(|e| e.to_string())?
-}
-
 /// One Session as an ordered timeline.
 ///
 /// Commit subjects are resolved from git here rather than in the crate: this is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -428,7 +428,6 @@ pub fn run() {
             commands::capture::capture_activate,
             commands::capture::capture_retry_failed,
             commands::capture::capture_retry_watcher,
-            commands::capture::artifacts_sessions,
             commands::capture::artifacts_session,
             commands::capture::artifacts_payload,
             commands::capture::capture_commit_sessions,


### PR DESCRIPTION
## Summary
- `artifacts_sessions` (`src-tauri/src/commands/capture.rs`) lost its only frontend caller when a memory view was removed and has been dead surface since; removed the fn and its `generate_handler!` registration in `lib.rs`.
- Shared helpers it called (`open_reader`, `workspace_id_for`, `session_summaries`) are still used by other commands in `capture.rs`, so those are untouched.

Closes #173

## Test plan
- [x] `cargo check` in `src-tauri` is warning-free
- [x] `bun run test` passes (609 tests, includes IPC contract test)
- [x] `bunx tsc --noEmit` passes
- [x] `bun run lint` passes