### PR TITLE
Update About panel copyright text

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
     "category": "DeveloperTool",
     "shortDescription": "Atlas — agent-first ideation and planning tool",
     "longDescription": "Atlas is a Tauri-based desktop app that hosts ACP-compatible coding agents (Claude Code, Codex, OpenCode) with first-class file, knowledge, and research integration.",
-    "copyright": "Copyright © 2026 Adib Mohsin",
+    "copyright": "https://tryatlas.cc/ Report bugs to Github: https://github.com/pacifio/atlas/issues/",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary
- The native macOS About panel (App menu ▸ About Atlas) showed a placeholder copyright line: "Copyright © 2026 Adib Mohsin".
- Replaced it with the project site and bug report link, since the `copyright` field in `tauri.conf.json` is what `AboutMetadata::default()` renders in `src-tauri/src/menu.rs`.

## Change
`src-tauri/tauri.conf.json`:
```
- "copyright": "Copyright © 2026 Adib Mohsin",
+ "copyright": "https://tryatlas.cc/ Report bugs to Github: https://github.com/pacifio/atlas/issues/",
```

## Test plan
- [ ] Build the Tauri app and open App menu ▸ About Atlas on macOS to confirm the new text renders correctly in the panel.