### PR TITLE
settings: add Clear filter action to empty tables

### DIFF
--- a/src/features/settings/components/models-manager.tsx
+++ b/src/features/settings/components/models-manager.tsx
@@ -121,6 +121,20 @@ export function ModelsManager() {
               <div className={COL.status}>Status</div>
               <div className={COL.use}>Use</div>
             </div>
+            {rows.length === 0 && query.trim() !== "" && (
+              <div className="grid place-items-center gap-2 h-[160px] text-[11px] text-text-tertiary">
+                No models match.
+                {query.trim() !== "" && (
+                  <button
+                    type="button"
+                    onClick={() => setQuery("")}
+                    className="h-6 rounded-md border border-border-default bg-bg-elevated px-2 text-[10px] text-text-primary hover:bg-bg-hover transition-colors"
+                  >
+                    Clear filter
+                  </button>
+                )}
+              </div>
+            )}
             {rows.map((m) => {
               const dl = downloading[m.id];
               const busy = pending === m.id;

--- a/src/features/settings/components/providers-settings.tsx
+++ b/src/features/settings/components/providers-settings.tsx
@@ -125,6 +125,14 @@ export function ProvidersSettings() {
     [],
   );
 
+  const hasActiveFilter = query.trim() !== "" || category !== "All" || configuredOnly;
+
+  const clearFilters = () => {
+    setQuery("");
+    setCategory("All");
+    setConfiguredOnly(false);
+  };
+
   return (
     <div className="h-full flex flex-col bg-bg-base">
       {/* Toolbar */}
@@ -224,8 +232,17 @@ export function ProvidersSettings() {
           </div>
 
           {rows.length === 0 ? (
-            <div className="grid place-items-center h-[160px] text-[11px] text-text-tertiary">
+            <div className="grid place-items-center gap-2 h-[160px] text-[11px] text-text-tertiary">
               No providers match.
+              {hasActiveFilter && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="h-6 rounded-md border border-border-default bg-bg-elevated px-2 text-[10px] text-text-primary hover:bg-bg-hover transition-colors"
+                >
+                  Clear filter
+                </button>
+              )}
             </div>
           ) : (
             rows.map((p) => (

--- a/src/features/settings/components/settings-filter-empty-state.test.tsx
+++ b/src/features/settings/components/settings-filter-empty-state.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+
+const mocks = vi.hoisted(() => ({
+  byok: {
+    entries: [] as Array<{
+      provider: string;
+      envVar: string;
+      last4: string;
+      editable: boolean;
+      file?: string;
+      line?: number;
+    }>,
+    profile: null,
+    loaded: true,
+    pending: null,
+    actions: { load: vi.fn(), save: vi.fn(), remove: vi.fn() },
+  },
+  models: {
+    list: [
+      {
+        id: "nomic-embed-text-v1.5",
+        kind: "embedding" as const,
+        name: "Nomic Embed Text",
+        repo: "nomic-ai/nomic-embed-text-v1.5",
+        files: [],
+        sizeMb: 274,
+        description: "A local embedding model",
+        compatible: true,
+        downloaded: false,
+        selected: false,
+      },
+    ],
+    loaded: true,
+    downloading: {},
+    pending: null,
+    actions: { init: vi.fn(), download: vi.fn(), remove: vi.fn(), select: vi.fn() },
+  },
+}));
+
+vi.mock("../stores/byok-store", () => ({
+  useByokStore: {
+    use: Object.fromEntries(
+      Object.keys(mocks.byok).map((key) => [key, () => mocks.byok[key as keyof typeof mocks.byok]]),
+    ),
+  },
+}));
+vi.mock("../stores/models-store", () => ({
+  useModelsStore: {
+    use: Object.fromEntries(
+      Object.keys(mocks.models).map((key) => [
+        key,
+        () => mocks.models[key as keyof typeof mocks.models],
+      ]),
+    ),
+  },
+}));
+vi.mock("@/features/project/stores/project-store", () => ({
+  useProjectStore: { use: { currentProject: () => null } },
+}));
+
+const { ProvidersSettings } = await import("./providers-settings");
+const { ModelsManager } = await import("./models-manager");
+
+afterEach(() => cleanup());
+beforeEach(() => {
+  mocks.byok.entries = [];
+  mocks.models.list = [mocks.models.list[0]];
+});
+
+describe("settings table filtered empty states", () => {
+  it("lets a filtered providers table clear its query and restore rows", async () => {
+    const user = userEvent.setup();
+    render(<ProvidersSettings />);
+
+    await user.type(screen.getByPlaceholderText("Search providers…"), "does-not-exist");
+    expect(screen.getByText("No providers match.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Clear filter" }));
+
+    expect(screen.getByPlaceholderText("Search providers…")).toHaveValue("");
+    expect(screen.getAllByText("OpenAI").some((element) => element.tagName === "SPAN")).toBe(true);
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
+  });
+
+  it("preserves the providers empty state without an active filter", () => {
+    const { rerender } = render(<ProvidersSettings />);
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
+
+    rerender(<ProvidersSettings />);
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
+  });
+
+  it("lets a filtered models table clear its query and restore rows", async () => {
+    const user = userEvent.setup();
+    render(<ModelsManager />);
+
+    await user.type(screen.getByPlaceholderText("Filter models…"), "does-not-exist");
+    expect(screen.getByText("No models match.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Clear filter" }));
+
+    expect(screen.getByPlaceholderText("Filter models…")).toHaveValue("");
+    expect(screen.getByText("Nomic Embed Text")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
+  });
+
+  it("preserves the models table when no filter is active", () => {
+    mocks.models.list = [];
+    render(<ModelsManager />);
+    expect(screen.queryByText("No models match.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #166

Adds a small `Clear filter` action to zero-result states in the providers and local models settings tables. The action restores the full list by clearing the active table filters.

Validation:
- Focused settings interaction tests: 4/4 passed
- Relevant settings/lib tests: 93/93 passed
- Changed-file lint/format and both TypeScript typechecks passed
- Full Vitest had 54 unrelated localStorage failures in existing chat/terminal tests under this Node environment; they are not regressions
- Bun is unavailable and Tauri runtime validation was not run