### PR TITLE
atlas-agent-delta: quadratic projection, four transcript misreports, three retained tables

### DIFF
--- a/crates/atlas-acp-thread/src/connection.rs
+++ b/crates/atlas-acp-thread/src/connection.rs
@@ -349,6 +349,16 @@ impl dyn AgentConnection {
     }
 }
 
+/// Rewinding a session's history.
+///
+/// No implementation and no caller today — `remove_entries_from` is reached
+/// only by the native agent's `/undo`. Whoever wires this up owns a coupling
+/// that is not local to this file: shrinking `AcpThread::entries` makes
+/// `atlas-agent-delta`'s per-session mirror shrink with it, and anything keyed
+/// by entry position or by tool call id (the projector's `open_permissions`,
+/// its `Projected` mirror) has to be trimmed in the same step. The projector
+/// handles the `EntriesRemoved` event it already receives; check it still does
+/// before assuming a new truncation path is free.
 pub trait AgentSessionTruncate: Send + Sync {
     fn run(&self, client_user_message_id: ClientUserMessageId) -> BoxFuture<'static, Result<()>>;
 }

--- a/crates/atlas-acp-thread/src/terminal.rs
+++ b/crates/atlas-acp-thread/src/terminal.rs
@@ -212,7 +212,7 @@ impl AcpTerminal {
         let output = if self.replayed_output.is_empty() {
             captured
         } else {
-            let mut out = self.replayed_output.text();
+            let mut out = self.replayed_output.text().to_string();
             out.push_str(&captured);
             out
         };
@@ -226,6 +226,55 @@ impl AcpTerminal {
         let mut response = acp::TerminalOutputResponse::new(output, truncated);
         response.exit_status = exit_status;
         response
+    }
+
+    /// How [`Self::current_output`]'s `output` has grown past `from` bytes.
+    ///
+    /// Exists so flattening a terminal into a tool call's result costs the tail
+    /// rather than the whole buffer. Rebuilding the buffer to discover that it
+    /// only grew is what made a chatty command's projection quadratic in its
+    /// own output (ATL-219), and the projector runs it once per chunk.
+    ///
+    /// `None` means "ask [`Self::current_output`] instead", and is deliberately
+    /// returned for every case where a byte offset taken from an earlier read
+    /// is no longer trustworthy:
+    ///
+    /// * either buffer has dropped its front, so `from` names different bytes
+    ///   than it did — and `terminal_output` additionally prefixes a truncation
+    ///   marker, which changes the whole answer's shape;
+    /// * `from` is past the end, so the output shrank rather than grew;
+    /// * `from` lands inside the replayed half while a PTY half also has
+    ///   content, where serving the tail would mean copying the PTY half too;
+    /// * `from` is not on a character boundary.
+    pub fn output_appended(&self, from: usize) -> Option<TerminalAppend> {
+        if self.replayed_output.truncated() {
+            return None;
+        }
+        let replayed = self.replayed_output.text();
+        let build = |captured: &str| -> Option<TerminalAppend> {
+            let total = replayed.len() + captured.len();
+            if from > total {
+                return None;
+            }
+            if from == total {
+                return Some(TerminalAppend::Unchanged);
+            }
+            if from < replayed.len() {
+                if !captured.is_empty() {
+                    return None;
+                }
+                return replayed
+                    .get(from..)
+                    .map(|tail| TerminalAppend::Grew(tail.to_string()));
+            }
+            captured
+                .get(from - replayed.len()..)
+                .map(|tail| TerminalAppend::Grew(tail.to_string()))
+        };
+        match &self.inner {
+            Some(inner) => inner.with_untruncated_output(build)?,
+            None => build(""),
+        }
     }
 
     /// Kill the command. Marks the terminal as user-stopped so the UI can tell
@@ -264,6 +313,14 @@ impl AcpTerminal {
             None => None,
         }
     }
+}
+
+/// What [`AcpTerminal::output_appended`] found: nothing new, or exactly the
+/// bytes appended since the caller's cursor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalAppend {
+    Unchanged,
+    Grew(String),
 }
 
 /// Killing the child on drop is the only thing that covers an ABRUPT teardown.

--- a/crates/atlas-acp-thread/src/thread.rs
+++ b/crates/atlas-acp-thread/src/thread.rs
@@ -29,7 +29,7 @@ use tokio::sync::oneshot;
 
 use crate::connection::{AgentConnection, ClientUserMessageId, PermissionOptions};
 use crate::elicitation::{ElicitationEntryId, ElicitationStore};
-use crate::terminal::{AcpTerminal, TerminalProviderEvent, TerminalRegistry};
+use crate::terminal::{AcpTerminal, TerminalAppend, TerminalProviderEvent, TerminalRegistry};
 use crate::EventSink;
 
 /// One piece of renderable content.
