### PR TITLE
Add command-palette entry and shortcut for Session Capture

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1415,6 +1415,14 @@ export function App() {
           data: {},
         }),
     },
+    {
+      // ⌘⌥C — open Session Capture (the popover behind the titlebar's
+      // project pill). Local `captureOpen` state lives in `ProjectLabel`,
+      // so this reaches it via the same `atlas:open-capture` event the
+      // command palette entry dispatches.
+      combo: { key: "c", meta: true, alt: true },
+      action: () => window.dispatchEvent(new CustomEvent("atlas:open-capture")),
+    },
     // ── Interface zoom (⌘+ / ⌘- / ⌘0) ──
     // `⌘+` on a US layout arrives as Shift+`=` (e.key === "+"); `⌘=` works too.
     // Both step the global UI scale up; `⌘-` down; `⌘0` resets to 100%.

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -29,6 +29,7 @@ import {
   Brain,
   Search,
   FolderOpen,
+  Circle,
 } from "lucide-react";
 import type { TabType } from "@/lib/constants";
 
@@ -325,6 +326,14 @@ export function CommandPalette({
         icon: Settings,
         category: "App",
         action: () => openTab("settings", "Settings"),
+      },
+      {
+        id: "open-capture",
+        label: "Open Session Capture",
+        shortcut: "⌘⌥C",
+        icon: Circle,
+        category: "App",
+        action: () => window.dispatchEvent(new CustomEvent("atlas:open-capture")),
       },
     ],
     [

--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -198,6 +198,14 @@ function ProjectLabel({
 
   useEffect(() => readCapture(), [readCapture]);
 
+  // Command palette + ⌘⌥C both open this popover from outside the component
+  // tree, since `captureOpen` is local state — see `atlas:open-capture`.
+  useEffect(() => {
+    const onOpenCapture = () => setCaptureOpen(true);
+    window.addEventListener("atlas:open-capture", onOpenCapture);
+    return () => window.removeEventListener("atlas:open-capture", onOpenCapture);
+  }, []);
+
   return (
     <div className="relative min-w-0">
       {/* Pill: `org / project`. The org segment is de-emphasised so the project

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -580,6 +580,7 @@ function KeybindingsSettings() {
         { action: "Global Search", keys: "⌘⇧F" },
         { action: "Settings", keys: "⌘," },
         { action: "New Window", keys: "⌘⇧N" },
+        { action: "Open Session Capture", keys: "⌘⌥C" },
         { action: "Zoom in", keys: "⌘+" },
         { action: "Zoom out", keys: "⌘-" },
         { action: "Reset zoom", keys: "⌘0" },


### PR DESCRIPTION
## Summary
- Adds an "Open Session Capture" command to the command palette
- Adds a global ⌘⌥C shortcut, wired through the same `atlas:open-capture` window event the popover's local state now listens for
- Adds the new shortcut to the Keybindings settings page's static list

Closes #174

## Test plan
- [x] `bun run lint`, `bun run format:check`, `bunx tsc --noEmit` all pass
- [x] Ran `bun run dev:app`, opened the command palette, searched "capture", ran the command, confirmed the Session Capture popover opens under the titlebar project pill
- [x] Confirmed ⌘⌥C opens the same popover