### PR TITLE
atlas-acp-thread: fix cancel-after-error, orphaned PTYs, and three unbounded buffers (ATL-213…218)

### DIFF
--- a/crates/atlas-acp-thread/Cargo.toml
+++ b/crates/atlas-acp-thread/Cargo.toml
@@ -8,8 +8,16 @@ edition = "2021"
 # a port of Zed's `acp_thread`, so it codes against the same schema revision;
 # porting the mechanism onto an older schema would mean re-deriving every place
 # the types moved between 1.4 and 2.0, which is exactly what the port exists to
-# avoid. Nothing else in Atlas links this crate yet, and each `crates/*` package
-# has its own lockfile, so the old stack stays on 1.3 untouched.
+# avoid.
+#
+# The pin's original justification — "nothing else links this crate" — expired.
+# Seven packages link it today: atlas-agent-manager, atlas-agent-servers,
+# atlas-agent-store, atlas-agent-delta, atlas-native-agent,
+# atlas-thread-metadata, and src-tauri. So the pin no longer isolates anything;
+# it now FIXES the schema revision for everything downstream of this crate, and
+# moving it is a change to all seven. What keeps that tractable is that each
+# `crates/*` package has its own lockfile, so a package that links neither this
+# crate nor those seven still resolves independently.
 agent-client-protocol = { version = "=2.0.0", features = ["unstable"] }
 atlas-terminal = { path = "../atlas-terminal" }
 anyhow = "1"

--- a/crates/atlas-acp-thread/src/connection.rs
+++ b/crates/atlas-acp-thread/src/connection.rs
@@ -125,7 +125,7 @@ impl From<&str> for AgentModelId {
 /// to run it — Atlas already streams a login CLI's output into `AgentOAuthModal`.
 /// Zed's `use_new_terminal` / `allow_concurrent_runs` / `hide: Always` are all
 /// consequences of running inside its terminal panel and have no meaning here.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct TerminalAuthCommand {
     pub id: String,
     pub label: String,
@@ -145,6 +145,28 @@ pub struct TerminalAuthCommand {
     /// the command themselves actually needs: their own shell already carries
     /// the rest.
     pub declared_env: Vec<(String, String)>,
+}
+
+/// Hand-written so `env` cannot reach a log line, a panic message, or an error
+/// report. The derive would have printed the user's entire environment —
+/// including the BYOK keys read out of the keychain — from any `{:?}` anywhere,
+/// which is precisely what this type's own doc comment forbids doing with it.
+/// Nothing formats it today; this is about the next `{:?}` somebody adds.
+///
+/// `declared_env` is the agent's own declaration and is safe to show, so it
+/// prints in full: redacting it would make the useful half unreadable to buy
+/// nothing.
+impl fmt::Debug for TerminalAuthCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TerminalAuthCommand")
+            .field("id", &self.id)
+            .field("label", &self.label)
+            .field("command", &self.command)
+            .field("args", &self.args)
+            .field("env", &format_args!("<redacted: {} vars>", self.env.len()))
+            .field("declared_env", &self.declared_env)
+            .finish()
+    }
 }
 
 /// Ported from `build_terminal_auth_task` (`connection.rs:69-89`).

