### PR TITLE
Esc clears the filter inputs in Settings tables

### DIFF
--- a/src/features/settings/components/models-manager.tsx
+++ b/src/features/settings/components/models-manager.tsx
@@ -91,6 +91,12 @@ export function ModelsManager() {
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && query) {
+                e.stopPropagation();
+                setQuery("");
+              }
+            }}
             placeholder="Filter models…"
             className={cn(
               "w-full h-7 pl-8 pr-2.5 rounded-md bg-bg-elevated border border-border-default",

--- a/src/features/settings/components/providers-settings.tsx
+++ b/src/features/settings/components/providers-settings.tsx
@@ -152,6 +152,12 @@ export function ProvidersSettings() {
           <input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && query) {
+                e.stopPropagation();
+                setQuery("");
+              }
+            }}
             placeholder="Search providers…"
             spellCheck={false}
             className="flex-1 min-w-0 bg-transparent outline-none text-[11px] text-text-primary placeholder:text-text-tertiary"


### PR DESCRIPTION
## Summary
- Add an `onKeyDown` handler to the API Keys search input and the Local Models filter input
- Pressing Esc while the input has a non-empty query clears it and stops propagation (keeping focus on the input)
- An already-empty filter lets Esc propagate unchanged, so it still closes the settings tab as before

Closes #165

## Test plan
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit`
- [ ] Manually verify in `bun run dev:app`: type in each search box, press Esc, confirm it clears and keeps focus; press Esc again on empty input and confirm settings tab closes