### PR TITLE
feat(models): add MiniLM-L12-v2 and mdbr-leaf-ir to the local embedding catalog

### DIFF
--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -100,6 +100,7 @@ pub fn builtin_catalog() -> Vec<ModelEntry> {
     vec![
         // ── Embedding (BERT-family) ──
         embed_repo("all-MiniLM-L6-v2", "MiniLM-L6-v2", "sentence-transformers/all-MiniLM-L6-v2", 384, 90, "Fast, tiny general-purpose embeddings. The default."),
+        embed_repo("all-MiniLM-L12-v2", "MiniLM-L12-v2", "sentence-transformers/all-MiniLM-L12-v2", 384, 130, "Higher-quality MiniLM (12 layers); still fast and 384-d."),
         embed_repo("bge-small-en-v1.5", "BGE-small-en v1.5", "BAAI/bge-small-en-v1.5", 384, 130, "Strong retrieval quality at 384-d; drop-in for MiniLM."),
         embed_repo("gte-small", "GTE-small", "thenlper/gte-small", 384, 70, "General Text Embeddings, small (384-d)."),
         embed_repo("e5-small-v2", "E5-small v2", "intfloat/e5-small-v2", 384, 130, "E5 retrieval embeddings (384-d)."),

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -104,6 +104,7 @@ pub fn builtin_catalog() -> Vec<ModelEntry> {
         embed_repo("bge-small-en-v1.5", "BGE-small-en v1.5", "BAAI/bge-small-en-v1.5", 384, 130, "Strong retrieval quality at 384-d; drop-in for MiniLM."),
         embed_repo("gte-small", "GTE-small", "thenlper/gte-small", 384, 70, "General Text Embeddings, small (384-d)."),
         embed_repo("e5-small-v2", "E5-small v2", "intfloat/e5-small-v2", 384, 130, "E5 retrieval embeddings (384-d)."),
+        embed_repo("mdbr-leaf-ir", "MDRB-leaf-ir", "MongoDB/mdbr-leaf-ir", 384, 86, "MongoDB's retrieval-focused distillate; #1 open model on BEIR under 100M."),
         embed_repo("bge-base-en-v1.5", "BGE-base-en v1.5", "BAAI/bge-base-en-v1.5", 768, 440, "Higher-quality 768-d embeddings (rebuilds the index)."),
         embed_repo("gte-base", "GTE-base", "thenlper/gte-base", 768, 220, "General Text Embeddings, base (768-d, rebuilds the index)."),
     ]


### PR DESCRIPTION
### What?

Adds two BERT-family sentence-transformers to `builtin_catalog()` (`src-tauri/src/commands/models.rs`) using the existing `embed_repo` constructor — both in the 384-d small tier.

### Why?

#171 asks for one more embedding model in the curated Local Models catalog. While implementing the issue's named example we evaluated the current small-model landscape and found a strictly stronger candidate, so this PR proposes both — happy to drop either line if you prefer a minimal change.

**1. `sentence-transformers/all-MiniLM-L12-v2`** (the issue's example): ~33M params, 12 layers vs L6's 6, same 384-d. `config.json` confirms `architectures: ["BertModel"]`; safetensors = 133,466,304 bytes ≈ 130 MB.

**2. `MongoDB/mdbr-leaf-ir`** (stronger find): at **22.6M params it is smaller than every model currently in the catalog**, yet tops the public **BEIR leaderboard for all open models ≤100M** (53.55 nDCG@10) — ahead of arctic-embed-s (51.98), bge-small-en-v1.5 (51.65) and OpenAI's text-embedding-3-small API (51.08). Best retrieval quality-per-byte of any candidate evaluated. Live constraint check: `BertModel`, 6 layers, hidden 384, mean-token pooling (same as the shipped MiniLM/e5 defaults), full file triplet present, safetensors = 90,272,656 bytes ≈ 86 MB. Apache-2.0 (MongoDB Research, arXiv 2509.12539).

Both ids double as on-disk directory names following the HF repo convention, so no migration concerns.

### How?

Two `embed_repo(…)` lines — each fills the standard three-file `FileSpec` triplet and marks the entry compatible. No frontend change: Settings → Local Models renders the catalog payload generically, and selecting a different model already routes through the expected reindex-confirm flow.

Fixes #171

## Checklist

- [x] Targets `main`
- [ ] New behaviour has a test — data-only catalog addition; `builtin_catalog()` has no content-pinning tests today. Happy to add one if you'd like the catalog locked down.
- [ ] You've run the app and used the change in a window — not done (no desktop session here); all six download URLs were verified live over HTTPS. In-app download/select left for reviewer click-through.

### Checks run

- `cargo check` in `src-tauri`: clean, zero warnings
- `bun run test`: the only failures are the 54 pre-existing ACP config-options/composer-pill failures already present on `main` (verified by stashing this change); everything else passes
- Pre-commit hooks (oxfmt/oxlint/typecheck) passed
