### PR TITLE
Add links to capabilities in README features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ You don't have to read the raw transcript to get the context back: select a chec
 
 ### Agents
 
-| Capability | Description |
-|---|---|
-| **Multi-agent sessions** | Claude Code, Codex, and Atlas's native agent, selectable per session and running in parallel across tabs. Sessions are independent of tabs, so switching never drops a run in flight |
-| **Shared agent memory** | On-device semantic index (local embeddings, HNSW search) that every agent reads from and writes to |
-| **`@` mentions** | Local resolution of files, folders, symbols, branches, commits, notes, skills, papers, and past sessions |
-| **Skills** | `SKILL.md` files scoped globally or per project, enabled per agent by symlinking into that agent's own skills directory |
-| **Packs** | Install a GitHub repo of skills, subagents, commands, hooks, rules, and scripts, discovered through the skills.sh index |
-| **Model chat** | Talk to a model directly in its own tab, with no agent loop around it |
-| **Organisations** | Sign in, create an organisation, and sync across devices and teammates |
+| Capability | Description | Link |
+|---|---|---|
+| Multi-agent sessions | Claude Code, Codex, and Atlas's native agent, selectable per session and running in parallel across tabs. Sessions are independent of tabs, so switching never drops a run in flight | [Chat & Sessions](https://docs.tryatlas.cc/docs/product/chat) |
+| Shared agent memory | On-device semantic index (local embeddings, HNSW search) that every agent reads from and writes to | [Memory](https://docs.tryatlas.cc/docs/context/memory) |
+| @ mentions | Local resolution of files, folders, symbols, branches, commits, notes, skills, papers, and past sessions | [Chat & Sessions](https://docs.tryatlas.cc/docs/product/chat) |
+| Skills | SKILL.md files scoped globally or per project, enabled per agent by symlinking into that agent's own skills directory | [Skills](https://docs.tryatlas.cc/docs/context/skills) |
+| Packs | Install a GitHub repo of skills, subagents, commands, hooks, rules, and scripts, discovered through the skills.sh index | [Skills](https://docs.tryatlas.cc/docs/context/skills) |
+| Model chat | Talk to a model directly in its own tab, with no agent loop around it | [Chat & Sessions](https://docs.tryatlas.cc/docs/product/chat) |
+| Organisations | Sign in, create an organisation, and sync across devices and teammates | [Organisations](https://docs.tryatlas.cc/docs/organisation/organisations) |
 
 ### Agent history
 


### PR DESCRIPTION
Updated the Features section to include links for each capability.

<!--
Thanks for the PR. Please read CONTRIBUTING.md if you haven't already.

## Which branch should this target?

Atlas ships versioned installable builds, so `main` always equals the latest
release — work collects on a version branch (e.g. `0.2.5`) first, and the
merge of that branch into `main` is the release itself.

- Target the **current version branch** for anything that isn't a small,
  self-contained fix.
- Target **`main`** directly only if the change has no version-branch
  dependency and doesn't need to wait for the next release (a doc fix, a
  one-line hotfix).

See CONTRIBUTING.md's "Branching model" section if you're not sure which
applies.
-->

### What?

### Why?

### How?

Fixes #

## Checklist

Only the things CI can't check for you:

- [ ] Targets the current version branch, unless it's a small standalone fix
- [ ] New behaviour has a test; a bug fix has a test that fails without it
- [ ] You've run the app and used the change in a window

CI now runs, on every PR: `bun run lint`, `bun run format:check`, `bun run
typecheck`, `bun run test`, `bun run build`, `cargo test` for all 14 crates,
and `cargo test` for `src-tauri`. So there are no boxes for those — if it
compiles and passes locally, CI is checking it too.
What CI still can't judge is whether the change actually works in a window, and
whether the behaviour you added is covered by a test.

If this adds a top-level dependency or touches the telemetry pipeline, say so in **Why?** above — both need discussion, and telemetry changes need `TELEMETRY.md` updated to match.
