### PR TITLE
a11y: add aria-label to icon-only buttons

### DIFF
--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -223,6 +223,7 @@ function ProjectLabel({
             // is why it sat visibly high.
             className="group flex h-[19px] max-w-[320px] min-w-0 cursor-pointer items-center gap-1 rounded-full border border-[#303030] bg-[#0C0C0C] px-2 text-[11px] leading-none font-medium transition-colors hover:bg-[#1f1f1f]"
             title={health?.summary ?? "Session capture"}
+            aria-label={health?.summary ?? "Session capture"}
           >
             {orgName && (
               <>
@@ -340,6 +341,7 @@ function WorkspaceToggle() {
         sidebarOpen ? "text-[#ccc]" : "text-[#555] hover:text-[#aaa]",
       )}
       title={sidebarOpen ? "Hide workspaces (⌘⇧.)" : "Show workspaces (⌘⇧.)"}
+      aria-label={sidebarOpen ? "Hide workspaces" : "Show workspaces"}
     >
       <Layers size={14} />
       {count > 1 && (
@@ -360,6 +362,7 @@ function LeftPanelToggle() {
       onClick={toggleLeftPanel}
       className="flex items-center justify-center w-6 h-6 rounded text-[#555] hover:text-[#aaa] hover:bg-[#ffffff08] transition-all duration-150"
       title={leftPanel.visible ? "Hide left panel" : "Show left panel"}
+      aria-label={leftPanel.visible ? "Hide left panel" : "Show left panel"}
     >
       <PanelLeft size={14} className={leftPanel.visible ? "" : "opacity-40"} />
     </button>
@@ -450,6 +453,7 @@ function UpdateButton() {
         ready || downloading ? "text-[#ccc]" : "text-[#555] hover:text-[#aaa]",
       )}
       title={title}
+      aria-label={title}
     >
       {checking ? (
         <Loader2 size={14} className="animate-spin" />
@@ -493,6 +497,7 @@ function NotificationButton() {
       onClick={toggle}
       className="relative flex items-center justify-center w-6 h-6 rounded text-[#555] hover:text-[#aaa] hover:bg-[#ffffff08] transition-all duration-150 outline-none focus:outline-none"
       title="Notifications"
+      aria-label="Notifications"
     >
       <Bell size={14} />
       {(hasUnread || needsAttention) && (
@@ -522,6 +527,7 @@ function RightPanelToggle() {
       onClick={toggleRightPanel}
       className="flex items-center justify-center w-6 h-6 rounded text-[#555] hover:text-[#aaa] hover:bg-[#ffffff08] transition-all duration-150"
       title={rightPanel.visible ? "Hide right panel" : "Show right panel"}
+      aria-label={rightPanel.visible ? "Hide right panel" : "Show right panel"}
     >
       <PanelRight size={14} className={rightPanel.visible ? "" : "opacity-40"} />
     </button>

--- a/src/features/memory/components/memory-timeline-panel.tsx
+++ b/src/features/memory/components/memory-timeline-panel.tsx
@@ -57,6 +57,7 @@ export function MemoryTimelinePanel({
             onClick={onClose}
             className="mt-1 flex items-center justify-center w-5 h-5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
             title="Close"
+            aria-label="Close"
           >
             <X size={13} />
           </button>

--- a/src/features/memory/components/memory-timeline-view.tsx
+++ b/src/features/memory/components/memory-timeline-view.tsx
@@ -271,6 +271,7 @@ export function MemoryTimelineView() {
           onClick={() => projectPath && void loadTimeline(projectPath, true)}
           className="flex items-center justify-center w-6 h-6 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
           title="Refresh"
+          aria-label="Refresh"
         >
           <RotateCw size={12} className={loading ? "animate-spin" : ""} />
         </button>

--- a/src/features/pdf/components/pdf-toolbar.tsx
+++ b/src/features/pdf/components/pdf-toolbar.tsx
@@ -92,6 +92,7 @@ export function PdfToolbar({ fileName, zoom, dirty, onZoomIn, onZoomOut }: PdfTo
           type="button"
           onClick={onZoomOut}
           title="Zoom out"
+          aria-label="Zoom out"
           className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
         >
           <ZoomOut size={13} />
@@ -103,6 +104,7 @@ export function PdfToolbar({ fileName, zoom, dirty, onZoomIn, onZoomOut }: PdfTo
           type="button"
           onClick={onZoomIn}
           title="Zoom in"
+          aria-label="Zoom in"
           className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-tertiary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
         >
           <ZoomIn size={13} />

--- a/src/features/settings/components/models-manager.tsx
+++ b/src/features/settings/components/models-manager.tsx
@@ -176,6 +176,11 @@ export function ModelsManager() {
                             ? `Use ${m.name} for embeddings`
                             : "Download this model first"
                         }
+                        aria-label={
+                          m.downloaded
+                            ? `Use ${m.name} for embeddings`
+                            : "Download this model first"
+                        }
                         onClick={() => void doUse(m)}
                         className="h-6 rounded-md px-2 text-[10px] font-medium border border-border-default bg-bg-elevated text-text-primary hover:bg-bg-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                       >
@@ -186,6 +191,7 @@ export function ModelsManager() {
                       <button
                         type="button"
                         title="Remove download"
+                        aria-label="Remove download"
                         disabled={busy}
                         onClick={() => void doRemove(m)}
                         className="h-6 w-6 flex items-center justify-center rounded-md text-text-tertiary hover:text-[var(--status-error)] hover:bg-bg-hover transition-colors disabled:opacity-50"

--- a/src/features/settings/components/providers-settings.tsx
+++ b/src/features/settings/components/providers-settings.tsx
@@ -163,6 +163,7 @@ export function ProvidersSettings() {
             <button
               className="flex items-center justify-center w-6 h-6 shrink-0 rounded text-text-tertiary hover:text-text-primary hover:bg-bg-hover cursor-pointer outline-none transition-colors"
               title="Filters & sort"
+              aria-label="Filters & sort"
             >
               <MoreHorizontal size={14} />
             </button>


### PR DESCRIPTION
## Summary
- Closes #177 — sweeps 13 icon-only buttons missing an accessible name, reusing existing `title` text for `aria-label`
- Covers: titlebar (capture pill, workspace toggle, left/right panel toggles, update button, notifications), models-manager (use/remove-download row actions), memory timeline (refresh, close), pdf-toolbar (zoom in/out), providers-settings (filters & sort)

## Test plan
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`
- [x] No visual changes — `aria-label` added alongside existing `title`, no markup/class changes