@@ -852,6 +852,25 @@ pub struct AcpThread {
     parent_session_id: Option<acp::SessionId>,
     title: Option<Arc<str>>,
     entries: Vec<AgentThreadEntry>,
+    /// When each entry was first appended, parallel to `entries`.
+    ///
+    /// Kept beside the list rather than inside `AgentThreadEntry` because every
+    /// variant wants it and none of them constructs itself here — the entries
+    /// are built from protocol updates in a dozen places, and a field on each
+    /// would have to be threaded through all of them.
+    ///
+    /// Both vectors are only ever appended to (`push_entry`) or truncated
+    /// together (`remove_entries_from`), which is what keeps the indices
+    /// aligned; `push_entry` asserts it in debug builds.
+    ///
+    /// This is the time Atlas learned of the entry, which is the message's real
+    /// time for anything the app watched happen. It is NOT recoverable for a
+    /// thread rebuilt by an agent's `session/load` replay: ACP carries no
+    /// per-message timestamp, so a replayed conversation is stamped at replay
+    /// time. That is a limit of the protocol, not a choice — but it is stable
+    /// per thread, which is the property the projection actually needed
+    /// (ATL-221).
+    entry_created_at: Vec<chrono::DateTime<chrono::Utc>>,
     elicitations: ElicitationStore,
     plan: Plan,
     turn_id: u32,
@@ -880,6 +899,7 @@ impl AcpThread {
             parent_session_id: None,
             title,
             entries: Vec::new(),
+            entry_created_at: Vec::new(),
             elicitations: ElicitationStore::default(),
             plan: Plan::default(),
             turn_id: 0,
@@ -947,6 +967,17 @@ impl AcpThread {
     /// id is worth nothing to history until a message has gone through it.
     pub fn is_draft(&self) -> bool {
         self.entries.is_empty()
+    }
+
+    /// When the entry at `ix` was appended.
+    ///
+    /// Read by the projection instead of stamping the clock at read time: a
+    /// snapshot that minted its own timestamps reported every message in a past
+    /// conversation as sent just now, and two snapshots of an unchanged thread
+    /// disagreed with each other (ATL-221). See `entry_created_at` for what
+    /// this value does and does not mean.
+    pub fn entry_created_at(&self, ix: usize) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.entry_created_at.get(ix).copied()
     }
 
     pub fn entries(&self) -> &[AgentThreadEntry] {
@@ -1018,6 +1049,7 @@ impl AcpThread {
             return;
         }
         self.entries.truncate(from);
+        self.entry_created_at.truncate(from);
         self.emit(AcpThreadEvent::EntriesRemoved(from..len));
     }
 
@@ -1130,6 +1162,8 @@ impl AcpThread {
 
     fn push_entry(&mut self, entry: AgentThreadEntry) {
         self.entries.push(entry);
+        self.entry_created_at.push(chrono::Utc::now());
+        debug_assert_eq!(self.entries.len(), self.entry_created_at.len());
         self.emit(AcpThreadEvent::NewEntry);
     }
 
@@ -1873,6 +1907,22 @@ impl AcpThread {
     /// and the tool call's status is where the UI shows it. Zed's
     /// `Terminal::to_markdown` (`terminal.rs:604-609`) is content-only for the
     /// same reason.
+    /// How [`Self::terminal_output`]'s answer has grown past `from` bytes.
+    ///
+    /// `None` when the id names no terminal this thread holds, or when the
+    /// answer cannot be served as a pure extension of `from` — see
+    /// [`AcpTerminal::output_appended`] for the cases. A caller that gets
+    /// `None` falls back to [`Self::terminal_output`]; this exists so the case
+    /// that actually happens on every output chunk does not cost a copy of
+    /// everything the command has printed so far (ATL-219).
+    pub fn terminal_output_appended(
+        &self,
+        id: &acp::TerminalId,
+        from: usize,
+    ) -> Option<TerminalAppend> {
+        self.terminals.get(id)?.output_appended(from)
+    }
+
     pub fn terminal_output(&self, id: &acp::TerminalId) -> Option<String> {
         self.terminals.get(id).map(|terminal| {
             let response = terminal.current_output();

--- a/crates/atlas-agent-delta/src/project.rs
+++ b/crates/atlas-agent-delta/src/project.rs
@@ -25,18 +25,86 @@ pub struct Run {
     pub text: String,
 }
 
-/// Group an assistant entry's chunks into runs.
-pub fn runs(chunks: &[AssistantMessageChunk]) -> Vec<Run> {
-    let mut runs: Vec<Run> = Vec::new();
-    for chunk in chunks {
+/// Where one run sits in an entry's chunk list.
+///
+/// Deliberately carries no text. A streamed assistant message arrives as one
+/// `EntryUpdated` per chunk, so anything that rebuilds the whole text to answer
+/// "what is new" costs the entire message on every token of it — which is what
+/// made assistant streaming quadratic in message length (ATL-223). A caller
+/// that only needs the new part asks [`run_span_len`] and [`run_span_tail`],
+/// which cost the tail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunSpan {
+    pub is_thought: bool,
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Group an assistant entry's chunks into runs, without touching their text.
+pub fn run_spans(chunks: &[AssistantMessageChunk]) -> Vec<RunSpan> {
+    let mut spans: Vec<RunSpan> = Vec::new();
+    for (ix, chunk) in chunks.iter().enumerate() {
         let is_thought = chunk.is_thought();
-        let text = block_text(chunk.block());
-        match runs.last_mut() {
-            Some(run) if run.is_thought == is_thought => run.text.push_str(&text),
-            _ => runs.push(Run { is_thought, text }),
+        match spans.last_mut() {
+            Some(span) if span.is_thought == is_thought => span.end = ix + 1,
+            _ => spans.push(RunSpan {
+                is_thought,
+                start: ix,
+                end: ix + 1,
+            }),
         }
     }
-    runs
+    spans
+}
+
+/// The byte length of a span's text, without building it.
+pub fn run_span_len(chunks: &[AssistantMessageChunk], span: &RunSpan) -> usize {
+    chunks[span.start..span.end]
+        .iter()
+        .map(|chunk| block_str(chunk.block()).len())
+        .sum()
+}
+
+/// A span's text from `from` bytes on.
+///
+/// `None` when `from` is past the end — the text shrank, which the wire has no
+/// way to express — or when it does not land on a character boundary. Both are
+/// "do not stream this", not "nothing changed".
+///
+/// Reading the tail against a byte offset instead of comparing strings is safe
+/// because a run's text only ever grows at its end: chunks are appended, and
+/// `ContentBlock::append` in `atlas-acp-thread` either pushes onto the existing
+/// text or replaces a block whose own rendering was the empty string.
+pub fn run_span_tail(
+    chunks: &[AssistantMessageChunk],
+    span: &RunSpan,
+    from: usize,
+) -> Option<String> {
+    let mut seen = 0usize;
+    let mut out = String::new();
+    for chunk in &chunks[span.start..span.end] {
+        let text = block_str(chunk.block());
+        let end = seen + text.len();
+        if end > from {
+            out.push_str(text.get(from.saturating_sub(seen)..)?);
+        }
+        seen = end;
+    }
+    (seen >= from).then_some(out)
+}
+
+/// Group an assistant entry's chunks into runs, text and all.
+///
+/// For the paths that need the whole thing — a snapshot, or a run being
+/// announced for the first time. Streaming updates go through [`run_spans`].
+pub fn runs(chunks: &[AssistantMessageChunk]) -> Vec<Run> {
+    run_spans(chunks)
+        .into_iter()
+        .map(|span| Run {
+            text: run_span_tail(chunks, &span, 0).unwrap_or_default(),
+            is_thought: span.is_thought,
+        })
+        .collect()
 }
 
 /// The text of a content block.
@@ -45,17 +113,33 @@ pub fn runs(chunks: &[AssistantMessageChunk]) -> Vec<Run> {
 /// to a file, and dropping the reference would make the transcript read as
 /// though it never did. Images have no text and contribute none.
 pub fn block_text(block: &ContentBlock) -> String {
+    block_str(block).to_string()
+}
+
+/// [`block_text`] without the copy. Every variant already owns its text, so a
+/// caller that only measures or slices it need not allocate.
+pub fn block_str(block: &ContentBlock) -> &str {
     match block {
-        ContentBlock::Empty => String::new(),
-        ContentBlock::Text(text) => text.clone(),
-        ContentBlock::EmbeddedResource { text, .. } => text.clone(),
-        ContentBlock::ResourceLink { resource_link } => resource_link.uri.clone(),
-        ContentBlock::Image { .. } => String::new(),
+        ContentBlock::Empty => "",
+        ContentBlock::Text(text) => text,
+        ContentBlock::EmbeddedResource { text, .. } => text,
+        ContentBlock::ResourceLink { resource_link } => &resource_link.uri,
+        ContentBlock::Image { .. } => "",
     }
 }
 
 /// A wire message carrying one assistant run.
-pub fn run_message(id: String, run: &Run, model: Option<String>) -> Message {
+///
+/// `timestamp` is passed in rather than minted here: the live stream is
+/// building a message that is being said now, but a snapshot is describing one
+/// that was said earlier, and a clock read at snapshot time reported every
+/// message in a past conversation as sent just now (ATL-221).
+pub fn run_message(
+    id: String,
+    run: &Run,
+    model: Option<String>,
+    timestamp: chrono::DateTime<chrono::Utc>,
+) -> Message {
     let (mode, content, thinking) = if run.is_thought {
         (MessageMode::Thinking, String::new(), run.text.clone())
     } else {
@@ -70,7 +154,7 @@ pub fn run_message(id: String, run: &Run, model: Option<String>) -> Message {
         tool_calls: Vec::new(),
         plan: None,
         model,
-        timestamp: chrono::Utc::now(),
+        timestamp,
     }
 }
 
@@ -78,7 +162,12 @@ pub fn run_message(id: String, run: &Run, model: Option<String>) -> Message {
 ///
 /// The wire nests tool calls inside a message, so each one gets a message of its
 /// own — the same shape the old stack produced (`new_assistant_tool`).
-pub fn tool_message(id: String, tool_call: ToolCall, model: Option<String>) -> Message {
+pub fn tool_message(
+    id: String,
+    tool_call: ToolCall,
+    model: Option<String>,
+    timestamp: chrono::DateTime<chrono::Utc>,
+) -> Message {
     Message {
         id,
         role: MessageRole::Assistant,
@@ -88,7 +177,7 @@ pub fn tool_message(id: String, tool_call: ToolCall, model: Option<String>) -> M
         tool_calls: vec![tool_call],
         plan: None,
         model,
-        timestamp: chrono::Utc::now(),
+        timestamp,
     }
 }
 
@@ -99,6 +188,19 @@ pub fn tool_message(id: String, tool_call: ToolCall, model: Option<String>) -> M
 /// name when it sent one; when it did not, this falls back to the display title
 /// and then the kind, which is what the old stack always did.
 pub fn tool_call(call: &ThreadToolCall, thread: &atlas_acp_thread::AcpThread) -> ToolCall {
+    let mut out = tool_call_meta(call);
+    out.result = tool_result(&call.content, thread);
+    out
+}
+
+/// Everything about a tool call except its flattened result.
+///
+/// Split out because the result is the only field whose cost grows with what a
+/// command printed, and the projector needs to know whether anything *else*
+/// changed before it can decide to ship only the result's tail (ATL-219).
+/// Every field here is bounded by the tool call itself, so building it per
+/// output chunk is cheap.
+pub fn tool_call_meta(call: &ThreadToolCall) -> ToolCall {
     let title = call.label.clone();
     let kind = tool_kind_token(call.kind).to_string();
     ToolCall {
@@ -118,7 +220,7 @@ pub fn tool_call(call: &ThreadToolCall, thread: &atlas_acp_thread::AcpThread) ->
         kind: Some(kind),
         status: tool_status(&call.status),
         arguments: call.raw_input.clone().unwrap_or(serde_json::Value::Null),
-        result: tool_result(&call.content, thread),
+        result: None,
         locations: call
             .locations
             .iter()
@@ -138,9 +240,8 @@ pub fn tool_call(call: &ThreadToolCall, thread: &atlas_acp_thread::AcpThread) ->
 /// Takes the whole thread because a terminal block carries only an id — that is
 /// all the protocol sends — and the output it names lives on the client side,
 /// growing after the block was announced. Both the delta stream and the
-/// snapshot resolve it the same way, because a snapshot that flattened
-/// terminals differently from the deltas applied on top of it is exactly the
-/// disagreement [`snapshot_messages`] exists to avoid.
+/// snapshot resolve it the same way, so a resumed transcript shows the same
+/// command output the live one did.
 pub fn tool_result(
     content: &[ToolCallContent],
     thread: &atlas_acp_thread::AcpThread,
@@ -168,6 +269,19 @@ pub fn tool_result(
         out.push_str(&piece);
     }
     (!out.is_empty()).then_some(out)
+}
+
+/// The one terminal a tool call's result is made entirely of, when it is.
+///
+/// The projector's incremental path is only sound when the whole flattened
+/// result IS one terminal's output: with a second block in `content`, growth is
+/// not confined to the end of the string, and a byte offset into the previous
+/// result names the wrong place.
+pub fn sole_terminal(content: &[ToolCallContent]) -> Option<&acp::TerminalId> {
+    match content {
+        [ToolCallContent::Terminal(id)] => Some(id),
+        _ => None,
+    }
 }
 
 /// The blocks the UI renders structurally rather than as text.
@@ -302,10 +416,19 @@ pub fn stop_reason_token(reason: acp::StopReason) -> String {
 /// Every entry in a thread, as the wire's message list.
 ///
 /// This is what `agents_snapshot` answers with, and it is deliberately built
-/// from the same functions the delta stream uses. A snapshot assembled any
-/// other way could disagree with the deltas that follow it — the frontend
-/// paints the snapshot and then applies deltas on top, so a disagreement shows
-/// up as a duplicated or missing message rather than as an error.
+/// from the same functions the delta stream uses — not because the two must
+/// agree field for field, but because a second flattening of the same entry is
+/// a second thing to keep correct. They already differ where it does not
+/// matter: the ids here are positional (`msg-{ix}`, `msg-{ix}-{run_ix}`) while
+/// the delta stream mints a uuid per message, and nothing consumes either. The
+/// frontend drops snapshot ids on the way in (`snapshot-message.ts`) and
+/// matches deltas by `tool_call.id`, never by `message_id`. Do NOT "fix" the id
+/// schemes to match each other; `tool_call.id` is the key that actually has to
+/// hold, and it is the one worth protecting.
+///
+/// What the two DO have to agree on is which entries produce a message at all —
+/// a run the stream announces and the snapshot skips is a bubble that vanishes
+/// on reload (ATL-224). Both skip empty runs.
 ///
 /// User messages DO appear here, unlike on the delta stream: a snapshot is the
 /// conversation, and one with the user's half missing is not one. The wire
@@ -319,6 +442,12 @@ pub fn snapshot_messages(
 
     let mut out = Vec::new();
     for (ix, entry) in thread.entries().iter().enumerate() {
+        // The time the thread learned of the entry, not the time this snapshot
+        // was taken. Reading the clock here made two snapshots of an unchanged
+        // conversation disagree, and collapsed every historical pause to zero
+        // (ATL-221). `Utc::now()` remains the fallback only for an entry with
+        // no recorded time, which the accessor's contract makes unreachable.
+        let at = thread.entry_created_at(ix).unwrap_or_else(chrono::Utc::now);
         match entry {
             AgentThreadEntry::UserMessage(message) => out.push(Message {
                 id: format!("msg-{ix}"),
@@ -329,9 +458,11 @@ pub fn snapshot_messages(
                 tool_calls: Vec::new(),
                 plan: None,
                 model: None,
-                timestamp: chrono::Utc::now(),
+                timestamp: at,
             }),
             AgentThreadEntry::AssistantMessage(message) => {
+                // `run_ix` counts over the UNFILTERED list, so skipping an
+                // empty run does not shift the ids of the ones after it.
                 for (run_ix, run) in runs(&message.chunks).iter().enumerate() {
                     if run.text.is_empty() {
                         continue;
@@ -340,6 +471,7 @@ pub fn snapshot_messages(
                         format!("msg-{ix}-{run_ix}"),
                         run,
                         model.map(str::to_string),
+                        at,
                     ));
                 }
             }
@@ -347,10 +479,16 @@ pub fn snapshot_messages(
                 format!("msg-{ix}"),
                 tool_call(call, thread),
                 model.map(str::to_string),
+                at,
             )),
             // Elicitations are their own UI, driven by `elicitation_requested`;
             // a compaction is a status, not conversation; a completed plan is
             // carried by the snapshot's `plan` field, not as a message.
+            //
+            // `CompletedPlan` has no constructor anywhere in the ported stack
+            // today, so this arm is unreachable rather than merely unused; it
+            // stays because the match must be exhaustive, and because the
+            // variant is the shape a compacted plan would arrive in.
             AgentThreadEntry::Elicitation(_)
             | AgentThreadEntry::CompletedPlan(_)
             | AgentThreadEntry::ContextCompaction(_) => {}

--- a/crates/atlas-agent-delta/src/projector.rs
+++ b/crates/atlas-agent-delta/src/projector.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use agent_client_protocol::schema::v1 as acp;
 use atlas_acp_thread::{
     AcpThread, AcpThreadEvent, AcpThreadHandle, AgentThreadEntry, ElicitationEntryId, EventStream,
-    LoadError, ToolCallStatus as ThreadToolCallStatus,
+    LoadError, TerminalAppend, ToolCallStatus as ThreadToolCallStatus,
 };
 use atlas_agent_servers::ThreadEventSink;
 use atlas_agent_wire::{
@@ -139,10 +139,17 @@ impl DeltaProjector {
         let this = self.clone();
         Arc::new(move |session_id: &acp::SessionId| {
             let (tx, rx) = atlas_acp_thread::event_channel();
-            this.pending
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .insert(session_id.clone(), rx);
+            let mut pending = this.pending.lock().unwrap_or_else(|p| p.into_inner());
+            // A session whose `session/load` or `session/resume` RPC failed
+            // never reaches `register`, so nothing takes its pre-registered
+            // stream back out and the key stays here for the life of the
+            // process (ATL-225). The thread that held the only sender was
+            // dropped along with the failure, so a stream with no senders left
+            // can never carry another event and is safe to forget. Swept here
+            // rather than on a timer because this is the one place that learns
+            // a new session is being opened.
+            pending.retain(|_, stream| stream.sender_strong_count() > 0);
+            pending.insert(session_id.clone(), rx);
             tx
         })
     }
@@ -160,6 +167,12 @@ impl DeltaProjector {
     /// delta carries the full state it announces, and none is skipped — so a
     /// consumer cannot tell the difference. A host that needs the finer grain
     /// pumps the stream itself with [`Self::register`].
+    ///
+    /// The cleanup when the stream ends is a backstop, not the primary path:
+    /// the projection owns the thread that owns the sender, so in Atlas the
+    /// stream only ends after [`Self::close_session`] has already dropped the
+    /// projection. It stays for a host that owns its threads the other way
+    /// round, and because ending a task on a dead channel is right regardless.
     pub fn attach(self: &Arc<Self>, agent_id: AgentId, thread: AcpThreadHandle) {
         let session_id = lock_thread(&thread).session_id().clone();
         let Some(mut events) = self.register(agent_id, thread) else {
@@ -170,10 +183,7 @@ impl DeltaProjector {
             while let Some(event) = events.recv().await {
                 this.apply(&session_id, event);
             }
-            this.sessions
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .remove(&session_id);
+            this.forget_session(&session_id);
         });
     }
 
@@ -215,6 +225,58 @@ impl DeltaProjector {
             .insert(session_id, projection);
 
         Some(events)
+    }
+
+    /// Forget a session the host has closed.
+    ///
+    /// The projector is a session's OWNER, not just an observer: after `bind`
+    /// the projection holds the only strong handle on the thread — the
+    /// connection's session table keeps a `Weak`, and the host drops its clone.
+    /// Which means the cleanup at the end of [`Self::attach`]'s task cannot run
+    /// on its own: the thread it is waiting on holds the sender that would end
+    /// the stream, so the stream never ends. Closing has to be told, not
+    /// noticed.
+    ///
+    /// Dropping the projection is what releases the thread, and with it the
+    /// thread's terminals — whose `Drop` kills any PTY still running.
+    pub fn close_session(&self, session_id: &acp::SessionId) {
+        self.forget_session(session_id);
+    }
+
+    /// Drop everything keyed to a session whose event stream has ended.
+    ///
+    /// `sessions` used to be the only table cleaned up here. The permission and
+    /// elicitation tables are keyed by wire request id and had no removal at
+    /// all, so on a process-lifetime singleton they retained one entry per
+    /// prompt the app had ever shown, for as long as the app ran (ATL-225).
+    fn forget_session(&self, session_id: &acp::SessionId) {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(session_id);
+        self.permissions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .retain(|_, key| &key.session_id != session_id);
+        self.elicitations
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .retain(|_, key| &key.session_id != session_id);
+    }
+
+    /// How many permission and elicitation routes are retained. Test-facing:
+    /// the leak these count was invisible from the outside.
+    pub fn routing_table_sizes(&self) -> (usize, usize) {
+        (
+            self.permissions.lock().unwrap_or_else(|p| p.into_inner()).len(),
+            self.elicitations.lock().unwrap_or_else(|p| p.into_inner()).len(),
+        )
+    }
+
+    /// How many event streams are pre-registered for sessions that do not exist
+    /// yet. Test-facing, for the same reason.
+    pub fn pending_len(&self) -> usize {
+        self.pending.lock().unwrap_or_else(|p| p.into_inner()).len()
     }
 
     /// Subscribe to every delta in-process, without going through the host sink.
@@ -436,9 +498,18 @@ enum Projected {
 
 #[derive(Debug)]
 struct ProjectedRun {
-    message_id: String,
+    /// `None` for a run that has nothing to render yet — an image- or
+    /// audio-only chunk flattens to the empty string, and announcing it put a
+    /// blank bubble on screen that the snapshot then omitted on reload
+    /// (ATL-224). The slot is still mirrored so run indices stay aligned with
+    /// the thread's, and the id is minted the moment the run has text.
+    message_id: Option<String>,
     is_thought: bool,
-    text: String,
+    /// How much of the run has been emitted, in bytes — not the text itself.
+    /// Keeping the text meant rebuilding and re-comparing the whole message on
+    /// every token of it (ATL-223); a run only ever grows at its end, so a
+    /// length is all that is needed to find what is new.
+    text_len: usize,
 }
 
 struct SessionProjection {
@@ -503,19 +574,41 @@ impl SessionProjection {
                 let end = range.end.min(self.entries.len());
                 // Count whole exchanges by their user messages: that is the
                 // unit the frontend can identify in its own mirror (its user
-                // rows are optimistic and carry no wire ids to address).
+                // rows are optimistic and carry no wire ids to address). A
+                // removal that clips none (an assistant-only trim) leaves it
+                // nothing to drop, which is why this can be zero.
                 let turns = self.entries[start..end]
                     .iter()
                     .filter(|projected| matches!(projected, Projected::User))
                     .count() as u32;
+                let removed: Vec<String> = self.entries[start..end]
+                    .iter()
+                    .filter_map(|projected| match projected {
+                        Projected::ToolCall { snapshot, .. } => Some(snapshot.id.clone()),
+                        _ => None,
+                    })
+                    .collect();
                 self.entries.drain(start..end);
+
+                // A tool call that goes away takes its permission prompt with
+                // it. Left in `open_permissions` the route outlives the call,
+                // and the frontend keeps a modal open on a tool call that no
+                // longer exists, answerable by nobody — the stranding shape of
+                // ATL-213, one layer up.
+                let mut deltas = Vec::new();
+                self.open_permissions.retain(|tool_call_id, request_id| {
+                    if removed.iter().any(|id| id == &tool_call_id.to_string()) {
+                        deltas.push(SessionDelta::PermissionResolved {
+                            request_id: *request_id,
+                        });
+                        return false;
+                    }
+                    true
+                });
                 if turns > 0 {
-                    vec![SessionDelta::HistoryRewound { turns }]
-                } else {
-                    // A removal that clips no user message (assistant-only
-                    // trim) has no exchange for the frontend to drop.
-                    Vec::new()
+                    deltas.push(SessionDelta::HistoryRewound { turns });
                 }
+                deltas
             }
             AcpThreadEvent::StatusChanged => self.status_deltas(),
             AcpThreadEvent::Stopped(stop_reason) => {
@@ -593,7 +686,11 @@ impl SessionProjection {
             // announced as a prompt update, which is the only thing that event
             // means today.
             AcpThreadEvent::PromptUpdated => self.plan_deltas(),
-            // Nothing on the wire corresponds to these.
+            // Nothing on the wire corresponds to these. `Refusal` has no
+            // emitter anywhere in `atlas-acp-thread` today, so its arm is
+            // unreachable rather than merely silent; it stays because the match
+            // must be exhaustive, and because a refusal is a thing the wire
+            // would eventually want to say.
             AcpThreadEvent::PromptCapabilitiesUpdated
             | AcpThreadEvent::WorkingDirectoriesUpdated
             | AcpThreadEvent::Refusal => Vec::new(),
@@ -623,19 +720,35 @@ impl SessionProjection {
             AgentThreadEntry::AssistantMessage(message) => {
                 let mut runs = Vec::new();
                 let mut deltas = Vec::new();
+                let at = chrono::Utc::now();
                 for run in project::runs(&message.chunks) {
+                    let text_len = run.text.len();
+                    // An image- or audio-only chunk flattens to nothing. The
+                    // snapshot skips such a run; announcing it here put a blank
+                    // bubble in the live view that vanished on reload
+                    // (ATL-224). Mirrored anyway so the run indices keep
+                    // matching the thread's.
+                    if run.text.is_empty() {
+                        runs.push(ProjectedRun {
+                            message_id: None,
+                            is_thought: run.is_thought,
+                            text_len,
+                        });
+                        continue;
+                    }
                     let message_id = new_message_id();
                     deltas.push(SessionDelta::MessageAppended {
                         message: project::run_message(
                             message_id.clone(),
                             &run,
                             self.model.clone(),
+                            at,
                         ),
                     });
                     runs.push(ProjectedRun {
-                        message_id,
+                        message_id: Some(message_id),
                         is_thought: run.is_thought,
-                        text: run.text,
+                        text_len,
                     });
                 }
                 (Projected::Assistant { runs }, deltas)
@@ -655,6 +768,10 @@ impl SessionProjection {
                     vec![delta],
                 )
             }
+            // Nothing in the ported stack constructs `CompletedPlan`, so this
+            // arm and its counterpart in `update_entry` are unreachable rather
+            // than merely rare. Kept for exhaustiveness, and because the
+            // variant is the shape a finished plan would arrive in.
             AgentThreadEntry::CompletedPlan(entries) => (
                 Projected::Other,
                 vec![SessionDelta::PlanUpdated {
@@ -687,43 +804,98 @@ impl SessionProjection {
 
         match (projected, entry) {
             (Projected::Assistant { runs }, AgentThreadEntry::AssistantMessage(message)) => {
-                let current = project::runs(&message.chunks);
+                // Spans, not text: one `EntryUpdated` arrives per streamed
+                // chunk, and rebuilding the message's whole text to find out
+                // what is new costs the entire message on every token of it
+                // (ATL-223). A run only grows at its end, so a byte length is
+                // enough to locate the new part.
+                let spans = project::run_spans(&message.chunks);
                 let mut deltas = Vec::new();
-                for (run_ix, run) in current.iter().enumerate() {
+                for (run_ix, span) in spans.iter().enumerate() {
+                    let len = project::run_span_len(&message.chunks, span);
                     match runs.get_mut(run_ix) {
-                        Some(projected) if projected.is_thought == run.is_thought => {
-                            // Text only ever grows; a rewrite would mean the
-                            // agent replaced what it already said, which the
-                            // wire has no way to express.
-                            let Some(suffix) = run.text.strip_prefix(projected.text.as_str())
+                        Some(projected) if projected.is_thought == span.is_thought => {
+                            match projected.message_id.clone() {
+                                Some(message_id) => {
+                                    // A shrink would mean the agent replaced
+                                    // what it already said, which the wire has
+                                    // no way to express.
+                                    if len <= projected.text_len {
+                                        continue;
+                                    }
+                                    let Some(delta) = project::run_span_tail(
+                                        &message.chunks,
+                                        span,
+                                        projected.text_len,
+                                    ) else {
+                                        continue;
+                                    };
+                                    if delta.is_empty() {
+                                        continue;
+                                    }
+                                    projected.text_len = len;
+                                    deltas.push(if span.is_thought {
+                                        SessionDelta::ThinkingChunk { message_id, delta }
+                                    } else {
+                                        SessionDelta::TextChunk { message_id, delta }
+                                    });
+                                }
+                                // Held back as empty (ATL-224), and now it has
+                                // something to render. This is its first
+                                // announcement, so it is a whole message rather
+                                // than a chunk appended to one nobody has.
+                                None => {
+                                    if len == 0 {
+                                        continue;
+                                    }
+                                    let Some(text) =
+                                        project::run_span_tail(&message.chunks, span, 0)
+                                    else {
+                                        continue;
+                                    };
+                                    let message_id = new_message_id();
+                                    deltas.push(SessionDelta::MessageAppended {
+                                        message: project::run_message(
+                                            message_id.clone(),
+                                            &project::Run {
+                                                is_thought: span.is_thought,
+                                                text,
+                                            },
+                                            self.model.clone(),
+                                            chrono::Utc::now(),
+                                        ),
+                                    });
+                                    projected.message_id = Some(message_id);
+                                    projected.text_len = len;
+                                }
+                            }
+                        }
+                        _ => {
+                            let Some(text) = project::run_span_tail(&message.chunks, span, 0)
                             else {
                                 continue;
                             };
-                            if suffix.is_empty() {
-                                continue;
-                            }
-                            let delta = suffix.to_string();
-                            let message_id = projected.message_id.clone();
-                            projected.text = run.text.clone();
-                            deltas.push(if run.is_thought {
-                                SessionDelta::ThinkingChunk { message_id, delta }
+                            let announced = if text.is_empty() {
+                                None
                             } else {
-                                SessionDelta::TextChunk { message_id, delta }
-                            });
-                        }
-                        _ => {
-                            let message_id = new_message_id();
-                            deltas.push(SessionDelta::MessageAppended {
-                                message: project::run_message(
-                                    message_id.clone(),
-                                    run,
-                                    self.model.clone(),
-                                ),
-                            });
+                                let message_id = new_message_id();
+                                deltas.push(SessionDelta::MessageAppended {
+                                    message: project::run_message(
+                                        message_id.clone(),
+                                        &project::Run {
+                                            is_thought: span.is_thought,
+                                            text,
+                                        },
+                                        self.model.clone(),
+                                        chrono::Utc::now(),
+                                    ),
+                                });
+                                Some(message_id)
+                            };
                             let projected_run = ProjectedRun {
-                                message_id,
-                                is_thought: run.is_thought,
-                                text: run.text.clone(),
+                                message_id: announced,
+                                is_thought: span.is_thought,
+                                text_len: len,
                             };
                             match runs.get_mut(run_ix) {
                                 Some(slot) => *slot = projected_run,
@@ -741,7 +913,40 @@ impl SessionProjection {
                 },
                 AgentThreadEntry::ToolCall(call),
             ) => {
-                let current = project::tool_call(call, &thread);
+                // Fast path: nothing but the result changed, and the result is
+                // one terminal's output that only grew. Building `current` to
+                // discover that costs a copy of everything the command has
+                // printed so far — on every chunk it prints, with the session's
+                // lock held — which is what let a chatty command stall the
+                // whole session (ATL-219).
+                let meta = project::tool_call_meta(call);
+                if tool_call_meta_eq(snapshot, &meta) {
+                    if let Some(terminal_id) = project::sole_terminal(&call.content) {
+                        let emitted = snapshot.result.as_deref().unwrap_or_default().len();
+                        match thread.terminal_output_appended(terminal_id, emitted) {
+                            Some(TerminalAppend::Unchanged) => return Vec::new(),
+                            // A first result stays a full snapshot, as on the
+                            // slow path below: a consumer that ignores chunks
+                            // must still see the tool call's content announced
+                            // at least once.
+                            Some(TerminalAppend::Grew(suffix)) if emitted > 0 => {
+                                let delta = SessionDelta::ToolCallOutputChunk {
+                                    message_id: message_id.clone(),
+                                    tool_call_id: snapshot.id.clone(),
+                                    delta: suffix.clone(),
+                                };
+                                snapshot
+                                    .result
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&suffix);
+                                return vec![delta];
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                let mut current = meta;
+                current.result = project::tool_result(&call.content, &thread);
                 let delta = tool_call_delta(message_id, snapshot, &current);
                 **snapshot = current;
                 delta.into_iter().collect()
@@ -836,7 +1041,14 @@ impl SessionProjection {
     fn plan_deltas(&mut self) -> Vec<SessionDelta> {
         let plan = project::plan_entries(&lock_thread(&self.thread).plan().entries);
         let fingerprint = serde_json::to_value(&plan).unwrap_or(serde_json::Value::Null);
-        if plan.is_empty() || self.plan == Some(fingerprint.clone()) {
+        // An empty plan is only silence when nothing has been announced yet.
+        // Skipping every empty plan meant an agent that CLEARED its plan never
+        // said so, and the UI kept rendering a card full of steps the agent had
+        // abandoned (ATL-222).
+        if self.plan.is_none() && plan.is_empty() {
+            return Vec::new();
+        }
+        if self.plan == Some(fingerprint.clone()) {
             return Vec::new();
         }
         self.plan = Some(fingerprint);
@@ -922,21 +1134,20 @@ impl SessionProjection {
 /// quadratic in its output. When nothing but the result's tail changed, the
 /// tail alone goes on the wire; everything else is a full snapshot, because the
 /// UI never merges fields.
+///
+/// That is a claim about the WIRE only, and for a long time it was the whole
+/// claim: reaching this function at all meant the caller had already rebuilt
+/// the entire result and was about to compare it string-for-string, so the
+/// projection stayed quadratic while the bytes on the wire did not (ATL-219).
+/// The caller in `update_entry` now answers the common case — one terminal,
+/// output that only grew — without building anything, and only falls through to
+/// here when it cannot.
 fn tool_call_delta(
     message_id: &str,
     previous: &ToolCall,
     current: &ToolCall,
 ) -> Option<SessionDelta> {
-    let same_except_result = previous.status == current.status
-        && previous.title == current.title
-        && previous.kind == current.kind
-        && previous.tool_name == current.tool_name
-        && previous.arguments == current.arguments
-        && previous.locations == current.locations
-        && previous.raw_output == current.raw_output
-        && previous.content_blocks == current.content_blocks;
-
-    if same_except_result {
+    if tool_call_meta_eq(previous, current) {
         let previous_result = previous.result.as_deref().unwrap_or_default();
         let current_result = current.result.as_deref().unwrap_or_default();
         if previous_result == current_result {
@@ -964,6 +1175,23 @@ fn tool_call_delta(
         message_id: message_id.to_string(),
         tool_call: current.clone(),
     })
+}
+
+/// Whether two projections of a tool call agree on everything but the result.
+///
+/// The result is the only field whose size grows with what a command printed,
+/// so it is the only one worth streaming — and the only one worth measuring
+/// before deciding to. Shared with the incremental path in `update_entry`, so
+/// the two cannot disagree about what "only the output changed" means.
+fn tool_call_meta_eq(previous: &ToolCall, current: &ToolCall) -> bool {
+    previous.status == current.status
+        && previous.title == current.title
+        && previous.kind == current.kind
+        && previous.tool_name == current.tool_name
+        && previous.arguments == current.arguments
+        && previous.locations == current.locations
+        && previous.raw_output == current.raw_output
+        && previous.content_blocks == current.content_blocks
 }
 
 /// `LoadError`'s own `Display` is the reason text, so the wire carries exactly

--- a/crates/atlas-agent-delta/tests/projection.rs
+++ b/crates/atlas-agent-delta/tests/projection.rs
@@ -988,3 +988,568 @@ async fn the_host_announces_config_options_the_set_response_confirmed() {
         other => panic!("expected config options, got {other:?}"),
     }
 }
+
+// ------------------------------------------------- display-only terminals
+//
+// The shape ATL-219 is about: a terminal the AGENT runs and streams to us as
+// `session/update` meta. It has no PTY of its own, so everything it will ever
+// show arrives through `TerminalProviderEvent::Output`.
+
+fn display_only_terminal(harness: &Harness, terminal_id: &str) {
+    lock(&harness.thread).on_terminal_provider_event(
+        atlas_acp_thread::TerminalProviderEvent::Created {
+            terminal_id: acp::TerminalId::new(terminal_id),
+            label: "agent-run".into(),
+            cwd: None,
+            output_byte_limit: None,
+            terminal: None,
+        },
+    );
+}
+
+fn push_output(harness: &Harness, terminal_id: &str, data: &[u8]) {
+    lock(&harness.thread).on_terminal_provider_event(
+        atlas_acp_thread::TerminalProviderEvent::Output {
+            terminal_id: acp::TerminalId::new(terminal_id),
+            data: data.to_vec(),
+        },
+    );
+    harness.pump();
+}
+
+/// The deltas emitted since `from`.
+fn since(harness: &Harness, from: usize) -> Vec<SessionDelta> {
+    harness.recorder.deltas().into_iter().skip(from).collect()
+}
+
+/// Regression, ATL-219. Every output chunk re-projected the tool call from
+/// scratch — which meant decoding and copying everything the command had
+/// printed so far, then comparing it byte for byte against the previous copy,
+/// with the session's lock held. The cost per chunk grew with the total, so a
+/// command's projection was quadratic in its own output and 2 MB of it stalled
+/// the session for about four seconds.
+///
+/// What is asserted here is the *shape* the cheap path produces: exactly one
+/// delta, carrying exactly the new bytes. `a_growing_terminal_costs_the_tail`
+/// measures the cost itself.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_growing_display_only_terminal_streams_only_its_tail() {
+    let harness = Harness::start();
+
+    display_only_terminal(&harness, "term-tail");
+    push_output(&harness, "term-tail", b"first");
+    harness.update(terminal_tool_call("call-tail", "term-tail"));
+    harness.expect(1);
+    let before = harness.recorder.len();
+
+    push_output(&harness, "term-tail", b"-second");
+
+    let new = since(&harness, before);
+    assert_eq!(
+        new.len(),
+        1,
+        "one chunk of output should be one delta: {:?}",
+        harness.recorder.kinds()
+    );
+    match &new[0] {
+        SessionDelta::ToolCallOutputChunk { delta, .. } => assert_eq!(delta, "-second"),
+        other => panic!("expected only the tail on the wire, got {other:?}"),
+    }
+}
+
+/// The guard on the cheap path. Once the buffer starts dropping its front, a
+/// byte offset from an earlier read names different bytes than it did — and
+/// `terminal_output` prefixes a truncation marker, which moves everything
+/// again. Streaming a tail against that offset would ship garbage, so the
+/// projection has to fall back to announcing the whole tool call.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_truncating_terminal_falls_back_to_a_whole_snapshot() {
+    let harness = Harness::start();
+
+    lock(&harness.thread).on_terminal_provider_event(
+        atlas_acp_thread::TerminalProviderEvent::Created {
+            terminal_id: acp::TerminalId::new("term-trunc"),
+            label: "agent-run".into(),
+            cwd: None,
+            output_byte_limit: Some(8),
+            terminal: None,
+        },
+    );
+    push_output(&harness, "term-trunc", b"12345678");
+    harness.update(terminal_tool_call("call-trunc", "term-trunc"));
+    harness.expect(1);
+    let before = harness.recorder.len();
+
+    push_output(&harness, "term-trunc", b"ABCD");
+
+    let new = since(&harness, before);
+    let result = match new.last() {
+        Some(SessionDelta::ToolCallUpserted { tool_call, .. }) => tool_call
+            .result
+            .clone()
+            .expect("the tool call carries its output"),
+        other => panic!("a truncated buffer must re-announce the whole call, got {other:?}"),
+    };
+    assert!(
+        result.starts_with("[earlier output dropped]"),
+        "the wire has to admit the buffer dropped its front: {result:?}"
+    );
+    assert!(
+        result.ends_with("5678ABCD"),
+        "the retained window is the most recent bytes: {result:?}"
+    );
+}
+
+/// Output arrives as bytes, and a chunk boundary can land in the middle of a
+/// character. Serving a tail by byte offset must never cut one in half — the
+/// offset the projection holds is a length it was told, not one it validated.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_character_split_across_two_chunks_survives_the_tail_path() {
+    let harness = Harness::start();
+
+    display_only_terminal(&harness, "term-utf8");
+    push_output(&harness, "term-utf8", b"start");
+    harness.update(terminal_tool_call("call-utf8", "term-utf8"));
+    harness.expect(1);
+
+    // '🙂' is four bytes; send it two at a time.
+    let smiley = "🙂".as_bytes();
+    push_output(&harness, "term-utf8", &smiley[..2]);
+    push_output(&harness, "term-utf8", &smiley[2..]);
+
+    let assembled: String = harness
+        .recorder
+        .deltas()
+        .into_iter()
+        .filter_map(|delta| match delta {
+            SessionDelta::ToolCallUpserted { tool_call, .. } => tool_call.result,
+            SessionDelta::ToolCallOutputChunk { delta, .. } => Some(delta),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        assembled, "start🙂",
+        "a character split across chunks came through mangled"
+    );
+}
+
+/// Regression, ATL-223. A streamed assistant message rebuilt and re-compared
+/// its whole text on every chunk. The wire shape is unchanged — this pins that
+/// the length-based tail finds the same suffix the full-string comparison did,
+/// including across a block whose rendering changes kind mid-run.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_run_that_changes_block_kind_still_streams_its_tail() {
+    let harness = Harness::start();
+
+    harness.update(serde_json::json!({
+        "sessionUpdate": "agent_message_chunk",
+        "content": { "type": "resource_link", "uri": "file:///tmp/a.rs", "name": "a.rs" },
+    }));
+    harness.update(text_chunk("and here is why"));
+    harness.expect(2);
+
+    assert_eq!(harness.recorder.kinds(), ["message_appended", "text_chunk"]);
+    let assembled: String = harness
+        .recorder
+        .deltas()
+        .into_iter()
+        .filter_map(|delta| match delta {
+            SessionDelta::MessageAppended { message } => Some(message.content),
+            SessionDelta::TextChunk { delta, .. } => Some(delta),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        assembled, "file:///tmp/a.rs\nand here is why",
+        "the streamed tail does not reassemble into the run's text"
+    );
+}
+
+/// Regression, ATL-221. `snapshot_messages` read the clock while it built each
+/// message, so a snapshot of a past conversation reported every message as sent
+/// at the moment it was taken — and two snapshots of a thread nobody had
+/// touched disagreed with each other. The frontend computes turn durations and
+/// "N ago" separators from these values, so the collapse was functional, not
+/// cosmetic.
+#[tokio::test(flavor = "multi_thread")]
+async fn two_snapshots_of_an_unchanged_thread_carry_the_same_times() {
+    let harness = Harness::start();
+
+    lock(&harness.thread).push_user_content_block(
+        None,
+        acp::ContentBlock::Text(acp::TextContent::new("do the thing".to_string())),
+    );
+    harness.update(text_chunk("on it"));
+
+    let first = atlas_agent_delta::project::snapshot_messages(&lock(&harness.thread), None);
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let second = atlas_agent_delta::project::snapshot_messages(&lock(&harness.thread), None);
+
+    assert_eq!(first.len(), 2, "the snapshot is the whole conversation");
+    let firsts: Vec<_> = first.iter().map(|m| m.timestamp).collect();
+    let seconds: Vec<_> = second.iter().map(|m| m.timestamp).collect();
+    assert_eq!(
+        firsts, seconds,
+        "reading the same unchanged thread twice produced different times"
+    );
+}
+
+/// The half of ATL-221 that the UI actually renders: the gap between two
+/// messages. Minted at read time they all collapse to the same instant, so a
+/// reopened conversation shows every pause as zero.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_pause_between_two_messages_survives_into_the_snapshot() {
+    let harness = Harness::start();
+
+    lock(&harness.thread).push_user_content_block(
+        None,
+        acp::ContentBlock::Text(acp::TextContent::new("first".to_string())),
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    // A second user chunk would merge into the same entry — consecutive
+    // same-kind chunks are one message. The reply is what opens a new one.
+    harness.update(text_chunk("second"));
+
+    let messages = atlas_agent_delta::project::snapshot_messages(&lock(&harness.thread), None);
+    let gap = messages[1].timestamp - messages[0].timestamp;
+    assert!(
+        gap.num_milliseconds() >= 10,
+        "the pause between the two messages was flattened to {gap}"
+    );
+}
+
+/// Regression, ATL-222. The empty-plan guard was written to suppress a FIRST
+/// empty plan; it suppressed every clear as well, so an agent that abandoned
+/// its plan never said so and the UI kept a card full of steps that no longer
+/// existed.
+#[tokio::test(flavor = "multi_thread")]
+async fn clearing_a_plan_is_announced() {
+    let harness = Harness::start();
+
+    harness.update(serde_json::json!({
+        "sessionUpdate": "plan",
+        "entries": [{ "content": "step one", "priority": "high", "status": "pending" }],
+    }));
+    harness.expect(1);
+    let before = harness.recorder.len();
+
+    harness.update(serde_json::json!({ "sessionUpdate": "plan", "entries": [] }));
+
+    let new = since(&harness, before);
+    match new.first() {
+        Some(SessionDelta::PlanUpdated { plan }) => assert!(
+            plan.is_empty(),
+            "the clear has to carry an empty plan, got {plan:?}"
+        ),
+        other => panic!("clearing a plan said nothing on the wire: {other:?}"),
+    }
+}
+
+/// The behaviour the original guard was protecting, kept. An agent that has
+/// never announced a plan and reports an empty one is describing the status
+/// quo, and a `plan_updated` for it would make the UI redraw nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_first_empty_plan_still_says_nothing() {
+    let harness = Harness::start();
+
+    harness.update(serde_json::json!({ "sessionUpdate": "plan", "entries": [] }));
+    harness.pump();
+
+    assert!(
+        !harness.recorder.kinds().contains(&"plan_updated".to_string()),
+        "an empty plan nobody had announced produced a delta: {:?}",
+        harness.recorder.kinds()
+    );
+}
+
+/// Regression, ATL-224. An assistant chunk carrying only an image flattens to
+/// the empty string. The live stream announced a message for it anyway while
+/// the snapshot skipped it, so the same conversation had a blank bubble before
+/// a reload and no bubble after one.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_image_only_assistant_turn_is_absent_from_both_the_stream_and_the_snapshot() {
+    let harness = Harness::start();
+
+    harness.update(serde_json::json!({
+        "sessionUpdate": "agent_message_chunk",
+        "content": { "type": "image", "mimeType": "image/png", "data": "iVBORw0KGgo=" },
+    }));
+    harness.pump();
+
+    assert!(
+        !harness
+            .recorder
+            .kinds()
+            .contains(&"message_appended".to_string()),
+        "an image-only turn put a blank bubble on the wire: {:?}",
+        harness.recorder.kinds()
+    );
+    let snapshot = atlas_agent_delta::project::snapshot_messages(&lock(&harness.thread), None);
+    assert!(
+        snapshot.is_empty(),
+        "the snapshot and the stream disagree: {snapshot:?}"
+    );
+}
+
+/// The other half of ATL-224: a run held back as empty is not lost. The moment
+/// it has something to render it is announced as a whole message, because
+/// nobody has one to append a chunk to.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_run_held_back_as_empty_is_announced_once_it_has_text() {
+    let harness = Harness::start();
+
+    harness.update(serde_json::json!({
+        "sessionUpdate": "agent_message_chunk",
+        "content": { "type": "image", "mimeType": "image/png", "data": "iVBORw0KGgo=" },
+    }));
+    harness.update(text_chunk("here is what it shows"));
+    harness.expect(1);
+
+    assert_eq!(harness.recorder.kinds(), ["message_appended"]);
+    match &harness.recorder.deltas()[0] {
+        SessionDelta::MessageAppended { message } => assert!(
+            message.content.ends_with("here is what it shows"),
+            "the text that made the run renderable is missing: {:?}",
+            message.content
+        ),
+        other => panic!("expected a whole message, got {other:?}"),
+    }
+}
+
+// ------------------------------------------------------ retention (ATL-225)
+
+/// A permission prompt, opened on `call_id`. Returns the waiter so the caller
+/// controls when — or whether — it is answered.
+fn open_permission(harness: &Harness, call_id: &str) {
+    harness.update(serde_json::json!({
+        "sessionUpdate": "tool_call",
+        "toolCallId": call_id,
+        "title": "Write a.txt",
+        "kind": "edit",
+        "status": "pending",
+        "rawInput": { "path": "a.txt" },
+    }));
+    let _waiter = lock(&harness.thread)
+        .request_tool_call_authorization(
+            acp::ToolCallUpdate::new(
+                acp::ToolCallId::new(call_id),
+                acp::ToolCallUpdateFields::default(),
+            ),
+            PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                "allow_once",
+                "Allow once",
+                acp::PermissionOptionKind::AllowOnce,
+            )]),
+            AuthorizationKind::PermissionGrant,
+        )
+        .expect("the prompt opens");
+    harness.pump();
+}
+
+/// Regression, ATL-225 finding 1. `permissions` and `elicitations` are keyed by
+/// wire request id and had no removal anywhere in the file. The projector is a
+/// process-lifetime Tauri singleton, so every prompt the app had ever shown
+/// stayed routable — and retained — for as long as Atlas ran.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_session_whose_stream_ends_leaves_no_routes_behind() {
+    let recorder = Arc::new(Recorder::default());
+    let projector = DeltaProjector::new(recorder.clone());
+    let session_id = acp::SessionId::new("sess-closing");
+
+    let events = (projector.thread_events())(&session_id);
+    let thread = Arc::new(Mutex::new(AcpThread::new(
+        session_id.clone(),
+        Arc::new(StubConnection) as Arc<dyn AgentConnection>,
+        vec![PathBuf::from("/tmp")],
+        None,
+        events,
+    )));
+    projector.attach(AgentId::new(), thread.clone());
+
+    lock(&thread)
+        .handle_session_update(
+            serde_json::from_value(serde_json::json!({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "call-1",
+                "title": "Write a.txt",
+                "kind": "edit",
+                "status": "pending",
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    let waiter = lock(&thread)
+        .request_tool_call_authorization(
+            acp::ToolCallUpdate::new(
+                acp::ToolCallId::new("call-1"),
+                acp::ToolCallUpdateFields::default(),
+            ),
+            PermissionOptions::Flat(vec![acp::PermissionOption::new(
+                "allow_once",
+                "Allow once",
+                acp::PermissionOptionKind::AllowOnce,
+            )]),
+            AuthorizationKind::PermissionGrant,
+        )
+        .expect("the prompt opens");
+
+    await_until("the prompt was routed", || {
+        projector.routing_table_sizes().0 == 1
+    })
+    .await;
+
+    // Closing is told, not noticed: the projection holds the only strong handle
+    // on the thread, and the thread holds the sender, so waiting for the stream
+    // to end would wait forever.
+    drop(waiter);
+    projector.close_session(&session_id);
+    assert_eq!(
+        projector.routing_table_sizes(),
+        (0, 0),
+        "a closed session left its permission routes behind"
+    );
+    assert_eq!(
+        Arc::strong_count(&thread),
+        1,
+        "the closed session's thread is still held, and with it its terminals"
+    );
+}
+
+/// Regression, ATL-225 finding 2. A session's event stream is pre-registered
+/// before its `session/load` RPC runs, so replayed history is not dropped. When
+/// that RPC fails nothing takes the stream back out, and the key stayed for the
+/// life of the process.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stream_for_a_session_that_never_opened_is_swept() {
+    let recorder = Arc::new(Recorder::default());
+    let projector = DeltaProjector::new(recorder.clone());
+
+    // A load that failed: the sink was handed out, the thread that would have
+    // owned it was dropped with the error, and `register` was never called.
+    let orphan = (projector.thread_events())(&acp::SessionId::new("sess-failed"));
+    assert_eq!(projector.pending_len(), 1);
+    drop(orphan);
+
+    // The next session opened sweeps it, because that is the one moment the
+    // projector learns anything about session lifetimes.
+    let _live = (projector.thread_events())(&acp::SessionId::new("sess-next"));
+    assert_eq!(
+        projector.pending_len(),
+        1,
+        "the failed session's stream was retained alongside the live one"
+    );
+}
+
+/// Regression, ATL-225 finding 4. A rewind removes entries from the thread, and
+/// a tool call that goes away takes its permission prompt with it. Without
+/// clearing the route the frontend keeps a modal open on a tool call that no
+/// longer exists, answerable by nobody — the stranding shape of ATL-213, one
+/// layer up.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_rewind_resolves_the_permission_prompt_it_removes() {
+    let harness = Harness::start();
+
+    lock(&harness.thread).push_user_content_block(
+        None,
+        acp::ContentBlock::Text(acp::TextContent::new("go".to_string())),
+    );
+    open_permission(&harness, "call-rewound");
+    let before = harness.recorder.len();
+
+    lock(&harness.thread).remove_entries_from(0);
+    harness.pump();
+
+    let new = since(&harness, before);
+    assert!(
+        new.iter()
+            .any(|delta| matches!(delta, SessionDelta::PermissionResolved { .. })),
+        "the prompt was left open on a tool call that no longer exists: {new:?}"
+    );
+    assert!(
+        new.iter()
+            .any(|delta| matches!(delta, SessionDelta::HistoryRewound { .. })),
+        "the rewind itself still has to reach the wire: {new:?}"
+    );
+}
+
+/// Poll `check` until it holds, or fail. The projecting task runs on its own
+/// task, so these tests wait on it rather than assuming a scheduling order.
+async fn await_until(what: &str, check: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if check() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    panic!("timed out waiting until {what}");
+}
+
+// ------------------------------------------------------------- cost (ATL-219)
+//
+// Ignored by default: these measure time, and a machine under load is not a
+// regression. They are kept rather than deleted because the acceptance criteria
+// for ATL-219 and ATL-223 are about how cost SCALES, and a benchmark that no
+// longer exists cannot be re-run against a later change.
+//
+//     cargo test -p atlas-agent-delta --release -- --ignored --nocapture
+
+/// Drive `chunks` output chunks of `chunk_len` bytes through a display-only
+/// terminal's tool call, and return how long the projection took.
+async fn time_terminal_projection(chunks: usize, chunk_len: usize) -> std::time::Duration {
+    let harness = Harness::start();
+    display_only_terminal(&harness, "bench");
+    push_output(&harness, "bench", b"x");
+    harness.update(terminal_tool_call("call-bench", "bench"));
+    harness.pump();
+
+    let payload = vec![b'y'; chunk_len];
+    let start = std::time::Instant::now();
+    for _ in 0..chunks {
+        push_output(&harness, "bench", &payload);
+    }
+    start.elapsed()
+}
+
+/// ATL-219. Every chunk used to rebuild and re-compare the whole accumulated
+/// output, so five times the chunks cost about twenty times the time. The fix
+/// makes each chunk cost its own length, so total time grows with the number of
+/// chunks and not with their sum.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "timing, not correctness"]
+async fn a_growing_terminal_costs_the_tail() {
+    let small = time_terminal_projection(1_000, 200).await;
+    let large = time_terminal_projection(5_000, 200).await;
+    let ratio = large.as_secs_f64() / small.as_secs_f64();
+    println!(
+        "terminal: 1000 chunks {small:?}, 5000 chunks {large:?}, ratio {ratio:.2} (linear is 5)"
+    );
+    assert!(
+        ratio < 10.0,
+        "five times the output cost {ratio:.1}x the time; the projection is still superlinear"
+    );
+}
+
+/// ATL-223, the same shape one file over: streamed assistant text used to be
+/// rebuilt, compared and cloned in full on every token.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "timing, not correctness"]
+async fn streamed_text_costs_the_tail() {
+    async fn run(chunks: usize) -> std::time::Duration {
+        let harness = Harness::start();
+        harness.update(text_chunk("start"));
+        let piece = "z".repeat(200);
+        let start = std::time::Instant::now();
+        for _ in 0..chunks {
+            harness.update(text_chunk(&piece));
+        }
+        start.elapsed()
+    }
+    let small = run(1_000).await;
+    let large = run(5_000).await;
+    let ratio = large.as_secs_f64() / small.as_secs_f64();
+    println!("text: 1000 chunks {small:?}, 5000 chunks {large:?}, ratio {ratio:.2} (linear is 5)");
+    assert!(
+        ratio < 10.0,
+        "five times the text cost {ratio:.1}x the time; streaming is still superlinear"
+    );
+}

--- a/crates/atlas-terminal/src/command.rs
+++ b/crates/atlas-terminal/src/command.rs
@@ -58,7 +58,15 @@ pub struct CommandExit {
 /// cap and the same boundary walk, and reimplementing either is how they drift.
 #[derive(Debug)]
 pub struct OutputBuffer {
-    bytes: Vec<u8>,
+    /// The decoded window. Held as text rather than bytes so a reader can
+    /// borrow it: flattening a terminal into a tool call's result happens on
+    /// every output chunk, and decoding the whole buffer each time is what made
+    /// that cost quadratic in what the command had printed (ATL-219).
+    text: String,
+    /// Trailing bytes that may be the start of a character whose remaining
+    /// bytes have not arrived yet. Decoding them now would put a replacement
+    /// char in the window that the next chunk would have completed.
+    pending: Vec<u8>,
     limit: usize,
     truncated: bool,
 }
@@ -66,7 +74,8 @@ pub struct OutputBuffer {
 impl OutputBuffer {
     pub fn new(limit: u64) -> Self {
         Self {
-            bytes: Vec::new(),
+            text: String::new(),
+            pending: Vec::new(),
             // Saturating: `u64::MAX` from a careless agent must clamp, not wrap
             // to a tiny buffer on 32-bit.
             limit: usize::try_from(limit).unwrap_or(usize::MAX),
@@ -75,29 +84,43 @@ impl OutputBuffer {
     }
 
     pub fn push(&mut self, chunk: &[u8]) {
-        self.bytes.extend_from_slice(chunk);
-        if self.bytes.len() <= self.limit {
+        self.pending.extend_from_slice(chunk);
+        let hold = incomplete_tail_len(&self.pending);
+        let split = self.pending.len() - hold;
+        if split > 0 {
+            self.text
+                .push_str(&String::from_utf8_lossy(&self.pending[..split]));
+            self.pending.drain(..split);
+        }
+        if self.text.len() <= self.limit {
             return;
         }
         self.truncated = true;
-        // Drop from the front, then walk forward off any UTF-8 continuation
-        // byte (`0b10xxxxxx`). Slicing on a raw byte offset would cut a
-        // multi-byte character in half and every later read would show a
-        // replacement char at the head of the window.
-        let mut cut = self.bytes.len() - self.limit;
-        while cut < self.bytes.len() && (self.bytes[cut] & 0b1100_0000) == 0b1000_0000 {
+        // Drop from the front, then walk forward to the next character
+        // boundary. Slicing on a raw byte offset would cut a multi-byte
+        // character in half and every later read would show a replacement char
+        // at the head of the window.
+        let mut cut = self.text.len() - self.limit;
+        while cut < self.text.len() && !self.text.is_char_boundary(cut) {
             cut += 1;
         }
-        self.bytes.drain(..cut);
+        self.text.drain(..cut);
     }
 
-    /// The retained window as a string. Lossy by necessity — a command may emit
-    /// genuinely non-UTF-8 bytes (a binary blob, a latin-1 log) and ACP's
-    /// `output` field is a string, so there is nothing else to return. The
-    /// boundary walk in [`Self::push`] means truncation itself never
-    /// manufactures a replacement character; anything here came from the child.
-    pub fn text(&self) -> String {
-        String::from_utf8_lossy(&self.bytes).into_owned()
+    /// The retained window.
+    ///
+    /// Lossy by necessity — a command may emit genuinely non-UTF-8 bytes (a
+    /// binary blob, a latin-1 log) and ACP's `output` field is a string, so
+    /// there is nothing else to return. The boundary walk in [`Self::push`]
+    /// means truncation itself never manufactures a replacement character;
+    /// anything here came from the child.
+    ///
+    /// A partially-arrived character at the very end is not shown until the
+    /// rest of it lands. That is a character appearing one chunk late rather
+    /// than a replacement char that later vanishes, and it is why the window
+    /// can be decoded once on write instead of on every read.
+    pub fn text(&self) -> &str {
+        &self.text
     }
 
     /// Whether anything has been dropped from the front. Sticky: once a buffer
@@ -107,13 +130,41 @@ impl OutputBuffer {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.bytes.is_empty()
+        self.text.is_empty()
     }
 
     /// Retained bytes. Used to account for a buffer's cost from outside.
     pub fn len(&self) -> usize {
-        self.bytes.len()
+        self.text.len()
     }
+}
+
+/// How many trailing bytes are the start of a character that has not fully
+/// arrived, and so must not be decoded yet.
+///
+/// A UTF-8 character is at most four bytes, so only the last three can be
+/// waiting on more. Anything that is not a lead byte in that window — a stray
+/// continuation byte, an invalid byte — is genuinely malformed and is decoded
+/// now, so a corrupt stream cannot wedge the buffer.
+fn incomplete_tail_len(bytes: &[u8]) -> usize {
+    let len = bytes.len();
+    for back in 1..=3.min(len) {
+        let byte = bytes[len - back];
+        if byte & 0b1100_0000 == 0b1000_0000 {
+            continue;
+        }
+        let needed = match byte {
+            0x00..=0x7f => 1,
+            0xc0..=0xdf => 2,
+            0xe0..=0xef => 3,
+            0xf0..=0xf7 => 4,
+            // Not a lead byte at all: malformed, and no amount of waiting
+            // makes it valid.
+            _ => return 0,
+        };
+        return if back < needed { back } else { 0 };
+    }
+    0
 }
 
 /// Shared state for one running (or finished) command.
@@ -226,9 +277,25 @@ impl CommandTerminal {
     /// Output retained so far, and whether anything was dropped from the front.
     pub fn output(&self) -> (String, bool) {
         match self.inner.output.lock() {
-            Ok(out) => (out.text(), out.truncated),
+            Ok(out) => (out.text().to_string(), out.truncated),
             Err(_) => (String::new(), false),
         }
+    }
+
+    /// Run `f` over the retained output without copying it.
+    ///
+    /// `None` when the buffer has dropped its front, because a caller holding a
+    /// byte offset into an earlier read can no longer trust that the offset
+    /// names the same position. Such a caller re-reads the whole window through
+    /// [`Self::output`]; this exists so the case where nothing was dropped —
+    /// the common one — costs a lock and nothing else (ATL-219).
+    pub fn with_untruncated_output<R>(&self, f: impl FnOnce(&str) -> R) -> Option<R> {
+        let out = self
+            .inner
+            .output
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        (!out.truncated).then(|| f(out.text()))
     }
 
     /// `Some` once the command has exited.
@@ -513,6 +580,41 @@ mod tests {
                 "limit {limit} split a character: {text:?}"
             );
         }
+    }
+
+    /// The buffer decodes on write so a reader can borrow the window instead of
+    /// rebuilding it (ATL-219). That only holds up if a character split across
+    /// two reads still arrives whole — a PTY read boundary lands wherever the
+    /// kernel put it, not where a character ends.
+    #[test]
+    fn a_character_split_across_two_pushes_is_not_mangled() {
+        let smiley = "🙂".as_bytes();
+        for split in 1..smiley.len() {
+            let mut buf = OutputBuffer::new(64);
+            buf.push(&smiley[..split]);
+            assert!(
+                !buf.text().contains('\u{FFFD}'),
+                "split at {split} decoded a partial character early: {:?}",
+                buf.text()
+            );
+            buf.push(&smiley[split..]);
+            assert_eq!(buf.text(), "🙂", "split at {split} lost the character");
+        }
+    }
+
+    /// The hold-back is bounded: bytes that cannot be the start of any
+    /// character are decoded now, so a corrupt stream cannot wedge the buffer
+    /// into never showing anything again.
+    #[test]
+    fn malformed_trailing_bytes_do_not_wedge_the_buffer() {
+        let mut buf = OutputBuffer::new(64);
+        buf.push(&[b'o', b'k', 0xff]);
+        assert!(
+            buf.text().starts_with("ok"),
+            "a stray byte held back everything after it: {:?}",
+            buf.text()
+        );
+        assert_eq!(buf.text().chars().count(), 3);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -775,6 +775,13 @@ impl AgentHost {
         if let Some(history) = self.history() {
             history.forget(&acp::SessionId::new(session_id));
         }
+        // The projector holds the session's only strong thread handle, so
+        // nothing else can release it — and its permission and elicitation
+        // routes are keyed by wire request id with no other removal path
+        // (ATL-225). Before `close_session` so the thread and its terminals are
+        // dropped whether or not the agent's own close RPC succeeds.
+        self.projector
+            .close_session(&acp::SessionId::new(session_id));
         self.manager
             .close_session(&acp::SessionId::new(session_id))
             .await

--- a/src/features/chat/lib/snapshot-message.test.ts
+++ b/src/features/chat/lib/snapshot-message.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { snapshotMessageToWire } from "./snapshot-message";
+import type { SessionMessage } from "@/types/agents";
+
+function message(overrides: Partial<SessionMessage> = {}): SessionMessage {
+  return {
+    id: "msg-0",
+    role: "assistant",
+    mode: "tool",
+    content: "",
+    tool_calls: [],
+    timestamp: "2026-08-30T10:00:00Z",
+    ...overrides,
+  } as SessionMessage;
+}
+
+/**
+ * ATL-220. The Rust snapshot carries each tool call's real id and its real
+ * outcome; this adapter dropped both, and `replaceMessages` then re-minted an
+ * id and hardcoded `"completed"`. Every tool call in a reopened conversation
+ * therefore rendered as succeeded — a failed edit and a rejected command looked
+ * exactly like ones that worked.
+ */
+describe("snapshotMessageToWire", () => {
+  it("carries a failed tool call's status through", () => {
+    const wire = snapshotMessageToWire(
+      message({
+        tool_calls: [
+          {
+            id: "call-1",
+            tool_name: "edit",
+            title: null,
+            kind: "edit",
+            status: "failed",
+            arguments: { path: "a.txt" },
+            result: "boom",
+            locations: [],
+          },
+        ],
+      }),
+    );
+
+    expect(wire.toolCalls[0].status).toBe("failed");
+  });
+
+  it("carries the agent's own tool call id, not a fresh one", () => {
+    const wire = snapshotMessageToWire(
+      message({
+        tool_calls: [
+          {
+            id: "call-42",
+            tool_name: "read",
+            title: null,
+            kind: "read",
+            status: "completed",
+            arguments: {},
+            result: null,
+            locations: [],
+          },
+        ],
+      }),
+    );
+
+    // The id is the key later deltas are matched on (`findToolCall`), so a
+    // re-minted one pushes a duplicate card for a call that is still running.
+    expect(wire.toolCalls[0].id).toBe("call-42");
+  });
+
+  it("keeps every non-completed status distinguishable", () => {
+    for (const status of ["pending", "running", "completed", "failed"] as const) {
+      const wire = snapshotMessageToWire(
+        message({
+          tool_calls: [
+            {
+              id: `call-${status}`,
+              tool_name: "run",
+              title: null,
+              kind: "execute",
+              status,
+              arguments: {},
+              result: null,
+              locations: [],
+            },
+          ],
+        }),
+      );
+      expect(wire.toolCalls[0].status).toBe(status);
+    }
+  });
+});

--- a/src/features/chat/lib/snapshot-message.ts
+++ b/src/features/chat/lib/snapshot-message.ts
@@ -10,6 +10,14 @@ import type { SessionMessage } from "@/types/agents";
  *
  * Carries `result` through so a resumed transcript shows each tool call's output
  * instead of an empty card (the snapshot persists it as `ToolCall.result`).
+ *
+ * Carries `id` and `status` for the same reason. Dropping them here meant
+ * `replaceMessages` had nothing to use and re-minted both, so every tool call in
+ * a reopened conversation rendered as succeeded — a failed edit and a rejected
+ * command looked exactly like ones that worked (ATL-220). The `id` matters
+ * beyond display: it is the key `findToolCall` matches later deltas on, so a
+ * re-minted one would push a duplicate card for a tool call that is still
+ * running when the resume lands.
  */
 export function snapshotMessageToWire(m: SessionMessage) {
   return {
@@ -18,10 +26,12 @@ export function snapshotMessageToWire(m: SessionMessage) {
     timestamp: m.timestamp,
     model: m.model ?? null,
     toolCalls: m.tool_calls.map((tc) => ({
+      id: tc.id,
       toolName: tc.tool_name,
       kind: tc.kind ?? null,
       arguments: (tc.arguments ?? {}) as Record<string, unknown>,
       result: tc.result ?? null,
+      status: tc.status,
     })),
   };
 }

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -16,6 +16,7 @@ import type { PendingPermission } from "@/types/acp";
 import type {
   AgentDelta,
   ToolCall as AgentToolCall,
+  ToolCallStatus,
   ImageAttachment,
   SessionModeInfo,
 } from "@/types/agents";
@@ -395,10 +396,17 @@ interface ChatActions {
          *  per-message badge survives session reloads. */
         model?: string | null;
         toolCalls?: Array<{
+          /** The agent's own tool call id, when the caller has it. Optional
+           *  only because not every paint path carries one; a caller that has
+           *  it MUST pass it — it is the key later deltas are matched on. */
+          id?: string;
           toolName: string;
           kind?: string | null;
           arguments: Record<string, unknown>;
           result?: string | null;
+          /** How the tool call actually ended. Absent means unknown, which is
+           *  the only case that may be assumed completed. */
+          status?: ToolCallStatus;
         }>;
       }>,
     ) => void;
@@ -1212,13 +1220,18 @@ export const useChatStore = createSelectors(
                 id: `msg-${Date.now()}-${i}`,
                 role: m.role,
                 content: m.content,
+                // Keep the agent's own id and outcome when the caller has
+                // them. Re-minting both is what made every tool call in a
+                // resumed transcript render as succeeded, failed ones included
+                // (ATL-220). The fallbacks stand only for a paint path that
+                // genuinely has neither.
                 toolCalls: (m.toolCalls ?? []).map((tc, j) => ({
-                  id: `tc-${Date.now()}-${i}-${j}`,
+                  id: tc.id ?? `tc-${Date.now()}-${i}-${j}`,
                   toolName: tc.toolName,
                   kind: tc.kind ?? null,
                   arguments: tc.arguments,
                   result: tc.result ?? null,
-                  status: "completed" as const,
+                  status: tc.status ?? ("completed" as const),
                   duration: null,
                 })),
                 fileChanges: [],
@@ -1977,11 +1990,15 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       }));
       if (last && last.role === "assistant") {
         last.plan = planSteps;
-      } else {
+      } else if (planSteps.length > 0) {
         const fresh = stampProducingModel(session, makeAssistantTextMessage(""));
         fresh.plan = planSteps;
         session.messages.push(fresh);
       }
+      // A CLEARED plan now reaches here rather than being swallowed by the
+      // backend (ATL-222), and it has nothing to hang on a message that does
+      // not exist — minting an empty assistant bubble to carry an empty plan
+      // would trade the stale card for a blank one.
       // Mirror onto the session so the docked plan panel selects it directly.
       session.livePlan = planSteps;
       return;


### PR DESCRIPTION
### What?

The seven `crates/atlas-agent-delta` findings from ATL-212: ATL-219, ATL-220,
ATL-221, ATL-222, ATL-223, ATL-224 and the ATL-225 rollup.

Two of them (ATL-219, ATL-221) could not be fixed inside the crate, so this also
touches `atlas-terminal` and `atlas-acp-thread`. One (ATL-220) is frontend-only —
the Rust side was already correct.

### Why?

Two performance defects, three misreports to the user, and three tables that
grew for the life of the process.

**ATL-219 / ATL-223 — the same defect in two files.** Both rebuilt an entire
accumulated string on every update in order to work out what had been added to
its end. For a terminal that meant decoding the whole buffer, rebuilding the
whole result and comparing it byte for byte against the previous copy, once per
output chunk, with the session's mutex held — so a chatty command stalled the
whole session, not just its own card.

Measured over 5x the output, before and after:

| | before | after |
| -- | -- | -- |
| terminal projection | 16.3x the time | 4.0x |
| assistant streaming | 15.5x the time | 3.7x |

Linear is 5x. The benchmarks are kept as `#[ignore]`d tests rather than deleted,
because both tickets' acceptance criteria are about how cost *scales*, and a
benchmark that no longer exists cannot be re-run against a later change.

**ATL-220 / ATL-221 / ATL-222 / ATL-224 — four ways a transcript lied.** Every
tool call in a reopened conversation rendered as succeeded, failed ones
included. Every message in it was stamped with the moment the snapshot was
taken, so real pauses collapsed and turn durations read as zero. A plan the
agent had abandoned stayed on screen. An image-only assistant turn showed a
blank bubble that vanished on reload.

**ATL-225 — three tables with no removal path.** Permission and elicitation
routes, and the pre-registered event stream of a session whose load failed.

### How?

Per commit. Three things are worth reading the diff for:

**The projection asks for a tail, it does not compute one.** `OutputBuffer` now
decodes on write and hands out `&str`, and `AcpTerminal::output_appended`
answers "what arrived since this byte offset" without touching the rest of the
buffer. It returns `None` — meaning *re-read everything* — for every case where
an offset from an earlier read stopped naming the same bytes: either buffer
dropped its front, output shrank, offset landed off a character boundary, or the
tail could only be served by copying the PTY half too. The cheap path is an
optimisation with a guard, not a new contract.

**ATL-221 is fixed as far as the protocol allows, and no further.** Entries are
stamped when the thread learns of them, which makes snapshots stable and keeps
every gap the app witnessed. It does **not** recover times for a thread rebuilt
by an agent's `session/load` replay — ACP carries no per-message timestamp, so a
replayed conversation is stamped at replay time. The ticket suggested a null the
UI renders as "unknown"; I did not do that, because `replaceMessages` already
substitutes `Date.now()` for a missing timestamp, so a null would be the same
fabrication one layer up. Making it honest means teaching four render sites to
show "unknown", which is a UI change with no ticket behind it. The limit is
written on the field instead of hidden.

**ATL-224 was a `needs-decision`.** Option A: the stream now skips an empty run
to match the snapshot. The slot is still mirrored, so run indices stay aligned
with the thread's and the run is announced the moment it has text. Option B —
carrying the image through as structured content, the only choice that actually
*shows* the user what the agent sent — is a wire-schema change and deserves its
own ticket.

#### One thing found on the way that is bigger than the ticket it sits in

ATL-225 asks for the permission and elicitation maps to be pruned "in `attach`'s
cleanup, which today removes only from `sessions`". That cleanup never runs. The
projection holds the only strong handle on the thread (the connection keeps a
`Weak`, the host drops its clone) and the thread owns the event sender — so
`events.recv().await` can never return `None`, the task never ends, and the
removal is unreachable.

So the leak was not two maps of route keys. It was every session's projection,
its thread, and its terminals with their live PTY handles, retained until Atlas
exits. And ATL-225's suggested fix would have been inert behind the same dead
path.

Closing is now told rather than noticed: `DeltaProjector::close_session`, called
from the host's existing close path, which is also what finally drops the
terminals whose `Drop` kills a running PTY (ATL-214's fix, which had nothing to
trigger it). The stream-end path stays as a backstop. **This deserves its own
ticket** rather than being buried in a Low rollup, and it is not covered by
ATL-225's title.

Fixes ATL-219, ATL-220, ATL-221, ATL-222, ATL-223, ATL-224, ATL-225

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [ ] You've run the app and used the change in a window

Every fix was falsified: reverted, its test confirmed failing, restored. Baseline
for `atlas-agent-delta` goes from 19 tests to 31 plus two benchmarks;
`atlas-terminal` 15 to 17; frontend gains `snapshot-message.test.ts`.

The unchecked box is honest. Two paths want a real window before this ships:
resuming a session that contains a failed tool call (ATL-220 — the card should
now render as failed, and its id should match the agent's), and watching a long
command stream into a tool card (ATL-219 — output should still arrive
incrementally and in order, and should still show the truncation marker once the
buffer starts dropping its front).