--- a/crates/atlas-acp-thread/src/elicitation.rs
+++ b/crates/atlas-acp-thread/src/elicitation.rs
@@ -257,6 +257,7 @@ impl ElicitationStore {
         acp::Error,
     > {
         Self::validate_request(&request)?;
+        self.reject_duplicate_url_elicitation(&request)?;
         let (id, response_rx) = self.insert_pending_elicitation(request);
         self.emit(ElicitationStoreEvent::ElicitationRequested(id.clone()));
 
@@ -359,6 +360,42 @@ impl ElicitationStore {
             .find_map(|(index, elicitation)| {
                 (&elicitation.id == id).then_some((index, elicitation))
             })
+    }
+
+    /// A URL elicitation id the agent is already using for an outstanding
+    /// elicitation is refused rather than accepted as a second entry.
+    ///
+    /// [`Self::entry_id_for_url_elicitation`] resolves an agent-supplied
+    /// `elicitation_id` by reverse-scanning, so with a duplicate the newest
+    /// entry wins every lookup and the older one can never be completed — it is
+    /// stuck `Accepted`, which [`Self::clear_resolved`] deliberately keeps, so
+    /// the stale row stays on screen for the life of the session. The schema
+    /// documents the field as unique; nothing enforced it.
+    ///
+    /// Scoped to entries that are still outstanding on purpose. A device-code
+    /// login legitimately reuses an id after the previous attempt was canceled
+    /// or completed, and refusing that would break the retry.
+    fn reject_duplicate_url_elicitation(
+        &self,
+        request: &acp::CreateElicitationRequest,
+    ) -> Result<(), acp::Error> {
+        let acp::ElicitationMode::Url(mode) = &request.mode else {
+            return Ok(());
+        };
+        let clashes = self.elicitations.iter().any(|elicitation| {
+            matches!(
+                (&elicitation.status, &elicitation.request.mode),
+                (
+                    ElicitationStatus::Pending { .. } | ElicitationStatus::Accepted,
+                    acp::ElicitationMode::Url(existing),
+                ) if existing.elicitation_id == mode.elicitation_id
+            )
+        });
+        if clashes {
+            return Err(acp::Error::invalid_params()
+                .data("elicitationId is already outstanding for another URL elicitation"));
+        }
+        Ok(())
     }
 
     pub(crate) fn entry_id_for_url_elicitation(

--- a/crates/atlas-acp-thread/src/lib.rs
+++ b/crates/atlas-acp-thread/src/lib.rs
@@ -7,9 +7,11 @@
 //! updates, out-of-order terminal buffering, cancel semantics) the logic is
 //! ported line-for-line and the Zed file:line is cited at the function.
 //!
-//! Nothing links this crate yet. It is stage 1 of
-//! `plans/atlas-acp-zed-port-plan.md`; the old ACP stack is untouched and stays
-//! on its own SDK version.
+//! This crate is the ACP stack now, not a staging area beside it. Seven
+//! packages link it: `atlas-agent-manager`, `atlas-agent-servers`,
+//! `atlas-agent-store`, `atlas-agent-delta`, `atlas-native-agent`,
+//! `atlas-thread-metadata`, and `src-tauri`. Anything changed here is a change
+//! to what ships — see `Cargo.toml` for what that means for the SDK pin.
 //!
 //! # What is deliberately NOT ported
 //!

--- a/crates/atlas-acp-thread/src/terminal.rs
+++ b/crates/atlas-acp-thread/src/terminal.rs
@@ -20,13 +20,30 @@
 //! (`SandboxWrap`) is not ported: it depends on Zed's `sandbox` crate and is a
 //! separate feature from the thread model.
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
 use agent_client_protocol::schema::v1 as acp;
-use atlas_terminal::command::{CommandExit, CommandTerminal};
+use atlas_terminal::command::{
+    CommandExit, CommandTerminal, OutputBuffer, DEFAULT_OUTPUT_BYTE_LIMIT,
+};
+use indexmap::IndexMap;
+
+/// How many terminal ids may have output or an exit status parked for them
+/// before the oldest is dropped.
+///
+/// The buffering exists for a race measured in milliseconds — the agent
+/// referencing a terminal id in a `session/update` before our own `Created`
+/// bookkeeping lands — so an id that is still unclaimed after 64 others have
+/// come and gone is not early, it is fabricated. See `handle_event`.
+const MAX_PENDING_TERMINALS: usize = 64;
+
+/// Total bytes parked across every not-yet-created terminal id.
+///
+/// Matched to [`DEFAULT_OUTPUT_BYTE_LIMIT`] so a terminal cannot buy more
+/// buffer by delaying its own announcement than it would get after it.
+const MAX_PENDING_OUTPUT_BYTES: usize = DEFAULT_OUTPUT_BYTE_LIMIT as usize;
 
 /// What the terminal provider tells the thread. Ported from
 /// `TerminalProviderEvent` (`acp_thread.rs:2183-2200`).
@@ -86,7 +103,12 @@ pub struct AcpTerminal {
     /// Output that arrived as provider events before/alongside the PTY's own
     /// capture. Held separately so replaying a pre-`Created` buffer cannot
     /// interleave into the middle of what the PTY reader collected.
-    replayed_output: Vec<u8>,
+    ///
+    /// Bounded by `output_byte_limit`. For a terminal we own this holds only
+    /// the pre-`Created` burst and the PTY buffer carries the rest; for a
+    /// DISPLAY-ONLY terminal it is the *entire* capture, and it is the only
+    /// thing standing between a watch-mode build and unbounded RSS.
+    replayed_output: OutputBuffer,
     exit_status: Option<acp::TerminalExitStatus>,
     stopped_by_user: bool,
 }
@@ -116,7 +138,14 @@ impl AcpTerminal {
             output_byte_limit,
             started_at: Instant::now(),
             inner,
-            replayed_output: Vec::new(),
+            // `None` means the agent declared no limit, not that it declared no
+            // limit *applies*: a display-only terminal never gets to declare
+            // one at all (`handle_session_update` has no field to read it from),
+            // so it lands on the same default a `terminal/create` without an
+            // `outputByteLimit` gets.
+            replayed_output: OutputBuffer::new(
+                output_byte_limit.unwrap_or(DEFAULT_OUTPUT_BYTE_LIMIT),
+            ),
             exit_status: None,
             stopped_by_user: false,
         }
@@ -158,7 +187,7 @@ impl AcpTerminal {
     }
 
     pub(crate) fn write_output(&mut self, data: &[u8]) {
-        self.replayed_output.extend_from_slice(data);
+        self.replayed_output.push(data);
     }
 
     pub(crate) fn set_exit_status(&mut self, status: acp::TerminalExitStatus) {
@@ -170,15 +199,20 @@ impl AcpTerminal {
     /// Replayed pre-`Created` bytes are prefixed, because they are by definition
     /// the earliest output of the command.
     pub fn current_output(&self) -> acp::TerminalOutputResponse {
-        let (captured, truncated) = match &self.inner {
+        let (captured, captured_truncated) = match &self.inner {
             Some(inner) => inner.output(),
             // Display-only: the meta events ARE the capture.
             None => (String::new(), false),
         };
+        // Either buffer having dropped its front makes the whole response
+        // partial. Reading `truncated` off the PTY alone is how a display-only
+        // terminal came to report a complete capture of a buffer it had been
+        // trimming for hours.
+        let truncated = captured_truncated || self.replayed_output.truncated();
         let output = if self.replayed_output.is_empty() {
             captured
         } else {
-            let mut out = String::from_utf8_lossy(&self.replayed_output).into_owned();
+            let mut out = self.replayed_output.text();
             out.push_str(&captured);
             out
         };
@@ -211,18 +245,47 @@ impl AcpTerminal {
         }
     }
 
-    pub async fn wait_for_exit(&self) -> acp::TerminalExitStatus {
+    /// `None` when this terminal cannot be awaited: a display-only terminal
+    /// whose exit has not arrived yet.
+    ///
+    /// The exit for one of those arrives as a meta event on some later
+    /// `session/update`, and nothing here can park on that. Returning a default
+    /// `TerminalExitStatus` instead would be indistinguishable from a clean
+    /// `exit 0` — the one answer a caller must not be handed when the truth is
+    /// "we have no idea". Unreachable in production today: the
+    /// `terminal/wait_for_exit` handler awaits the PTY directly and refuses
+    /// display-only terminals before it would get here.
+    pub async fn wait_for_exit(&self) -> Option<acp::TerminalExitStatus> {
         if let Some(status) = &self.exit_status {
-            return status.clone();
+            return Some(status.clone());
         }
         match &self.inner {
-            Some(inner) => exit_status_from_command(inner.wait_for_exit().await),
-            // Display-only with no exit yet: the exit arrives as a meta event,
-            // and nothing here can await it. Unreachable in production today —
-            // the `terminal/wait_for_exit` handler awaits the PTY directly and
-            // refuses display-only terminals before it would get here — so an
-            // empty status is the honest answer for a test or future caller.
-            None => acp::TerminalExitStatus::new(),
+            Some(inner) => Some(exit_status_from_command(inner.wait_for_exit().await)),
+            None => None,
+        }
+    }
+}
+
+/// Killing the child on drop is the only thing that covers an ABRUPT teardown.
+///
+/// The tidy path is already safe — `terminal/release` kills before it drops
+/// (`atlas-agent-servers/src/handlers.rs`) — but a session closed with a build
+/// still running never reaches it: `close_session` drops the last
+/// `AcpThreadHandle`, which drops the `TerminalRegistry`, which drops us. And
+/// nothing below here saves it. `portable-pty`'s unix child is a plain
+/// `std::process::Child`, which does not kill on drop, and the reader thread
+/// holds a dup'd master fd, so the PTY never even hangs up. The child would
+/// outlive Atlas as an orphan, still writing into a buffer nobody will read.
+///
+/// Display-only terminals have no process of ours to kill, and `kill()` says so
+/// with an error — expected here, not a failure.
+impl Drop for AcpTerminal {
+    fn drop(&mut self) {
+        if self.inner.is_none() {
+            return;
+        }
+        if let Err(err) = self.kill() {
+            tracing::debug!(terminal_id = %self.id, "killing terminal on drop failed: {err:#}");
         }
     }
 }
@@ -237,11 +300,26 @@ pub fn exit_status_from_command(exit: CommandExit) -> acp::TerminalExitStatus {
 /// The thread's terminal side-tables, kept together so the buffering rule has
 /// one owner. Ported from `AcpThread`'s `terminals` /
 /// `pending_terminal_output` / `pending_terminal_exit` fields.
+///
+/// `terminals` itself is deliberately uncapped, unlike the two pending maps.
+/// Every entry in it cost the agent a `terminal/create` that spawned a real
+/// process, so the OS bounds it long before this map does, and the only ways to
+/// cap it here are worse than the growth: refusing `terminal/create` is a
+/// policy the handler should own and answer with a protocol error, and evicting
+/// an entry would kill a command the agent is still using. The pending maps
+/// have neither excuse — nothing was spawned, and an id parked there may not
+/// exist at all (ATL-218 finding 6).
 #[derive(Default)]
 pub struct TerminalRegistry {
-    terminals: HashMap<acp::TerminalId, AcpTerminal>,
-    pending_output: HashMap<acp::TerminalId, Vec<Vec<u8>>>,
-    pending_exit: HashMap<acp::TerminalId, acp::TerminalExitStatus>,
+    terminals: IndexMap<acp::TerminalId, AcpTerminal>,
+    /// Insertion-ordered so eviction can be oldest-first. A `HashMap` would
+    /// leave "which id has been waiting longest" unanswerable, and the id that
+    /// has waited longest is exactly the one least likely to ever be claimed.
+    pending_output: IndexMap<acp::TerminalId, Vec<Vec<u8>>>,
+    pending_exit: IndexMap<acp::TerminalId, acp::TerminalExitStatus>,
+    /// Running total of every chunk in `pending_output`, so the byte budget is
+    /// enforced without walking the map on each event.
+    pending_output_bytes: usize,
 }
 
 impl TerminalRegistry {
@@ -270,9 +348,73 @@ impl TerminalRegistry {
     }
 
     pub fn remove(&mut self, id: &acp::TerminalId) -> Option<AcpTerminal> {
-        self.pending_output.remove(id);
-        self.pending_exit.remove(id);
-        self.terminals.remove(id)
+        self.take_pending_output(id);
+        self.pending_exit.shift_remove(id);
+        self.terminals.shift_remove(id)
+    }
+
+    /// Take an id's parked chunks, keeping the byte accounting straight.
+    fn take_pending_output(&mut self, id: &acp::TerminalId) -> Option<Vec<Vec<u8>>> {
+        let chunks = self.pending_output.shift_remove(id)?;
+        let bytes: usize = chunks.iter().map(Vec::len).sum();
+        self.pending_output_bytes = self.pending_output_bytes.saturating_sub(bytes);
+        Some(chunks)
+    }
+
+    /// Park output for a terminal that has not been announced yet, then bring
+    /// the side-tables back inside their budget.
+    ///
+    /// The buffering itself is load-bearing and stays: out-of-order arrival is
+    /// a real, documented case. What is bounded is how long an id that will
+    /// NEVER be announced gets to hold memory — `handle_session_update` reads
+    /// `terminal_id` off agent-supplied meta with no membership check, and
+    /// `terminal/release` refuses ids it does not know, so nothing else prunes
+    /// a fabricated one before the session ends.
+    fn park_output(&mut self, id: acp::TerminalId, data: Vec<u8>) {
+        self.pending_output_bytes += data.len();
+        self.pending_output.entry(id).or_default().push(data);
+
+        while self.pending_output.len() > MAX_PENDING_TERMINALS {
+            let oldest = self
+                .pending_output
+                .get_index(0)
+                .map(|(id, _)| id.clone())
+                .expect("non-empty above the cap");
+            self.take_pending_output(&oldest);
+        }
+
+        // Over the byte budget, drop the OLDEST chunk of the OLDEST id rather
+        // than the id that just arrived: the newest bytes are the ones most
+        // likely to belong to a terminal that is about to be announced.
+        while self.pending_output_bytes > MAX_PENDING_OUTPUT_BYTES {
+            let Some((id, chunks)) = self.pending_output.get_index_mut(0) else {
+                // Cannot happen — the total is the sum of what is in the map —
+                // but resetting beats spinning if it ever did.
+                self.pending_output_bytes = 0;
+                break;
+            };
+            if chunks.is_empty() {
+                let id = id.clone();
+                self.pending_output.shift_remove(&id);
+                continue;
+            }
+            let dropped = chunks.remove(0).len();
+            self.pending_output_bytes = self.pending_output_bytes.saturating_sub(dropped);
+            if chunks.is_empty() {
+                let id = id.clone();
+                self.pending_output.shift_remove(&id);
+            }
+        }
+    }
+
+    /// Park an exit status for an unannounced terminal. Capped by id count
+    /// only: a `TerminalExitStatus` is two small fields, so the id ceiling is
+    /// the whole of the bound.
+    fn park_exit(&mut self, id: acp::TerminalId, status: acp::TerminalExitStatus) {
+        self.pending_exit.insert(id, status);
+        while self.pending_exit.len() > MAX_PENDING_TERMINALS {
+            self.pending_exit.shift_remove_index(0);
+        }
     }
 
     /// Ported from `AcpThread::on_terminal_provider_event`
@@ -296,13 +438,13 @@ impl TerminalRegistry {
 
                 // Drain anything that arrived first. Order within the buffer is
                 // arrival order, which is the order the PTY produced it.
-                if let Some(chunks) = self.pending_output.remove(&terminal_id) {
+                if let Some(chunks) = self.take_pending_output(&terminal_id) {
                     for data in chunks {
                         acp_terminal.write_output(&data);
                     }
                 }
 
-                if let Some(status) = self.pending_exit.remove(&terminal_id) {
+                if let Some(status) = self.pending_exit.shift_remove(&terminal_id) {
                     acp_terminal.set_exit_status(status);
                 }
 
@@ -312,10 +454,7 @@ impl TerminalRegistry {
                 if let Some(terminal) = self.terminals.get_mut(&terminal_id) {
                     terminal.write_output(&data);
                 } else {
-                    self.pending_output
-                        .entry(terminal_id)
-                        .or_default()
-                        .push(data);
+                    self.park_output(terminal_id, data);
                 }
             }
             TerminalProviderEvent::TitleChanged { terminal_id, title } => {
@@ -330,7 +469,7 @@ impl TerminalRegistry {
                 if let Some(terminal) = self.terminals.get_mut(&terminal_id) {
                     terminal.set_exit_status(status);
                 } else {
-                    self.pending_exit.insert(terminal_id, status);
+                    self.park_exit(terminal_id, status);
                 }
             }
         }
@@ -346,5 +485,16 @@ impl TerminalRegistry {
     /// Whether an exit status arrived before the terminal it belongs to.
     pub fn has_pending_exit(&self, id: &acp::TerminalId) -> bool {
         self.pending_exit.contains_key(id)
+    }
+
+    /// How many terminal ids have output parked for them, and how many bytes
+    /// that costs. Exposed so the bound can be asserted directly.
+    pub fn pending_output_stats(&self) -> (usize, usize) {
+        (self.pending_output.len(), self.pending_output_bytes)
+    }
+
+    /// How many exit statuses are parked for terminals not yet announced.
+    pub fn pending_exit_len(&self) -> usize {
+        self.pending_exit.len()
     }
 }

--- a/crates/atlas-acp-thread/src/thread.rs
+++ b/crates/atlas-acp-thread/src/thread.rs
@@ -1712,6 +1712,15 @@ impl AcpThread {
 
     /// Closes the running turn. `stop_reason` is emitted so the UI leaves the
     /// generating state for the same reasons Zed does.
+    ///
+    /// Deliberately NOT guarded on `running_turn`. A guard would make
+    /// `set_error()` followed by `end_turn()` emit nothing instead of a second
+    /// `Stopped` — but no caller does that pair (`atlas-agent-manager`'s
+    /// `prompt` reaches `end_turn` only on the Ok arm and `set_error` only on
+    /// the Err one), and both this crate's callers and
+    /// `atlas-agent-delta`'s tests use `end_turn` as "announce Stopped" without
+    /// a turn open. Adding the guard would break that use for a case nothing
+    /// reaches. Checked while fixing `cancel_inner` below (ATL-218 finding 4).
     pub fn end_turn(&mut self, stop_reason: acp::StopReason) {
         self.running_turn = None;
         self.emit(AcpThreadEvent::Stopped(stop_reason));
@@ -1737,13 +1746,32 @@ impl AcpThread {
         self.cancel_inner(RequestPermissionOutcome::Cancelled)
     }
 
+    /// Resolving the thread's own state is unconditional; telling the AGENT is
+    /// what needs a running turn.
+    ///
+    /// The two halves used to sit on opposite sides of the early return, and
+    /// the split was the bug. `set_error()` and `emit_load_error()` both clear
+    /// `running_turn` before anything can cancel, so after either one every
+    /// later `cancel()` returned above `mark_pending_entries_as_canceled` and
+    /// a tool call sat in `WaitingForConfirmation` forever — holding a
+    /// `respond_tx` nobody would ever send on, and masking the error state,
+    /// since the projection reads `WaitingForConfirmation` before `had_error`
+    /// and reports the session as Waiting. `begin_turn()` cancels BEFORE it
+    /// sets `running_turn`, so the next turn early-returned too: there was no
+    /// self-heal path, and the only escape was the user clicking an option on a
+    /// prompt belonging to a dead turn.
+    ///
+    /// So: entries and elicitations are resolved on every call, because they
+    /// are ours and a turn that is gone cannot advance them either way. Only
+    /// `connection.cancel()` stays behind the check — an idle thread must not
+    /// send `session/cancel` for a turn the agent already finished.
     fn cancel_inner(&mut self, permission_outcome: RequestPermissionOutcome) {
         self.cancel_outstanding_elicitations();
+        self.mark_pending_entries_as_canceled(permission_outcome);
 
         if self.running_turn.take().is_none() {
             return;
         }
-        self.mark_pending_entries_as_canceled(permission_outcome);
         self.connection.cancel(&self.session_id);
         self.emit(AcpThreadEvent::StatusChanged);
     }

--- a/crates/atlas-acp-thread/tests/elicitation.rs
+++ b/crates/atlas-acp-thread/tests/elicitation.rs
@@ -268,3 +268,41 @@ async fn an_unknown_elicitation_mode_is_rejected() {
 
     assert!(store.request_elicitation(request).is_err());
 }
+
+/// Regression, ATL-218 finding 2. `entry_id_for_url_elicitation` resolves an
+/// agent-supplied `elicitationId` by reverse-scanning, so a duplicate meant
+/// last-wins: the older entry could never be completed, stayed `Accepted`
+/// (which `clear_resolved` deliberately keeps), and left a stale row on screen
+/// for the life of the session. The schema documents the field as unique;
+/// nothing enforced it.
+#[tokio::test]
+async fn a_duplicate_url_elicitation_id_is_refused_while_the_first_is_outstanding() {
+    let (mut store, _events) = new_store();
+
+    let (_first, _waiter) = store
+        .request_elicitation(url_request("s1", "e1", "https://example.com/device"))
+        .unwrap();
+
+    let duplicate = store.request_elicitation(url_request("s1", "e1", "https://example.com/other"));
+
+    assert!(duplicate.is_err(), "a second live elicitation took the same id");
+    assert_eq!(store.elicitations().len(), 1);
+}
+
+/// The scope of that refusal matters: a device-code login legitimately retries
+/// with the same id after the first attempt was cancelled, and refusing THAT
+/// would break the retry rather than fix anything.
+#[tokio::test]
+async fn a_url_elicitation_id_can_be_reused_once_the_first_is_resolved() {
+    let (mut store, _events) = new_store();
+
+    let (first, waiter) = store
+        .request_elicitation(url_request("s1", "e1", "https://example.com/device"))
+        .unwrap();
+    store.cancel_elicitation(&first);
+    let _ = waiter.await;
+
+    assert!(store
+        .request_elicitation(url_request("s1", "e1", "https://example.com/device"))
+        .is_ok());
+}

--- a/crates/atlas-acp-thread/tests/terminal.rs
+++ b/crates/atlas-acp-thread/tests/terminal.rs
@@ -287,7 +287,229 @@ fn a_display_only_terminal_refuses_a_kill_and_reports_a_known_exit() {
     assert!(terminal.kill().is_err(), "no process of ours to kill");
     assert!(terminal.inner().is_none());
     assert_eq!(
-        futures::executor::block_on(terminal.wait_for_exit()).exit_code,
+        futures::executor::block_on(terminal.wait_for_exit())
+            .expect("a known exit is answerable even without a process")
+            .exit_code,
         Some(2)
+    );
+}
+
+/// The other half of the same contract: a display-only terminal whose exit has
+/// NOT arrived answers `None`, not a default status that reads as `exit 0`.
+#[test]
+fn a_display_only_terminal_without_an_exit_admits_it_does_not_know() {
+    let mut registry = TerminalRegistry::new();
+    let id = terminal_id("emb");
+    registry.handle_event(display_only(&id));
+
+    let terminal = registry.get(&id).expect("registered");
+    assert!(futures::executor::block_on(terminal.wait_for_exit()).is_none());
+}
+
+// ------------------------------------------------------------------- limits
+
+/// A display-only terminal, announced through `terminal_info` meta with no
+/// `outputByteLimit` the agent could ever have declared.
+fn display_only_unlimited(id: &acp::TerminalId) -> TerminalProviderEvent {
+    TerminalProviderEvent::Created {
+        terminal_id: id.clone(),
+        label: "agent-run".into(),
+        cwd: None,
+        output_byte_limit: None,
+        terminal: None,
+    }
+}
+
+/// Regression, ATL-215. `output_byte_limit` was stored, exposed by a getter
+/// nothing called, and never enforced. A display-only terminal has no
+/// `CommandTerminal`, so the PTY buffer's cap does not apply to it and the
+/// buffer grew for the life of the session — while `truncated` was read off
+/// the PTY alone and so reported `false` no matter how much had accumulated.
+#[test]
+fn a_display_only_terminal_bounds_its_buffer_and_admits_the_truncation() {
+    let mut registry = TerminalRegistry::new();
+    let id = terminal_id("emb");
+    registry.handle_event(TerminalProviderEvent::Created {
+        terminal_id: id.clone(),
+        label: "agent-run".into(),
+        cwd: None,
+        output_byte_limit: Some(64),
+        terminal: None,
+    });
+
+    for _ in 0..100 {
+        registry.handle_event(TerminalProviderEvent::Output {
+            terminal_id: id.clone(),
+            data: vec![b'x'; 64],
+        });
+    }
+
+    let response = registry.get(&id).expect("registered").current_output();
+    assert!(response.truncated, "a trimmed buffer must say so");
+    assert_eq!(
+        response.output.len(),
+        64,
+        "the retained window is the declared limit, not everything that arrived"
+    );
+}
+
+/// The same bound applies when the agent declares nothing, which for a
+/// display-only terminal is always: `handle_session_update` has no field to
+/// read a limit from. `None` must mean the default, not "unbounded".
+#[test]
+fn an_undeclared_limit_still_bounds_a_display_only_terminal() {
+    let mut registry = TerminalRegistry::new();
+    let id = terminal_id("emb");
+    registry.handle_event(display_only_unlimited(&id));
+
+    // Comfortably past the 1 MiB default.
+    for _ in 0..40 {
+        registry.handle_event(TerminalProviderEvent::Output {
+            terminal_id: id.clone(),
+            data: vec![b'x'; 64 * 1024],
+        });
+    }
+
+    let response = registry.get(&id).expect("registered").current_output();
+    assert!(response.truncated);
+    assert_eq!(response.output.len(), 1024 * 1024);
+}
+
+/// Truncation never manufactures a replacement character: the window is walked
+/// forward off any UTF-8 continuation byte before it is kept.
+#[test]
+fn trimming_a_display_only_buffer_keeps_it_valid_utf8() {
+    let mut registry = TerminalRegistry::new();
+    let id = terminal_id("emb");
+    registry.handle_event(TerminalProviderEvent::Created {
+        terminal_id: id.clone(),
+        label: "agent-run".into(),
+        cwd: None,
+        output_byte_limit: Some(16),
+        terminal: None,
+    });
+
+    for _ in 0..20 {
+        registry.handle_event(TerminalProviderEvent::Output {
+            terminal_id: id.clone(),
+            // 4 bytes each, so the naive cut lands mid-character.
+            data: "🌍".as_bytes().to_vec(),
+        });
+    }
+
+    let output = registry.get(&id).expect("registered").current_output().output;
+    assert!(!output.contains('\u{fffd}'), "cut a character in half: {output:?}");
+    assert!(output.chars().all(|c| c == '🌍'));
+}
+
+/// Regression, ATL-216. Output parked for an id that is never announced was
+/// retained for the life of the session with no cap of any kind — and
+/// `handle_session_update` takes the id straight off agent-supplied meta with
+/// no membership check, so a buggy agent could park output for ids that will
+/// never exist.
+#[test]
+fn parked_output_for_ids_that_never_arrive_is_bounded() {
+    let mut registry = TerminalRegistry::new();
+
+    for n in 0..512 {
+        registry.handle_event(TerminalProviderEvent::Output {
+            terminal_id: terminal_id(&format!("ghost-{n}")),
+            data: vec![b'x'; 16 * 1024],
+        });
+    }
+
+    let (ids, bytes) = registry.pending_output_stats();
+    assert!(ids <= 64, "parked ids unbounded: {ids}");
+    assert!(bytes <= 1024 * 1024, "parked bytes unbounded: {bytes}");
+}
+
+/// Eviction is oldest-first, so the id most likely to still be announced — the
+/// one that just arrived — is the one that survives.
+#[test]
+fn evicting_parked_output_keeps_the_newest_id() {
+    let mut registry = TerminalRegistry::new();
+
+    for n in 0..200 {
+        registry.handle_event(TerminalProviderEvent::Output {
+            terminal_id: terminal_id(&format!("t{n}")),
+            data: b"chunk".to_vec(),
+        });
+    }
+
+    assert_eq!(registry.pending_output_len(&terminal_id("t0")), 0);
+    assert_eq!(registry.pending_output_len(&terminal_id("t199")), 1);
+}
+
+/// Parked exit statuses are capped the same way. Nothing prunes them either:
+/// `terminal/release` errors out for an id it does not know.
+#[test]
+fn parked_exit_statuses_are_bounded() {
+    let mut registry = TerminalRegistry::new();
+
+    for n in 0..512 {
+        registry.handle_event(TerminalProviderEvent::Exit {
+            terminal_id: terminal_id(&format!("ghost-{n}")),
+            status: exit_status(0),
+        });
+    }
+
+    assert!(registry.pending_exit_len() <= 64);
+    assert!(registry.has_pending_exit(&terminal_id("ghost-511")));
+}
+
+/// The cap must not break the thing the side-tables exist for: output that
+/// arrives just before its `Created` is still replayed in full.
+#[test]
+fn bounding_the_side_tables_does_not_break_ordinary_out_of_order_replay() {
+    let mut registry = TerminalRegistry::new();
+    let id = terminal_id("t1");
+
+    registry.handle_event(TerminalProviderEvent::Output {
+        terminal_id: id.clone(),
+        data: b"early".to_vec(),
+    });
+    registry.handle_event(display_only_unlimited(&id));
+
+    let (ids, bytes) = registry.pending_output_stats();
+    assert_eq!((ids, bytes), (0, 0), "draining must clear the accounting");
+    assert_eq!(
+        registry.get(&id).expect("registered").current_output().output,
+        "early"
+    );
+}
+
+/// Regression, ATL-214. A session torn down with a command still running left
+/// the child as an orphan of the Atlas process: nothing on the path killed it,
+/// `portable-pty`'s unix child does not kill on drop, and the reader thread
+/// holds the master fd open so there is no SIGHUP either.
+///
+/// Uses `sleep`, because `true(1)` would exit on its own and prove nothing.
+#[tokio::test]
+async fn dropping_the_registry_kills_a_running_command() {
+    let mut registry = TerminalRegistry::new();
+    let id = terminal_id("t1");
+    let terminal = Arc::new(
+        CommandTerminal::spawn("sleep", &["30".into()], &[], None, 1024)
+            .expect("failed to spawn sleep"),
+    );
+    registry.handle_event(TerminalProviderEvent::Created {
+        terminal_id: id.clone(),
+        label: "sleep 30".into(),
+        cwd: None,
+        output_byte_limit: Some(1024),
+        terminal: Some(terminal.clone()),
+    });
+    assert!(terminal.exit_status().is_none(), "sleep exited early");
+
+    // What `close_session` does: drop the last handle on the thread, which
+    // drops the registry, which drops the terminal.
+    drop(registry);
+
+    let exit = tokio::time::timeout(std::time::Duration::from_secs(10), terminal.wait_for_exit())
+        .await
+        .expect("the child outlived the registry that owned it");
+    assert!(
+        exit.signal.is_some() || exit.exit_code != Some(0),
+        "sleep(1) should have died by signal, got {exit:?}"
     );
 }

--- a/crates/atlas-acp-thread/tests/thread.rs
+++ b/crates/atlas-acp-thread/tests/thread.rs
@@ -452,6 +452,87 @@ async fn cancel_resolves_every_pending_permission_and_tells_the_connection() {
     assert!(!thread.is_generating());
 }
 
+/// Regression, ATL-213. A turn that FAILED still has to resolve what it left
+/// open.
+///
+/// `set_error()` clears `running_turn`, and `cancel_inner` used to return on
+/// that before it reached the tool-call half — so the permission prompt stayed
+/// `WaitingForConfirmation` holding a `respond_tx` nobody would ever send on.
+/// The projection reads `WaitingForConfirmation` before `had_error`, so the
+/// session reported Waiting forever and the error was masked rather than
+/// delayed.
+#[tokio::test]
+async fn cancel_after_an_error_still_resolves_an_open_permission_prompt() {
+    let (mut thread, _events, connection) = new_thread();
+
+    thread.begin_turn();
+    thread
+        .upsert_tool_call(tool_call("t1", "run", acp::ToolCallStatus::Pending))
+        .unwrap();
+    let waiter = thread
+        .request_tool_call_authorization(
+            tool_call_update("t1", None),
+            PermissionOptions::Flat(Vec::new()),
+            AuthorizationKind::PermissionGrant,
+        )
+        .unwrap();
+
+    // The turn fails — the agent's `prompt` returned an error, or its process
+    // died and every thread got an `emit_load_error`.
+    thread.set_error();
+    assert_eq!(status_of(&thread, "t1"), "Waiting for confirmation");
+
+    // The user presses stop.
+    thread.cancel();
+
+    // Bounded: with the bug the waiter simply never resolves, and an
+    // unqualified `.await` here would hang CI instead of failing it.
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+        .await
+        .expect("the permission waiter was left stranded by a cancel after an error");
+    assert!(matches!(outcome, RequestPermissionOutcome::Cancelled));
+    assert_eq!(status_of(&thread, "t1"), "Canceled");
+    // Still no `session/cancel`: there is no turn for the agent to cancel. The
+    // fix is about resolving OUR state, not about talking to a dead peer.
+    assert_eq!(connection.cancel_count.load(Ordering::SeqCst), 0);
+}
+
+/// Regression, ATL-213, the follow-up variant. `begin_turn()` cancels BEFORE it
+/// sets `running_turn`, so with the early return in the wrong place a stale
+/// call from a failed turn survived every subsequent turn as `InProgress`.
+#[tokio::test]
+async fn a_new_turn_clears_a_stale_call_left_by_a_failed_one() {
+    let (mut thread, _events, _conn) = new_thread();
+
+    thread.begin_turn();
+    thread
+        .upsert_tool_call(tool_call("t1", "run", acp::ToolCallStatus::InProgress))
+        .unwrap();
+    thread.set_error();
+
+    thread.begin_turn();
+
+    assert_eq!(status_of(&thread, "t1"), "Canceled");
+}
+
+/// The counterpart guard: resolving entries unconditionally must not start
+/// sending `session/cancel` from an idle thread. Complements
+/// `cancelling_an_idle_thread_does_not_notify_the_agent` by putting a
+/// cancellable entry in front of it, which is the case that would regress.
+#[tokio::test]
+async fn cancelling_an_idle_thread_resolves_entries_without_notifying_the_agent() {
+    let (mut thread, _events, connection) = new_thread();
+
+    thread
+        .upsert_tool_call(tool_call("t1", "run", acp::ToolCallStatus::InProgress))
+        .unwrap();
+
+    thread.cancel();
+
+    assert_eq!(status_of(&thread, "t1"), "Canceled");
+    assert_eq!(connection.cancel_count.load(Ordering::SeqCst), 0);
+}
+
 /// Adapted from `run_turn` (`acp_thread.rs:3743`): a follow-up send cancels the
 /// previous turn with `InterruptedByFollowUp`, which is a different outcome from
 /// the user pressing stop and is visible to whoever was awaiting permission.

--- a/crates/atlas-agent-servers/src/handlers.rs
+++ b/crates/atlas-agent-servers/src/handlers.rs
@@ -586,7 +586,10 @@ pub fn handle_create_terminal(
 /// - the command exits (checked after each wake);
 /// - the thread is gone (the upgrade fails, checked before parking again);
 /// - the terminal is released or the session torn down, both of which kill the
-///   command — which is an exit, so the first condition fires.
+///   command — which is an exit, so the first condition fires. Release kills
+///   explicitly, just below; teardown kills through `AcpTerminal`'s `Drop`,
+///   which is the only thing covering an ABRUPT teardown — `close_session`
+///   drops the thread handle without ever reaching this code.
 pub fn follow_terminal_output(
     thread: AcpThreadHandle,
     terminal: Arc<CommandTerminal>,

--- a/crates/atlas-terminal/src/command.rs
+++ b/crates/atlas-terminal/src/command.rs
@@ -50,15 +50,21 @@ pub struct CommandExit {
 /// what matters to an agent reading a failure — and requires that the retained
 /// bytes stay a valid string. Both are easy to get subtly wrong, so they live
 /// here behind tests rather than at the call site.
+///
+/// Public because a PTY is not the only thing that accumulates a command's
+/// output: a DISPLAY-ONLY terminal (one the agent runs itself, streaming its
+/// output to us as `session/update` meta) has no `CommandTerminal` at all, and
+/// `atlas-acp-thread` buffers those bytes directly. That buffer needs the same
+/// cap and the same boundary walk, and reimplementing either is how they drift.
 #[derive(Debug)]
-struct OutputBuffer {
+pub struct OutputBuffer {
     bytes: Vec<u8>,
     limit: usize,
     truncated: bool,
 }
 
 impl OutputBuffer {
-    fn new(limit: u64) -> Self {
+    pub fn new(limit: u64) -> Self {
         Self {
             bytes: Vec::new(),
             // Saturating: `u64::MAX` from a careless agent must clamp, not wrap
@@ -68,7 +74,7 @@ impl OutputBuffer {
         }
     }
 
-    fn push(&mut self, chunk: &[u8]) {
+    pub fn push(&mut self, chunk: &[u8]) {
         self.bytes.extend_from_slice(chunk);
         if self.bytes.len() <= self.limit {
             return;
@@ -90,8 +96,23 @@ impl OutputBuffer {
     /// `output` field is a string, so there is nothing else to return. The
     /// boundary walk in [`Self::push`] means truncation itself never
     /// manufactures a replacement character; anything here came from the child.
-    fn text(&self) -> String {
+    pub fn text(&self) -> String {
         String::from_utf8_lossy(&self.bytes).into_owned()
+    }
+
+    /// Whether anything has been dropped from the front. Sticky: once a buffer
+    /// has truncated, no later read can honestly claim a complete capture.
+    pub fn truncated(&self) -> bool {
+        self.truncated
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// Retained bytes. Used to account for a buffer's cost from outside.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
     }
 }
 

--- a/crates/atlas-terminal/src/lib.rs
+++ b/crates/atlas-terminal/src/lib.rs
@@ -29,6 +29,12 @@ pub struct TerminalOutput {
     pub data: Vec<u8>,
 }
 
+impl Default for TerminalManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TerminalManager {
     pub fn new() -> Self {
         Self {
@@ -197,7 +203,7 @@ impl TerminalManager {
             if error.raw_os_error() == Some(libc::ESRCH) {
                 return Ok(false);
             }
-            return Err(error.into());
+            Err(error.into())
         }
 
         #[cfg(not(unix))]


### PR DESCRIPTION
### What?

Fixes all six `crates/atlas-acp-thread` findings from the 2026-08-29 end-to-end
review filed under ATL-212: **ATL-213, ATL-214, ATL-215, ATL-216, ATL-217, ATL-218**.

| Issue | Priority | Defect |
| -- | -- | -- |
| ATL-213 | Urgent | `cancel()` permanently a no-op after `set_error()` — permission prompts strand, session reports Waiting forever |
| ATL-214 | High | PTY children orphaned when a session is torn down with a command still running |
| ATL-215 | High | `output_byte_limit` stored but never enforced; display-only output grows unbounded and reports `truncated: false` |
| ATL-216 | Medium | `pending_output` / `pending_exit` never evicted for terminal ids that are never announced |
| ATL-217 | Low | Crate docs claim nothing links the crate — seven packages do |
| ATL-218 | Low | Minor findings rollup (findings 1, 2 and 5 fixed; 3, 4, 6, 7 resolved as no-change with reasons) |

### Why?

Five of the six are reachable by an ordinary agent doing ordinary things, and
none was visible to the test suite: at review time the crate was 21/21 green and
clippy clean. Two of them are the kind of failure a user reads as "Atlas is
broken" rather than "the agent failed":

**ATL-213** is the worst of them. `cancel_inner` resolved elicitations *above*
its early return and tool calls *below* it. `set_error()` and `emit_load_error()`
both clear `running_turn` before anything can cancel, so after either one every
later `cancel()` returned before it reached the tool-call half. A tool call sat
in `WaitingForConfirmation` forever holding a `respond_tx` nobody would send on,
and because `atlas-agent-delta`'s projection checks `WaitingForConfirmation`
*before* `had_error`, the session reported `Waiting` permanently — the error was
masked, not delayed. `begin_turn()` cancels before it sets `running_turn`, so the
next turn early-returned too. There was no self-heal path; the only escape was
the user clicking an option on a prompt belonging to a dead turn.

**ATL-214** leaves a real process running. Close a session with `npm run dev` or
a test runner going and the child outlives Atlas as an orphan. Nothing on the
path saved it: `terminal/release` kills before it drops, but `close_session`
never reaches that code; portable-pty's unix child is a plain
`std::process::Child`, which does not kill on drop; and the reader thread holds a
dup'd master fd, so the PTY does not even hang up.

**ATL-215** and **ATL-216** are two unbounded buffers plus a `truncated` flag
that lied about a third.

### How?

**ATL-213** — resolving the thread's own state is now unconditional; only
`connection.cancel()` stays behind the `running_turn` check. Entries and
elicitations are ours, and a turn that is gone cannot advance them either way;
an idle thread must still not send `session/cancel` for a turn the agent already
finished.

**ATL-214** — `impl Drop for AcpTerminal` kills the child. This was the option
the ticket preferred over killing the registry from `close_session`, because it
also covers the abrupt-teardown path that never reaches any explicit call.

**ATL-215** — `replayed_output` becomes an `OutputBuffer`, the bounded UTF-8-safe
window `atlas-terminal` already had behind tests (made `pub` for this; no
behaviour change on its existing use). `current_output` now ORs `truncated`
across both halves rather than reading it off the PTY alone.

> The ticket flagged one decision: what limit a display-only terminal gets, since
> `handlers.rs` passes `None` and the agent never declares one. Resolved as
> `DEFAULT_OUTPUT_BYTE_LIMIT` (1 MiB) — the same default a `terminal/create`
> without an `outputByteLimit` already gets. A display-only terminal has no field
> to declare a limit in, so `None` there cannot be read as the agent opting out
> of one.

**ATL-216** — both side-tables become insertion-ordered and bounded: 64 ids, and
for output a 1 MiB total-parked-bytes budget, evicting oldest-first. The
buffering itself is load-bearing and stays — out-of-order arrival is a real,
documented case — only the unboundedness is gone. `terminals` itself is
deliberately left uncapped, and the doc comment says why (every entry cost a real
spawned process, and both ways to cap it here are worse than the growth).

**ATL-218** — findings 1 (redacting `Debug` so BYOK keys cannot reach a log
line), 2 (duplicate URL `elicitationId` refused while the first is outstanding —
scoped so a device-code retry still works) and 5 (`wait_for_exit` returns
`Option` instead of fabricating a status indistinguishable from `exit 0`) are
fixed. Findings 4 and 6 were checked and deliberately left alone, with the
reasoning written into the doc comments at `end_turn` and `TerminalRegistry` so
they are not re-raised later as omissions. Finding 3 (`EntriesRemoved` emitted
nowhere) was true at review time and has since been fixed by 630a9357, which
added `remove_entries_from`. Finding 7 stands as filed — the ticket asks for a
measurement before any change.

Out of scope and untouched: ATL-218's two theoretical residuals (both in
`src-tauri`, both undemonstrated) and its `AgentConnection` trait observations,
which the ticket labels design rather than defects.

#### Tests

Nine new tests, each confirmed to fail against the code it replaces:

- `cancel_after_an_error_still_resolves_an_open_permission_prompt` — ATL-213's
  first acceptance criterion. The waiter await is bounded, because with the bug
  it simply never resolves and a bare `.await` would hang CI instead of failing it.
- `a_new_turn_clears_a_stale_call_left_by_a_failed_one` — ATL-213's second.
- `cancelling_an_idle_thread_resolves_entries_without_notifying_the_agent` — the
  counterpart guard, so the fix cannot regress into sending `session/cancel` from
  an idle thread.
- `dropping_the_registry_kills_a_running_command` — ATL-214. Uses `sleep 30`
  against a real PTY; `true(1)` would exit on its own and prove nothing.
- `a_display_only_terminal_bounds_its_buffer_and_admits_the_truncation`,
  `an_undeclared_limit_still_bounds_a_display_only_terminal`,
  `trimming_a_display_only_buffer_keeps_it_valid_utf8` — ATL-215.
- `parked_output_for_ids_that_never_arrive_is_bounded`,
  `evicting_parked_output_keeps_the_newest_id`, `parked_exit_statuses_are_bounded`,
  `bounding_the_side_tables_does_not_break_ordinary_out_of_order_replay` — ATL-216.
- `a_duplicate_url_elicitation_id_is_refused_while_the_first_is_outstanding`,
  `a_url_elicitation_id_can_be_reused_once_the_first_is_resolved`,
  `a_display_only_terminal_without_an_exit_admits_it_does_not_know` — ATL-218.

`atlas-acp-thread` goes 21 → 68 tests, all passing. `atlas-terminal` 15/15.
`cargo clippy --all-targets -- -D warnings` clean on both.

#### Two things worth flagging

1. **`atlas-terminal`'s clippy gate was already red on `0.3.1`**, in
   `src/lib.rs` — `new_without_default` and `needless_return`, neither in code
   this PR touches. Fixed here, because a PR that modifies the crate should not
   leave its own gate failing. This is *not* ATL-234.
2. **ATL-234 is still red and is left alone.** The `atlas-agent-servers` clippy
   failure is `src/debug_log.rs:103` (`question_mark`), predates this branch, and
   belongs to its own ticket — whose stated likely cause is an unpinned CI
   toolchain rather than the lint itself. Silently fixing the lint here would
   half-answer that ticket. The only change to that crate in this PR is one doc
   comment that ATL-214 asked for.

#### Related, not fixed here

ATL-213 and **ATL-232** are the same user action failing in two layers — ATL-232
is `cancel()` being only a wire notification a wedged agent can ignore, in
`atlas-agent-servers`. Fixing this one still leaves that reachable case.
ATL-215 bounds N for **ATL-219**'s quadratic terminal-output projection in
`atlas-agent-delta`, but does not remove the quadratic term; both still need doing.

Fixes ATL-213, ATL-214, ATL-215, ATL-216, ATL-217, ATL-218

## Checklist

- [x] Targets the current version branch (`0.3.1`)
- [x] New behaviour has a test; every bug fix here has a test confirmed to fail without it
- [ ] You've run the app and used the change in a window

> The last box is honest rather than checked: this was verified against the real
> types with `cargo test`, including a real PTY for ATL-214, but not by driving
> an agent through a running Atlas window. ATL-213's path in particular is worth
> a manual pass — open a permission prompt, kill the agent process, press stop.
