### PR TITLE
docs: describe the agent stack Atlas actually has

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,11 +25,10 @@ src/features/<feature>/components  →  stores (Zustand)  →  lib/*-api.ts (inv
 │  │  React 19 frontend          │    │  Rust backend                  │ │
 │  │  (WKWebView on macOS)       │◀──▶│  (tokio + tauri 2)              │ │
 │  │                             │ IPC│                                 │ │
-│  │  • Zustand stores           │    │  • commands/ — ~326 IPC verbs   │ │
-│  │  • CodeMirror, xterm,       │    │    across 67 domain modules     │ │
-│  │    Tiptap, Pixi, TanStack   │    │  • atlas-acp (ACP/JSON-RPC)     │ │
-│  │  • Tailwind v4              │    │  • atlas-agents (session actor) │ │
-│  │                             │    │  • atlas-cersei (native agent)  │ │
+│  │  • Zustand stores           │    │  • commands/ — 354 IPC verbs    │ │
+│  │  • CodeMirror, xterm,       │    │    across 69 domain modules     │ │
+│  │    Tiptap, Pixi, TanStack   │    │  • ported ACP stack (10 crates) │ │
+│  │  • Tailwind v4              │    │  • atlas-cersei (native agent)  │ │
 │  │                             │    │  • atlas-terminal (PTY)         │ │
 │  │                             │    │  • atlas-memory / atlas-embed   │ │
 │  │                             │    │  • spawn_blocking for all I/O   │ │
@@ -39,9 +38,8 @@ src/features/<feature>/components  →  stores (Zustand)  →  lib/*-api.ts (inv
 │  • Per-project: <project>/.atlas/ (knowledge, canvas.json,             │
 │    editor-state.json, logs.jsonl, memory index, codebase-index,        │
 │    cloned repos, skills, packs)                                        │
-│  • Global:      ~/.atlas/ (pinned log rows)                            │
-│  • Claude Code: ~/.claude/projects/<slug>/*.jsonl (read directly,      │
-│    never mirrored)                                                     │
+│  • Global:      ~/.atlas/ (pinned log rows),                           │
+│                 <app-config-dir>/threads.db (session history)          │
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -74,7 +72,7 @@ src/features/<feature>/
 
 | Subsystem | Store holds (UI only) | Real state lives in |
 |---|---|---|
-| Chat | queues, draft text, scroll position (`chat/stores/chat-store.ts`) | `atlas-agents`' per-session actor — message log, tool calls, run status, streamed over `atlas:agents` |
+| Chat | queues, draft text, scroll position (`chat/stores/chat-store.ts`) | the ported thread behind `AgentConnection` — message log, tool calls, run status, projected to the frozen wire and streamed over `atlas:agents` |
 | Editor | open-file metadata, dirty flags (`editor/stores/editor-store.ts`) | CodeMirror owns the document text |
 | Terminal | split/pane layout (`terminal/stores/terminal-store.ts`) | `atlas-terminal`'s PTY session owns the byte buffer |
 
@@ -90,28 +88,27 @@ Other stores: `project/stores/project-store.ts` (current project, recents), `git
 - **Up to 3 columns** (`groupOrder`, capped at 3). Each tab carries a `groupId` naming its column.
 - A maintained `activeTabId` mirrors the focused column's active tab, so most readers don't need to know splits exist.
 
-`src/lib/constants.ts` holds `TAB_TYPES` (the tab-type registry); `CenterPanel.tsx` holds the lazy-import map keyed off it. New panel type = lazy import in `CenterPanel.tsx` + entry in `TAB_TYPES` + entry in `NEW_TAB_OPTIONS` if it should reach the `+` menu.
+`src/lib/constants.ts` holds `TAB_TYPES` (the tab-type registry); `src/features/layout/components/center-panel.tsx` holds the lazy-import map keyed off it. New panel type = lazy import in `center-panel.tsx` + entry in `TAB_TYPES` + entry in `NEW_TAB_OPTIONS` if it should reach the `+` menu.
 
 **Persistent module types — editor, terminal, browser, knowledge-graph, pdf — stay mounted across tab switches** via `display: contents` / `display: none` instead of unmounting. Remounting would rebuild CodeMirror instances, kill the PTY's rendered scrollback, or tear down the native embedded webview.
 
 ## Backend (`src-tauri/src/`)
 
-One Rust module per IPC domain under `src-tauri/src/commands/`. `commands/mod.rs` declares 67 `pub mod` domain files:
+One Rust module per IPC domain under `src-tauri/src/commands/`. `commands/mod.rs` declares 69 `pub mod` domain files:
 
 | Domain group | Modules |
 |---|---|
-| Agents & Claude | agents, claude, claude_setup |
+| Agents (ported ACP stack) | agents, agent_host, agent_transcript, agent_analytics, agent_memory, catalog, registry, capture |
+| Native agent | cersei |
 | Terminal / browser / fs | terminal, browser, fs |
-| Git | git, git_graph, git_watcher, gitdiff |
+| Git | git, git_graph, git_watcher, gitdiff, git_ops, git_conflicts, git_snapshot, git_stage_ops |
 | GitHub | github |
-| Knowledge | knowledge, knowledge_meta, knowledge_links, knowledge_export |
-| Canvas / misc | canvas, log |
-| Memory | memory_* — chat, sessions, graph, pack, policy, sharing, summarize, timeline, delta, inject, compile, indexer, retrieve |
-| Models | models, models_pricing |
-| Model chat | modelchat, modelchat_sessions |
-| Shared memory | agent_memory, shared_memory |
-| Analytics & feedback | agent_analytics, tool_stats, feedback |
-| Other | mission_control, pdf_annotations, plans, project_session, search, sessions_watch, skills, telemetry, updater, window, byok, auth, node_setup, mcp, cersei, codebase_index, clipboard, fileindex, mention_search, recent_files, app_state, cli, compose_prompt, git_ops, knowledge_graph_layout |
+| Knowledge | knowledge, knowledge_meta, knowledge_links, knowledge_export, knowledge_graph_layout |
+| Memory | memory_* — graph, pack, policy, sharing, summarize, timeline, delta, inject, compile, indexer, retrieve; plus shared_memory |
+| Models & usage | models, models_pricing, usage, tool_stats |
+| Session chat | session_chat, session_chat_sessions, modelchat |
+| Auth & environment | auth, byok, shell_profile, mcp |
+| Other | app_state, canvas, cli, clipboard, codebase_index, compose_prompt, feedback, fileindex, log, mention_search, mission_control, pdf_annotations, plans, project_session, recent_files, search, skills, telemetry, updater, window |
 
 Adding a command is a three-edit rule:
 
@@ -130,124 +127,137 @@ Streaming from Rust to the UI runs on Tauri events, `atlas:*` channels, most pay
 | Channel | Carries |
 |---|---|
 | `atlas:agents` | every agent delta — message append, content-block delta, tool call, permission request, status, error, done |
-| `atlas:memory-chat`, `atlas:modelchat` | memory/RAG chat and model-chat streaming |
-| `atlas:review` | code-review streaming |
+| `atlas:threads-changed` | thread-metadata store changed; the sidebar's only refresh signal |
+| `atlas:capture-changed` | Timeline / checkpoint record updated |
+| `atlas:agent-elicitation`, `atlas:agent-elicitation-resolved` | agent-initiated prompts to the user |
+| `atlas:agent-catalog:changed`, `atlas:registry-install:progress` / `:done` | Marketplace catalog and install lifecycle |
+| `atlas:auth-run:progress` / `:done` | interactive agent sign-in run |
+| `atlas:modelchat` | model-chat streaming |
 | `atlas:browser-nav` | embedded-webview navigation state |
-| `atlas:git-changed`, `atlas:git-status-fresh` | git state invalidation from the fs-watcher |
+| `atlas:git-changed`, `atlas:git-status-fresh`, `atlas:git:op` | git state invalidation from the fs-watcher, and long-op progress |
 | `atlas:codebase-index:progress` | codebase-index build progress |
 | `atlas:update-checking` / `-available` / `-progress` / `-ready` / `-applied` / `-error` | auto-updater lifecycle |
 | `atlas:auth-changed` / `-signed-out` / `-error` | account/session state |
-| `atlas:sessions-changed`, `atlas:recent-files-changed`, `atlas:models-changed`, `atlas:models-pricing-updated` | cache-invalidation broadcasts |
+| `atlas:byok-env-updated` | shell-profile API-key environment changed |
+| `atlas:recent-files-changed`, `atlas:models-changed`, `atlas:models-pricing-updated` | cache-invalidation broadcasts |
 | `atlas:cli-open-project`, `atlas:close-active-tab` | native menu / single-instance-relaunch plumbing |
 | `atlas:explorer:changed`, `atlas:fileindex:updated` | file-tree and file-index invalidation |
 | `atlas:knowledge:links-changed`, `atlas:knowledge:meta-changed` | knowledge-base backlink and metadata updates |
-| `atlas:claude-install:*`, `atlas:node-install:*` | `claude` CLI and Node bootstrap progress |
 | `atlas:model-download:*`, `atlas:memory-embed:*` | local model download and embedding progress |
 
 ## Agent runtime
 
-Atlas ships three selectable agents. **Claude Code** and **Codex** run as external subprocesses speaking ACP (Agent Client Protocol, JSON-RPC over stdio). **Atlas** is the native, in-process agent, driving the Cersei agent SDK directly, and translates Cersei's event stream into the same `AcpEvent` shapes the subprocess agents produce — the session actor, the delta wire format, and the UI stay identical regardless of which agent is running.
+Atlas's agent stack is a port of Zed's, taken as a mechanism rather than rewritten. Two kinds of agent run behind one seam: **Cersei**, the native in-process agent driving the Cersei SDK, and any number of **external ACP agents** — subprocesses speaking Agent Client Protocol (JSON-RPC over stdio). Nothing above the seam knows which it is talking to.
 
-The ACP registry (`crates/atlas-acp/src/registry.rs`) also carries scaffolding for an OpenCode ACP bridge (`AgentSpec::opencode`) and two Claude Code launch variants (`claude_code_ts` — the canonical `@agentclientprotocol/claude-agent-acp` — and `claude_code_rs`). Claude Code, Codex, and the native Atlas agent are the three meant to be user-selectable today.
+**A fresh install has no ACP agents at all.** Only Cersei is offered. An external agent exists exactly when the user installed it from the Marketplace, which writes the single entry in the installed-agents map; nothing else makes an agent runnable. Finding a binary on `PATH` is a *detection* — an offer the user can accept, never a spawn candidate. See [ADR-0002](docs/adr/0002-no-default-acp-agents.md).
 
-### The seam: `AgentBackend`
+### The seam: `AgentConnection`
 
-`AgentBackend` (`crates/atlas-agents/src/backend.rs`) is the trait that makes the two transports interchangeable above this line:
+`AgentConnection` (`crates/atlas-acp-thread/src/connection.rs`) is the trait every agent implements — one live connection, with turns driven through `prompt`.
 
-```
-new_session, load_session, send_prompt,
-set_session_mode, set_session_model,
-cancel_turn, respond_permission,
-register_session, drop_session,
-authenticate, kill
-```
-
-| Implementation | Wraps | Drives |
+| Implementation | Crate | Drives |
 |---|---|---|
-| `AcpBackend` | `atlas_acp::AgentRegistry` | Claude Code / Codex subprocesses over JSON-RPC |
-| `CerseiBackend` | `atlas_cersei::CerseiRuntime` | the native agent, in-process |
+| external ACP agent | `atlas-agent-servers` | a subprocess over JSON-RPC/stdio |
+| Cersei | `atlas-native-agent` | the native agent, in-process |
 
-`AgentManager::spawn` (`crates/atlas-agents/src/manager.rs`) picks the backend at spawn time: the Cersei plugin gets a `CerseiBackend`, anything else gets an `AcpBackend`. Everything downstream — the actor, event dispatch, `SessionState`, the frontend — talks to `Arc<dyn AgentBackend>` and never branches on transport.
+Beyond `prompt` / `cancel` / `authenticate`, **every optional behaviour is capability-gated** — either a `supports_*` predicate (`supports_load_session`, `supports_resume_session`, `supports_close_session`, `supports_logout`) or an `Option<Arc<dyn …>>` sub-trait the connection returns only when the agent advertised it (`model_selector`, `session_modes`, `session_config_options`, `session_list`, `truncate`, `retry`, `set_title`, `telemetry`). A caller asks the connection what it can do; it never asks who it is.
 
-### The per-session actor
+**Branching on agent identity is forbidden.** Capabilities come from what the agent advertised at `initialize`. An `if agent_id == "claude"` is a bug, not a shortcut — it is what made the pre-port stack impossible to extend to an agent nobody had hand-written support for.
 
-Each session runs on one single-owner tokio task, `SessionActor` (`crates/atlas-agents/src/actor.rs`), spawned by the manager and handed back as an `ActorHandle` (a control sender + a stream sender) — not a shared worker pool. Its `tokio::select!` loop multiplexes two inputs into one FIFO:
+### Manager, host, and the delta projection
 
-- **`control_rx`** — user intents: `Send`, `Cancel`, `RespondPermission`, `SetMode`, `SetModel`, `SetEffort`, `SetCompress`.
-- **`stream_rx`** — an ordered `ActorMsg` stream: inbound `Acp` events routed from the manager's event sink, plus the turn's own lifecycle signals (`TurnDone`, `FinalizeTimeout`, `CancelDeadline`, `Disconnect`, `SettingResult`).
+Three layers sit between the connection and the IPC surface:
 
-Agent events and turn-completion share the same FIFO, so ordering is structural rather than polled or inferred. One caveat: `TurnDone` can resolve before a turn's tool calls have all reported terminal, so finalization also gates on tool-call quiescence, backstopped by a bounded `FinalizeTimeout`. A monotonic `TurnId` plus an `is_same_turn` check makes preemption (cancel-then-send) safe — a superseded turn's late events drop instead of corrupting a fresh turn's state.
+- **`AgentManager`** (`crates/atlas-agent-manager`) owns who is connected and which sessions are open on them — ported from Zed's `AgentConnectionStore`. Three behaviours worth knowing: a second connect request while the first is still connecting *joins* it rather than starting a second process; a failed connection does not stick (the entry records the error for waiters, then goes, so the next request retries instead of replaying the failure forever); and a version bump drops the connection, because the running process is on the old binary.
+- **`AgentHost`** (`src-tauri/src/commands/agent_host.rs`) is what `commands/agents.rs` talks to. It holds the three things the ported stack deliberately does not do: the **identity map** between the frontend's per-spawn `AgentId`/`SessionKey` and the manager's own keys, the **history** row kept current in the thread-metadata store, and cheap **session metadata** (`snapshot_meta`) on the send path.
+- **`DeltaProjector`** (`crates/atlas-agent-delta`) turns thread events into the wire the rest of Atlas consumes.
 
-One owner of session mutation state closes the races that used to require careful locking under an older shared-worker design. `AgentManager` (`crates/atlas-agents/src/manager.rs`) is the registry above the actors — installed plugins, running sessions, which session belongs to which UI tab — not a place where message state lives.
+### The frozen wire
+
+Every delta travels an ordered `OutboundPipeline` (`atlas-bus`) of independent middleware: `BroadcastMiddleware` (the `atlas:agents` window event), `CaptureMiddleware` (Timeline + the permanent checkpoint record), `AnalyticsMiddleware`, `TranscriptMiddleware`, `MemoryIngestMiddleware`.
+
+The `SessionDelta` shapes those consumers pattern-match live in **`crates/atlas-agent-wire`** and are **frozen**. `crates/atlas-agent-wire/tests/contract.rs` is the enforcement: it spells the contract out itself and fails if the enum drifts from it. (It also cross-checks `docs/agents/delta-wire-contract.md` when that file is present — the prose contract is a working note and is git-ignored, which is exactly why the test does not rely on it.) The thread model and the wire disagree about what a "message" is — the thread keeps one entry per assistant message with interleaved text and thought chunks; the wire emits one message per contiguous run of a kind — and reconciling that gap is precisely `atlas-agent-delta`'s job.
 
 ### `commands/agents.rs`
 
-| IPC verb | |
-|---|---|
-| `agents_list_plugins`, `agents_new_session`, `agents_load_session`, `agents_send`, `agents_cancel`, `agents_set_mode`, `agents_set_model`, `agents_respond_permission` | plus related session-lifecycle calls |
+37 IPC verbs. The session lifecycle (`agents_spawn`, `agents_new_session`, `agents_send`, `agents_cancel`, `agents_kill`), the capability-gated knobs (`agents_set_mode`, `agents_set_model`, `agents_set_effort`, `agents_set_config_option`), permissions and elicitation (`agents_respond_permission`, `agents_respond_elicitation`), auth (`agents_authenticate`, `agents_list_auth_methods`, `agents_run_auth_method`, `agents_logout`), and the history surface (`threads_history`, `threads_resume`, `threads_archive`, `threads_delete`, `threads_projects`, `threads_import`, `threads_import_candidates`).
 
-Deltas return over the single `atlas:agents` channel, payload-typed by `kind`: `message_appended`, `content_block_delta`, `tool_call`, `permission_request`, `status`, `error`, `done`.
+Deltas return over the single `atlas:agents` channel, payload-typed by `kind`.
 
-### Two invariants
+### Three invariants
 
-- **`acpSessionId` is the single source of truth.** It's both the wire session id and the filename stem under `~/.claude/projects/<slug>/<acpSessionId>.jsonl` — never split, derived, or rewritten elsewhere. UI tabs, history rows, and the on-disk transcript all key off the exact same string. Code that reconstructs or transforms this id is a bug.
-- **Streams are tab-independent.** The actor, not any UI component, owns the message log and broadcasts deltas — three concurrent prompts in three tabs (or the history sidebar) keep streaming regardless of focus. Switching tabs just resubscribes to that session's actor broadcast; no in-flight state is created, paused, or lost.
+- **Atlas owns its history.** The sidebar reads the app-owned thread-metadata store (`crates/atlas-thread-metadata`, `threads.db`) and nothing else. Atlas does not read any agent CLI's private storage to build history — the per-agent scrape readers were deleted and must not come back. See [ADR-0001](docs/adr/0001-app-owned-thread-metadata-store.md), and `CONTEXT.md` for the thread/session/draft/archive vocabulary.
+- **A thread is not a session.** A *thread* is the conversation Atlas tracks, keyed by an id Atlas mints; it exists before any agent process and outlives one forgetting the session. A *session* is the agent-side conversation, keyed by an ACP session id. A thread references at most one session. Collapsing the two is the mistake the old `acpSessionId`-as-filename design made.
+- **Streams are tab-independent.** The projector owns the broadcast, not any UI component — concurrent prompts in several tabs keep streaming regardless of focus. Switching tabs resubscribes; no in-flight state is created, paused, or lost.
 
-**History.** The history sidebar reads Claude Code session JSONL files directly from `~/.claude/projects/<slug>/` — Atlas never mirrors them into its own store. Resuming a past conversation is a `loadSession` ACP call against the same session id.
+**PATH resolution.** macOS strips `PATH` from GUI-launched processes, so a bundled `.app` cannot see a user-installed agent CLI that a terminal in the same account finds fine. `crates/atlas-agent-servers/src/host_env.rs` resolves the real one: a fast guessed pass, then the user's actual login-shell `PATH` via `$SHELL -lc 'echo $PATH'` under a short timeout, because no static guess covers every version manager.
 
-**PATH resolution.** In production builds, `claude_setup.rs` resolves `claude` (and the Codex/OpenCode CLIs) via a login-shell lookup, because macOS strips `PATH` from GUI-launched processes. Without this the bundled `.app` can't find any user-installed agent CLI even though a terminal in the same account can.
+## Crates (`crates/`)
 
-## Workspace crates (`crates/`)
+All wired in as `path` dependencies from `src-tauri/Cargo.toml`. **There is no `[workspace]`** — the ported stack pins `agent-client-protocol` 2.0 with its schema crate pinned exactly, and no single Cargo resolution could hold that alongside the old stack's exact `=1.4.0` pin. That collision is why the port had to land as one change rather than gradually, and why the repo still resolves each crate on its own.
 
-All wired in as `path` dependencies from `src-tauri/Cargo.toml`.
+### The ported ACP stack
 
 | Crate | Role |
 |---|---|
-| `atlas-acp` | ACP client transport. Speaks JSON-RPC to any ACP-speaking agent binary (Claude Code, Codex, OpenCode); forwards permission prompts, tool calls, content blocks. Tauri-independent — exposes an `EventSink` trait the host implements to fan events out as window events. |
-| `atlas-agentkit` | Protocol-agnostic core that makes native and ACP-subprocess agents look identical: `AgentConnection` (one live agent connection, turns driven through `prompt`, optional capabilities as `Option<Arc<dyn …>>` sub-traits) and `TurnId`/`RunningTurn` (the monotonic turn identity the actor uses to drop superseded work). |
-| `atlas-agents` | Multi-agent orchestration above `atlas-acp`: the plugin registry, `AgentManager`, the per-session `SessionActor`, `SessionState`/`SessionSnapshot`, the `SessionDelta` wire shape, JSONL transcript replay for `load_session`. |
-| `atlas-bus` | Global event broadcaster + middleware pipeline: a cloneable `tokio::sync::broadcast`-backed `EventBus` fan-out (lagging subscribers drop rather than block the producer), plus `OutboundPipeline`/`InboundPipeline` middleware chains. |
-| `atlas-cersei` | Atlas's native, in-process coding agent, built on the Cersei agent SDK. Read `crates/atlas-cersei/ARCHITECTURE.md` before touching agent lifecycle, tools, permissions, providers, or persistence. |
+| `atlas-acp-thread` | Port of Zed's `acp_thread`: the agent session model and the `AgentConnection` seam every agent plugs into. Chunk merging by `messageId`, permission prompts surviving concurrent status changes. |
+| `atlas-agent-servers` | Port of Zed's `agent_servers`: transport to an external ACP agent and the launcher that starts one. Where the port's reliability lives — connect, initialize, cancel, retry — plus `host_env.rs`'s PATH resolution. |
+| `atlas-agent-store` | Port of Zed's agent store: where an external agent comes from and how its command line is resolved. Backs the Marketplace and the installed-agents map. |
+| `atlas-agent-manager` | Who is connected, and which sessions are open on them. Ported from Zed's `AgentConnectionStore`, with the session ownership Zed spreads across its per-agent view folded in. |
+| `atlas-agent-delta` | Projects ported-thread events into the frozen `SessionDelta` wire. Reconciles the thread's one-entry-per-message model with the wire's one-message-per-contiguous-run model. |
+| `atlas-agent-wire` | The frozen session-delta wire shapes, enforced by `tests/contract.rs`. |
+| `atlas-native-agent` | Cersei on the `AgentConnection` seam — the native agent as just another connection. |
+| `atlas-agent-transcript` | Where an agent keeps its record of a conversation, and how to read Atlas's own text back out of one. The Claude JSONL replay it used to hold is gone. |
+| `atlas-thread-metadata` | The app-owned thread-metadata store (`threads.db`) — Atlas's only source for the sidebar and history. Metadata only, never transcript content. Ported from Zed's `ThreadMetadataStore`. See ADR-0001. |
+| `atlas-bus` | Event broadcaster + middleware pipeline seam: a `tokio::sync::broadcast`-backed fan-out (lagging subscribers drop rather than block the producer), plus `OutboundPipeline`/`InboundPipeline`. Generic — no dependency on any agent or ACP type. |
+
+### Everything else
+
+| Crate | Role |
+|---|---|
+| `atlas-cersei` | Atlas's native in-process coding agent, built on the Cersei SDK. Read `crates/atlas-cersei/ARCHITECTURE.md` before touching agent lifecycle, tools, permissions, providers, or persistence. |
+| `atlas-checkpoint` | The agent-session record: local SQLite store (`.atlas/sessions.db`), redact-on-write capture, git commit linkage, transcript import, sync outbox. Tauri-free, so the whole surface is testable against a real database and a real git repo. |
+| `atlas-redact` | Single source of truth for secret redaction: layered scrubbing (Shannon entropy, vendored betterleaks rules, provider prefixes, credentialed URIs, connection strings) with JSON-aware traversal. String in, redacted string out — no I/O, no async. |
+| `atlas-git` | Git execution layer: one spawn chokepoint over the real `git` binary (so hooks run), a typed stderr→error taxonomy with friendly messages (ported from GitHub Desktop/dugite), porcelain-v2 status parsing, streaming output for long operations. |
+| `atlas-gitdiff` | Structured side-by-side diff engine: parses unified diffs, computes word-level intra-line change spans (word-diff vendored from `dandavison/delta`, MIT). |
 | `atlas-terminal` | Wraps `portable-pty`, manages `TerminalSession`s, bridges PTY bytes to Tauri events. |
 | `atlas-memory` | On-device RAG/memory engine: MiniLM → usearch HNSW plus grafeo graph memory, behind a `MemorySearchFn` seam. Read its `README.md` and `MIGRATION.md` before changing on-disk index formats. |
-| `atlas-embed` | On-device text embeddings (BERT-family sentence-transformers) and a small vector store, isolated so `candle`'s heavy dependency tree doesn't slow incremental builds of everything else. Embedding only — on-device generation was removed 2026-08-22. |
+| `atlas-embed` | On-device text embeddings (BERT-family sentence-transformers) and a small vector store, isolated so `candle`'s heavy dependency tree doesn't slow everything else's incremental builds. Embedding only — on-device generation was removed 2026-08-22. |
 | `atlas-codeindex` | Deterministic codebase scanner: turns live source into structural, embeddable docs via its own tree-sitter code intelligence (Rust/TS/TSX/JS/Python/Go). |
-| `atlas-gitdiff` | Structured side-by-side git diff engine: parses unified diffs, computes word-level intra-line change spans (word-diff algorithm vendored from `dandavison/delta`, MIT). |
-| `atlas-kb-server` | Standalone static-server binary produced by the knowledge base's "Export server" action. Embeds the exported HTML/CSS via `include_dir!`, serves it on `localhost:4747`. |
+| `atlas-kb-server` | Standalone static-server binary produced by the knowledge base's "Export server" action. Embeds the exported HTML/CSS via `include_dir!`, serves on `localhost:4747`. |
 
 ## Persistence
 
-No SQLite for app state — `rusqlite` is bundled only so the Codex-history reader can read Codex's own history DB in-process. State is plain files, by design.
+Most app state is plain files, by design — but **two subsystems are SQLite**, and both are Atlas's own databases rather than anyone else's:
 
-| Location | Contents |
-|---|---|
-| `<project-root>/.atlas/knowledge/` | markdown notes, in subdirectories |
-| `<project-root>/.atlas/logs.jsonl` | per-project activity log |
-| `<project-root>/.atlas/canvas.json` | ReactFlow node/edge state (Canvas / Spaces) |
-| `<project-root>/.atlas/editor-state.json` | open tabs + split-column layout |
-| `<project-root>/.atlas/memory/` | on-device RAG index (`atlas-memory`) |
-| `<project-root>/.atlas/codebase-index/` | `atlas-codeindex` output |
-| `<project-root>/.atlas/repos/` | repos cloned via the GitHub panel |
-| `~/.atlas/log/pinned.jsonl` | pinned activity-log rows, survive restart |
-| `~/.claude/projects/<slug>/*.jsonl` | Claude Code history, read directly, never mirrored. Filename stem is the `acpSessionId`. |
+| Store | Path | Crate |
+|---|---|---|
+| Session history (thread metadata) | `<app-config-dir>/threads.db` | `atlas-thread-metadata` |
+| Session record / Timeline (checkpoints) | `<project-root>/.atlas/sessions.db` + blob sidecar | `atlas-checkpoint` |
 
-Almost everything is per-project. `~/.atlas/` holds one file.
+`<app-config-dir>` is Tauri's `app_config_dir()` — `~/Library/Application Support/dev.atlas.ide/` on macOS. History is global because threads are grouped *across* projects; the checkpoint record is per-project because a Timeline is about one worktree.
+
+**Atlas does not read another program's storage to build session history.** The per-agent scrape readers are deleted (ADR-0001). Two deliberate reads of CLI directories remain and are not history: the checkpoint importer, under its own preserved contract, and the memory/skills surfaces, which read instruction files (`CLAUDE.md`, `AGENTS.md`, skills) as documents. `CONTEXT.md` records one flagged exception — the Memory panel's Codex thread list.
+
+Everything else is per-project files under `<project-root>/.atlas/`:
 
 ```
 <project-root>/.atlas/
+├── sessions.db               checkpoint/Timeline record (SQLite) + blobs/
 ├── knowledge/                markdown notes, in subdirectories
 ├── shared-memory/            cross-agent memory facts
 ├── memory/                   on-device RAG index (atlas-memory)
 ├── codebase-index/           atlas-codeindex output
 ├── repos/                    repos cloned via the GitHub panel
-├── skills/                   project-scoped SKILL.md files
+├── skills/, agent-skills/    SKILL.md files
 ├── packs/                    installed packs
+├── plans/                    plan documents
+├── screenshots/, canvas-media/
 ├── logs.jsonl                per-project activity log
 ├── interactions.jsonl        knowledge-base interaction history
 ├── canvas.json               ReactFlow node/edge state (Canvas / Spaces)
 ├── editor-state.json         open tabs + split-column layout
 ├── project.json              per-project settings
-├── reviews.json              code-review results
 ├── recent-files.json         recent-file list
 └── git-status-cache.json     cached git status
 ```
@@ -281,26 +291,35 @@ atlas/
 │   │   ├── state/                 shared AppState
 │   │   ├── telemetry/             PostHog client (opt-out, on by default)
 │   │   ├── logging.rs, menu.rs
-│   │   └── commands/               one .rs per IPC domain (67 modules)
+│   │   └── commands/               one .rs per IPC domain (69 modules)
 │   ├── capabilities/              Tauri v2 permission manifests
 │   ├── icons/                     bundle icons
 │   ├── bin/, resources/           bundled helper scripts (atlas-cli.sh, nvm.sh)
 │   ├── build.rs                   build script
 │   ├── tauri.conf.json            bundle config, CSP, window
-│   └── Cargo.toml                 workspace deps + [patch.crates-io] + release profile
+│   └── Cargo.toml                 path deps + [patch.crates-io] + release profile
 │
-├── crates/                        Rust workspace crates
-│   ├── atlas-acp                  ACP transport
-│   ├── atlas-agentkit             protocol-agnostic agent core (AgentConnection, TurnId)
-│   ├── atlas-agents                per-session actor + AgentManager
-│   ├── atlas-bus                   event bus + middleware pipeline
-│   ├── atlas-cersei                 native in-process agent (Cersei SDK)
-│   ├── atlas-terminal               PTY (portable-pty)
-│   ├── atlas-memory                 on-device RAG/memory engine
-│   ├── atlas-embed                  on-device embeddings (candle)
-│   ├── atlas-codeindex               tree-sitter codebase scanner
-│   ├── atlas-gitdiff                 structured diff engine
-│   └── atlas-kb-server                self-contained KB static-server binary
+├── crates/                        Rust crates (path deps; no [workspace])
+│   ├── atlas-acp-thread           session model + the AgentConnection seam
+│   ├── atlas-agent-servers        external ACP transport + launcher + host env
+│   ├── atlas-agent-store          where an agent comes from (Marketplace)
+│   ├── atlas-agent-manager        connections and their open sessions
+│   ├── atlas-agent-delta          thread events → frozen SessionDelta wire
+│   ├── atlas-agent-wire           the frozen wire shapes (contract-tested)
+│   ├── atlas-agent-transcript     an agent's own record of a conversation
+│   ├── atlas-native-agent         Cersei on the AgentConnection seam
+│   ├── atlas-thread-metadata      app-owned session history (threads.db)
+│   ├── atlas-bus                  event bus + middleware pipeline
+│   ├── atlas-cersei               native in-process agent (Cersei SDK)
+│   ├── atlas-checkpoint           session record / Timeline (sessions.db)
+│   ├── atlas-redact               secret redaction (single source of truth)
+│   ├── atlas-git                  git spawn chokepoint + error taxonomy
+│   ├── atlas-gitdiff              structured diff engine
+│   ├── atlas-terminal             PTY (portable-pty)
+│   ├── atlas-memory               on-device RAG/memory engine
+│   ├── atlas-embed                on-device embeddings (candle)
+│   ├── atlas-codeindex            tree-sitter codebase scanner
+│   └── atlas-kb-server            self-contained KB static-server binary
 │
 ├── vendor/                        [patch.crates-io] overrides
 │   ├── cersei-provider              UTF-8 chunk-boundary fix

--- a/crates/atlas-cersei/ARCHITECTURE.md
+++ b/crates/atlas-cersei/ARCHITECTURE.md
@@ -38,10 +38,10 @@ Atlas        ─┘   in-process, drives Cersei SDK, FAKES AcpEvent ┘
 └───────────────▲──────────────────────────────┬─────────────────────────┘
                 │                                ▼
 ┌───────────────┴────────────────────────────────────────────────────────┐
-│ atlas-agents  — AgentManager + SessionWorker  (agent-agnostic)           │
-│   backend.rs:  trait AgentBackend                                        │
-│      ├─ AcpBackend     → atlas_acp::AgentRegistry   (Claude Code, Codex)  │
-│      └─ CerseiBackend  → atlas_cersei::CerseiRuntime (Atlas)  ◀───────┐   │
+│ ported ACP stack — AgentHost / AgentManager  (agent-agnostic)            │
+│   atlas-acp-thread:  trait AgentConnection                               │
+│      ├─ atlas-agent-servers → an external ACP subprocess (Marketplace)    │
+│      └─ atlas-native-agent  → atlas_cersei::CerseiRuntime (Cersei) ◀───┐  │
 └──────────────────────────────────────────────────────────────────────┼──┘
                                                                         │
 ┌───────────────────────────────────────────────────────────────────── ┴──┐
@@ -63,10 +63,14 @@ Atlas        ─┘   in-process, drives Cersei SDK, FAKES AcpEvent ┘
 ```
 
 The seam that makes two very different agents interchangeable is the
-`AgentBackend` trait in `atlas-agents/src/backend.rs`. The manager/worker only ever
-call that trait. `CerseiBackend` is a thin wrapper that forwards each call into
-`CerseiRuntime`. So Atlas is "an ACP agent" from the manager's point of view, even
-though under the hood it never speaks ACP on a wire.
+`AgentConnection` trait in `crates/atlas-acp-thread/src/connection.rs`. Everything
+above it calls only that trait, and asks it about *capabilities* rather than
+identity. `atlas-native-agent` is the thin implementation that forwards each call
+into `CerseiRuntime`. So Cersei is "an ACP agent" from the manager's point of view,
+even though under the hood it never speaks ACP on a wire.
+
+See the root `ARCHITECTURE.md` for the seam, the manager, and the frozen delta wire;
+this document is about what sits *below* it, inside this crate.
 
 ---
 
@@ -152,7 +156,7 @@ This is the heart of the crate. When you hit send:
 ```mermaid
 sequenceDiagram
     participant UI as Frontend
-    participant W as atlas-agents Worker
+    participant W as AgentHost / AgentManager
     participant R as CerseiRuntime
     participant SDK as cersei::Agent
     participant P as Provider (LLM)
@@ -412,5 +416,5 @@ actual repo state.
 | change session storage / resume | `store.rs` |
 | debug "file not found" on relative paths | `tools/cwd.rs` (`resolve_path` / `CwdTool`) |
 | wire MCP | `mcp.rs` + `<config_dir>/mcp-servers.json` |
-| connect it to the rest of Atlas | `atlas-agents/src/backend.rs` (`CerseiBackend`) |
+| connect it to the rest of Atlas | `crates/atlas-native-agent` (the `AgentConnection` impl) |
 ```


### PR DESCRIPTION
Documentation only. `ARCHITECTURE.md` still described the stack the Zed ACP port (#198) replaced — the follow-up flagged in #201.

## The scale of the drift

Nearly every agent-runtime claim pointed at deleted code:

| The doc said | Reality |
|---|---|
| seam is `AgentBackend` (`crates/atlas-agents/src/backend.rs`) | seam is `AgentConnection` (`crates/atlas-acp-thread`) |
| `SessionActor` (`actor.rs`), `AgentManager` (`manager.rs`) | `AgentManager` (`atlas-agent-manager`), `AgentHost`, `DeltaProjector` |
| `atlas-acp` registry, OpenCode + `claude_code_rs` variants | registry-only installs; ADR-0002, no default ACP agents |
| sidebar reads `~/.claude/projects/<slug>/*.jsonl` directly | Atlas owns its history — ADR-0001; scrape readers deleted |
| "No SQLite for app state" | `threads.db` and `.atlas/sessions.db` |
| PATH via `claude_setup.rs` | `atlas-agent-servers/src/host_env.rs` |
| crate table: 11 crates, 3 deleted | 20 crates, grouped by ported-stack vs the rest |

The counts were stale too: **69** command modules and **354** IPC verbs, not 67/~326. The event-channel table listed four channels nothing emits any more (`atlas:review`, `atlas:memory-chat`, `atlas:claude-install:*`, `atlas:node-install:*`) and omitted the ones the port introduced (`atlas:threads-changed`, `atlas:capture-changed`, elicitation, registry-install, auth-run). `CenterPanel.tsx` no longer exists; it is `src/features/layout/components/center-panel.tsx`.

## What the rewrite emphasises

The invariant worth having in a doc is **capability gating**: optional behaviour is discovered through `supports_*` predicates and `Option<Arc<dyn …>>` sub-traits, so a caller asks a connection what it can do and never who it is. Branching on agent identity is now called out as a bug rather than left implicit — it is precisely what made the old stack impossible to extend to an agent nobody had hand-written support for.

`crates/atlas-cersei/ARCHITECTURE.md` gets the same treatment where it redrew the old `AgentBackend`/`CerseiBackend` seam, and now defers to the root document for everything above the seam instead of duplicating it.

`CONTEXT.md` and `docs/adr/` were already accurate — the domain docs were maintained through the port and only `ARCHITECTURE.md` fell behind. So it links to them rather than restating them.

## Checks

- **Every path in both documents was verified to resolve**, which is how the dangling `CenterPanel.tsx` turned up. The only non-resolving reference left is `AGENTS.md`, correct as prose since it names a file in *user* projects.
- The one reference to git-ignored `docs/agents/` now says inline that it is a working note — and the claim about it was corrected: `crates/atlas-agent-wire/tests/contract.rs` spells the contract out itself and only cross-checks the document when present, precisely because it is not in the repo. The doc previously implied the file was the authority.
- `cargo test -p atlas-agent-wire --test contract` — 8/8 pass.
- Pre-commit `typecheck` (both tsconfigs) passed.

## Not included

`docs/adr/*.md` and a couple of crate READMEs cite research under `plans/`, which is git-ignored — those citations were never followable from a clean clone. That is a pre-existing and separate question about where primary-source research should live, and rewriting citations inside accepted ADRs did not belong in a doc refresh.