### PR TITLE
fix(memory): persist timeline day range

### DIFF
--- a/src/features/memory/components/memory-timeline-view-prefs.test.ts
+++ b/src/features/memory/components/memory-timeline-view-prefs.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  loadMemoryTimelineDayCount,
+  saveMemoryTimelineDayCount,
+} from "./memory-timeline-view-prefs";
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      clear: () => values.clear(),
+    },
+  });
+  localStorage.clear();
+});
+
+describe("memory timeline day-count preference", () => {
+  it("defaults to 4 days when storage is missing", () => {
+    expect(loadMemoryTimelineDayCount()).toBe(4);
+  });
+
+  it.each([3, 4, 7] as const)("restores a valid persisted value: %d", (dayCount) => {
+    saveMemoryTimelineDayCount(dayCount);
+    expect(loadMemoryTimelineDayCount()).toBe(dayCount);
+  });
+
+  it.each(["", "2", "5", "three", "null"])(
+    "falls back to 4 for an invalid persisted value: %j",
+    (value) => {
+      localStorage.setItem("atlas-memory-timeline-day-count", value);
+      expect(loadMemoryTimelineDayCount()).toBe(4);
+    },
+  );
+
+  it("persists a changed valid value for the next mount", () => {
+    saveMemoryTimelineDayCount(7);
+    expect(loadMemoryTimelineDayCount()).toBe(7);
+    saveMemoryTimelineDayCount(3);
+    expect(loadMemoryTimelineDayCount()).toBe(3);
+  });
+});

--- a/src/features/memory/components/memory-timeline-view-prefs.ts
+++ b/src/features/memory/components/memory-timeline-view-prefs.ts
@@ -1,0 +1,20 @@
+export type MemoryTimelineDayCount = 3 | 4 | 7;
+
+const DAY_COUNT_KEY = "atlas-memory-timeline-day-count";
+
+export function loadMemoryTimelineDayCount(): MemoryTimelineDayCount {
+  try {
+    const value = localStorage.getItem(DAY_COUNT_KEY);
+    return value === "3" ? 3 : value === "7" ? 7 : 4;
+  } catch {
+    return 4;
+  }
+}
+
+export function saveMemoryTimelineDayCount(dayCount: MemoryTimelineDayCount) {
+  try {
+    localStorage.setItem(DAY_COUNT_KEY, String(dayCount));
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/features/memory/components/memory-timeline-view.tsx
+++ b/src/features/memory/components/memory-timeline-view.tsx
@@ -8,6 +8,11 @@ import { MemoryTimelineCalendar } from "./memory-timeline-calendar";
 import { MemoryTimelinePanel, type PanelItem } from "./memory-timeline-panel";
 import { memoryGraph } from "../lib/memory-graph-api";
 import type { MemoryTimeline, TimelineCommit, TimelineMemory } from "../lib/memory-timeline-api";
+import {
+  loadMemoryTimelineDayCount,
+  saveMemoryTimelineDayCount,
+  type MemoryTimelineDayCount,
+} from "./memory-timeline-view-prefs";
 
 // ── Influence chain over the timeline (memory → session → commit) ──
 function buildChain(t: MemoryTimeline) {
@@ -104,7 +109,11 @@ export function MemoryTimelineView() {
   const [highlightIds, setHighlightIds] = useState<Set<string> | null>(null);
 
   // Day-range columns; 4 by default, user-selectable via the header toggle.
-  const [dayCount, setDayCount] = useState<3 | 4 | 7>(4);
+  const [dayCount, setDayCount] = useState<MemoryTimelineDayCount>(loadMemoryTimelineDayCount);
+  const setPersistedDayCount = (nextDayCount: MemoryTimelineDayCount) => {
+    setDayCount(nextDayCount);
+    saveMemoryTimelineDayCount(nextDayCount);
+  };
 
   useEffect(() => {
     ensureProject(projectPath);
@@ -254,7 +263,7 @@ export function MemoryTimelineView() {
           {([3, 4, 7] as const).map((n) => (
             <button
               key={n}
-              onClick={() => setDayCount(n)}
+              onClick={() => setPersistedDayCount(n)}
               className={cn(
                 "px-2 h-6 text-[10px] tabular-nums transition-colors cursor-pointer border-l border-[var(--border-default)] first:border-l-0",
                 dayCount === n


### PR DESCRIPTION
Fixes #167

Persist the Memory Timeline 3d/4d/7d selection in localStorage, restoring valid values on mount and falling back to 4 for missing or invalid values.

Validation:
- Focused timeline preference tests: 10/10 passed
- TypeScript app and test checks: passed
- Changed-file format and lint checks: passed
- Full Vitest: 814/815 passed under Node localStorage compatibility mode; one unrelated existing last-mode-pref storage-isolation test fails
- Full lint retains two unrelated pre-existing no-useless-empty-export findings

No Tauri runtime validation was run.