### PR TITLE
Codex-port hardening: the deep-review fix pass, org-scoped billing, and Timeline alignment for Atlas Agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,25 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --locked --all-targets
 
+  engine-dialect:
+    # The Atlas-authored gateway dialect (~2,700 lines under
+    # vendor/codex/codex-api/src/atlas_chat/) is first-party code that happens
+    # to live in vendor/ — its request/SSE fixture suites are the primary
+    # evidence for the dialect's correctness, and until #64 they ran in no CI
+    # job at all. One package, deliberately not a blanket vendor job: several
+    # upstream suites are permanently red after the phone-home removals (#43),
+    # and re-greening crates Atlas does not ship is not the point.
+    name: engine dialect (codex-api)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+      - name: Test
+        run: cargo test --locked -p codex-api
+
   crates:
     # Every crate gets its own job so a failure names the crate rather than the
     # workspace. Adding a crate here is a one-line change, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,14 +94,14 @@ jobs:
       # Compiles the app and its command surface, then runs its 194 tests.
       - name: Test
         working-directory: src-tauri
-        run: cargo test
+        run: cargo test --locked
       # Plain clippy, no `-D warnings`: the workspace lint table (`[lints]`
       # in the manifest, #60) already carries its own denies, and this is the
       # crate where the #54 cfg outage happened — the deny has to be able to
       # fail a build here, not only warn.
       - name: Clippy (workspace lint table)
         working-directory: src-tauri
-        run: cargo clippy --all-targets
+        run: cargo clippy --locked --all-targets
 
   crates:
     # Every crate gets its own job so a failure names the crate rather than the
@@ -173,14 +173,14 @@ jobs:
           git config --global user.email "ci@example.invalid"
       - name: Test
         working-directory: crates/${{ matrix.crate }}
-        run: cargo test
+        run: cargo test --locked
       # Every member crate, no flag: plain clippy enforces the workspace lint
       # table (`[lints] workspace = true`, #60), whose entries are denies of
       # their own. The stricter `-D warnings` step below stays opt-in.
       - name: Clippy (workspace lint table)
         working-directory: crates/${{ matrix.crate }}
-        run: cargo clippy --all-targets
+        run: cargo clippy --locked --all-targets
       - name: Clippy
         if: matrix.clippy
         working-directory: crates/${{ matrix.crate }}
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       # One cargo workspace since #38: the lockfile and the target dir both
       # live at the repo root, so that is what the cache keys off.
       - uses: Swatinem/rust-cache@v2
@@ -93,6 +95,13 @@ jobs:
       - name: Test
         working-directory: src-tauri
         run: cargo test
+      # Plain clippy, no `-D warnings`: the workspace lint table (`[lints]`
+      # in the manifest, #60) already carries its own denies, and this is the
+      # crate where the #54 cfg outage happened — the deny has to be able to
+      # fail a build here, not only warn.
+      - name: Clippy (workspace lint table)
+        working-directory: src-tauri
+        run: cargo clippy --all-targets
 
   crates:
     # Every crate gets its own job so a failure names the crate rather than the
@@ -165,6 +174,12 @@ jobs:
       - name: Test
         working-directory: crates/${{ matrix.crate }}
         run: cargo test
+      # Every member crate, no flag: plain clippy enforces the workspace lint
+      # table (`[lints] workspace = true`, #60), whose entries are denies of
+      # their own. The stricter `-D warnings` step below stays opt-in.
+      - name: Clippy (workspace lint table)
+        working-directory: crates/${{ matrix.crate }}
+        run: cargo clippy --all-targets
       - name: Clippy
         if: matrix.clippy
         working-directory: crates/${{ matrix.crate }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history, not the depth-1 default: vendor-licensing.test.ts
+          # derives its fork point as the oldest commit touching vendor/codex,
+          # and on a shallow clone that resolves to HEAD — the modification
+          # set comes back empty and the suite fails (#58).
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
       - name: Install
         run: bun install --frozen-lockfile

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,7 +215,6 @@ All wired in as `path` dependencies from `src-tauri/Cargo.toml`, and all members
 
 | Crate | Role |
 |---|---|
-| `atlas-cersei` | Atlas's native in-process coding agent, built on the Cersei SDK. Read `crates/atlas-cersei/ARCHITECTURE.md` before touching agent lifecycle, tools, permissions, providers, or persistence. |
 | `atlas-checkpoint` | The agent-session record: local SQLite store (`.atlas/sessions.db`), redact-on-write capture, git commit linkage, transcript import, sync outbox. Tauri-free, so the whole surface is testable against a real database and a real git repo. |
 | `atlas-redact` | Single source of truth for secret redaction: layered scrubbing (Shannon entropy, vendored betterleaks rules, provider prefixes, credentialed URIs, connection strings) with JSON-aware traversal. String in, redacted string out — no I/O, no async. |
 | `atlas-git` | Git execution layer: one spawn chokepoint over the real `git` binary (so hooks run), a typed stderr→error taxonomy with friendly messages (ported from GitHub Desktop/dugite), porcelain-v2 status parsing, streaming output for long operations. |
@@ -307,10 +306,9 @@ atlas/
 │   ├── atlas-agent-delta          thread events → frozen SessionDelta wire
 │   ├── atlas-agent-wire           the frozen wire shapes (contract-tested)
 │   ├── atlas-agent-transcript     an agent's own record of a conversation
-│   ├── atlas-native-agent         Cersei on the AgentConnection seam
+│   ├── atlas-native-agent         the vendored engine on the AgentConnection seam
 │   ├── atlas-thread-metadata      app-owned session history (threads.db)
 │   ├── atlas-bus                  event bus + middleware pipeline
-│   ├── atlas-cersei               native in-process agent (Cersei SDK)
 │   ├── atlas-checkpoint           session record / Timeline (sessions.db)
 │   ├── atlas-redact               secret redaction (single source of truth)
 │   ├── atlas-git                  git spawn chokepoint + error taxonomy
@@ -321,9 +319,8 @@ atlas/
 │   ├── atlas-codeindex            tree-sitter codebase scanner
 │   └── atlas-kb-server            self-contained KB static-server binary
 │
-├── vendor/                        [patch.crates-io] overrides
-│   ├── cersei-provider              UTF-8 chunk-boundary fix
-│   └── cersei-agent                 tool-cancel race fix
+├── vendor/                        vendored source, workspace members
+│   └── codex                        the engine behind Atlas Agent (ADR-0004)
 │
 ├── scripts/                       build/release helpers (with-posthog-env.mjs)
 ├── landing/                       marketing site source
@@ -344,7 +341,7 @@ atlas/
 
 ## Gotchas
 
-- **Vendored Cersei patches.** `cersei-provider` and `cersei-agent` are `[patch.crates-io]`'d in `src-tauri/Cargo.toml` to `vendor/cersei-provider` and `vendor/cersei-agent` instead of the crates.io release: the published `cersei-provider` corrupts multi-byte UTF-8 characters split across HTTP chunk boundaries, and the published `cersei-agent` never raced `tool.execute()` against the cancel token, leaving orphaned `tool_use` blocks in provider history on cancel. Compile-time guards (`_CERSEI_UTF8_PATCH_GUARD` in `src-tauri/src/lib.rs`, `_CERSEI_CANCEL_PATCH_GUARD` in `crates/atlas-cersei/src/lib.rs`) fail `cargo check` if either patch stops applying — that means the vendor override stopped resolving. Don't delete the guards to fix the build.
+- **The Cersei patch table is gone (#54).** The `cersei-provider`/`cersei-agent` `[patch.crates-io]` overrides and their compile guards were deleted with the Cersei path itself. The two failure classes they fixed are still guarded, by tests against the engine that replaced them rather than by a patch table: a chunk-split fixture that splits an SSE frame at every byte position, and a cancel test that asserts on the filesystem — the killed command's marker file never appears. See the root `Cargo.toml`'s `[patch.crates-io]` comment.
 - **`vite.config.ts`'s `dedupe` is load-bearing.** Lazy-loaded language packages (`lang-json`, `lang-rust`, …) each transitively import `@codemirror/{state,view,language}` and `@lezer/*`; without `dedupe`, Rollup can ship two copies in the production bundle. `EditorView.theme(...)` then registers against one copy's `StyleModule` while the `EditorView` construction uses the other, and the theme silently no-ops — text renders unstyled. Same story for `pdfjs-dist`: two copies mismatch the worker against the main-thread API version and PDF rendering fails. Dev mode does not reproduce either failure (Vite serves a single pre-bundled instance) — this only shows up in production builds.
 - **Release-profile `panic = "unwind"` is required.** The local-LLM loader (`atlas-embed`, used by memory chat) `catch_unwind`s candle's Metal kernel-compile panic to fall back to CPU. `panic = "abort"` would crash the app outright instead of degrading gracefully; the cost is a small amount of extra binary size for unwind tables.
 - **The single-instance plugin is release-only.** Registered behind `#[cfg(not(debug_assertions))]` in `src-tauri/src/lib.rs`. Registering it in debug builds kills `tauri dev` the instant it starts whenever the installed `/Applications/Atlas.app` is already running — the dev process gets treated as the "second instance," forwards its argv, and exits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,9 +172,9 @@ anywhere — as does running from inside the crate's own directory, which is wha
 CI does:
 
 ```bash
-cargo test -p atlas-cersei                                # the native agent
-cargo test -p atlas-cersei --test tools_eval              # a single file
-cd crates/atlas-cersei && cargo test                      # same thing, from the crate
+cargo test -p atlas-native-agent                          # the native agent
+cargo test -p atlas-native-agent --test engine_turn       # a single file
+cd crates/atlas-native-agent && cargo test                # same thing, from the crate
 ```
 
 Run `bun run test:rust` from the repository root to test every crate and the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -722,3 +722,343 @@ opt-level = 1
 opt-level = 1
 [profile.dev.package.atlas-thread-metadata]
 opt-level = 1
+
+# The vendored engine's members, same reasoning as the stanzas above (#65).
+# #42's exemption — "quarantined, on no runtime path until the seam is rewired
+# (#45)" — expired when #45 and #54 landed: the engine now runs on EVERY dev
+# turn (streaming, rollout I/O, sandboxing, apply-patch, ~600k LOC), and at
+# the profile's opt-level 0 it was the slowest code on the hottest path. The
+# cost is a longer first clean build; the `"*"` override cannot cover these
+# because workspace members are excluded from it by cargo. Generated from the
+# member list — a new vendored member belongs here too, and
+# tests/cargo-workspace.test.ts fails if it is missing.
+
+[profile.dev.package.app_test_support]
+opt-level = 1
+
+[profile.dev.package.codex-agent-extension]
+opt-level = 1
+
+[profile.dev.package.codex-agent-graph-store]
+opt-level = 1
+
+[profile.dev.package.codex-agent-identity]
+opt-level = 1
+
+[profile.dev.package.codex-analytics]
+opt-level = 1
+
+[profile.dev.package.codex-api]
+opt-level = 1
+
+[profile.dev.package.codex-app-server]
+opt-level = 1
+
+[profile.dev.package.codex-app-server-client]
+opt-level = 1
+
+[profile.dev.package.codex-app-server-protocol]
+opt-level = 1
+
+[profile.dev.package.codex-app-server-protocol-noop-macros]
+opt-level = 1
+
+[profile.dev.package.codex-app-server-transport]
+opt-level = 1
+
+[profile.dev.package.codex-apply-patch]
+opt-level = 1
+
+[profile.dev.package.codex-arg0]
+opt-level = 1
+
+[profile.dev.package.codex-async-utils]
+opt-level = 1
+
+[profile.dev.package.codex-aws-auth]
+opt-level = 1
+
+[profile.dev.package.codex-backend-client]
+opt-level = 1
+
+[profile.dev.package.codex-backend-openapi-models]
+opt-level = 1
+
+[profile.dev.package.codex-chatgpt]
+opt-level = 1
+
+[profile.dev.package.codex-client]
+opt-level = 1
+
+[profile.dev.package.codex-cloud-config]
+opt-level = 1
+
+[profile.dev.package.codex-code-mode]
+opt-level = 1
+
+[profile.dev.package.codex-code-mode-protocol]
+opt-level = 1
+
+[profile.dev.package.codex-collaboration-mode-templates]
+opt-level = 1
+
+[profile.dev.package.codex-config]
+opt-level = 1
+
+[profile.dev.package.codex-connectors]
+opt-level = 1
+
+[profile.dev.package.codex-connectors-extension]
+opt-level = 1
+
+[profile.dev.package.codex-context-fragments]
+opt-level = 1
+
+[profile.dev.package.codex-core]
+opt-level = 1
+
+[profile.dev.package.codex-core-plugins]
+opt-level = 1
+
+[profile.dev.package.codex-diagnostics]
+opt-level = 1
+
+[profile.dev.package.codex-exec-server]
+opt-level = 1
+
+[profile.dev.package.codex-exec-server-protocol]
+opt-level = 1
+
+[profile.dev.package.codex-exec-server-test-support]
+opt-level = 1
+
+[profile.dev.package.codex-execpolicy]
+opt-level = 1
+
+[profile.dev.package.codex-experimental-api-macros]
+opt-level = 1
+
+[profile.dev.package.codex-extension-api]
+opt-level = 1
+
+[profile.dev.package.codex-extension-items]
+opt-level = 1
+
+[profile.dev.package.codex-external-agent-migration]
+opt-level = 1
+
+[profile.dev.package.codex-features]
+opt-level = 1
+
+[profile.dev.package.codex-feedback]
+opt-level = 1
+
+[profile.dev.package.codex-file-search]
+opt-level = 1
+
+[profile.dev.package.codex-file-system]
+opt-level = 1
+
+[profile.dev.package.codex-file-watcher]
+opt-level = 1
+
+[profile.dev.package.codex-git-attribution]
+opt-level = 1
+
+[profile.dev.package.codex-git-utils]
+opt-level = 1
+
+[profile.dev.package.codex-goal-extension]
+opt-level = 1
+
+[profile.dev.package.codex-guardian]
+opt-level = 1
+
+[profile.dev.package.codex-guardian-v2]
+opt-level = 1
+
+[profile.dev.package.codex-history]
+opt-level = 1
+
+[profile.dev.package.codex-home]
+opt-level = 1
+
+[profile.dev.package.codex-hooks]
+opt-level = 1
+
+[profile.dev.package.codex-http-client]
+opt-level = 1
+
+[profile.dev.package.codex-image-generation-extension]
+opt-level = 1
+
+[profile.dev.package.codex-install-context]
+opt-level = 1
+
+[profile.dev.package.codex-keyring-store]
+opt-level = 1
+
+[profile.dev.package.codex-linux-sandbox]
+opt-level = 1
+
+[profile.dev.package.codex-login]
+opt-level = 1
+
+[profile.dev.package.codex-mcp]
+opt-level = 1
+
+[profile.dev.package.codex-mcp-extension]
+opt-level = 1
+
+[profile.dev.package.codex-memories-extension]
+opt-level = 1
+
+[profile.dev.package.codex-memories-read]
+opt-level = 1
+
+[profile.dev.package.codex-memories-write]
+opt-level = 1
+
+[profile.dev.package.codex-model-provider]
+opt-level = 1
+
+[profile.dev.package.codex-model-provider-info]
+opt-level = 1
+
+[profile.dev.package.codex-models-manager]
+opt-level = 1
+
+[profile.dev.package.codex-network-proxy]
+opt-level = 1
+
+[profile.dev.package.codex-otel]
+opt-level = 1
+
+[profile.dev.package.codex-plugin]
+opt-level = 1
+
+[profile.dev.package.codex-process-hardening]
+opt-level = 1
+
+[profile.dev.package.codex-prompts]
+opt-level = 1
+
+[profile.dev.package.codex-protocol]
+opt-level = 1
+
+[profile.dev.package.codex-queue-extension]
+opt-level = 1
+
+[profile.dev.package.codex-response-debug-context]
+opt-level = 1
+
+[profile.dev.package.codex-rmcp-client]
+opt-level = 1
+
+[profile.dev.package.codex-rollout]
+opt-level = 1
+
+[profile.dev.package.codex-rollout-trace]
+opt-level = 1
+
+[profile.dev.package.codex-sandboxing]
+opt-level = 1
+
+[profile.dev.package.codex-secrets]
+opt-level = 1
+
+[profile.dev.package.codex-shell-command]
+opt-level = 1
+
+[profile.dev.package.codex-shell-escalation]
+opt-level = 1
+
+[profile.dev.package.codex-skills]
+opt-level = 1
+
+[profile.dev.package.codex-skills-extension]
+opt-level = 1
+
+[profile.dev.package.codex-state]
+opt-level = 1
+
+[profile.dev.package.codex-terminal-detection]
+opt-level = 1
+
+[profile.dev.package.codex-test-binary-support]
+opt-level = 1
+
+[profile.dev.package.codex-thread-store]
+opt-level = 1
+
+[profile.dev.package.codex-tools]
+opt-level = 1
+
+[profile.dev.package.codex-uds]
+opt-level = 1
+
+[profile.dev.package.codex-utils-absolute-path]
+opt-level = 1
+
+[profile.dev.package.codex-utils-audio]
+opt-level = 1
+
+[profile.dev.package.codex-utils-cache]
+opt-level = 1
+
+[profile.dev.package.codex-utils-cargo-bin]
+opt-level = 1
+
+[profile.dev.package.codex-utils-cli]
+opt-level = 1
+
+[profile.dev.package.codex-utils-home-dir]
+opt-level = 1
+
+[profile.dev.package.codex-utils-image]
+opt-level = 1
+
+[profile.dev.package.codex-utils-json-to-toml]
+opt-level = 1
+
+[profile.dev.package.codex-utils-output-truncation]
+opt-level = 1
+
+[profile.dev.package.codex-utils-path]
+opt-level = 1
+
+[profile.dev.package.codex-utils-path-uri]
+opt-level = 1
+
+[profile.dev.package.codex-utils-plugins]
+opt-level = 1
+
+[profile.dev.package.codex-utils-pty]
+opt-level = 1
+
+[profile.dev.package.codex-utils-rustls-provider]
+opt-level = 1
+
+[profile.dev.package.codex-utils-stream-parser]
+opt-level = 1
+
+[profile.dev.package.codex-utils-string]
+opt-level = 1
+
+[profile.dev.package.codex-utils-template]
+opt-level = 1
+
+[profile.dev.package.codex-web-search-extension]
+opt-level = 1
+
+[profile.dev.package.codex-websocket-client]
+opt-level = 1
+
+[profile.dev.package.codex-windows-sandbox]
+opt-level = 1
+
+[profile.dev.package.codex-workload-identity]
+opt-level = 1
+
+[profile.dev.package.core_test_support]
+opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,10 +565,14 @@ rust = { unexpected_cfgs = "deny" }
 
 [workspace.lints.clippy]
 
+# `unwrap_used` and `expect_used` are STAGED, not enforced: turning the table
+# on for the first-party members (#60) surfaced ~220 violations of the pair,
+# overwhelmingly in test code where a panic IS the failure report. Re-add them
+# behind a cleanup pass rather than allowlisting two hundred call sites in one
+# sweep. Every other deny below is live and clean.
 await_holding_invalid_type = "deny"
 await_holding_lock = "deny"
 disallowed_methods = "deny"
-expect_used = "deny"
 identity_op = "deny"
 manual_clamp = "deny"
 manual_filter = "deny"
@@ -600,7 +604,6 @@ unnecessary_filter_map = "deny"
 unnecessary_lazy_evaluations = "deny"
 unnecessary_sort_by = "deny"
 unnecessary_to_owned = "deny"
-unwrap_used = "deny"
 
 # cargo-shear cannot see the platform-specific openssl-sys usage, so we
 # silence the false positive here instead of deleting a real dependency.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Agents now write a large share of the code and keep none of the reasoning behind
 
 Atlas runs your agents as they are, and enriches what they see.
 
-Claude Code and Codex run as external subprocesses over [ACP](https://github.com/zed-industries/agent-client-protocol), the most-used, most-tested path. The Atlas agent runs in-process on [Cersei](https://docs.tryatlas.cc/), our Rust agent framework.
+Claude Code and Codex run as external subprocesses over [ACP](https://github.com/zed-industries/agent-client-protocol), the most-used, most-tested path. Atlas Agent, the native agent, runs in-process on a hard fork of the Codex engine (see `CONTEXT.md` and ADR-0004).
 
 Beyond those, Atlas can spawn any agent in the ACP registry (Cursor, OpenCode, Kilo Code, and more), pulling in each one's official binary automatically. All of them go through the same send path, so everything below applies whichever one you pick.
 

--- a/crates/atlas-acp-thread/Cargo.toml
+++ b/crates/atlas-acp-thread/Cargo.toml
@@ -25,3 +25,8 @@ tracing = "0.1.44"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-acp-thread/src/terminal.rs
+++ b/crates/atlas-acp-thread/src/terminal.rs
@@ -340,7 +340,7 @@ impl TerminalRegistry {
     /// created yet. Exposed so the buffering invariant can be asserted directly
     /// rather than inferred from the rendered output.
     pub fn pending_output_len(&self, id: &acp::TerminalId) -> usize {
-        self.pending_output.get(id).map_or(0, |c| c.len())
+        self.pending_output.get(id).map_or(0, std::vec::Vec::len)
     }
 
     /// Whether an exit status arrived before the terminal it belongs to.

--- a/crates/atlas-acp-thread/src/thread.rs
+++ b/crates/atlas-acp-thread/src/thread.rs
@@ -514,7 +514,7 @@ pub struct ToolCall {
 
 impl ToolCall {
     pub fn from_acp(tool_call: acp::ToolCall, status: ToolCallStatus) -> Result<Self> {
-        let label = Self::label_for(&tool_call.kind, tool_call.title);
+        let label = Self::label_for(tool_call.kind, tool_call.title);
         let mut content = Vec::with_capacity(tool_call.content.len());
         for item in tool_call.content {
             if let Some(item) = ToolCallContent::from_acp(item)? {
@@ -539,8 +539,8 @@ impl ToolCall {
     /// label as markdown. Nothing renders markdown in this crate, so only the
     /// multi-line truncation — which is real behaviour, not presentation —
     /// is ported.
-    fn label_for(kind: &acp::ToolKind, title: String) -> String {
-        if *kind == acp::ToolKind::Execute || *kind == acp::ToolKind::Edit {
+    fn label_for(kind: acp::ToolKind, title: String) -> String {
+        if kind == acp::ToolKind::Execute || kind == acp::ToolKind::Edit {
             title
         } else if let Some((first_line, _)) = title.split_once('\n') {
             first_line.to_owned() + "…"
@@ -578,7 +578,7 @@ impl ToolCall {
         }
 
         if let Some(title) = title {
-            self.label = Self::label_for(&self.kind, title);
+            self.label = Self::label_for(self.kind, title);
         }
 
         if let Some(content) = content {

--- a/crates/atlas-agent-delta/Cargo.toml
+++ b/crates/atlas-agent-delta/Cargo.toml
@@ -29,3 +29,8 @@ anyhow = "1"
 futures = "0.3"
 tokio = { version = "1", features = ["full", "test-util"] }
 uuid = { version = "1", features = ["v4"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-agent-delta/src/project.rs
+++ b/crates/atlas-agent-delta/src/project.rs
@@ -106,7 +106,7 @@ pub fn tool_call(call: &ThreadToolCall, thread: &atlas_acp_thread::AcpThread) ->
         tool_name: call
             .tool_name
             .as_ref()
-            .map(|name| name.to_string())
+            .map(std::string::ToString::to_string)
             .unwrap_or_else(|| {
                 if title.is_empty() {
                     kind.clone()

--- a/crates/atlas-agent-delta/src/projector.rs
+++ b/crates/atlas-agent-delta/src/projector.rs
@@ -131,7 +131,7 @@ impl DeltaProjector {
     /// Install the thread observer. Call before any session is created;
     /// events emitted before this are not replayed to it.
     pub fn observe_threads(&self, observer: Arc<dyn ThreadObserver>) {
-        *self.observer.lock().unwrap_or_else(|p| p.into_inner()) = Some(observer);
+        *self.observer.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(observer);
     }
 
     /// The sink factory to hand to `ConnectOptions`.
@@ -141,7 +141,7 @@ impl DeltaProjector {
             let (tx, rx) = atlas_acp_thread::event_channel();
             this.pending
                 .lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .insert(session_id.clone(), rx);
             tx
         })
@@ -172,7 +172,7 @@ impl DeltaProjector {
             }
             this.sessions
                 .lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .remove(&session_id);
         });
     }
@@ -191,7 +191,7 @@ impl DeltaProjector {
         let Some(events) = self
             .pending
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(&session_id)
         else {
             // No stream was handed out for this session, so nothing will ever
@@ -211,7 +211,7 @@ impl DeltaProjector {
         )));
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(session_id, projection);
 
         Some(events)
@@ -231,7 +231,7 @@ impl DeltaProjector {
         let observer = self
             .observer
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
         let Some(observer) = observer else {
             return;
@@ -240,7 +240,7 @@ impl DeltaProjector {
         // thread itself, and holding the projection's lock across that call
         // would put the history store behind the wire projection's lock.
         let (agent_id, thread) = {
-            let projection = projection.lock().unwrap_or_else(|p| p.into_inner());
+            let projection = projection.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             (projection.agent_id, projection.thread.clone())
         };
         observer.on_thread_event(agent_id, session_id, event, &thread);
@@ -264,7 +264,7 @@ impl DeltaProjector {
     pub fn permission_key(&self, request_id: &Uuid) -> Option<PermissionKey> {
         self.permissions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(request_id)
             .cloned()
     }
@@ -277,7 +277,7 @@ impl DeltaProjector {
     pub fn elicitation_key(&self, request_id: &Uuid) -> Option<ElicitationKey> {
         self.elicitations
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(request_id)
             .cloned()
     }
@@ -354,7 +354,7 @@ impl DeltaProjector {
         };
         self.notify_observer(session_id, &event, &projection);
         let (envelopes, permissions, elicitations) = {
-            let mut projection = projection.lock().unwrap_or_else(|p| p.into_inner());
+            let mut projection = projection.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let deltas = projection.apply(event);
             let envelopes = projection.wrap(deltas);
             (
@@ -364,13 +364,13 @@ impl DeltaProjector {
             )
         };
         if !permissions.is_empty() {
-            let mut table = self.permissions.lock().unwrap_or_else(|p| p.into_inner());
+            let mut table = self.permissions.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             for (request_id, key) in permissions {
                 table.insert(request_id, key);
             }
         }
         if !elicitations.is_empty() {
-            let mut table = self.elicitations.lock().unwrap_or_else(|p| p.into_inner());
+            let mut table = self.elicitations.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             for (request_id, key) in elicitations {
                 table.insert(request_id, key);
             }
@@ -383,7 +383,7 @@ impl DeltaProjector {
     fn session(&self, session_id: &acp::SessionId) -> Option<Arc<Mutex<SessionProjection>>> {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(session_id)
             .cloned()
     }
@@ -394,7 +394,7 @@ impl DeltaProjector {
         f: impl FnOnce(&mut SessionProjection) -> R,
     ) -> Option<R> {
         let projection = self.session(session_id)?;
-        let mut projection = projection.lock().unwrap_or_else(|p| p.into_inner());
+        let mut projection = projection.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         Some(f(&mut projection))
     }
 
@@ -407,7 +407,7 @@ impl DeltaProjector {
             return;
         };
         let envelopes = {
-            let projection = projection.lock().unwrap_or_else(|p| p.into_inner());
+            let projection = projection.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             projection.wrap(f(&projection))
         };
         for envelope in envelopes {
@@ -539,7 +539,7 @@ impl SessionProjection {
             AcpThreadEvent::TitleUpdated => {
                 let title = lock_thread(&self.thread)
                     .title()
-                    .map(|title| title.to_string());
+                    .map(std::string::ToString::to_string);
                 title
                     .map(|title| vec![SessionDelta::TitleUpdated { title }])
                     .unwrap_or_default()
@@ -977,5 +977,5 @@ fn new_message_id() -> String {
 }
 
 fn lock_thread(thread: &AcpThreadHandle) -> std::sync::MutexGuard<'_, AcpThread> {
-    thread.lock().unwrap_or_else(|p| p.into_inner())
+    thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/crates/atlas-agent-delta/tests/projection.rs
+++ b/crates/atlas-agent-delta/tests/projection.rs
@@ -160,7 +160,7 @@ impl Harness {
 }
 
 fn lock(thread: &AcpThreadHandle) -> std::sync::MutexGuard<'_, AcpThread> {
-    thread.lock().unwrap_or_else(|p| p.into_inner())
+    thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn text_chunk(text: &str) -> serde_json::Value {
@@ -755,7 +755,7 @@ async fn create_terminal(harness: &Harness, terminal_id: &str, args: &[&str]) {
     let terminal = std::sync::Arc::new(
         atlas_terminal::command::CommandTerminal::spawn(
             echo_binary(),
-            &args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            &args.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
             &[],
             None,
             4096,

--- a/crates/atlas-agent-manager/Cargo.toml
+++ b/crates/atlas-agent-manager/Cargo.toml
@@ -20,3 +20,8 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-agent-manager/src/manager.rs
+++ b/crates/atlas-agent-manager/src/manager.rs
@@ -504,7 +504,7 @@ impl AgentManager {
     }
 
     fn lock_entries(&self) -> std::sync::MutexGuard<'_, HashMap<Agent, Entry>> {
-        self.entries.lock().unwrap_or_else(|p| p.into_inner())
+        self.entries.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     // ---- sessions -------------------------------------------------------
@@ -721,14 +721,14 @@ impl AgentManager {
     }
 
     fn lock_sessions(&self) -> std::sync::MutexGuard<'_, HashMap<acp::SessionId, SessionHandle>> {
-        self.sessions.lock().unwrap_or_else(|p| p.into_inner())
+        self.sessions.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
 fn lock(entry: &Entry) -> std::sync::MutexGuard<'_, AgentConnectionEntry> {
-    entry.lock().unwrap_or_else(|p| p.into_inner())
+    entry.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn lock_thread(thread: &AcpThreadHandle) -> std::sync::MutexGuard<'_, AcpThread> {
-    thread.lock().unwrap_or_else(|p| p.into_inner())
+    thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/crates/atlas-agent-manager/tests/resume.rs
+++ b/crates/atlas-agent-manager/tests/resume.rs
@@ -293,7 +293,7 @@ impl Harness {
         let thread_events: ThreadEventSink =
             Arc::new(|_session_id| atlas_acp_thread::event_channel().0);
         let manager = AgentManager::new(
-            Arc::new(FakeCatalog(id.clone())),
+            Arc::new(FakeCatalog(id)),
             server,
             ConnectOptions {
                 root_dir: None,

--- a/crates/atlas-agent-servers/Cargo.toml
+++ b/crates/atlas-agent-servers/Cargo.toml
@@ -22,3 +22,8 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-agent-servers/src/connection.rs
+++ b/crates/atlas-agent-servers/src/connection.rs
@@ -259,7 +259,7 @@ impl AcpConnection {
                 for thread in sessions.all_threads() {
                     thread
                         .lock()
-                        .unwrap_or_else(|p| p.into_inner())
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .emit_load_error(load_error.clone());
                 }
             }
@@ -913,7 +913,7 @@ impl AgentConnection for AcpConnection {
             &options
                 .config_options
                 .lock()
-                .unwrap_or_else(|p| p.into_inner()),
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
         )?;
         Some(Arc::new(AcpModelSelector {
             connection: self.connection.clone(),
@@ -956,7 +956,7 @@ impl AcpConnection {
         };
 
         let initial = {
-            let mut modes = modes.lock().unwrap_or_else(|p| p.into_inner());
+            let mut modes = modes.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             if !modes
                 .available_modes
                 .iter()
@@ -979,7 +979,7 @@ impl AcpConnection {
             .await
             .is_err()
         {
-            modes.lock().unwrap_or_else(|p| p.into_inner()).current_mode_id = initial;
+            modes.lock().unwrap_or_else(std::sync::PoisonError::into_inner).current_mode_id = initial;
         }
     }
 }
@@ -994,7 +994,7 @@ impl AgentSessionModes for AcpSessionModes {
     fn current_mode(&self) -> acp::SessionModeId {
         self.modes
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .current_mode_id
             .clone()
     }
@@ -1002,7 +1002,7 @@ impl AgentSessionModes for AcpSessionModes {
     fn all_modes(&self) -> Vec<acp::SessionMode> {
         self.modes
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .available_modes
             .clone()
     }
@@ -1014,7 +1014,7 @@ impl AgentSessionModes for AcpSessionModes {
         let previous = self.current_mode();
         modes
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .current_mode_id = mode.clone();
 
         async move {
@@ -1027,7 +1027,7 @@ impl AgentSessionModes for AcpSessionModes {
                 Err(err) => {
                     modes
                         .lock()
-                        .unwrap_or_else(|p| p.into_inner())
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .current_mode_id = previous;
                     Err(anyhow!(err))
                 }
@@ -1125,7 +1125,7 @@ impl AcpModelSelector {
                 .options
                 .config_options
                 .lock()
-                .unwrap_or_else(|p| p.into_inner()),
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
         )
         .ok_or_else(|| anyhow!("this agent no longer advertises a model selector"))
     }
@@ -1174,7 +1174,7 @@ impl AgentModelSelector for AcpModelSelector {
             *options
                 .config_options
                 .lock()
-                .unwrap_or_else(|p| p.into_inner()) = response.config_options;
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = response.config_options;
             options.notify();
             Ok(())
         }
@@ -1197,7 +1197,7 @@ impl AgentSessionConfigOptions for AcpSessionConfigOptions {
         self.options
             .config_options
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
@@ -1222,7 +1222,7 @@ impl AgentSessionConfigOptions for AcpSessionConfigOptions {
             *options
                 .config_options
                 .lock()
-                .unwrap_or_else(|p| p.into_inner()) = response.config_options.clone();
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = response.config_options.clone();
             options.notify();
             Ok(response.config_options)
         }

--- a/crates/atlas-agent-servers/src/debug_log.rs
+++ b/crates/atlas-agent-servers/src/debug_log.rs
@@ -219,6 +219,6 @@ impl AcpDebugLog {
     fn lock(&self) -> std::sync::MutexGuard<'_, AcpDebugLogState> {
         self.state
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }

--- a/crates/atlas-agent-servers/src/handlers.rs
+++ b/crates/atlas-agent-servers/src/handlers.rs
@@ -54,7 +54,7 @@ pub struct ClientContext {
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 // ------------------------------------------------------------------- dispatch
@@ -494,7 +494,7 @@ pub fn handle_session_notification(
         if let Some(exit) = meta.and_then(|meta| meta.get("terminal_exit")) {
             if let Some(terminal_id) = exit.get("terminal_id").and_then(|v| v.as_str()) {
                 let mut status = acp::TerminalExitStatus::new();
-                status.exit_code = exit.get("exit_code").and_then(|v| v.as_u64()).map(|c| c as u32);
+                status.exit_code = exit.get("exit_code").and_then(serde_json::Value::as_u64).map(|c| c as u32);
                 status.signal = exit
                     .get("signal")
                     .and_then(|v| v.as_str())

--- a/crates/atlas-agent-servers/src/session.rs
+++ b/crates/atlas-agent-servers/src/session.rs
@@ -126,7 +126,7 @@ impl SessionRegistry {
     pub fn thread(&self, session_id: &acp::SessionId) -> Result<Arc<Mutex<AcpThread>>, acp::Error> {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(session_id)
             .and_then(|session| session.thread.upgrade())
             .ok_or_else(|| {
@@ -137,7 +137,7 @@ impl SessionRegistry {
     pub fn all_threads(&self) -> Vec<Arc<Mutex<AcpThread>>> {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .values()
             .filter_map(|session| session.thread.upgrade())
             .collect()
@@ -150,7 +150,7 @@ impl SessionRegistry {
     ) -> Option<R> {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get_mut(session_id)
             .map(f)
     }
@@ -158,27 +158,27 @@ impl SessionRegistry {
     pub fn insert(&self, session_id: acp::SessionId, session: AcpSession) {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(session_id, session);
     }
 
     pub fn remove(&self, session_id: &acp::SessionId) -> Option<AcpSession> {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(session_id)
     }
 
     pub fn contains(&self, session_id: &acp::SessionId) -> bool {
         self.sessions
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .contains_key(session_id)
     }
 
     /// `Some(new_count)` when the session is known, after decrementing.
     pub fn release(&self, session_id: &acp::SessionId) -> Option<usize> {
-        let mut sessions = self.sessions.lock().unwrap_or_else(|p| p.into_inner());
+        let mut sessions = self.sessions.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let session = sessions.get_mut(session_id)?;
         session.ref_count = session.ref_count.saturating_sub(1);
         let remaining = session.ref_count;
@@ -190,7 +190,7 @@ impl SessionRegistry {
 
     /// Adds a handle to an already-open session, if there is one.
     pub fn acquire(&self, session_id: &acp::SessionId) -> Option<Arc<Mutex<AcpThread>>> {
-        let mut sessions = self.sessions.lock().unwrap_or_else(|p| p.into_inner());
+        let mut sessions = self.sessions.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let session = sessions.get_mut(session_id)?;
         let thread = session.thread.upgrade()?;
         session.ref_count += 1;
@@ -198,7 +198,7 @@ impl SessionRegistry {
     }
 
     pub fn pending_acquire(&self, session_id: &acp::SessionId) -> bool {
-        let mut pending = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         match pending.get_mut(session_id) {
             Some(entry) => {
                 entry.ref_count += 1;
@@ -211,21 +211,21 @@ impl SessionRegistry {
     pub fn pending_begin(&self, session_id: acp::SessionId) {
         self.pending
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(session_id, PendingAcpSession { ref_count: 1 });
     }
 
     pub fn pending_take(&self, session_id: &acp::SessionId) -> Option<usize> {
         self.pending
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(session_id)
             .map(|pending| pending.ref_count)
     }
 
     /// `Some(new_count)` when a load is in flight, after decrementing.
     pub fn pending_release(&self, session_id: &acp::SessionId) -> Option<usize> {
-        let mut pending = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let entry = pending.get_mut(session_id)?;
         entry.ref_count = entry.ref_count.saturating_sub(1);
         let remaining = entry.ref_count;

--- a/crates/atlas-agent-servers/tests/connect.rs
+++ b/crates/atlas-agent-servers/tests/connect.rs
@@ -67,7 +67,7 @@ fn request_elicitation_events() -> RequestElicitationSink {
 fn command(path: &str, args: &[&str]) -> AgentServerCommand {
     AgentServerCommand {
         path: PathBuf::from(path),
-        args: args.iter().map(|arg| arg.to_string()).collect(),
+        args: args.iter().map(std::string::ToString::to_string).collect(),
         env: Some(HashMap::new()),
     }
 }
@@ -351,7 +351,7 @@ async fn session_on(config_options: serde_json::Value) -> Option<(Arc<AcpConnect
         .expect("session/new failed");
     let session_id = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .session_id()
         .clone();
     // The thread must outlive this call: the session registry holds it weakly.
@@ -518,7 +518,7 @@ async fn a_pending_permission_does_not_block_the_messages_behind_it() {
         .expect("session/new failed");
     let session_id = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .session_id()
         .clone();
 
@@ -533,7 +533,7 @@ async fn a_pending_permission_does_not_block_the_messages_behind_it() {
     let (mut saw_chunk, mut saw_prompt) = (false, false);
     while std::time::Instant::now() < deadline && !(saw_chunk && saw_prompt) {
         {
-            let thread = thread.lock().unwrap_or_else(|p| p.into_inner());
+            let thread = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             for entry in thread.entries() {
                 match entry {
                     AgentThreadEntry::AssistantMessage(message) => {
@@ -568,7 +568,7 @@ async fn a_pending_permission_does_not_block_the_messages_behind_it() {
     // Answer it; the agent then ends the turn.
     thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .authorize_tool_call(
             acp::ToolCallId::new("call-1"),
             atlas_acp_thread::SelectedPermissionOutcome::new(
@@ -649,7 +649,7 @@ async fn an_embedded_terminal_in_tool_call_meta_is_created_and_streams() {
         .expect("session/new failed");
     let session_id = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .session_id()
         .clone();
 
@@ -665,7 +665,7 @@ async fn an_embedded_terminal_in_tool_call_meta_is_created_and_streams() {
     .expect("prompt failed");
     assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
 
-    let thread = thread.lock().unwrap_or_else(|p| p.into_inner());
+    let thread = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let call = thread
         .entries()
         .iter()

--- a/crates/atlas-agent-store/Cargo.toml
+++ b/crates/atlas-agent-store/Cargo.toml
@@ -40,3 +40,8 @@ zip = "8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-agent-store/src/archive.rs
+++ b/crates/atlas-agent-store/src/archive.rs
@@ -135,7 +135,7 @@ pub fn github_release_archive_from_url(archive_url: &str) -> Option<GithubReleas
         percent_decode_str(segment)
             .decode_utf8()
             .ok()
-            .map(|segment| segment.into_owned())
+            .map(std::borrow::Cow::into_owned)
     }
 
     let url = Url::parse(archive_url).ok()?;

--- a/crates/atlas-agent-store/src/node.rs
+++ b/crates/atlas-agent-store/src/node.rs
@@ -272,7 +272,7 @@ fn npm_command_args(
             .to_string_lossy()
             .into_owned(),
     );
-    command_args.extend(args.iter().map(|arg| arg.to_string()));
+    command_args.extend(args.iter().map(std::string::ToString::to_string));
     command_args
 }
 

--- a/crates/atlas-agent-transcript/Cargo.toml
+++ b/crates/atlas-agent-transcript/Cargo.toml
@@ -15,3 +15,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 uuid = { version = "1", features = ["v4"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-agent-wire/Cargo.toml
+++ b/crates/atlas-agent-wire/Cargo.toml
@@ -17,3 +17,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-agent-wire/tests/contract.rs
+++ b/crates/atlas-agent-wire/tests/contract.rs
@@ -61,7 +61,7 @@ fn expected() -> BTreeMap<String, BTreeSet<String>> {
     .map(|(kind, fields)| {
         (
             kind.to_string(),
-            fields.iter().map(|f| f.to_string()).collect(),
+            fields.iter().map(std::string::ToString::to_string).collect(),
         )
     })
     .collect()

--- a/crates/atlas-bus/Cargo.toml
+++ b/crates/atlas-bus/Cargo.toml
@@ -10,3 +10,8 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "rt"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-checkpoint/Cargo.toml
+++ b/crates/atlas-checkpoint/Cargo.toml
@@ -37,3 +37,8 @@ reqwest = { version = "0.12", default-features = false, features = [
 
 [dev-dependencies]
 tempfile = "3"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-checkpoint/src/git.rs
+++ b/crates/atlas-checkpoint/src/git.rs
@@ -657,7 +657,7 @@ fn head_tracked_set(repo: &Path) -> Option<std::sync::Arc<std::collections::Hash
     let head_mtime = mtime(git_dir.join("HEAD"))?;
     let index_mtime = mtime(git_dir.join("index"))?;
 
-    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let mut cache = CACHE.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     if let Some(entry) = cache.get(repo) {
         if entry.head_mtime == head_mtime && entry.index_mtime == index_mtime {
             return Some(entry.paths.clone());

--- a/crates/atlas-checkpoint/src/import.rs
+++ b/crates/atlas-checkpoint/src/import.rs
@@ -130,7 +130,7 @@ impl TranscriptSource {
             return Vec::new();
         };
         let mut files: Vec<PathBuf> = entries
-            .filter_map(|entry| entry.ok())
+            .filter_map(std::result::Result::ok)
             .map(|entry| entry.path())
             .filter(|path| path.extension().is_some_and(|ext| ext == "jsonl"))
             .collect();
@@ -374,7 +374,7 @@ fn import_file(
     let session_key = SessionKey {
         workspace_id: workspace_id.to_string(),
         source: Source::ExternalJsonl,
-        native_session_id: native_session_id.clone(),
+        native_session_id,
     };
 
     // Resume from the last clean pass when the state is present, parses, and
@@ -457,7 +457,7 @@ fn import_file(
             if line.trim().is_empty() {
                 continue;
             }
-            let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
                 // A transcript being appended to while it is read ends mid-object.
                 outcome.malformed_lines += 1;
                 continue;
@@ -564,7 +564,7 @@ fn import_file(
                 let native_id = turn
                     .native_id
                     .clone()
-                    .unwrap_or_else(|| synthetic_line_id(line_index, &line));
+                    .unwrap_or_else(|| synthetic_line_id(line_index, line));
 
                 match capture.record_turn(
                     &id,

--- a/crates/atlas-checkpoint/tests/capture.rs
+++ b/crates/atlas-checkpoint/tests/capture.rs
@@ -136,13 +136,13 @@ fn the_title_derives_from_the_user_prompt_which_is_not_on_the_delta_stream() {
         Some("Investigate why the watcher misses renames")
     );
 
-    let prompts: Vec<_> = store
+    let prompts = store
         .messages_for_session(&session_id)
         .unwrap()
         .into_iter()
         .filter(|m| m.role == Role::User)
-        .collect();
-    assert_eq!(prompts.len(), 1, "the prompt itself is stored, not only its title");
+        .count();
+    assert_eq!(prompts, 1, "the prompt itself is stored, not only its title");
 }
 
 #[test]

--- a/crates/atlas-checkpoint/tests/drain.rs
+++ b/crates/atlas-checkpoint/tests/drain.rs
@@ -643,7 +643,7 @@ fn batches_respect_the_byte_ceiling_independently_of_the_count() {
     }
 
     let batch = store.pending_artifacts(WORKSPACE, WIRE_WORKSPACE, ORG, 100, 64 * 1024).unwrap();
-    let bytes: usize = batch.iter().map(|a| a.approx_bytes()).sum();
+    let bytes: usize = batch.iter().map(atlas_checkpoint::artifacts::AtlasArtifact::approx_bytes).sum();
     assert!(batch.len() < 100, "the byte ceiling bit before the count did");
     assert!(bytes < 512 * 1024, "batch was {bytes} bytes");
 }

--- a/crates/atlas-checkpoint/tests/rewrites.rs
+++ b/crates/atlas-checkpoint/tests/rewrites.rs
@@ -325,7 +325,7 @@ fn a_cherry_pick_collision_orphans_rather_than_picking_arbitrarily() {
         "agent work\n",
         "agent work",
     );
-    let original = only_checkpoint(&store, &session).commit_sha.clone();
+    let original = only_checkpoint(&store, &session).commit_sha;
 
     // Two branches each cherry-pick the same change. Each needs its own
     // preceding commit: without a differing parent, git produces a
@@ -377,7 +377,7 @@ fn a_patch_id_collision_resolves_to_the_checkpoints_recorded_branch_when_it_can(
         "agent work\n",
         "agent work",
     );
-    let original = only_checkpoint(&store, &session).commit_sha.clone();
+    let original = only_checkpoint(&store, &session).commit_sha;
 
     // The same change is cherry-picked to another branch…
     fixture.git(&["checkout", "-b", "release", "main"]);
@@ -433,7 +433,7 @@ fn an_orphan_whose_commit_becomes_reachable_again_is_re_linked() {
     fixture.walk(&store);
 
     let session = agent_commit(&fixture, &mut store, "s1", "src/lib.rs", "agent\n", "agent change");
-    let commit = only_checkpoint(&store, &session).commit_sha.clone();
+    let commit = only_checkpoint(&store, &session).commit_sha;
 
     // Rewind past it, so the commit is unreachable and the Checkpoint orphans.
     fixture.git(&["reset", "--hard", "HEAD~1"]);

--- a/crates/atlas-codeindex/Cargo.toml
+++ b/crates/atlas-codeindex/Cargo.toml
@@ -23,3 +23,8 @@ sha2 = "0.10"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-codeindex/src/code_intel.rs
+++ b/crates/atlas-codeindex/src/code_intel.rs
@@ -236,6 +236,9 @@ pub fn analyze_source(lang: Language, source: &str) -> Option<FileIntel> {
             // The stack is LIFO, so push children reversed to pop them — and
             // therefore emit imports/symbols — in source order.
             let mut cursor = node.walk();
+            // The collect is load-bearing: tree-sitter's children iterator is
+            // not double-ended, so reversing needs the Vec.
+            #[allow(clippy::needless_collect)]
             let children: Vec<_> = node.children(&mut cursor).collect();
             for child in children.into_iter().rev() {
                 stack.push(child);

--- a/crates/atlas-embed/Cargo.toml
+++ b/crates/atlas-embed/Cargo.toml
@@ -23,3 +23,8 @@ candle-nn = "0.11.0"
 candle-transformers = "0.11.0"
 serde_json = "1.0.150"
 tokenizers = "0.23.1"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-git/Cargo.toml
+++ b/crates/atlas-git/Cargo.toml
@@ -10,3 +10,8 @@ name = "atlas_git"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 regex = "1"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-git/src/exec.rs
+++ b/crates/atlas-git/src/exec.rs
@@ -63,7 +63,7 @@ impl GitCommand {
     pub fn new(cwd: impl Into<PathBuf>, args: &[&str]) -> Self {
         GitCommand {
             cwd: cwd.into(),
-            args: args.iter().map(|s| s.to_string()).collect(),
+            args: args.iter().map(std::string::ToString::to_string).collect(),
             envs: Vec::new(),
             success_exit_codes: HashSet::from([0]),
             stdin: None,

--- a/crates/atlas-git/src/patch.rs
+++ b/crates/atlas-git/src/patch.rs
@@ -127,8 +127,8 @@ pub fn hunk_signature(h: &Hunk) -> Vec<(u8, &str)> {
 /// Find the hunk in `fresh` whose content matches `displayed_body` — the
 /// body the UI showed, one `(marker, content)` per line in order, markers
 /// being `' '`, `'+'`, `'-'` (no-newline markers omitted).
-pub fn find_matching_hunk<'a>(
-    fresh: &'a FilePatch,
+pub fn find_matching_hunk(
+    fresh: &FilePatch,
     displayed_body: &[(u8, String)],
 ) -> Option<usize> {
     let want: Vec<(u8, &str)> = displayed_body.iter().map(|(m, c)| (*m, c.as_str())).collect();

--- a/crates/atlas-git/src/status.rs
+++ b/crates/atlas-git/src/status.rs
@@ -54,7 +54,7 @@ pub fn parse(bytes: &[u8]) -> StatusV2 {
             // `2 XY sub mH mI mW hH hI Xscore path` NUL origPath
             Some('2') => {
                 if let Some((xy, sub, path)) = split_fields(tok, 9) {
-                    let orig = tokens.next().map(|s| s.to_string());
+                    let orig = tokens.next().map(std::string::ToString::to_string);
                     out.entries.push(entry(path, orig, xy, sub, None, false));
                 }
             }

--- a/crates/atlas-gitdiff/Cargo.toml
+++ b/crates/atlas-gitdiff/Cargo.toml
@@ -13,3 +13,8 @@ serde = { version = "1", features = ["derive"] }
 regex = "1"
 unicode-segmentation = "1"
 unicode-width = "0.2"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-memory/Cargo.toml
+++ b/crates/atlas-memory/Cargo.toml
@@ -30,3 +30,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-memory/MIGRATION.md
+++ b/crates/atlas-memory/MIGRATION.md
@@ -6,8 +6,10 @@ graph** engine in this crate. Covers the on-disk layout, the legacy migration,
 the feature flags, the retained rollback fallbacks, and the **manual** 3-agent
 runtime verification.
 
-Background: `plans/atlas-cersei-rag-replan.md` (full build plan) and
-`crates/atlas-cersei/ARCHITECTURE.md` §6e (the frozen `search_memory` seam).
+Background: the originating plan (`plans/atlas-cersei-rag-replan.md`) and the
+frozen-seam spec (`crates/atlas-cersei/ARCHITECTURE.md` §6e) were deleted with
+the Cersei path (#54); the frozen seam is restated just below, and the native
+consumer is now `atlas-native-agent`'s `search_memory` dynamic tool.
 
 > **Frozen seam — unchanged.** `MemDoc { title, source, text }` +
 > `MemorySearchFn(cwd, query, limit) -> Vec<MemDoc>` are untouched. All three

--- a/crates/atlas-memory/README.md
+++ b/crates/atlas-memory/README.md
@@ -18,8 +18,12 @@ share it without special-casing.
 > duplicate `:Topic` nodes, an inert `recall_top_k` ranking); fixing one means
 > editing that file in the same commit.
 
-> rationale + the build plan? See `plans/atlas-cersei-rag-replan.md` and
-> `crates/atlas-cersei/ARCHITECTURE.md` §6e.
+> rationale + the build plan? The originating plan and the frozen-seam spec
+> lived in `plans/atlas-cersei-rag-replan.md` and
+> `crates/atlas-cersei/ARCHITECTURE.md` §6e — both deleted with the Cersei
+> path (#54). The seam itself is stated below and enforced by this crate's
+> tests; the native consumer is now `atlas-native-agent`'s `search_memory`
+> dynamic tool.
 
 ---
 

--- a/crates/atlas-memory/src/consolidate.rs
+++ b/crates/atlas-memory/src/consolidate.rs
@@ -240,7 +240,7 @@ fn prune_memdir(memory_dir: &Path) -> Result<(usize, usize)> {
     }
 
     // Rewrite each file with its survivors (or delete it if none remain).
-    for ((path, _), survivors) in files.iter().zip(per_file.into_iter()) {
+    for ((path, _), survivors) in files.iter().zip(per_file) {
         if survivors.is_empty() {
             let _ = std::fs::remove_file(path);
             continue;
@@ -260,7 +260,7 @@ fn apply_floor_and_cap(per_file: &mut [Vec<RawEntry>], floor: f32, cap: usize) -
         entries.retain(|e| e.confidence >= floor);
     }
 
-    let surviving: usize = per_file.iter().map(|e| e.len()).sum();
+    let surviving: usize = per_file.iter().map(std::vec::Vec::len).sum();
     if surviving <= cap {
         return surviving;
     }
@@ -291,7 +291,7 @@ fn apply_floor_and_cap(per_file: &mut [Vec<RawEntry>], floor: f32, cap: usize) -
         });
     }
 
-    per_file.iter().map(|e| e.len()).sum()
+    per_file.iter().map(std::vec::Vec::len).sum()
 }
 
 /// Parse the `- **[cat]** content *(confidence: NN%)*` bullets out of one memdir
@@ -423,7 +423,7 @@ mod tests {
         force_session_gate(&memory_dir);
 
         // Simulate another consolidation already holding the lock.
-        let other = AutoDream::new(memory_dir.clone(), memory_dir.clone());
+        let other = AutoDream::new(memory_dir.clone(), memory_dir);
         other.acquire_lock().unwrap();
 
         let outcome = consolidate(&mut engine).unwrap();

--- a/crates/atlas-memory/src/manifest.rs
+++ b/crates/atlas-memory/src/manifest.rs
@@ -120,7 +120,7 @@ impl Manifest {
 
     /// Id for a key, if known.
     pub fn id_for(&self, key: u64) -> Option<&str> {
-        self.key_to_id.get(&key).map(|s| s.as_str())
+        self.key_to_id.get(&key).map(std::string::String::as_str)
     }
 
     /// Insert or update the entry for `id` (assigning a key if needed) and keep

--- a/crates/atlas-memory/src/migrate.rs
+++ b/crates/atlas-memory/src/migrate.rs
@@ -176,7 +176,7 @@ mod tests {
             &root,
             LEGACY_MODEL,
             DIM,
-            &[("doc-a", "hash-a", va.clone()), ("doc-b", "hash-b", vb.clone())],
+            &[("doc-a", "hash-a", va.clone()), ("doc-b", "hash-b", vb)],
         );
 
         // `open` runs migration internally.

--- a/crates/atlas-memory/src/parity_bench.rs
+++ b/crates/atlas-memory/src/parity_bench.rs
@@ -249,7 +249,7 @@ fn bench_hnsw_vs_brute_force() {
     }
     let hnsw_build = build_start.elapsed();
 
-    let brute = BruteForce::new(vectors.clone());
+    let brute = BruteForce::new(vectors);
 
     // ── Time HNSW search ──
     let t = Instant::now();

--- a/crates/atlas-memory/src/retrieve.rs
+++ b/crates/atlas-memory/src/retrieve.rs
@@ -215,7 +215,7 @@ fn rrf_fuse_weighted(lists: &[(&[Ranked], f32)]) -> Vec<(RetrievedDoc, f32)> {
     }
 
     let mut fused: Vec<(f32, RetrievedDoc, usize)> =
-        acc.into_values().map(|(s, d, o)| (s, d, o)).collect();
+        acc.into_values().collect();
     // Highest fused score first; break ties by first-seen order (embedding first).
     fused.sort_by(|a, b| {
         b.0.partial_cmp(&a.0)

--- a/crates/atlas-memory/src/store.rs
+++ b/crates/atlas-memory/src/store.rs
@@ -173,7 +173,7 @@ mod tests {
         let q = unit_vec(5);
         let hits = reloaded.search(&q, 3).unwrap();
         assert!(!hits.is_empty());
-        assert_eq!(hits[0].0, 5, "nearest key should be 5, got {:?}", hits);
+        assert_eq!(hits[0].0, 5, "nearest key should be 5, got {hits:?}");
         // Cosine similarity of the (near-)identical vector should be ~1.
         assert!(hits[0].1 > 0.9, "similarity too low: {}", hits[0].1);
 

--- a/crates/atlas-native-agent/Cargo.toml
+++ b/crates/atlas-native-agent/Cargo.toml
@@ -73,3 +73,8 @@ tokio = { version = "1", features = ["full", "test-util"] }
 # Seam-1 contract tests drive a real turn against a local mock model, so the
 # streaming path is exercised without a live provider or a credential.
 wiremock = "0.6"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-native-agent/src/engine/auth.rs
+++ b/crates/atlas-native-agent/src/engine/auth.rs
@@ -162,7 +162,7 @@ impl AtlasExternalAuth {
 
     fn cached_if_fresh(&self) -> Option<String> {
         let now = self.clock.now_unix();
-        let cached = self.cached.lock().unwrap_or_else(|p| p.into_inner());
+        let cached = self.cached.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         cached
             .as_ref()
             .filter(|c| now < c.renew_after)
@@ -180,7 +180,7 @@ impl AtlasExternalAuth {
             Some(exp) => exp.saturating_sub(REMINT_MARGIN.as_secs()).max(now + 1),
             None => now + ASSUMED_TTL.as_secs() - REMINT_MARGIN.as_secs(),
         };
-        *self.cached.lock().unwrap_or_else(|p| p.into_inner()) = Some(CachedToken {
+        *self.cached.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(CachedToken {
             token: token.clone(),
             renew_after,
         });

--- a/crates/atlas-native-agent/src/engine/connection.rs
+++ b/crates/atlas-native-agent/src/engine/connection.rs
@@ -974,11 +974,19 @@ impl AgentConnection for EngineConnection {
                     match read {
                         Ok(response) => (response.thread.id, response.thread.turns),
                         Err(read_err) => {
-                            tracing::info!(
+                            // `warn!`, not `info!`: this arm is reached by an
+                            // unknown thread id (a pre-cutover row — expected)
+                            // but also by a transport failure or a bad reply,
+                            // and those mean the model continues with no
+                            // context while the chat repaints from Atlas's own
+                            // transcript and looks fine. The two errors are
+                            // printed so the reader can tell which it was.
+                            tracing::warn!(
                                 target: "atlas_native_agent::engine",
-                                "the engine does not know thread {session_id}; opening it \
-                                 fresh (a row from before the engine changed): \
-                                 resume: {resume_err}; read: {read_err}",
+                                "opening thread {session_id} fresh: the engine could not \
+                                 resume it or read it back — either it does not know the \
+                                 id (a row from before the engine changed) or the calls \
+                                 themselves failed. resume: {resume_err}; read: {read_err}",
                             );
                             let started: v2::ThreadStartResponse = self
                                 .call(|request_id| ClientRequest::ThreadStart {
@@ -1003,8 +1011,9 @@ impl AgentConnection for EngineConnection {
 
             // Keyed by the id the engine will stamp on its events, which is
             // the only id the sink can match. For a pre-cutover row that is a
-            // new id, and the live feed rebinds the store row to it — the same
-            // path a draft takes.
+            // new id — the caller reads it off the returned thread and rebinds
+            // the store row (`resume_thread` compares it to the stored id and
+            // adopts, #56); nothing here writes to history.
             let engine_session_id = acp::SessionId::new(engine_thread_id.as_str());
             let thread = self.new_thread(engine_session_id.clone(), work_dirs, title);
             {

--- a/crates/atlas-native-agent/src/engine/connection.rs
+++ b/crates/atlas-native-agent/src/engine/connection.rs
@@ -118,6 +118,18 @@ pub struct TurnWaiters {
     /// Completions that arrived before anyone asked for them. See the module
     /// docs: this is what closes the register-after-response race.
     unclaimed: Mutex<std::collections::VecDeque<v2::Turn>>,
+    /// Threads whose prompt is between entry and [`TurnWaiters::register`] —
+    /// the window in which a stop has no turn id to interrupt (#57). The
+    /// register-after-response race has a cancel half too: `active` is only
+    /// written by `register`, which runs after the `turn/start` round trip, so
+    /// a stop pressed during that round trip used to find nothing and return —
+    /// while the UI, whose `running_turn` was already taken, dropped the Stop
+    /// button in the same instant. The turn then ran to completion with no way
+    /// to stop it.
+    starting: Mutex<std::collections::HashSet<String>>,
+    /// Stops pressed inside that window. Recorded here by [`TurnWaiters::cancel_requested`]
+    /// and honoured by the prompt path the moment the turn id exists.
+    pending_cancel: Mutex<std::collections::HashSet<String>>,
 }
 
 impl TurnWaiters {
@@ -186,6 +198,41 @@ impl TurnWaiters {
     /// The turn to interrupt for a session, if one is running.
     pub(crate) fn active_turn(&self, thread_id: &str) -> Option<String> {
         self.active().get(thread_id).cloned()
+    }
+
+    /// The prompt path is about to send `turn/start`. Until [`TurnWaiters::end_prompt`]
+    /// a cancel for this thread has no turn id; it is recorded instead and
+    /// honoured when the id exists.
+    fn begin_prompt(&self, thread_id: &str) {
+        self.starting().insert(thread_id.to_string());
+    }
+
+    /// A cancel arrived with no active turn. Records it if a prompt is inside
+    /// its starting window, and answers whether it was recorded — `false`
+    /// means nothing is running or starting, a true no-op.
+    pub(crate) fn cancel_requested(&self, thread_id: &str) -> bool {
+        if !self.starting().contains(thread_id) {
+            return false;
+        }
+        self.pending_cancel().insert(thread_id.to_string());
+        true
+    }
+
+    /// The starting window is over — the turn registered, failed to start, or
+    /// finished before it could be waited on. Answers whether a cancel arrived
+    /// inside the window; the flag is consumed either way, so a stop aimed at
+    /// a turn that never ran cannot leak into the next one.
+    fn end_prompt(&self, thread_id: &str) -> bool {
+        self.starting().remove(thread_id);
+        self.pending_cancel().remove(thread_id)
+    }
+
+    fn starting(&self) -> std::sync::MutexGuard<'_, std::collections::HashSet<String>> {
+        self.starting.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn pending_cancel(&self) -> std::sync::MutexGuard<'_, std::collections::HashSet<String>> {
+        self.pending_cancel.lock().unwrap_or_else(|p| p.into_inner())
     }
 
     fn forget(&self, thread_id: &str, turn_id: &str) {
@@ -1286,13 +1333,18 @@ impl AgentConnection for EngineConnection {
             // parent thread's model, which the gateway serves.
             Some(crate::engine::commands::Command::Review(instructions)) => {
                 let thread_id = thread_id.clone();
+                let request_ids = self.request_ids.clone();
                 return async move {
                     let target = match instructions {
                         Some(instructions) => v2::ReviewTarget::Custom { instructions },
                         None => v2::ReviewTarget::UncommittedChanges,
                     };
-                    let started: v2::ReviewStartResponse = requests
-                        .request_typed(ClientRequest::ReviewStart {
+                    // The review runs as a turn, so it has the same stop
+                    // window as a prompt: no id to interrupt until
+                    // `review/start` answers (#57).
+                    turns.begin_prompt(&thread_id);
+                    let started = match requests
+                        .request_typed::<v2::ReviewStartResponse>(ClientRequest::ReviewStart {
                             request_id,
                             params: v2::ReviewStartParams {
                                 thread_id: thread_id.clone(),
@@ -1301,11 +1353,27 @@ impl AgentConnection for EngineConnection {
                             },
                         })
                         .await
-                        .map_err(|e| anyhow!("the review could not start: {e}"))?;
+                    {
+                        Ok(started) => started,
+                        Err(e) => {
+                            turns.end_prompt(&thread_id);
+                            return Err(anyhow!("the review could not start: {e}"));
+                        }
+                    };
                     if started.turn.status != v2::TurnStatus::InProgress {
+                        turns.end_prompt(&thread_id);
                         return Ok(acp::PromptResponse::new(stop_reason(&started.turn)?));
                     }
                     let waiter = turns.register(&thread_id, &started.turn.id);
+                    if turns.end_prompt(&thread_id) {
+                        send_interrupt(
+                            &requests,
+                            &request_ids,
+                            thread_id.clone(),
+                            started.turn.id.clone(),
+                        )
+                        .await;
+                    }
                     match waiter.await {
                         Ok(turn) => Ok(acp::PromptResponse::new(stop_reason(&turn)?)),
                         Err(_) => {
@@ -1331,9 +1399,13 @@ impl AgentConnection for EngineConnection {
             None => {}
         }
 
+        let request_ids = self.request_ids.clone();
         async move {
-            let started: v2::TurnStartResponse = requests
-                .request_typed(ClientRequest::TurnStart {
+            // Opens the window a stop can land in with no turn id to
+            // interrupt. Every exit below closes it via `end_prompt` (#57).
+            turns.begin_prompt(&thread_id);
+            let started = match requests
+                .request_typed::<v2::TurnStartResponse>(ClientRequest::TurnStart {
                     request_id,
                     params: v2::TurnStartParams {
                         thread_id: thread_id.clone(),
@@ -1348,16 +1420,38 @@ impl AgentConnection for EngineConnection {
                     },
                 })
                 .await
-                .map_err(|e| anyhow!("{e}"))?;
+            {
+                Ok(started) => started,
+                Err(e) => {
+                    // The turn never ran; a stop aimed at it succeeded
+                    // vacuously and must not leak into the next turn.
+                    turns.end_prompt(&thread_id);
+                    return Err(anyhow!("{e}"));
+                }
+            };
 
             // If the turn already finished, its outcome is in the response and
             // no notification is coming — registering a waiter for it would
             // hang forever.
             if started.turn.status != v2::TurnStatus::InProgress {
+                turns.end_prompt(&thread_id);
                 return Ok(acp::PromptResponse::new(stop_reason(&started.turn)?));
             }
 
             let waiter = turns.register(&thread_id, &started.turn.id);
+            // A stop pressed while `turn/start` was in flight had no id to
+            // interrupt. It was recorded; honour it now that the id exists.
+            // The engine answers by completing the turn as `Interrupted`,
+            // which the waiter below reports the usual way.
+            if turns.end_prompt(&thread_id) {
+                send_interrupt(
+                    &requests,
+                    &request_ids,
+                    thread_id.clone(),
+                    started.turn.id.clone(),
+                )
+                .await;
+            }
             let turn = match waiter.await {
                 Ok(turn) => turn,
                 Err(_) => {
@@ -1404,17 +1498,29 @@ impl AgentConnection for EngineConnection {
     fn cancel(&self, session_id: &acp::SessionId) {
         let thread_id = session_id.to_string();
         let Some(turn_id) = self.turns.active_turn(&thread_id) else {
-            // Nothing is running. Not an error — a cancel can race a turn that
-            // just finished — but worth saying, because the other reading is
-            // that the turn was never recorded and cancel is silently dead.
-            tracing::debug!(
-                target: "atlas_native_agent::engine",
-                "cancel for {thread_id} with no turn in flight",
-            );
+            // No turn is registered — but one may be mid-`turn/start`, with
+            // no id to interrupt yet. That stop used to be silently dropped,
+            // and the Stop button disappeared with it (#57): recorded now,
+            // and the prompt path honours it the moment the id exists.
+            if self.turns.cancel_requested(&thread_id) {
+                tracing::info!(
+                    target: "atlas_native_agent::engine",
+                    "cancel for {thread_id} recorded while its turn is still starting",
+                );
+            } else {
+                // Nothing running or starting. Not an error — a cancel can
+                // race a turn that just finished — but worth saying, because
+                // the other reading is that the turn was never recorded and
+                // cancel is silently dead.
+                tracing::debug!(
+                    target: "atlas_native_agent::engine",
+                    "cancel for {thread_id} with no turn in flight",
+                );
+            }
             return;
         };
         let requests = self.requests.clone();
-        let request_id = self.request_ids.next();
+        let request_ids = self.request_ids.clone();
         // Fire and forget, like the Cersei path: the caller is awaiting the
         // turn's own completion, and the engine answers an interrupt by
         // finishing that turn as `Interrupted`.
@@ -1424,25 +1530,84 @@ impl AgentConnection for EngineConnection {
         // the main thread, where there is no ambient runtime — a bare spawn
         // there panicked and took the whole app down with it.
         self.runtime.handle().spawn(async move {
-            let result = requests
-                .request_typed::<v2::TurnInterruptResponse>(ClientRequest::TurnInterrupt {
-                    request_id,
-                    params: v2::TurnInterruptParams { thread_id, turn_id },
-                })
-                .await;
-            if let Err(e) = result {
-                tracing::warn!(
-                    target: "atlas_native_agent::engine",
-                    "interrupting the engine turn failed: {e}",
-                );
-            }
+            send_interrupt(&requests, &request_ids, thread_id, turn_id).await;
         });
+    }
+}
+
+/// Send `turn/interrupt` and log a failure. The caller is awaiting the turn's
+/// own completion, which the engine answers by finishing it as `Interrupted` —
+/// so the response here carries nothing to act on, only an error to surface.
+async fn send_interrupt(
+    requests: &InProcessAppServerRequestHandle,
+    request_ids: &RequestIds,
+    thread_id: String,
+    turn_id: String,
+) {
+    let result = requests
+        .request_typed::<v2::TurnInterruptResponse>(ClientRequest::TurnInterrupt {
+            request_id: request_ids.next(),
+            params: v2::TurnInterruptParams { thread_id, turn_id },
+        })
+        .await;
+    if let Err(e) = result {
+        tracing::warn!(
+            target: "atlas_native_agent::engine",
+            "interrupting the engine turn failed: {e}",
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── #57: the stop window between `turn/start` and `register` ──────────
+    //
+    // The integration test presses Stop once against a real engine; these pin
+    // the interleavings deterministically, because which side of `register`
+    // the press lands on cannot be scripted from outside.
+
+    #[test]
+    fn a_cancel_during_the_starting_window_is_recorded_and_handed_to_the_prompt() {
+        let turns = TurnWaiters::default();
+        turns.begin_prompt("t1");
+        assert!(
+            turns.cancel_requested("t1"),
+            "a stop with a prompt mid-start is recorded, not dropped",
+        );
+        let _rx = turns.register("t1", "turn-1");
+        assert!(
+            turns.end_prompt("t1"),
+            "the recorded stop reaches the prompt path once the id exists",
+        );
+        assert!(!turns.end_prompt("t1"), "and is consumed by it");
+    }
+
+    #[test]
+    fn a_cancel_with_nothing_running_or_starting_stays_a_no_op() {
+        let turns = TurnWaiters::default();
+        assert!(!turns.cancel_requested("t1"));
+        turns.begin_prompt("t1");
+        assert!(!turns.end_prompt("t1"), "no stop was pressed");
+        assert!(
+            !turns.cancel_requested("t1"),
+            "the window is closed; a late stop is a no-op again",
+        );
+    }
+
+    #[test]
+    fn a_stop_aimed_at_a_turn_that_never_ran_does_not_leak_into_the_next_one() {
+        let turns = TurnWaiters::default();
+        turns.begin_prompt("t1");
+        assert!(turns.cancel_requested("t1"));
+        // `turn/start` failed: the prompt path closes the window, and the
+        // stop succeeded vacuously.
+        assert!(turns.end_prompt("t1"));
+        // The user's next message must not be killed by the stale press.
+        turns.begin_prompt("t1");
+        assert!(!turns.end_prompt("t1"));
+    }
 
     fn message_delta(thread: &str, item: &str, delta: &str) -> InProcessServerEvent {
         InProcessServerEvent::ServerNotification(Box::new(

--- a/crates/atlas-native-agent/src/engine/connection.rs
+++ b/crates/atlas-native-agent/src/engine/connection.rs
@@ -556,12 +556,23 @@ async fn pump_events(
             biased;
 
             Some(answer) = answers_rx.recv() => {
+                // A failed delivery here is the worst silent outcome this
+                // loop has: the engine turn waits forever for an answer that
+                // will never arrive, and the user sees a spinner (#69). It
+                // cannot be retried — the request id may be gone — but it
+                // must never be invisible.
                 match answer.result {
                     Ok(value) => {
-                        let _ = client.resolve_server_request(answer.request_id, value).await;
+                        if let Err(e) = client.resolve_server_request(answer.request_id, value).await {
+                            tracing::warn!(
+                                target: "atlas_native_agent::engine",
+                                "delivering an approval to the engine failed; \
+                                 the waiting turn may hang: {e}",
+                            );
+                        }
                     }
                     Err(message) => {
-                        let _ = client
+                        if let Err(e) = client
                             .reject_server_request(
                                 answer.request_id,
                                 codex_app_server_protocol::JSONRPCErrorError {
@@ -570,7 +581,14 @@ async fn pump_events(
                                     data: None,
                                 },
                             )
-                            .await;
+                            .await
+                        {
+                            tracing::warn!(
+                                target: "atlas_native_agent::engine",
+                                "delivering a rejection to the engine failed; \
+                                 the waiting turn may hang: {e}",
+                            );
+                        }
                     }
                 }
             }

--- a/crates/atlas-native-agent/src/engine/connection.rs
+++ b/crates/atlas-native-agent/src/engine/connection.rs
@@ -166,7 +166,7 @@ impl TurnWaiters {
 
         self.attempts
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(&turn.id);
 
         if let Some(tx) = self.waiters().remove(&turn.id) {
@@ -185,19 +185,26 @@ impl TurnWaiters {
     /// Records one retry notice for a turn and returns its attempt number,
     /// counting from 1.
     pub(crate) fn note_retry(&self, turn_id: &str) -> usize {
-        let mut attempts = self.attempts.lock().unwrap_or_else(|p| p.into_inner());
+        let mut attempts = self.attempts.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let counter = attempts.entry(turn_id.to_string()).or_insert(0);
         *counter += 1;
         *counter
     }
 
     fn unclaimed(&self) -> std::sync::MutexGuard<'_, std::collections::VecDeque<v2::Turn>> {
-        self.unclaimed.lock().unwrap_or_else(|p| p.into_inner())
+        self.unclaimed.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     /// The turn to interrupt for a session, if one is running.
     pub(crate) fn active_turn(&self, thread_id: &str) -> Option<String> {
         self.active().get(thread_id).cloned()
+    }
+
+    /// Whether a turn is running or starting on this thread — the state in
+    /// which a mode switch would relabel the picker without touching the
+    /// turn's frozen context (#61).
+    pub(crate) fn is_busy(&self, thread_id: &str) -> bool {
+        self.active().contains_key(thread_id) || self.starting().contains(thread_id)
     }
 
     /// The prompt path is about to send `turn/start`. Until [`TurnWaiters::end_prompt`]
@@ -228,11 +235,11 @@ impl TurnWaiters {
     }
 
     fn starting(&self) -> std::sync::MutexGuard<'_, std::collections::HashSet<String>> {
-        self.starting.lock().unwrap_or_else(|p| p.into_inner())
+        self.starting.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     fn pending_cancel(&self) -> std::sync::MutexGuard<'_, std::collections::HashSet<String>> {
-        self.pending_cancel.lock().unwrap_or_else(|p| p.into_inner())
+        self.pending_cancel.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     fn forget(&self, thread_id: &str, turn_id: &str) {
@@ -244,11 +251,11 @@ impl TurnWaiters {
     }
 
     fn waiters(&self) -> std::sync::MutexGuard<'_, HashMap<String, oneshot::Sender<v2::Turn>>> {
-        self.waiters.lock().unwrap_or_else(|p| p.into_inner())
+        self.waiters.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     fn active(&self) -> std::sync::MutexGuard<'_, HashMap<String, String>> {
-        self.active.lock().unwrap_or_else(|p| p.into_inner())
+        self.active.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -385,7 +392,7 @@ impl EngineConnection {
             .await?;
         self.session_modes
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(session_id.clone(), mode.clone());
         Ok(())
     }
@@ -470,7 +477,7 @@ impl EngineConnection {
         if let Some(thread) = self.sessions.thread(session_id) {
             let _ = thread
                 .lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .handle_session_update(acp::SessionUpdate::AvailableCommandsUpdate(
                     acp::AvailableCommandsUpdate::new(crate::engine::commands::available(&skills)),
                 ));
@@ -730,7 +737,7 @@ fn handle_server_request(
 
     // Take the waiter out under the lock, then await it on its own task.
     let waiter = {
-        let mut thread = thread.lock().unwrap_or_else(|p| p.into_inner());
+        let mut thread = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         thread.request_tool_call_authorization(
             prompt,
             approvals::options(),
@@ -1070,7 +1077,7 @@ impl AgentConnection for EngineConnection {
                 // it (see `engine::replay`). A pre-cutover row took the
                 // fresh-thread arm above and has no turns; it opens empty,
                 // which D6 accepted, and now only that row does.
-                let mut locked = thread.lock().unwrap_or_else(|p| p.into_inner());
+                let mut locked = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                 crate::engine::replay::replay_turns(&mut locked, &stored_turns);
             }
             self.sessions.insert(
@@ -1129,7 +1136,7 @@ impl AgentConnection for EngineConnection {
         let mut turn_input: Option<Vec<v2::UserInput>> = None;
         match crate::engine::commands::parse(&text, &skills) {
             Some(crate::engine::commands::Command::Compact) => {
-                let thread_id = thread_id.clone();
+                let thread_id = thread_id;
                 return async move {
                     let _: v2::ThreadCompactStartResponse = requests
                         .request_typed(ClientRequest::ThreadCompactStart {
@@ -1157,7 +1164,7 @@ impl AgentConnection for EngineConnection {
             // the turn ends; no model is consulted and nothing is billed.
             Some(crate::engine::commands::Command::Diff) => {
                 let sessions = self.sessions.clone();
-                let session_id = params.session_id.clone();
+                let session_id = params.session_id;
                 return async move {
                     let cwd = sessions
                         .cwd(&session_id)
@@ -1172,7 +1179,7 @@ impl AgentConnection for EngineConnection {
                     if let Some(thread) = sessions.thread(&session_id) {
                         thread
                             .lock()
-                            .unwrap_or_else(|p| p.into_inner())
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
                             .push_assistant_content_block(
                                 acp::ContentBlock::Text(acp::TextContent::new(reply)),
                                 false,
@@ -1184,7 +1191,7 @@ impl AgentConnection for EngineConnection {
             }
             Some(crate::engine::commands::Command::Status) => {
                 let sessions = self.sessions.clone();
-                let session_id = params.session_id.clone();
+                let session_id = params.session_id;
                 return async move {
                     let cwd = sessions
                         .cwd(&session_id)
@@ -1193,7 +1200,7 @@ impl AgentConnection for EngineConnection {
                     if let Some(thread) = sessions.thread(&session_id) {
                         thread
                             .lock()
-                            .unwrap_or_else(|p| p.into_inner())
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
                             .push_assistant_content_block(
                                 acp::ContentBlock::Text(acp::TextContent::new(reply)),
                                 false,
@@ -1208,8 +1215,8 @@ impl AgentConnection for EngineConnection {
             // to match so the transcript shows what the model now remembers.
             Some(crate::engine::commands::Command::Undo) => {
                 let sessions = self.sessions.clone();
-                let session_id = params.session_id.clone();
-                let thread_id = thread_id.clone();
+                let session_id = params.session_id;
+                let thread_id = thread_id;
                 return async move {
                     let rolled = requests
                         .request_typed::<v2::ThreadRollbackResponse>(ClientRequest::ThreadRollback {
@@ -1224,7 +1231,7 @@ impl AgentConnection for EngineConnection {
                         Ok(_) => {
                             if let Some(thread) = sessions.thread(&session_id) {
                                 let mut locked =
-                                    thread.lock().unwrap_or_else(|p| p.into_inner());
+                                    thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
                                 // The LAST user entry is "/undo" itself — the
                                 // host pushed it before prompt() ran. The
                                 // exchange being undone starts at the user
@@ -1260,7 +1267,7 @@ impl AgentConnection for EngineConnection {
                     if let Some(thread) = sessions.thread(&session_id) {
                         thread
                             .lock()
-                            .unwrap_or_else(|p| p.into_inner())
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
                             .push_assistant_content_block(
                                 acp::ContentBlock::Text(acp::TextContent::new(reply)),
                                 false,
@@ -1273,8 +1280,8 @@ impl AgentConnection for EngineConnection {
             // `/goal` — set with input, show without.
             Some(crate::engine::commands::Command::Goal(objective)) => {
                 let sessions = self.sessions.clone();
-                let session_id = params.session_id.clone();
-                let thread_id = thread_id.clone();
+                let session_id = params.session_id;
+                let thread_id = thread_id;
                 return async move {
                     let reply = match objective {
                         Some(objective_text) => {
@@ -1315,7 +1322,7 @@ impl AgentConnection for EngineConnection {
                     if let Some(thread) = sessions.thread(&session_id) {
                         thread
                             .lock()
-                            .unwrap_or_else(|p| p.into_inner())
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
                             .push_assistant_content_block(
                                 acp::ContentBlock::Text(acp::TextContent::new(reply)),
                                 false,
@@ -1332,7 +1339,7 @@ impl AgentConnection for EngineConnection {
             // `review_model` unset on purpose, and the engine then uses the
             // parent thread's model, which the gateway serves.
             Some(crate::engine::commands::Command::Review(instructions)) => {
-                let thread_id = thread_id.clone();
+                let thread_id = thread_id;
                 let request_ids = self.request_ids.clone();
                 return async move {
                     let target = match instructions {
@@ -1843,6 +1850,8 @@ struct ConnectionHandle {
     requests: InProcessAppServerRequestHandle,
     request_ids: Arc<RequestIds>,
     session_modes: Arc<Mutex<HashMap<acp::SessionId, acp::SessionModeId>>>,
+    /// For the in-flight-turn check in `set_mode` (#61).
+    turns: Arc<TurnWaiters>,
 }
 
 impl EngineConnection {
@@ -1851,6 +1860,7 @@ impl EngineConnection {
             requests: self.requests.clone(),
             request_ids: self.request_ids.clone(),
             session_modes: self.session_modes.clone(),
+            turns: self.turns.clone(),
         }
     }
 }
@@ -1888,7 +1898,7 @@ impl AgentSessionModes for EngineSessionModes {
         self.connection
             .session_modes
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(&self.session_id)
             .cloned()
             .unwrap_or_else(|| acp::SessionModeId::new(modes::DEFAULT_MODE_ID))
@@ -1902,6 +1912,21 @@ impl AgentSessionModes for EngineSessionModes {
         let connection = self.connection.clone();
         let session_id = self.session_id.clone();
         async move {
+            // Refused, not silently narrowed to the picker: the engine's
+            // `update_settings` writes only the session configuration, and a
+            // running turn keeps the frozen context it started with — so a
+            // mid-turn switch would change the label while every remaining
+            // tool call executes under the old policy. Showing "Plan —
+            // read-only" over a turn still running with full access is the
+            // one shape worse than no control at all (#61). Stop the turn,
+            // then switch; the next turn picks the new mode up at start.
+            if connection.turns.is_busy(&session_id.to_string()) {
+                return Err(anyhow!(
+                    "The permission mode can't change while a turn is running — \
+                     it would only relabel the picker; the running turn keeps \
+                     the permissions it started with. Stop the turn first."
+                ));
+            }
             let (approval_policy, sandbox_policy) = modes::engine_policy(&mode.0);
             connection
                 .update_settings(&session_id, |params| {
@@ -1914,7 +1939,7 @@ impl AgentSessionModes for EngineSessionModes {
             connection
                 .session_modes
                 .lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .insert(session_id, mode);
             Ok(())
         }

--- a/crates/atlas-native-agent/src/engine/memory.rs
+++ b/crates/atlas-native-agent/src/engine/memory.rs
@@ -129,7 +129,7 @@ pub fn parse_arguments(arguments: &serde_json::Value) -> Option<(String, usize)>
     }
     let limit = arguments
         .get("limit")
-        .and_then(|l| l.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .map(|l| l as usize)
         .unwrap_or(DEFAULT_LIMIT)
         .clamp(1, MAX_LIMIT);

--- a/crates/atlas-native-agent/src/engine/mod.rs
+++ b/crates/atlas-native-agent/src/engine/mod.rs
@@ -1,12 +1,12 @@
 //! The ported Codex engine, behind the seam.
 //!
-//! Everything in here is gated on the `ported-engine` feature — the
-//! development-time switch of spec Phase 2. With the feature off this module
-//! does not exist, the engine is not in the dependency graph, and the shipped
-//! app is byte-for-byte the Cersei path it is today. That is deliberate: the
-//! Cersei path keeps shipping until the acceptance bar is green (Cutover
-//! Sequence, Phase 5), so the switch must not be able to leak the engine into
-//! a release build by accident.
+//! This module used to be gated on the `ported-engine` feature — the
+//! development-time switch of spec Phase 2, kept while the Cersei path was
+//! still shipping. The cutover happened: #54 deleted the feature and the
+//! Cersei path with it, so the engine is unconditional now and there is no
+//! kill switch here. (The feature's deletion also caused the #54 auth outage
+//! — four `#[cfg(feature = "ported-engine")]` blocks compiled to nothing —
+//! which is why `unexpected_cfgs` is a workspace deny, #60.)
 //!
 //! The surface is ADR-0004's: the engine is driven **in-process at the
 //! app-server layer**, through `codex-app-server-client`, and `src-tauri` sees

--- a/crates/atlas-native-agent/src/engine/sink.rs
+++ b/crates/atlas-native-agent/src/engine/sink.rs
@@ -270,6 +270,15 @@ fn tool_call_of(item: &ThreadItem) -> Option<acp::ToolCall> {
                 )
                 .raw_input(serde_json::json!({
                     "paths": changes.iter().map(|c| c.path.clone()).collect::<Vec<_>>(),
+                    // The engine's own per-file unified diffs, joined. This is
+                    // what capture's `edit_patch` stores for the Timeline's
+                    // checkpoint diff/restore view — its first arm reads
+                    // `arguments["patch"]`, and without this key every native
+                    // edit produced a checkpoint with nothing to show (#75).
+                    // The structured Diff content block is not an option: it
+                    // wants full old/new text, which a unified diff cannot
+                    // reconstruct.
+                    "patch": diffs,
                 }));
             if !diffs.trim().is_empty() {
                 call = call.content(vec![acp::ToolCallContent::Content(acp::Content::new(
@@ -510,6 +519,33 @@ pub fn apply_notification(
             turns.complete(&params.thread_id, params.turn);
         }
 
+        // The thread's cumulative token usage. Everything downstream was
+        // already built and waiting — `update_token_usage` fires the
+        // TokenUsageUpdated event, the projector turns it into the
+        // UsageUpdated (real input/output split) and ContextUsage (gauge)
+        // deltas, and capture's `record_usage` OVERWRITES totals, which is
+        // exactly right for a cumulative figure. Ignoring this notification
+        // is why the native agent — the one agent that reports a real split —
+        // showed no token consumption on the Timeline at all (#74).
+        ServerNotification::ThreadTokenUsageUpdated(params) => {
+            let Some(thread) = sessions.thread(&session_id(&params.thread_id)) else {
+                return;
+            };
+            let total = &params.token_usage.total;
+            let clamp = |n: i64| n.max(0) as u64;
+            lock(&thread).update_token_usage(Some(atlas_acp_thread::TokenUsage {
+                max_tokens: params
+                    .token_usage
+                    .model_context_window
+                    .map(clamp)
+                    .unwrap_or(0),
+                used_tokens: clamp(total.total_tokens),
+                input_tokens: clamp(total.input_tokens),
+                output_tokens: clamp(total.output_tokens),
+                max_output_tokens: None,
+            }));
+        }
+
         // A stream error. `will_retry` is the engine telling us whether it is
         // about to try again, and it is the difference between a retry pill
         // and a dead turn: a retrying turn has NOT ended, so the only correct
@@ -658,6 +694,59 @@ mod tests {
             Some(""),
             "the accumulator starts empty again after the turn",
         );
+    }
+
+    #[test]
+    fn a_file_change_ships_its_patch_for_the_checkpoint_diff() {
+        // #75: the engine reports an edit with a per-file unified diff. The
+        // capture path stores a patch for the Timeline's diff/restore view,
+        // and its extractor's first arm reads `arguments["patch"]` — a key
+        // this sink never wrote, so every native edit produced a checkpoint
+        // with nothing to show or restore. (The structured Diff content
+        // block wants full old/new text, which a unified diff cannot
+        // reconstruct — the patch argument is the honest carrier.)
+        let sessions = EngineSessions::default();
+        let turns = TurnWaiters::default();
+        let id = acp::SessionId::new("t-patch");
+        let thread = crate::engine::test_support::detached_thread(id.clone());
+        sessions.insert(id, &thread, "/tmp".to_string());
+
+        apply_notification(
+            &sessions,
+            &turns,
+            3,
+            ServerNotification::ItemCompleted(codex_app_server_protocol::ItemCompletedNotification {
+                thread_id: "t-patch".to_string(),
+                turn_id: "turn-1".to_string(),
+                item: ThreadItem::FileChange {
+                    id: "item-1".to_string(),
+                    status: codex_app_server_protocol::PatchApplyStatus::Completed,
+                    changes: vec![codex_app_server_protocol::FileUpdateChange {
+                        path: "src/foo.rs".to_string(),
+                        kind: codex_app_server_protocol::PatchChangeKind::Update { move_path: None },
+                        diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+                    }],
+                },
+                completed_at_ms: 0,
+            }),
+        );
+
+        let locked = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let call = locked
+            .entries()
+            .iter()
+            .find_map(|e| match e {
+                atlas_acp_thread::AgentThreadEntry::ToolCall(call) => Some(call),
+                _ => None,
+            })
+            .expect("the file change reaches the thread as a tool call");
+        let patch = call
+            .raw_input
+            .as_ref()
+            .and_then(|args| args.get("patch"))
+            .and_then(|p| p.as_str())
+            .expect("the edit's arguments carry the patch the checkpoint stores");
+        assert!(patch.contains("+new"), "the patch is the engine's own diff: {patch}");
     }
 
     #[test]

--- a/crates/atlas-native-agent/src/engine/sink.rs
+++ b/crates/atlas-native-agent/src/engine/sink.rs
@@ -75,7 +75,16 @@ pub struct EngineSessions {
 
 impl EngineSessions {
     pub fn insert(&self, session_id: acp::SessionId, thread: &AcpThreadHandle, cwd: String) {
-        self.lock().insert(
+        let mut sessions = self.lock();
+        // Reap entries whose thread the host has dropped (#66). The map has
+        // no other removal path — the connection lives as long as the process
+        // — and while `thread` is Weak, everything else in the entry
+        // (`streamed`, `command_output`, `cwd`, `skills`) is owned here and
+        // outlived the AcpThread it described. Swept at insert, so the state
+        // is bounded by live sessions rather than by every session the
+        // process ever opened.
+        sessions.retain(|_, session| session.thread.strong_count() > 0);
+        sessions.insert(
             session_id,
             EngineSession {
                 thread: Arc::downgrade(thread),
@@ -132,6 +141,20 @@ impl EngineSessions {
     fn clear_command_output(&self, session_id: &acp::SessionId, item_id: &str) {
         if let Some(session) = self.lock().get_mut(session_id) {
             session.command_output.remove(item_id);
+        }
+    }
+
+    /// The turn is over: drop every live-output accumulator for the session.
+    ///
+    /// `ItemCompleted` clears each item's entry, but an item aborted by an
+    /// interrupt never completes — the engine gives a task 100 ms to wind
+    /// down and then aborts it — so its accumulated output stayed for the
+    /// life of the process, one verbose build per press of Stop (#66). The
+    /// turn's end is the honest boundary: whatever is still accumulating
+    /// belongs to an item that will never report.
+    fn end_of_turn_cleanup(&self, session_id: &acp::SessionId) {
+        if let Some(session) = self.lock().get_mut(session_id) {
+            session.command_output.clear();
         }
     }
 
@@ -483,6 +506,7 @@ pub fn apply_notification(
         // The turn's outcome. This is what `prompt` is awaiting — without it a
         // prompt future never resolves and the composer stays spinning.
         ServerNotification::TurnCompleted(params) => {
+            sessions.end_of_turn_cleanup(&session_id(&params.thread_id));
             turns.complete(&params.thread_id, params.turn);
         }
 
@@ -587,6 +611,53 @@ mod tests {
         // `ResourceLink::new` is (name, uri) — the display name first.
         let link = acp::ContentBlock::ResourceLink(acp::ResourceLink::new("a.rs", "file:///tmp/a.rs"));
         assert_eq!(flatten_prompt(&[link]), "file:///tmp/a.rs");
+    }
+
+    #[test]
+    fn a_dropped_threads_state_is_reaped_at_the_next_insert() {
+        // #66: the Weak thread was collectable, but the ENTRY — with its
+        // owned `streamed`, `command_output`, `cwd` and `skills` — had no
+        // removal path and lived as long as the process. Inserting a new
+        // session sweeps the dead ones.
+        let sessions = EngineSessions::default();
+        let dead = acp::SessionId::new("dead");
+        {
+            let thread = crate::engine::test_support::detached_thread(dead.clone());
+            sessions.insert(dead.clone(), &thread, "/tmp".to_string());
+        }
+        assert!(
+            sessions.cwd(&dead).is_some(),
+            "the entry itself outlives the thread…",
+        );
+
+        let live = acp::SessionId::new("live");
+        let thread = crate::engine::test_support::detached_thread(live.clone());
+        sessions.insert(live.clone(), &thread, "/tmp".to_string());
+        assert!(
+            sessions.cwd(&dead).is_none(),
+            "…until the next insert sweeps it",
+        );
+        assert!(sessions.cwd(&live).is_some());
+    }
+
+    #[test]
+    fn an_aborted_commands_output_is_dropped_when_the_turn_ends() {
+        // #66: `ItemCompleted` clears per item, but a task interrupted by
+        // Stop is aborted after its 100 ms grace and never completes — its
+        // accumulated output stayed for the life of the process. The turn's
+        // end clears whatever is still accumulating.
+        let sessions = EngineSessions::default();
+        let id = acp::SessionId::new("t1");
+        let thread = crate::engine::test_support::detached_thread(id.clone());
+        sessions.insert(id.clone(), &thread, "/tmp".to_string());
+
+        sessions.append_command_output(&id, "item-1", "a very verbose build log");
+        sessions.end_of_turn_cleanup(&id);
+        assert_eq!(
+            sessions.append_command_output(&id, "item-1", "").as_deref(),
+            Some(""),
+            "the accumulator starts empty again after the turn",
+        );
     }
 
     #[test]

--- a/crates/atlas-native-agent/src/engine/sink.rs
+++ b/crates/atlas-native-agent/src/engine/sink.rs
@@ -165,7 +165,7 @@ impl EngineSessions {
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<acp::SessionId, EngineSession>> {
-        self.sessions.lock().unwrap_or_else(|p| p.into_inner())
+        self.sessions.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -329,7 +329,7 @@ fn session_id(thread_id: &str) -> acp::SessionId {
 }
 
 fn lock(thread: &AcpThreadHandle) -> std::sync::MutexGuard<'_, AcpThread> {
-    thread.lock().unwrap_or_else(|p| p.into_inner())
+    thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Applies one engine notification.
@@ -446,7 +446,7 @@ pub fn apply_notification(
             };
             if let Some(thread) = sessions.thread(&session) {
                 let update = acp::ToolCallUpdate::new(
-                    acp::ToolCallId::new(params.item_id.clone()),
+                    acp::ToolCallId::new(params.item_id),
                     acp::ToolCallUpdateFields::new().content(vec![
                         acp::ToolCallContent::Content(acp::Content::new(text_block(&total))),
                     ]),

--- a/crates/atlas-native-agent/tests/engine_gateway_turn.rs
+++ b/crates/atlas-native-agent/tests/engine_gateway_turn.rs
@@ -98,12 +98,12 @@ impl Harness {
         };
         let id = thread
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .session_id()
             .clone();
         self.threads
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(thread);
         id
     }
@@ -112,13 +112,13 @@ impl Harness {
         let Some(thread) = self
             .threads
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .last()
             .cloned()
         else {
             panic!("a thread must be open");
         };
-        let thread = thread.lock().unwrap_or_else(|p| p.into_inner());
+        let thread = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         thread
             .entries()
             .iter()
@@ -142,9 +142,7 @@ impl Harness {
             panic!("the mock server must be recording requests");
         };
         let Some(last) = received
-            .iter()
-            .filter(|r| r.url.path().ends_with("/chat/completions"))
-            .next_back()
+            .iter().rfind(|r| r.url.path().ends_with("/chat/completions"))
         else {
             panic!("no completion request reached the gateway");
         };
@@ -193,7 +191,7 @@ async fn harness_with_token(
             while let Some(event) = thread_rx.recv().await {
                 if out
                     .lock()
-                    .unwrap_or_else(|p| p.into_inner())
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .send(event)
                     .is_err()
                 {
@@ -328,9 +326,7 @@ async fn the_minted_token_is_what_authorises_the_request() {
         panic!("the mock server must be recording requests");
     };
     let Some(last) = received
-        .iter()
-        .filter(|r| r.url.path().ends_with("/chat/completions"))
-        .next_back()
+        .iter().rfind(|r| r.url.path().ends_with("/chat/completions"))
     else {
         panic!("no completion request reached the gateway");
     };
@@ -631,7 +627,7 @@ async fn a_new_session_advertises_its_commands_and_no_login() {
     let Some(thread) = h
         .threads
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .last()
         .cloned()
     else {
@@ -639,7 +635,7 @@ async fn a_new_session_advertises_its_commands_and_no_login() {
     };
     let names: Vec<String> = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .available_commands()
         .iter()
         .map(|c| c.name.clone())
@@ -669,7 +665,7 @@ async fn the_paying_org_rides_every_request_and_follows_a_switch() {
     let org = Arc::new(std::sync::Mutex::new(Some("org_first".to_string())));
     let reader = org.clone();
     atlas_native_agent::engine::set_org_source(Arc::new(move || {
-        reader.lock().unwrap_or_else(|p| p.into_inner()).clone()
+        reader.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
     }));
 
     let h = harness(vec![(None, sse_ok(answer("ok")))]).await;
@@ -679,7 +675,7 @@ async fn the_paying_org_rides_every_request_and_follows_a_switch() {
         .prompt(acp::PromptRequest::new(session_id.clone(), text("one")))
         .await;
 
-    *org.lock().unwrap_or_else(|p| p.into_inner()) = Some("org_second".to_string());
+    *org.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some("org_second".to_string());
     let _ = h
         .connection
         .prompt(acp::PromptRequest::new(session_id, text("two")))
@@ -729,7 +725,7 @@ async fn a_resumed_session_advertises_the_same_commands_a_new_one_does() {
     };
     let names: Vec<String> = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .available_commands()
         .iter()
         .map(|c| c.name.clone())
@@ -845,7 +841,7 @@ async fn connection_at(
             while let Some(event) = thread_rx.recv().await {
                 if out
                     .lock()
-                    .unwrap_or_else(|p| p.into_inner())
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .send(event)
                     .is_err()
                 {
@@ -870,7 +866,7 @@ async fn connection_at(
 }
 
 fn thread_texts(thread: &atlas_acp_thread::AcpThreadHandle) -> Vec<(String, String)> {
-    let locked = thread.lock().unwrap_or_else(|p| p.into_inner());
+    let locked = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     locked
         .entries()
         .iter()
@@ -916,7 +912,7 @@ async fn a_reopened_session_replays_its_whole_conversation() {
             .expect("a session should open");
         let id = thread
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .session_id()
             .clone();
         let response = connection
@@ -938,7 +934,7 @@ async fn a_reopened_session_replays_its_whole_conversation() {
 
     let reopened_id = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .session_id()
         .clone();
     assert_eq!(
@@ -974,7 +970,7 @@ async fn a_reopened_session_replays_its_whole_conversation() {
 fn push_user(thread: &atlas_acp_thread::AcpThreadHandle, id: &str, text_content: &str) {
     let _ = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .handle_session_update(acp::SessionUpdate::UserMessageChunk(
             acp::ContentChunk::new(acp::ContentBlock::Text(acp::TextContent::new(
                 text_content.to_string(),
@@ -990,7 +986,7 @@ async fn undo_rewinds_the_engine_and_trims_the_transcript_to_match() {
     let thread = h
         .threads
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .last()
         .cloned()
         .expect("thread");
@@ -1012,7 +1008,7 @@ async fn undo_rewinds_the_engine_and_trims_the_transcript_to_match() {
 
     let all = format!(
         "{:?}",
-        thread.lock().unwrap_or_else(|p| p.into_inner()).entries()
+        thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner).entries()
     );
     assert!(
         !all.contains("first question") && !all.contains("a regrettable answer"),
@@ -1130,13 +1126,13 @@ async fn a_repo_skill_joins_the_picker_and_runs_as_a_skill_turn() {
         .expect("session");
     let session_id = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .session_id()
         .clone();
 
     let names: Vec<String> = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .available_commands()
         .iter()
         .map(|c| c.name.clone())
@@ -1248,7 +1244,7 @@ async fn compact_is_visible_in_the_thread_not_a_silent_shrug() {
     let thread = h
         .threads
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .last()
         .cloned()
         .expect("thread");
@@ -1256,7 +1252,7 @@ async fn compact_is_visible_in_the_thread_not_a_silent_shrug() {
     for _ in 0..200 {
         let has_compaction = thread
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .entries()
             .iter()
             .any(|entry| {
@@ -1326,11 +1322,11 @@ async fn an_executed_command_appears_as_a_tool_call_with_its_output() {
     let thread = h
         .threads
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .last()
         .cloned()
         .expect("thread");
-    let locked = thread.lock().unwrap_or_else(|p| p.into_inner());
+    let locked = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let call = locked
         .entries()
         .iter()

--- a/crates/atlas-native-agent/tests/engine_turn.rs
+++ b/crates/atlas-native-agent/tests/engine_turn.rs
@@ -334,24 +334,20 @@ async fn a_cancelled_turn_ends_aborted_rather_than_hanging_or_ending_normally() 
         })
     };
 
-    // Cancel needs a turn in flight, and `turn/start` has to have returned
-    // before the seam knows the turn id to interrupt. Rather than sleep a
-    // guessed interval, retry the cancel until the prompt finishes: a cancel
-    // with nothing running is a documented no-op, so repeating it is safe.
-    let cancelled = tokio::time::timeout(Duration::from_secs(20), async {
-        while !prompting.is_finished() {
-            h.connection.cancel(&session_id);
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await;
-    assert!(
-        cancelled.is_ok(),
-        "the cancel never took effect — the turn was still running after 20s",
-    );
+    // ONE press, like production (#57). The earlier version of this test
+    // retried cancel in a 100 ms loop, which could never fail on the lost
+    // press: a stop landing while `turn/start` is still in flight used to be
+    // silently dropped, and the loop's next iteration papered over it. The
+    // press may land before or after the turn registers — the seam records
+    // a too-early stop and honours it the moment the turn id exists, so a
+    // single press must take the turn down from either side of that line.
+    // (`connection.rs` unit-tests both interleavings deterministically.)
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    h.connection.cancel(&session_id);
 
-    let response = prompting
+    let response = tokio::time::timeout(Duration::from_secs(20), prompting)
         .await
+        .expect("one press must take the turn down — 20s later it was still running")
         .expect("the prompt task should not panic")
         .expect("a cancelled turn is an outcome, not an error");
 

--- a/crates/atlas-native-agent/tests/engine_turn.rs
+++ b/crates/atlas-native-agent/tests/engine_turn.rs
@@ -103,12 +103,12 @@ impl Harness {
             .expect("the engine should start a thread");
         let id = thread
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .session_id()
             .clone();
         self.threads
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .push(thread);
         id
     }
@@ -116,7 +116,7 @@ impl Harness {
     /// The assistant text currently rendered in the newest thread.
     fn assistant_text(&self) -> String {
         let thread = self.thread();
-        let thread = thread.lock().unwrap_or_else(|p| p.into_inner());
+        let thread = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         thread
             .entries()
             .iter()
@@ -133,7 +133,7 @@ impl Harness {
     fn thread(&self) -> atlas_acp_thread::AcpThreadHandle {
         self.threads
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .last()
             .cloned()
             .expect("a thread must be open")
@@ -196,7 +196,7 @@ async fn harness_full(
             while let Some(event) = thread_rx.recv().await {
                 if out
                     .lock()
-                    .unwrap_or_else(|p| p.into_inner())
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .send(event)
                     .is_err()
                 {
@@ -549,6 +549,59 @@ async fn a_turn_still_completes_after_switching_into_plan_mode() {
 }
 
 #[tokio::test]
+async fn a_mode_switch_during_a_turn_is_refused_rather_than_relabelling_the_picker() {
+    // #61. The engine's `update_settings` writes the session configuration; a
+    // RUNNING turn keeps the frozen context it started with. Accepting the
+    // switch mid-turn would flip the picker to "Plan — read-only, no edits or
+    // commands" while the turn's remaining tool calls execute with whatever
+    // the turn began with — a security control displayed as active while
+    // absent. Refusing is the honest answer.
+    let h = harness_with(vec![
+        (
+            Some(1),
+            sse_ok(assistant_turn("slow answer")).set_delay(Duration::from_secs(5)),
+        ),
+        (None, sse_ok(assistant_turn("ok"))),
+    ])
+    .await;
+    let session_id = h.open_thread().await;
+    let modes = h.connection.session_modes(&session_id).expect("modes");
+
+    let connection = h.connection.clone();
+    let prompting = {
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            connection
+                .prompt(acp::PromptRequest::new(session_id, text("take your time")))
+                .await
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert!(
+        modes.set_mode(acp::SessionModeId::new("plan")).await.is_err(),
+        "a mid-turn mode switch must be refused, not displayed",
+    );
+    assert_eq!(
+        modes.current_mode().to_string(),
+        "default",
+        "the picker must keep reporting the mode really in force",
+    );
+
+    let response = prompting
+        .await
+        .expect("the prompt task should not panic")
+        .expect("the refused switch must not break the running turn");
+    assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
+
+    // With the turn over, the same switch is accepted.
+    modes
+        .set_mode(acp::SessionModeId::new("plan"))
+        .await
+        .expect("the switch is accepted once nothing is running");
+}
+
+#[tokio::test]
 async fn per_session_controls_share_the_connection_request_id_counter() {
     // Regression, with an honest caveat about how strong it is.
     //
@@ -658,7 +711,7 @@ async fn answer_first_authorization(
                     .unwrap_or_else(|| panic!("no {pick:?} option was offered"));
                 h.thread()
                     .lock()
-                    .unwrap_or_else(|p| p.into_inner())
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .authorize_tool_call(
                         id,
                         atlas_acp_thread::SelectedPermissionOutcome::new(
@@ -1020,7 +1073,7 @@ fn recording_search() -> (atlas_native_agent::engine::memory::MemorySearch, Sear
     let search: atlas_native_agent::engine::memory::MemorySearch =
         Arc::new(move |cwd: String, query: String, limit: usize| {
             seen.lock()
-                .unwrap_or_else(|p| p.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .push((cwd, query.clone(), limit));
             Box::pin(async move {
                 vec![atlas_native_agent::engine::memory::MemDoc {
@@ -1057,7 +1110,7 @@ async fn search_memory_is_registered_and_returns_live_results() {
         .expect("the turn should complete");
     assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
 
-    let calls = calls.lock().unwrap_or_else(|p| p.into_inner()).clone();
+    let calls = calls.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone();
     assert_eq!(calls.len(), 1, "the engine should have called search_memory once");
     let (cwd, query, limit) = &calls[0];
     assert_eq!(query, "how does auth work");
@@ -1106,7 +1159,7 @@ async fn a_memory_call_with_no_query_is_answered_rather_than_left_hanging() {
         .expect("an empty query must not hang the turn");
     assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
     assert!(
-        calls.lock().unwrap_or_else(|p| p.into_inner()).is_empty(),
+        calls.lock().unwrap_or_else(std::sync::PoisonError::into_inner).is_empty(),
         "an empty query should never reach retrieval",
     );
 }
@@ -1136,12 +1189,12 @@ async fn a_row_from_before_the_engine_changed_opens_instead_of_erroring() {
 
     let session_id = thread
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .session_id()
         .clone();
     h.threads
         .lock()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .push(thread);
 
     // And the conversation continues from there, which is what the notice

--- a/crates/atlas-native-agent/tests/engine_turn.rs
+++ b/crates/atlas-native-agent/tests/engine_turn.rs
@@ -70,6 +70,33 @@ fn assistant_turn(text: &str) -> String {
     ])
 }
 
+/// Like [`assistant_turn`], with a real token-usage block (#74).
+fn assistant_turn_with_usage(text: &str) -> String {
+    sse(vec![
+        json!({"type": "response.created", "response": {"id": "resp-u"}}),
+        json!({
+            "type": "response.output_item.done",
+            "item": {
+                "type": "message",
+                "role": "assistant",
+                "id": "msg-1",
+                "content": [{"type": "output_text", "text": text}]
+            }
+        }),
+        json!({
+            "type": "response.completed",
+            "response": {
+                "id": "resp-u",
+                "usage": {
+                    "input_tokens": 100, "input_tokens_details": {"cached_tokens": 40},
+                    "output_tokens": 42, "output_tokens_details": null,
+                    "total_tokens": 142
+                }
+            }
+        }),
+    ])
+}
+
 struct Harness {
     _server: MockServer,
     _home: tempfile::TempDir,
@@ -281,6 +308,32 @@ async fn a_turn_completes_end_to_end_on_the_ported_engine() {
         acp::StopReason::EndTurn,
         "a turn the model finished normally must end the turn",
     );
+}
+
+#[tokio::test]
+async fn token_usage_reaches_the_thread_the_app_reads() {
+    // #74. The engine emits `thread/tokenUsage/updated` after a completion,
+    // and everything downstream of the thread is already built: the
+    // TokenUsageUpdated event drives the projector's UsageUpdated delta,
+    // which is what the Timeline's token-consumption display and capture's
+    // record_usage consume. The sink ignoring the notification is why the
+    // native agent — the one agent that reports a REAL input/output split —
+    // showed no consumption at all.
+    let h = harness(assistant_turn_with_usage("ok")).await;
+    let session_id = h.open_thread().await;
+
+    h.connection
+        .prompt(acp::PromptRequest::new(session_id, text("count me")))
+        .await
+        .expect("the turn should complete");
+
+    let thread = h.thread();
+    let locked = thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let usage = locked
+        .token_usage()
+        .expect("a turn that reported usage must leave it on the thread");
+    assert_eq!(usage.input_tokens, 100);
+    assert_eq!(usage.output_tokens, 42);
 }
 
 #[tokio::test]

--- a/crates/atlas-redact/Cargo.toml
+++ b/crates/atlas-redact/Cargo.toml
@@ -13,3 +13,8 @@ regex = "1"
 # transcripts are JSON-shaped and a redactor that mangles the envelope makes the
 # transcript unreadable.
 serde_json = "1"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-redact/src/credential.rs
+++ b/crates/atlas-redact/src/credential.rs
@@ -177,7 +177,7 @@ fn segments(key: &str) -> Vec<String> {
             prev_lower = false;
             continue;
         }
-        let next_lower = chars.peek().is_some_and(|nc| nc.is_ascii_lowercase());
+        let next_lower = chars.peek().is_some_and(char::is_ascii_lowercase);
         if ch.is_ascii_uppercase() && !current.is_empty() && (prev_lower || (prev_upper && next_lower))
         {
             out.push(std::mem::take(&mut current));

--- a/crates/atlas-terminal/Cargo.toml
+++ b/crates/atlas-terminal/Cargo.toml
@@ -12,3 +12,8 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-terminal/src/lib.rs
+++ b/crates/atlas-terminal/src/lib.rs
@@ -29,6 +29,12 @@ pub struct TerminalOutput {
     pub data: Vec<u8>,
 }
 
+impl Default for TerminalManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TerminalManager {
     pub fn new() -> Self {
         Self {
@@ -145,7 +151,7 @@ impl TerminalManager {
         let session = self
             .sessions
             .get(id)
-            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {}", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {id}"))?;
         let mut writer = session.writer.lock().unwrap();
         writer.write_all(data)?;
         writer.flush()?;
@@ -156,7 +162,7 @@ impl TerminalManager {
         let session = self
             .sessions
             .get(id)
-            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {}", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {id}"))?;
         let master = session
             .master
             .lock()
@@ -177,7 +183,7 @@ impl TerminalManager {
         let session = self
             .sessions
             .get(id)
-            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {}", id))?;
+            .ok_or_else(|| anyhow::anyhow!("Terminal session not found: {id}"))?;
 
         #[cfg(unix)]
         {
@@ -197,7 +203,7 @@ impl TerminalManager {
             if error.raw_os_error() == Some(libc::ESRCH) {
                 return Ok(false);
             }
-            return Err(error.into());
+            Err(error.into())
         }
 
         #[cfg(not(unix))]
@@ -305,7 +311,7 @@ pub fn cwd_of_pid(pid: u32) -> Option<String> {
             .ok()?;
         let s = String::from_utf8_lossy(&out.stdout);
         s.lines()
-            .find_map(|l| l.strip_prefix('n').map(|p| p.to_string()))
+            .find_map(|l| l.strip_prefix('n').map(std::string::ToString::to_string))
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {

--- a/crates/atlas-thread-metadata/Cargo.toml
+++ b/crates/atlas-thread-metadata/Cargo.toml
@@ -48,3 +48,8 @@ tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 chrono = "0.4"
 # Same pin as the `[dependencies]` entry above, and for the same reason.
 rusqlite = { version = "0.39", features = ["bundled"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/crates/atlas-thread-metadata/src/paths.rs
+++ b/crates/atlas-thread-metadata/src/paths.rs
@@ -107,7 +107,7 @@ impl PathList {
             order: self
                 .order
                 .iter()
-                .map(|i| i.to_string())
+                .map(std::string::ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(","),
         }

--- a/crates/atlas-thread-metadata/tests/recorder.rs
+++ b/crates/atlas-thread-metadata/tests/recorder.rs
@@ -246,12 +246,7 @@ fn every_agent_is_recorded_the_same_way() {
     }
     store.flush().unwrap();
 
-    let agents: Vec<String> = store
-        .threads()
-        .iter()
-        .map(|t| t.agent_id.to_string())
-        .collect();
-    assert_eq!(agents.len(), 5, "one row each, no agent singled out");
+    assert_eq!(store.threads().len(), 5, "one row each, no agent singled out");
 }
 
 #[test]

--- a/crates/atlas-thread-metadata/tests/store.rs
+++ b/crates/atlas-thread-metadata/tests/store.rs
@@ -174,7 +174,7 @@ fn threads_are_grouped_by_project_across_every_project() {
     let atlas_one = thread("cersei", &["/tmp/atlas"]);
     let atlas_two = thread("claude-code", &["/tmp/atlas"]);
     let other = thread("cersei", &["/tmp/other"]);
-    store.save_all(vec![atlas_one.clone(), atlas_two.clone(), other.clone()]);
+    store.save_all(vec![atlas_one.clone(), atlas_two.clone(), other]);
     store.flush().unwrap();
 
     let atlas = PathList::new(&[PathBuf::from("/tmp/atlas")]);
@@ -202,7 +202,7 @@ fn a_project_opened_in_either_order_is_the_same_group() {
     let dir = tempfile::tempdir().unwrap();
     let store = open(&dir);
     let saved = thread("cersei", &["/tmp/b", "/tmp/a"]);
-    store.save_one(saved.clone());
+    store.save_one(saved);
     store.flush().unwrap();
 
     let queried = PathList::new(&[PathBuf::from("/tmp/a"), PathBuf::from("/tmp/b")]);
@@ -219,7 +219,7 @@ fn a_thread_in_a_linked_worktree_is_findable_under_its_main_project() {
         PathList::new(&[PathBuf::from("/tmp/atlas-feature")]),
     )
     .unwrap();
-    store.save_one(saved.clone());
+    store.save_one(saved);
     store.flush().unwrap();
 
     let main = PathList::new(&[PathBuf::from("/tmp/atlas")]);
@@ -629,7 +629,7 @@ fn clearing_the_history_view_deletes_every_thread_it_showed() {
     let store = open(&dir);
     let one = thread("cersei", &["/tmp/atlas"]);
     let two = thread("claude-code", &["/tmp/other"]);
-    store.save_all(vec![one.clone(), two.clone()]);
+    store.save_all(vec![one, two.clone()]);
     store.archive(two.thread_id);
 
     store.delete_all(store.history(ThreadFilter::All).into_iter().map(|t| t.thread_id));
@@ -656,7 +656,7 @@ fn the_sidebar_sees_every_project_at_once_newest_first() {
     };
     let shelved = thread("cersei", &["/tmp/atlas"]);
     store.save_all(vec![
-        older_project.clone(),
+        older_project,
         this_project_old.clone(),
         this_project_new.clone(),
         shelved.clone(),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -172,3 +172,8 @@ objc2 = "0.6"
 # Turn on atlas-embed's Metal backend so the on-device embedder runs on the
 # Apple-Silicon GPU. Feature is additive over the base path dep in `[dependencies]`.
 atlas-embed = { path = "../crates/atlas-embed", features = ["metal"] }
+
+# The workspace lint table is only real for members that opt in —
+# without this stanza it is dead configuration (#60).
+[lints]
+workspace = true

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -331,6 +331,38 @@ impl AuthCore {
         }
     }
 
+    /// Record which organisation the desktop is acting for (#73).
+    ///
+    /// This writes the same field the web's `/organization/set-active` feeds,
+    /// but locally only — the server is not told, deliberately: web and
+    /// desktop each keep their own last choice, the same independence they
+    /// had before, just symmetric now.
+    ///
+    /// The store's doc used to say this field is "never written from the
+    /// desktop". That held while it only decided which organisation the
+    /// sidebar displays — and stopped holding the moment it became the
+    /// organisation every gateway request bills: the `Atlas-Org` source reads
+    /// the snapshot per request, so a switch that never lands here keeps
+    /// billing (and entitlement-checking) the previous org, which is exactly
+    /// how an unentitled org appeared to work — its turns were quietly
+    /// charged to the entitled one.
+    ///
+    /// `None` clears the desktop's choice; display and billing then fall back
+    /// the way [`StoredIdentity::active_org`] documents (web-set value, else
+    /// the first org). An id that is not in the org list is stored anyway and
+    /// tolerated on the read side, same as the web's value — membership lists
+    /// can lag.
+    pub fn set_active_org(&self, org_id: Option<String>) -> Result<(), String> {
+        let Some(mut session) = self.stored() else {
+            return Err("not signed in".to_string());
+        };
+        let Some(identity) = session.identity.as_mut() else {
+            return Err("no identity yet — try again in a moment".to_string());
+        };
+        identity.active_org_id = org_id;
+        store::save(&self.dir, &session)
+    }
+
     // ---- identity --------------------------------------------------------
 
     /// Read the signed-in user from the server.

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -1291,11 +1291,14 @@ impl AuthCore {
     /// here pretends otherwise: [`Self::snapshot`] is derived from the file, so
     /// the state the caller broadcasts next is whatever is really on disk.
     ///
-    /// There is still no in-memory access token to clear. ATL-51 added none:
-    /// the JWT it needs for the `orgs` claim is minted, read, and dropped inside
-    /// a single call, and nothing else in the desktop consumes one. A cache
-    /// would buy nothing and would be one more thing this function had to
-    /// remember to clear.
+    /// One in-memory access token DOES exist elsewhere: #51 gave the native
+    /// agent's connection a cache that serves the JWT until its own `exp`,
+    /// and this function cannot reach it. The `auth_sign_out` command drops
+    /// that connection alongside calling this (#62) — a future caller of
+    /// `sign_out` from anywhere else must do the same, or the engine keeps
+    /// making org-billed calls for up to ~9 minutes on a revoked account.
+    /// (The JWT verifies statelessly against JWKS; revoking the session
+    /// token does not invalidate it.)
     pub fn sign_out(&self) -> Option<RevocationTicket> {
         let stored = self.stored();
         // Before the credential, not after: the identity is where the path to

--- a/src-tauri/src/auth/store.rs
+++ b/src-tauri/src/auth/store.rs
@@ -129,9 +129,11 @@ pub struct StoredIdentity {
     ///   is omitted when there is no profile yet.
     #[serde(default)]
     pub orgs: Option<Vec<StoredOrg>>,
-    /// The organisation the user last made active **on the web**, when they ever
-    /// did. Never written from the desktop: `/organization/set-active` is
-    /// ATL-36's, and this ticket is read-only.
+    /// The organisation the user last made active — **on the web**, or, since
+    /// #73, from the desktop's own org switcher (`AuthCore::set_active_org`).
+    /// The desktop write is local-only; `/organization/set-active` stays
+    /// ATL-36's. This stopped being read-only the moment the field became the
+    /// org every gateway request bills.
     ///
     /// Kept separate from "which one to display" — see [`Self::active_org`],
     /// which resolves that and has to cope with this being `None`, the common

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -920,7 +920,7 @@ fn a_hostile_retry_after_cannot_escape_the_window() {
 fn cached_avatars(dir: &TempDir) -> Vec<PathBuf> {
     let mut found: Vec<PathBuf> = std::fs::read_dir(dir.path())
         .expect("read config dir")
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .map(|e| e.path())
         .filter(|p| {
             p.file_name()

--- a/src-tauri/src/auth/tests.rs
+++ b/src-tauri/src/auth/tests.rs
@@ -1598,6 +1598,46 @@ async fn the_active_organisation_follows_the_web_and_falls_back_when_it_cannot()
     );
 }
 
+/// #73: the desktop org switcher must reach billing. The active org used to
+/// be writable only from the web — that held while the field just picked
+/// which org the sidebar shows, and stopped holding when it became the org
+/// every gateway request bills. A frontend-only switch kept billing (and
+/// entitlement-checking) the previous org, so an unentitled org appeared to
+/// work: its turns were quietly charged to the entitled one.
+#[tokio::test]
+async fn the_desktop_can_set_the_active_organisation_it_bills() {
+    let stub = Stub::start().await;
+    let dir = TempDir::new();
+    scripted_grant_with_roles(&stub, &[("org_a", "admin"), ("org_b", "member")]);
+    stub.org_list(&[("org_a", "Entitled"), ("org_b", "Unentitled")]);
+    stub.profile("Ada Lovelace", None);
+
+    let auth = core(&stub, &dir);
+    sign_in(&auth).await;
+    assert_eq!(
+        active_org_of(&auth.snapshot()).as_deref(),
+        Some("org_a"),
+        "list order is the fallback before any switch",
+    );
+
+    auth.set_active_org(Some("org_b".to_string()))
+        .expect("a signed-in user can switch");
+    assert_eq!(
+        active_org_of(&auth.snapshot()).as_deref(),
+        Some("org_b"),
+        "the switch is what the gateway's Atlas-Org source reads next",
+    );
+
+    // Survives a restart: the choice lives in the credential file.
+    let reopened = core(&stub, &dir);
+    assert_eq!(active_org_of(&reopened.snapshot()).as_deref(), Some("org_b"));
+
+    // Clearing returns to the documented fallback (web-set value, else first) —
+    // the state a local-only org (no server id) selects.
+    auth.set_active_org(None).expect("clearing is a valid state");
+    assert_eq!(active_org_of(&auth.snapshot()).as_deref(), Some("org_a"));
+}
+
 // ---------------------------------------------------------------- sign-out
 //
 // The ordering is the whole ticket (ATL-50): everything local goes first and

--- a/src-tauri/src/commands/agent_analytics.rs
+++ b/src-tauri/src/commands/agent_analytics.rs
@@ -445,7 +445,7 @@ mod tests {
         }
         // The prompt is answered; Running arrives again for turn 7.
         st.begin_turn("s1", 7);
-        st.with_turn("s1", |a| a.note_permission_resolved());
+        st.with_turn("s1", super::TurnAcc::note_permission_resolved);
 
         let props = st.finish_turn("s1", 7).expect("event");
         assert_eq!(props["tool_call_count"], json!(3));

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -350,7 +350,7 @@ impl AgentHost {
             // the store itself only knows entry ids, and the forwarder has to
             // know which connection to read the elicitation back from.
             request_elicitation_events: {
-                let tx = elicitation_tx.clone();
+                let tx = elicitation_tx;
                 Arc::new(move |agent_id: &ThreadAgentId| {
                     let (agent_tx, mut agent_rx) = mpsc::unbounded_channel();
                     let tx = tx.clone();
@@ -770,7 +770,7 @@ impl AgentHost {
                 .map(|mode| SessionModeInfo {
                     id: mode.id.to_string(),
                     name: mode.name.clone(),
-                    description: mode.description.clone(),
+                    description: mode.description,
                 })
                 .collect(),
         )
@@ -1151,7 +1151,7 @@ impl AgentHost {
         self.request_elicitations
             .stream
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
     }
 
@@ -1168,7 +1168,7 @@ impl AgentHost {
         let connection = self.manager.connection_by_agent_id(agent_id)?;
         let store = connection.request_elicitations()?;
         let wire = {
-            let store = store.lock().unwrap_or_else(|p| p.into_inner());
+            let store = store.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let (_, elicitation) = store.elicitation(entry_id)?;
             atlas_agent_delta::elicitation_wire(elicitation)
         };
@@ -1176,7 +1176,7 @@ impl AgentHost {
         self.request_elicitations
             .answered_by
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(request_id, (agent_id.clone(), entry_id.clone()));
         Some((request_id, wire))
     }
@@ -1199,7 +1199,7 @@ impl AgentHost {
         let connection = self.manager.connection_by_agent_id(agent_id)?;
         let store = connection.request_elicitations()?;
         let still_pending = {
-            let store = store.lock().unwrap_or_else(|p| p.into_inner());
+            let store = store.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let (_, elicitation) = store.elicitation(entry_id)?;
             matches!(
                 elicitation.status,
@@ -1213,7 +1213,7 @@ impl AgentHost {
             .request_elicitations
             .answered_by
             .lock()
-            .unwrap_or_else(|p| p.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let request_id = answered_by
             .iter()
             .find(|(_, (agent, entry))| agent == agent_id && entry == entry_id)
@@ -1232,7 +1232,7 @@ impl AgentHost {
         self.request_elicitations
             .answered_by
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .retain(|_, (agent, _)| agent != agent_id);
     }
 
@@ -1254,7 +1254,7 @@ impl AgentHost {
             .request_elicitations
             .answered_by
             .lock()
-            .unwrap_or_else(|p| p.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(&request_id);
         if let Some((agent_id, entry_id)) = request_scoped {
             let Some(connection) = self.manager.connection_by_agent_id(&agent_id) else {
@@ -1263,7 +1263,7 @@ impl AgentHost {
             let Some(store) = connection.request_elicitations() else {
                 return Ok(());
             };
-            let mut store = store.lock().unwrap_or_else(|p| p.into_inner());
+            let mut store = store.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             match elicitation_response(action, content)? {
                 Some(response) => store.respond_to_elicitation(&entry_id, response),
                 None => store.cancel_elicitation(&entry_id),
@@ -1821,7 +1821,7 @@ pub struct ThreadProjectWire {
 fn thread_row(thread: &ThreadMetadata) -> ThreadRow {
     ThreadRow {
         thread_id: thread.thread_id.to_key_string(),
-        session_id: thread.session_id.as_ref().map(|id| id.to_string()),
+        session_id: thread.session_id.as_ref().map(std::string::ToString::to_string),
         agent_id: thread.agent_id.to_string(),
         title: thread.display_title().to_string(),
         updated_at: thread.updated_at.to_rfc3339(),
@@ -2093,8 +2093,8 @@ fn parse_env_var(v: &serde_json::Value) -> Option<AuthEnvVar> {
     Some(AuthEnvVar {
         name: obj.get("name")?.as_str()?.to_string(),
         label: obj.get("label").and_then(|l| l.as_str()).map(str::to_string),
-        secret: obj.get("secret").and_then(|s| s.as_bool()).unwrap_or(true),
-        optional: obj.get("optional").and_then(|o| o.as_bool()).unwrap_or(false),
+        secret: obj.get("secret").and_then(serde_json::Value::as_bool).unwrap_or(true),
+        optional: obj.get("optional").and_then(serde_json::Value::as_bool).unwrap_or(false),
     })
 }
 
@@ -2132,11 +2132,11 @@ fn pending_option_kind(
 }
 
 fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    m.lock().unwrap_or_else(|p| p.into_inner())
+    m.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 fn lock_thread(thread: &AcpThreadHandle) -> std::sync::MutexGuard<'_, AcpThread> {
-    thread.lock().unwrap_or_else(|p| p.into_inner())
+    thread.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 // ── The installed map on disk ───────────────────────────────────────────────

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -652,6 +652,23 @@ impl AgentHost {
         Ok(())
     }
 
+    /// Drop the native agent's connection, if one is open.
+    ///
+    /// Sign-out calls this (#62): the engine's token cache lives on the
+    /// connection and serves the access JWT until the JWT's own `exp` — the
+    /// JWT verifies statelessly against JWKS, so revoking the session token
+    /// does not invalidate it, and an open connection would keep making
+    /// authenticated, org-billed gateway calls for up to ~9 minutes after
+    /// the user signed out. Dropping the connection is what actually stops
+    /// them: the cache dies with it, and so does any in-flight turn. The
+    /// next spawn reconnects and mints fresh — or fails, honestly, now that
+    /// there is nothing to mint with.
+    pub fn drop_native_connection(&self) {
+        self.forget_request_elicitations(&ThreadAgentId::new(CERSEI_AGENT_ID));
+        self.manager.drop_connection(&Agent::Native);
+        lock(&self.sessions).retain(|_, session| session.agent != Agent::Native);
+    }
+
     pub async fn new_session(
         &self,
         agent_id: AgentId,
@@ -2429,6 +2446,34 @@ mod tests {
         fn into_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
             self
         }
+    }
+
+    /// Issue #62: sign-out drops the native connection — the engine's token
+    /// cache lives on it, and the JWT it holds outlives the revoked session
+    /// token. This pins the host half: after the drop nothing is running, so
+    /// the next spawn builds a fresh connection (and with it a fresh, empty
+    /// cache) instead of reusing the credentialled one.
+    #[tokio::test]
+    async fn dropping_the_native_connection_leaves_nothing_running() {
+        let native = Arc::new(RebindingNative { fresh_id: "s-1" });
+        let (host, dir) = fresh_host_with_native(native);
+
+        host.spawn(CERSEI_AGENT_ID).await.expect("native agent spawns");
+        // The Connecting→Connected flip runs on a spawned task; on the test's
+        // current-thread runtime it needs the yield before `connected` sees it.
+        tokio::task::yield_now().await;
+        assert!(
+            host.manager().connected(&Agent::Native).is_some(),
+            "a connection is open",
+        );
+
+        host.drop_native_connection();
+        assert!(
+            host.manager().connected(&Agent::Native).is_none(),
+            "sign-out leaves nothing running",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Issue #56 (B1): the engine may answer a resume with a *different*

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -2353,6 +2353,42 @@ mod tests {
         fresh_id: &'static str,
     }
 
+    /// A selector that knows its default before any pick — the shape the
+    /// engine's catalogue-backed selector has (#76).
+    struct FakeSelector;
+
+    impl atlas_acp_thread::AgentModelSelector for FakeSelector {
+        fn list_models(
+            &self,
+        ) -> BoxFuture<'static, anyhow::Result<atlas_acp_thread::AgentModelList>> {
+            async { Ok(atlas_acp_thread::AgentModelList::Flat(Vec::new())) }.boxed()
+        }
+
+        fn select_model(
+            &self,
+            _model_id: atlas_acp_thread::AgentModelId,
+        ) -> BoxFuture<'static, anyhow::Result<()>> {
+            async { Ok(()) }.boxed()
+        }
+
+        fn selected_model(
+            &self,
+        ) -> BoxFuture<'static, anyhow::Result<atlas_acp_thread::AgentModelInfo>> {
+            async {
+                Ok(atlas_acp_thread::AgentModelInfo {
+                    id: atlas_acp_thread::AgentModelId::new("fake-default-model"),
+                    name: "Fake Default".into(),
+                    description: None,
+                    icon: None,
+                    is_latest: true,
+                    cost: None,
+                    disabled: None,
+                })
+            }
+            .boxed()
+        }
+    }
+
     impl AgentConnection for RebindingNative {
         fn agent_id(&self) -> atlas_acp_thread::AgentId {
             atlas_acp_thread::AgentId::new(CERSEI_AGENT_ID)
@@ -2406,6 +2442,13 @@ mod tests {
 
         fn cancel(&self, _session_id: &acp::SessionId) {}
 
+        fn model_selector(
+            &self,
+            _session_id: &acp::SessionId,
+        ) -> Option<Arc<dyn atlas_acp_thread::AgentModelSelector>> {
+            Some(Arc::new(FakeSelector))
+        }
+
         fn into_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
             self
         }
@@ -2446,6 +2489,32 @@ mod tests {
         fn into_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
             self
         }
+    }
+
+    /// Issue #76: a native session's model must be known to capture BEFORE
+    /// the user ever touches the picker. `current_model` used to be written
+    /// only by an explicit pick, so the common case — running on the default —
+    /// told capture `None` on every turn and the Timeline row showed no
+    /// model, while the agent knew its model the whole time.
+    #[tokio::test]
+    async fn a_new_native_session_knows_its_model_before_any_pick() {
+        let native = Arc::new(RebindingNative { fresh_id: "s-model" });
+        let (host, dir) = fresh_host_with_native(native);
+
+        let agent_id = host.spawn(CERSEI_AGENT_ID).await.expect("spawn").agent_id;
+        let init = host
+            .new_session(agent_id, PathBuf::from("/tmp/atlas"), Vec::new())
+            .await
+            .expect("a session opens");
+
+        let snap = host.snapshot_meta(&init.key).expect("meta");
+        assert_eq!(
+            snap.current_model.as_deref(),
+            Some("fake-default-model"),
+            "the record carries the agent's own default before any pick",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Issue #62: sign-out drops the native connection — the engine's token

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -39,7 +39,7 @@ use atlas_acp_thread::{
 };
 use atlas_agent_delta::{project, DeltaProjector, DeltaSink, ThreadObserver};
 use atlas_agent_manager::{Agent, AgentManager, ResumeMode};
-use atlas_agent_servers::{AcpConnectionDefaults, ConnectOptions};
+use atlas_agent_servers::{AcpConnectionDefaults, AgentServer, ConnectOptions};
 use atlas_agent_store::{AgentRegistryStore, AgentServerStore, ExternalAgentSource};
 use atlas_agent_transcript::TranscriptKind;
 use atlas_agent_wire::{
@@ -320,6 +320,19 @@ impl AgentHost {
         store: Arc<AgentServerStore>,
         registry: Arc<AgentRegistryStore>,
     ) -> Arc<Self> {
+        let native = select_native_agent(&config_dir);
+        Self::with_native(sink, config_dir, store, registry, native)
+    }
+
+    /// [`AgentHost::new`] with the native agent supplied by the caller — the
+    /// seam tests use to stand in a scripted agent.
+    pub(crate) fn with_native(
+        sink: Arc<dyn DeltaSink>,
+        config_dir: PathBuf,
+        store: Arc<AgentServerStore>,
+        registry: Arc<AgentRegistryStore>,
+        native: Arc<dyn AgentServer>,
+    ) -> Arc<Self> {
         let projector = DeltaProjector::new(sink);
         let history = match ThreadMetadataStore::open(atlas_thread_metadata::db_path(&config_dir)) {
             Ok(store) => Some(ThreadRecorder::new(store)),
@@ -328,7 +341,6 @@ impl AgentHost {
                 None
             }
         };
-        let native = select_native_agent(&config_dir);
         let (elicitation_tx, elicitation_rx) = mpsc::unbounded_channel();
         let options = ConnectOptions {
             root_dir: None,
@@ -1340,12 +1352,23 @@ impl AgentHost {
                     .manager
                     .resume_stored_session(
                         record.agent.clone(),
-                        session_id,
+                        session_id.clone(),
                         work_dirs,
                         thread.title(),
                     )
                     .await
                     .map_err(HostError::from)?;
+                // The agent may have answered with a different session id than
+                // the stored one — the engine's fresh-thread fallback for a
+                // pre-cutover row does exactly that. The row is bound to the
+                // id the live feed will stamp on its events, the same
+                // invariant the draft arm above keeps; without it the feed's
+                // first write mints a duplicate row and the one the user
+                // clicked is orphaned on the dead id (#56).
+                let opened_session_id = lock_thread(&resumed.thread).session_id().clone();
+                if opened_session_id != session_id {
+                    history.adopt(opened_session_id, thread_id);
+                }
                 (resumed.thread, resumed.mode == ResumeMode::WithoutHistory)
             }
         };
@@ -2300,7 +2323,163 @@ mod auth_method_wire_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::test_support::fresh_host;
+    use super::test_support::{fresh_host, fresh_host_with_native};
+    use atlas_acp_thread::{AcpThread, AcpThreadHandle, AgentConnection};
+    use atlas_agent_servers::AgentServerDelegate;
+    use futures::future::BoxFuture;
+    use futures::FutureExt;
+
+    /// A native agent that reopens every session under one fixed id of its
+    /// own choosing — the shape of the engine's fresh-thread fallback for a
+    /// row whose stored id it does not know.
+    struct RebindingNative {
+        fresh_id: &'static str,
+    }
+
+    impl AgentConnection for RebindingNative {
+        fn agent_id(&self) -> atlas_acp_thread::AgentId {
+            atlas_acp_thread::AgentId::new(CERSEI_AGENT_ID)
+        }
+
+        fn telemetry_id(&self) -> Arc<str> {
+            CERSEI_AGENT_ID.into()
+        }
+
+        fn new_session(
+            self: Arc<Self>,
+            work_dirs: Vec<PathBuf>,
+        ) -> BoxFuture<'static, anyhow::Result<AcpThreadHandle>> {
+            let thread = self.thread(acp::SessionId::new(self.fresh_id), work_dirs);
+            async move { Ok(thread) }.boxed()
+        }
+
+        fn supports_load_session(&self) -> bool {
+            true
+        }
+
+        fn load_session(
+            self: Arc<Self>,
+            _session_id: acp::SessionId,
+            work_dirs: Vec<PathBuf>,
+            _title: Option<Arc<str>>,
+        ) -> BoxFuture<'static, anyhow::Result<AcpThreadHandle>> {
+            // The stored id is not honoured: the thread comes back under the
+            // agent's own fresh id, exactly like the engine's fallback.
+            let thread = self.thread(acp::SessionId::new(self.fresh_id), work_dirs);
+            async move { Ok(thread) }.boxed()
+        }
+
+        fn auth_methods(&self) -> &[acp::AuthMethod] {
+            &[]
+        }
+
+        fn authenticate(
+            &self,
+            _method: acp::AuthMethodId,
+        ) -> BoxFuture<'static, anyhow::Result<()>> {
+            async { Ok(()) }.boxed()
+        }
+
+        fn prompt(
+            &self,
+            _params: acp::PromptRequest,
+        ) -> BoxFuture<'static, anyhow::Result<acp::PromptResponse>> {
+            async { Ok(acp::PromptResponse::new(acp::StopReason::EndTurn)) }.boxed()
+        }
+
+        fn cancel(&self, _session_id: &acp::SessionId) {}
+
+        fn into_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+            self
+        }
+    }
+
+    impl RebindingNative {
+        fn thread(
+            self: &Arc<Self>,
+            session_id: acp::SessionId,
+            work_dirs: Vec<PathBuf>,
+        ) -> AcpThreadHandle {
+            Arc::new(std::sync::Mutex::new(AcpThread::new(
+                session_id,
+                self.clone() as Arc<dyn AgentConnection>,
+                work_dirs,
+                None,
+                atlas_acp_thread::event_channel().0,
+            )))
+        }
+    }
+
+    impl AgentServer for RebindingNative {
+        fn agent_id(&self) -> atlas_acp_thread::AgentId {
+            atlas_acp_thread::AgentId::new(CERSEI_AGENT_ID)
+        }
+
+        fn connect(
+            &self,
+            _delegate: AgentServerDelegate,
+            _options: ConnectOptions,
+        ) -> BoxFuture<'static, anyhow::Result<Arc<dyn AgentConnection>>> {
+            let connection = Arc::new(RebindingNative {
+                fresh_id: self.fresh_id,
+            });
+            async move { Ok(connection as Arc<dyn AgentConnection>) }.boxed()
+        }
+
+        fn into_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+            self
+        }
+    }
+
+    /// Issue #56 (B1): the engine may answer a resume with a *different*
+    /// session id than the stored one — its fresh-thread fallback for a
+    /// pre-cutover row does exactly that. The row the user clicked must be
+    /// rebound to the id the live feed will stamp on its events; otherwise the
+    /// feed's first write mints a duplicate sidebar row and the original is
+    /// orphaned on the dead id.
+    #[tokio::test]
+    async fn a_resume_that_comes_back_under_a_new_id_rebinds_the_row() {
+        let native = Arc::new(RebindingNative {
+            fresh_id: "engine-fresh-id",
+        });
+        let (host, dir) = fresh_host_with_native(native);
+        let history = host.history().expect("a fresh host has history");
+
+        let thread = atlas_thread_metadata::ThreadMetadata {
+            session_id: Some(acp::SessionId::new("cersei-era-id")),
+            ..atlas_thread_metadata::ThreadMetadata::new(
+                atlas_thread_metadata::ThreadId::new(),
+                CERSEI_AGENT_ID.into(),
+                atlas_thread_metadata::PathList::new(&[PathBuf::from("/tmp/atlas")]),
+            )
+        };
+        let thread_id = thread.thread_id;
+        history.store().save_all(vec![thread]);
+
+        let resumed = host.resume_thread(thread_id).await.expect("resume succeeds");
+        assert_eq!(resumed.key.session_id, "engine-fresh-id");
+
+        // The live feed's first write under the new id must land on the row
+        // the user clicked, not mint a second one.
+        history.record_connected(
+            &atlas_acp_thread::AgentId::new(CERSEI_AGENT_ID),
+            &acp::SessionId::new("engine-fresh-id"),
+            atlas_thread_metadata::ThreadSnapshot {
+                is_draft: false,
+                title: None,
+                work_dirs: vec![PathBuf::from("/tmp/atlas")],
+            },
+        );
+        let rows = history.store().threads();
+        assert_eq!(rows.len(), 1, "one conversation, one row");
+        assert_eq!(rows[0].thread_id, thread_id);
+        assert_eq!(
+            rows[0].session_id,
+            Some(acp::SessionId::new("engine-fresh-id"))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// The whole no-default-agents rule, checked at the only place that
     /// enforces it. A fresh install must offer exactly one agent, and every
@@ -2549,4 +2728,41 @@ pub(crate) mod test_support {
         (host, dir)
     }
 
+    /// [`fresh_host`], but the native agent is the caller's scripted stand-in
+    /// rather than the real engine.
+    pub(crate) fn fresh_host_with_native(
+        native: Arc<dyn AgentServer>,
+    ) -> (Arc<AgentHost>, PathBuf) {
+        let dir = std::env::temp_dir().join(format!("atlas-host-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        struct Discard;
+        impl DeltaSink for Discard {
+            fn emit(&self, _envelope: atlas_agent_wire::SessionDeltaEnvelope) {}
+        }
+        struct Offline;
+        impl atlas_agent_store::HttpClient for Offline {
+            fn get(
+                &self,
+                _url: &str,
+            ) -> futures::future::BoxFuture<'static, anyhow::Result<atlas_agent_store::HttpResponse>>
+            {
+                use futures::FutureExt;
+                async { Err(anyhow::anyhow!("offline in tests")) }.boxed()
+            }
+        }
+        let http: Arc<dyn atlas_agent_store::HttpClient> = Arc::new(Offline);
+        let registry = Arc::new(atlas_agent_store::AgentRegistryStore::new(
+            dir.clone(),
+            http.clone(),
+        ));
+        let store = Arc::new(AgentServerStore::new(
+            dir.clone(),
+            http,
+            atlas_agent_store::NodeRuntime::unavailable("not needed in this test"),
+            Arc::new(atlas_agent_store::InheritedProjectEnvironment),
+            Some(registry.clone()),
+        ));
+        let host = AgentHost::with_native(Arc::new(Discard), dir.clone(), store, registry, native);
+        (host, dir)
+    }
 }

--- a/src-tauri/src/commands/agent_transcript.rs
+++ b/src-tauri/src/commands/agent_transcript.rs
@@ -311,7 +311,7 @@ pub fn list(config_dir: &Path, cwd: &str) -> Vec<AgentSessionMeta> {
         return Vec::new();
     };
     let mut out: Vec<AgentSessionMeta> = entries
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
         .filter_map(|e| {
             let bytes = std::fs::read(e.path()).ok()?;

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -216,14 +216,14 @@ impl OutboundMiddleware<SessionDeltaEnvelope> for AnalyticsMiddleware {
                 st.with_turn(sid, |a| a.note_context(*used, *size, *cost))
             }
             SessionDelta::PermissionRequest { .. } => {
-                st.with_turn(sid, |a| a.note_permission_request())
+                st.with_turn(sid, super::agent_analytics::TurnAcc::note_permission_request)
             }
             SessionDelta::PermissionResolved { .. } => {
-                st.with_turn(sid, |a| a.note_permission_resolved())
+                st.with_turn(sid, super::agent_analytics::TurnAcc::note_permission_resolved)
             }
-            SessionDelta::RetryStatus { .. } => st.with_turn(sid, |a| a.note_retry()),
+            SessionDelta::RetryStatus { .. } => st.with_turn(sid, super::agent_analytics::TurnAcc::note_retry),
             SessionDelta::Compaction { active } if *active => {
-                st.with_turn(sid, |a| a.note_compaction())
+                st.with_turn(sid, super::agent_analytics::TurnAcc::note_compaction)
             }
             SessionDelta::CompressionSaved { saved_tokens } => {
                 st.with_turn(sid, |a| a.note_compression_saved(*saved_tokens))
@@ -231,13 +231,13 @@ impl OutboundMiddleware<SessionDeltaEnvelope> for AnalyticsMiddleware {
             SessionDelta::ModelChanged { model_id } => {
                 st.with_turn(sid, |a| a.note_model(model_id))
             }
-            SessionDelta::ModeChanged { .. } => st.with_turn(sid, |a| a.note_mode_change()),
+            SessionDelta::ModeChanged { .. } => st.with_turn(sid, super::agent_analytics::TurnAcc::note_mode_change),
             SessionDelta::MessageAppended { message } => {
                 if message.role == MessageRole::Assistant {
-                    st.with_turn(sid, |a| a.note_assistant_message());
+                    st.with_turn(sid, super::agent_analytics::TurnAcc::note_assistant_message);
                 }
             }
-            SessionDelta::PlanUpdated { .. } => st.with_turn(sid, |a| a.note_plan_update()),
+            SessionDelta::PlanUpdated { .. } => st.with_turn(sid, super::agent_analytics::TurnAcc::note_plan_update),
 
             SessionDelta::TurnFinished {
                 stop_reason,
@@ -449,7 +449,7 @@ impl OutboundMiddleware<SessionDeltaEnvelope> for MemoryIngestMiddleware {
                     let _ = registry.enqueue(super::memory_indexer::Job::ExtractSession {
                         cwd,
                         agent: agent_id.0.to_string(),
-                        session: session_id.clone(),
+                        session: session_id,
                     });
                 }
             } else {
@@ -561,7 +561,7 @@ pub fn install_manager(app: &AppHandle) {
     let store = Arc::new(AgentServerStore::new(
         data_dir.clone(),
         http.clone(),
-        NodeRuntime::managed(&data_dir, http.clone()),
+        NodeRuntime::managed(&data_dir, http),
         Arc::new(InheritedProjectEnvironment),
         Some(registry.clone()),
     ));
@@ -658,7 +658,7 @@ pub fn install_manager(app: &AppHandle) {
         // Cache-first, then network: the installed map is what makes agents
         // spawnable, so it is read and applied before anything is fetched.
         let app = app.clone();
-        let host = host.clone();
+        let host = host;
         tauri::async_runtime::spawn(async move {
             let installed = super::agent_host::load_installed(&data_dir);
             let _ = registry.load_cached().await;

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -197,6 +197,30 @@ pub fn auth_cancel_sign_in(app: AppHandle, state: State<'_, AuthState>) -> AuthS
     snapshot
 }
 
+/// Which organisation the desktop acts for — billing included (#73).
+///
+/// The org switcher used to be frontend-only: it re-pointed workspaces and
+/// telemetry and told the Rust side nothing, while every gateway request
+/// reads the active org from the auth snapshot. So the switch changed what
+/// the user SAW and not who they BILLED — an unentitled org appeared to work
+/// because its turns were charged to the entitled one. The switcher calls
+/// this now; broadcast after writing so every window's auth state agrees.
+///
+/// `org_id` is the SERVER org id (`remoteId`), or `None` for a local-only
+/// org, which clears the desktop's choice and falls back the way the store
+/// documents.
+#[tauri::command]
+pub async fn auth_set_active_org(
+    app: AppHandle,
+    state: State<'_, AuthState>,
+    org_id: Option<String>,
+) -> Result<(), String> {
+    let core = state.core();
+    core.set_active_org(org_id)?;
+    broadcast(&app, core.snapshot());
+    Ok(())
+}
+
 /// Sign out (ATL-50).
 ///
 /// Local state is gone and the signed-out snapshot has been broadcast to every

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -214,6 +214,15 @@ pub fn auth_cancel_sign_in(app: AppHandle, state: State<'_, AuthState>) -> AuthS
 pub async fn auth_sign_out(app: AppHandle, state: State<'_, AuthState>) -> Result<bool, String> {
     let core = state.core();
     let ticket = core.sign_out();
+    // The native agent's connection caches an access JWT that outlives the
+    // revoked session token — the JWT verifies statelessly against JWKS — and
+    // would keep making org-billed gateway calls until its own expiry, up to
+    // ~9 minutes (#62). Signing out locally means the engine's credential goes
+    // too, in-flight turn included. `try_state` because sign-out must work
+    // even if the agent host never initialised.
+    if let Some(host) = app.try_state::<std::sync::Arc<super::agent_host::AgentHost>>() {
+        host.drop_native_connection();
+    }
     // Capture BEFORE broadcasting. `broadcast` resets the telemetry identity to
     // the device, so the order matters: reversed, the event that describes the
     // account leaving would be filed against the anonymous device person.

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -105,7 +105,7 @@ fn sync_identity(app: &AppHandle, snapshot: &AuthSnapshot) {
                 org_role: active
                     .and_then(|o| o.role)
                     .map(|r| format!("{r:?}").to_lowercase()),
-                org_count: orgs.as_ref().map(|v| v.len()).unwrap_or(0),
+                org_count: orgs.as_ref().map(std::vec::Vec::len).unwrap_or(0),
             });
         }
         AuthSnapshot::SignedOut => tel.reset_identity(),
@@ -165,7 +165,7 @@ pub async fn auth_sign_in(
                 raise(&task_app);
                 let (org_count, has_active) = match &snap {
                     AuthSnapshot::SignedIn { orgs, active_org_id, .. } => (
-                        orgs.as_ref().map(|v| v.len()).unwrap_or(0),
+                        orgs.as_ref().map(std::vec::Vec::len).unwrap_or(0),
                         active_org_id.is_some(),
                     ),
                     _ => (0, false),

--- a/src-tauri/src/commands/browser.rs
+++ b/src-tauri/src/commands/browser.rs
@@ -242,9 +242,9 @@ pub fn browser_embed_create(
     let nav_started = state.nav.clone();
     let nav_finished = state.nav.clone();
     let app_started = app.clone();
-    let app_finished = app.clone();
+    let app_finished = app;
     let id_started = id.clone();
-    let id_finished = id.clone();
+    let id_finished = id;
 
     let builder = tauri::webview::WebviewBuilder::new(&label, WebviewUrl::External(parsed))
         .data_directory(profile)
@@ -262,7 +262,7 @@ pub fn browser_embed_create(
                     let app2 = app_finished.clone();
                     let nav2 = nav_finished.clone();
                     let id2 = id_finished.clone();
-                    let url2 = url.clone();
+                    let url2 = url;
                     let _ = webview.eval_with_callback("document.title", move |raw| {
                         let title = raw.trim().trim_matches('"').to_string();
                         let title = if title.is_empty() { None } else { Some(title) };

--- a/src-tauri/src/commands/byok.rs
+++ b/src-tauri/src/commands/byok.rs
@@ -382,9 +382,7 @@ fn locate_in_profiles(var: &str) -> Option<(PathBuf, shell_profile::Assignment)>
         };
         // Last assignment wins — that is what the shell ends up with.
         if let Some(a) = shell_profile::parse_assignments(&content)
-            .into_iter()
-            .filter(|a| a.var == var)
-            .next_back()
+            .into_iter().rfind(|a| a.var == var)
         {
             return Some((path, a));
         }

--- a/src-tauri/src/commands/canvas.rs
+++ b/src-tauri/src/commands/canvas.rs
@@ -76,7 +76,7 @@ pub async fn canvas_media_data_url(project_path: String, src: String) -> Result<
         let mime = match abs
             .extension()
             .and_then(|e| e.to_str())
-            .map(|e| e.to_lowercase())
+            .map(str::to_lowercase)
             .as_deref()
         {
             Some("png") => "image/png",
@@ -92,7 +92,7 @@ pub async fn canvas_media_data_url(project_path: String, src: String) -> Result<
             _ => "application/octet-stream",
         };
         let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-        Ok(format!("data:{};base64,{}", mime, b64))
+        Ok(format!("data:{mime};base64,{b64}"))
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src-tauri/src/commands/catalog.rs
+++ b/src-tauri/src/commands/catalog.rs
@@ -193,7 +193,7 @@ fn build(host: &AgentHost) -> AgentCatalog {
                     .filter(|d| !d.is_empty()),
                 version: entry
                     .as_ref()
-                    .and_then(|entry| entry.version.as_ref().map(|v| v.to_string()))
+                    .and_then(|entry| entry.version.as_ref().map(std::string::ToString::to_string))
                     .or_else(|| market.as_ref().map(|agent| agent.version().to_string()))
                     .filter(|v| !v.is_empty()),
                 kind: if is_native { "native" } else { "external" }.to_string(),
@@ -223,7 +223,7 @@ fn build(host: &AgentHost) -> AgentCatalog {
                 platform_supported: is_native
                     || market
                         .as_ref()
-                        .map(|agent| agent.supports_current_platform())
+                        .map(atlas_agent_store::RegistryAgent::supports_current_platform)
                         .unwrap_or(true),
                 distribution_kind,
                 unverified: matches!(

--- a/src-tauri/src/commands/codebase_index.rs
+++ b/src-tauri/src/commands/codebase_index.rs
@@ -90,7 +90,7 @@ pub async fn codebase_index_build(
     emit(&app, "scanning", 0, 0);
     let scan_pp = pp.clone();
     let scanned: Vec<ScannedFile> =
-        tokio::task::spawn_blocking(move || scan(Path::new(&scan_pp), |p| mtime_ms(p)))
+        tokio::task::spawn_blocking(move || scan(Path::new(&scan_pp), mtime_ms))
             .await
             .map_err(|e| format!("scan join: {e}"))?;
 
@@ -248,7 +248,7 @@ fn build_summary_user(doc: &CodebaseDoc) -> String {
 }
 
 fn clean_summary(t: &str) -> String {
-    let one_line = t.trim().split_whitespace().collect::<Vec<_>>().join(" ");
+    let one_line = t.split_whitespace().collect::<Vec<_>>().join(" ");
     one_line.chars().take(400).collect()
 }
 

--- a/src-tauri/src/commands/fileindex.rs
+++ b/src-tauri/src/commands/fileindex.rs
@@ -515,7 +515,7 @@ pub fn fileindex_search_dirs(
                 .map(|score| (score, (rel, abs)))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(limit.max(1))
@@ -576,7 +576,7 @@ pub fn fileindex_search(
         })
         .collect();
     // Highest score first; stable order on ties (insertion = file walk order).
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(limit.max(1))

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -28,7 +28,7 @@ pub async fn read_directory(path: String) -> Result<Vec<FileEntry>, String> {
 fn read_directory_sync(path: &str) -> Result<Vec<FileEntry>, String> {
     let dir = Path::new(path);
     if !dir.is_dir() {
-        return Err(format!("Not a directory: {}", path));
+        return Err(format!("Not a directory: {path}"));
     }
 
     let mut entries = Vec::new();
@@ -73,7 +73,7 @@ fn read_directory_sync(path: &str) -> Result<Vec<FileEntry>, String> {
 #[tauri::command]
 pub async fn read_file_content(path: String) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
-        fs::read_to_string(&path).map_err(|e| format!("Failed to read {}: {}", path, e))
+        fs::read_to_string(&path).map_err(|e| format!("Failed to read {path}: {e}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -90,7 +90,7 @@ pub async fn read_file_content(path: String) -> Result<String, String> {
 pub async fn read_file_base64(path: String) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         use base64::Engine;
-        let bytes = fs::read(&path).map_err(|e| format!("Failed to read {}: {}", path, e))?;
+        let bytes = fs::read(&path).map_err(|e| format!("Failed to read {path}: {e}"))?;
         Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
     })
     .await
@@ -181,11 +181,11 @@ pub async fn is_text_file(path: String) -> Result<bool, String> {
     tokio::task::spawn_blocking(move || {
         use std::io::Read;
         let mut f =
-            fs::File::open(&path).map_err(|e| format!("Failed to open {}: {}", path, e))?;
+            fs::File::open(&path).map_err(|e| format!("Failed to open {path}: {e}"))?;
         let mut buf = [0u8; 8192];
         let n = f
             .read(&mut buf)
-            .map_err(|e| format!("Failed to read {}: {}", path, e))?;
+            .map_err(|e| format!("Failed to read {path}: {e}"))?;
         let slice = &buf[..n];
         // Empty file → treat as text (an empty editor is fine).
         if slice.is_empty() {
@@ -241,7 +241,7 @@ pub async fn file_mtime_ms(path: String) -> Result<i64, String> {
 #[tauri::command]
 pub async fn write_file_content(path: String, content: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
-        fs::write(&path, &content).map_err(|e| format!("Failed to write {}: {}", path, e))
+        fs::write(&path, &content).map_err(|e| format!("Failed to write {path}: {e}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -257,7 +257,7 @@ pub async fn write_file_base64(path: String, contents: String) -> Result<(), Str
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(contents.as_bytes())
             .map_err(|e| format!("bad base64: {e}"))?;
-        fs::write(&path, &bytes).map_err(|e| format!("Failed to write {}: {}", path, e))
+        fs::write(&path, &bytes).map_err(|e| format!("Failed to write {path}: {e}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -274,12 +274,12 @@ pub async fn fs_create_file(path: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let p = Path::new(&path);
         if p.exists() {
-            return Err(format!("Already exists: {}", path));
+            return Err(format!("Already exists: {path}"));
         }
         if let Some(parent) = p.parent() {
             fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
-        fs::write(p, "").map_err(|e| format!("Failed to create {}: {}", path, e))
+        fs::write(p, "").map_err(|e| format!("Failed to create {path}: {e}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -290,9 +290,9 @@ pub async fn fs_create_dir(path: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let p = Path::new(&path);
         if p.exists() {
-            return Err(format!("Already exists: {}", path));
+            return Err(format!("Already exists: {path}"));
         }
-        fs::create_dir_all(p).map_err(|e| format!("Failed to mkdir {}: {}", path, e))
+        fs::create_dir_all(p).map_err(|e| format!("Failed to mkdir {path}: {e}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -303,7 +303,7 @@ pub async fn fs_rename(from: String, to: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let dst = Path::new(&to);
         if dst.exists() {
-            return Err(format!("Target already exists: {}", to));
+            return Err(format!("Target already exists: {to}"));
         }
         fs::rename(&from, &to).map_err(|e| format!("Failed to rename: {e}"))
     })
@@ -335,7 +335,7 @@ pub async fn fs_copy(from: String, to: String) -> Result<(), String> {
         let src = Path::new(&from);
         let dst = Path::new(&to);
         if dst.exists() {
-            return Err(format!("Target already exists: {}", to));
+            return Err(format!("Target already exists: {to}"));
         }
         if src.is_dir() {
             copy_dir_recursive(src, dst)
@@ -376,7 +376,7 @@ pub async fn fs_duplicate(path: String) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         let src = Path::new(&path);
         if !src.exists() {
-            return Err(format!("Not found: {}", path));
+            return Err(format!("Not found: {path}"));
         }
         let parent = src.parent().ok_or("No parent dir")?;
         let stem = src
@@ -535,7 +535,7 @@ fn ensure_atlas_gitignore_sync(
     let gitignore = root.join(".gitignore");
 
     if !gitignore.exists() {
-        fs::write(&gitignore, format!("{}\n", ATLAS_GITIGNORE_PATTERN))
+        fs::write(&gitignore, format!("{ATLAS_GITIGNORE_PATTERN}\n"))
             .map_err(|e| format!("could not create .gitignore: {e}"))?;
         tracing::info!(
             target: "atlas::gitignore",

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -239,7 +239,7 @@ async fn git_status_compute(path: &str) -> Result<GitStatus, String> {
         .lines()
         .filter(|l| l.len() >= 3)
         .map(|line| {
-            let index = line.chars().nth(0).unwrap_or(' ');
+            let index = line.chars().next().unwrap_or(' ');
             let worktree = line.chars().nth(1).unwrap_or(' ');
             let file_path = line[3..].to_string();
             let (status, staged) = if index != ' ' && index != '?' {
@@ -317,7 +317,7 @@ pub(crate) fn git_log_compute(
             }
             let parents: Vec<String> = parts[6]
                 .split_whitespace()
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
                 .collect();
             let refs: Vec<String> = parts[7]
                 .split(',')
@@ -456,7 +456,7 @@ pub async fn git_graph_signature(path: String) -> Result<String, String> {
         for b in head.bytes().chain(joined.bytes()) {
             h = h.wrapping_mul(33) ^ (b as u64);
         }
-        Ok(format!("{}-{:016x}", head, h))
+        Ok(format!("{head}-{h:016x}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -605,7 +605,7 @@ pub async fn git_list_branches(path: String) -> Result<Vec<GitBranch>, String> {
                 let parts: Vec<&str> = line.split('\x1f').collect();
                 GitBranch {
                     name: parts.first().unwrap_or(&"").to_string(),
-                    is_current: parts.get(1).map_or(false, |h| h.trim() == "*"),
+                    is_current: parts.get(1).is_some_and(|h| h.trim() == "*"),
                 }
             })
             .collect();

--- a/src-tauri/src/commands/git_ops.rs
+++ b/src-tauri/src/commands/git_ops.rs
@@ -143,7 +143,7 @@ pub async fn git_branches_full(path: String) -> Result<Vec<BranchInfo>, GitError
                 let upstream = p.get(2).copied().unwrap_or("");
                 Some(BranchInfo {
                     name,
-                    is_current: p.get(1).map_or(false, |h| h.trim() == "*"),
+                    is_current: p.get(1).is_some_and(|h| h.trim() == "*"),
                     is_remote,
                     upstream: if upstream.is_empty() {
                         None
@@ -603,7 +603,7 @@ pub async fn git_stash_push(
             args.push("-m".into());
             args.push(m);
         }
-        let argv: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let argv: Vec<&str> = args.iter().map(std::string::String::as_str).collect();
         git_mut(&app, &path, &argv)?;
         Ok(())
     })
@@ -655,7 +655,7 @@ pub async fn git_discard(path: String, files: Vec<String>, app: AppHandle) -> Re
             "--".to_string(),
         ];
         args.extend(files);
-        let argv: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let argv: Vec<&str> = args.iter().map(std::string::String::as_str).collect();
         git_mut(&app, &path, &argv)?;
         Ok(())
     })
@@ -685,7 +685,7 @@ pub async fn git_delete_added(
             "--".to_string(),
         ];
         args.extend(files.clone());
-        let argv: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let argv: Vec<&str> = args.iter().map(std::string::String::as_str).collect();
         let _ = git_mut(&app, &path, &argv);
         // Delete the working-tree copies.
         for f in &files {
@@ -772,7 +772,7 @@ pub async fn git_create_tag(
         if let Some(t) = target.filter(|t| !t.is_empty()) {
             args.push(t);
         }
-        let argv: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let argv: Vec<&str> = args.iter().map(std::string::String::as_str).collect();
         git_mut(&app, &path, &argv)?;
         Ok(())
     })

--- a/src-tauri/src/commands/gitdiff.rs
+++ b/src-tauri/src/commands/gitdiff.rs
@@ -248,7 +248,7 @@ pub async fn git_commit_changed_files(
             let mut parts = line.split('\t');
             let status = parts.next().unwrap_or("").to_string();
             // Renames are `R100\told\tnew` — take the last field (new path).
-            let file = parts.last().unwrap_or("").to_string();
+            let file = parts.next_back().unwrap_or("").to_string();
             if !file.is_empty() {
                 out.push(CommitFile { path: file, status });
             }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -45,7 +45,7 @@ fn derive_display_name(repo_dir: &Path, dir_name: &str) -> String {
             // Normalise `git@host:owner/repo.git` and `https://host/owner/repo.git`
             // down to `owner/repo`.
             let tail = url
-                .rsplit(|c| c == '/' || c == ':')
+                .rsplit(['/', ':'])
                 .take(2)
                 .collect::<Vec<_>>();
             if tail.len() == 2 {
@@ -80,10 +80,10 @@ pub async fn search_github(query: String) -> Result<Vec<GithubRepo>, String> {
         .unwrap_or_default();
 
     let resp = client.get(&url).send().await
-        .map_err(|e| format!("GitHub API request failed: {}", e))?;
+        .map_err(|e| format!("GitHub API request failed: {e}"))?;
 
     let json: serde_json::Value = resp.json().await
-        .map_err(|e| format!("Failed to parse response: {}", e))?;
+        .map_err(|e| format!("Failed to parse response: {e}"))?;
 
     let items = json.get("items").and_then(|v| v.as_array()).cloned().unwrap_or_default();
 
@@ -95,8 +95,8 @@ pub async fn search_github(query: String) -> Result<Vec<GithubRepo>, String> {
             html_url: item.get("html_url").and_then(|v| v.as_str()).unwrap_or("").to_string(),
             clone_url: item.get("clone_url").and_then(|v| v.as_str()).unwrap_or("").to_string(),
             language: item.get("language").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-            stars: item.get("stargazers_count").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
-            forks: item.get("forks_count").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+            stars: item.get("stargazers_count").and_then(serde_json::Value::as_u64).unwrap_or(0) as u32,
+            forks: item.get("forks_count").and_then(serde_json::Value::as_u64).unwrap_or(0) as u32,
             updated_at: item.get("updated_at").and_then(|v| v.as_str()).unwrap_or("").to_string(),
         }
     }).collect();
@@ -115,7 +115,7 @@ pub async fn clone_github_repo(
 
     let dest = repos_dir.join(&repo_name);
     if dest.exists() {
-        return Err(format!("Repository '{}' already cloned", repo_name));
+        return Err(format!("Repository '{repo_name}' already cloned"));
     }
 
     let dest_str = dest.to_string_lossy().to_string();
@@ -123,7 +123,7 @@ pub async fn clone_github_repo(
         let output = std::process::Command::new("git")
             .args(["clone", "--depth", "1", &clone_url, &dest_str])
             .output()
-            .map_err(|e| format!("Git clone failed: {}", e))?;
+            .map_err(|e| format!("Git clone failed: {e}"))?;
 
         if !output.status.success() {
             return Err(String::from_utf8_lossy(&output.stderr).to_string());

--- a/src-tauri/src/commands/knowledge.rs
+++ b/src-tauri/src/commands/knowledge.rs
@@ -107,7 +107,7 @@ pub async fn save_knowledge_note(
 ) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         let kb_dir = Path::new(&project_path).join(".atlas").join("knowledge");
-        let filepath = kb_dir.join(format!("{}.md", id));
+        let filepath = kb_dir.join(format!("{id}.md"));
         if let Some(parent) = filepath.parent() {
             fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
@@ -132,7 +132,7 @@ fn unique_dest(dest: &Path) -> std::path::PathBuf {
     }
     let stem = dest.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
     let ext = dest.extension().map(|e| e.to_string_lossy().to_string());
-    let parent = dest.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+    let parent = dest.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
     for n in 1.. {
         let name = match &ext {
             Some(e) => format!("{stem}-{n}.{e}"),
@@ -213,7 +213,7 @@ pub async fn delete_knowledge_note(
         let filepath = Path::new(&project_path)
             .join(".atlas")
             .join("knowledge")
-            .join(format!("{}.md", id));
+            .join(format!("{id}.md"));
         if filepath.exists() {
             fs::remove_file(&filepath).map_err(|e| e.to_string())?;
         }
@@ -260,7 +260,7 @@ pub async fn knowledge_cover_upload(
         // Flatten the entry id so a nested note (`folder/note-123`) still
         // gets a flat filename safe for the covers directory.
         let safe_name = entry_id.replace('/', "__");
-        let rel = format!("covers/{}.{}", safe_name, ext);
+        let rel = format!("covers/{safe_name}.{ext}");
         let dest = Path::new(&project_path)
             .join(".atlas")
             .join("knowledge")
@@ -299,7 +299,7 @@ pub async fn knowledge_cover_data_url(
         let mime = match abs
             .extension()
             .and_then(|e| e.to_str())
-            .map(|e| e.to_lowercase())
+            .map(str::to_lowercase)
             .as_deref()
         {
             Some("png") => "image/png",
@@ -310,7 +310,7 @@ pub async fn knowledge_cover_data_url(
             _ => "image/jpeg",
         };
         let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-        Ok(format!("data:{};base64,{}", mime, b64))
+        Ok(format!("data:{mime};base64,{b64}"))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -395,11 +395,11 @@ pub async fn fetch_readable(url: String) -> Result<ReadableContent, String> {
         .unwrap_or_default();
 
     let response = client.get(&url).send().await
-        .map_err(|e| format!("Fetch failed: {}", e))?;
+        .map_err(|e| format!("Fetch failed: {e}"))?;
 
     let final_url = response.url().to_string();
     let html = response.text().await
-        .map_err(|e| format!("Read failed: {}", e))?;
+        .map_err(|e| format!("Read failed: {e}"))?;
 
     let title = extract_html_title(&html).unwrap_or_else(|| url.clone());
     let sanitized = sanitize_html(&html, &final_url);
@@ -434,11 +434,7 @@ fn strip_style_attributes(html: &str) -> String {
         // Find style=" or style='
         let pos = if let Some(p) = lower.find("style=\"") {
             Some((p, '"', 7))
-        } else if let Some(p) = lower.find("style='") {
-            Some((p, '\'', 7))
-        } else {
-            None
-        };
+        } else { lower.find("style='").map(|p| (p, '\'', 7)) };
 
         if let Some((start, quote, offset)) = pos {
             if let Some(end) = result[start + offset..].find(quote) {
@@ -479,8 +475,8 @@ fn sanitize_html(html: &str, base_url: &str) -> String {
 fn remove_tags(html: &str, tags: &[&str]) -> String {
     let mut result = html.to_string();
     for tag in tags {
-        let open = format!("<{}", tag);
-        let close = format!("</{}>", tag);
+        let open = format!("<{tag}");
+        let close = format!("</{tag}>");
         loop {
             let rl = result.to_lowercase();
             if let Some(start) = rl.find(&open) {
@@ -529,11 +525,11 @@ fn resolve_urls(html: &str, base: &str, origin: &str) -> String {
                     let resolved = if url_val.starts_with("http://") || url_val.starts_with("https://") || url_val.starts_with("data:") || url_val.starts_with("mailto:") || url_val.starts_with('#') {
                         url_val.to_string()
                     } else if url_val.starts_with("//") {
-                        format!("https:{}", url_val)
+                        format!("https:{url_val}")
                     } else if url_val.starts_with('/') {
-                        format!("{}{}", origin, url_val)
+                        format!("{origin}{url_val}")
                     } else {
-                        format!("{}/{}", base, url_val)
+                        format!("{base}/{url_val}")
                     };
                     if resolved != url_val {
                         result = format!("{}{}{}", &result[..abs_start], resolved, &result[abs_start + end..]);

--- a/src-tauri/src/commands/knowledge_export.rs
+++ b/src-tauri/src/commands/knowledge_export.rs
@@ -101,7 +101,7 @@ fn walk_notes(project_path: &str) -> Vec<NoteFile> {
     }
     let mut out: Vec<NoteFile> = Vec::new();
     walk(&root, &root, project_path, &mut out);
-    out.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+    out.sort_by_key(|a| a.title.to_lowercase());
     out
 }
 

--- a/src-tauri/src/commands/knowledge_links.rs
+++ b/src-tauri/src/commands/knowledge_links.rs
@@ -209,7 +209,7 @@ fn find_refs(body: &str) -> Vec<RefHit> {
 
     // @kind:id mentions (only the kinds we treat as knowledge refs).
     for kind in &["knowledge", "note", "page"] {
-        let needle = format!("@{}:", kind);
+        let needle = format!("@{kind}:");
         let mut search_from = 0;
         while let Some(pos_in_slice) = body[search_from..].find(&needle) {
             let pos = search_from + pos_in_slice;
@@ -286,15 +286,11 @@ fn read_quoted_attr(src: &str, name: &str) -> Option<String> {
 fn extract_snippet(body: &str, start: usize, end: usize) -> String {
     let lo = body
         .char_indices()
-        .map(|(i, _)| i)
-        .filter(|i| *i + SNIPPET_RADIUS >= start)
-        .next()
+        .map(|(i, _)| i).find(|i| *i + SNIPPET_RADIUS >= start)
         .unwrap_or(start.saturating_sub(SNIPPET_RADIUS));
     let hi = body
         .char_indices()
-        .map(|(i, c)| i + c.len_utf8())
-        .filter(|i| *i >= end + SNIPPET_RADIUS)
-        .next()
+        .map(|(i, c)| i + c.len_utf8()).find(|i| *i >= end + SNIPPET_RADIUS)
         .unwrap_or((end + SNIPPET_RADIUS).min(body.len()));
 
     let lo = clamp_to_char_boundary(body, lo);
@@ -373,8 +369,8 @@ pub async fn knowledge_link_counts(
             _ => return Ok(LinkCounts::default()),
         };
         Ok(LinkCounts {
-            backlinks: graph.backlinks.get(&entry_id).map(|v| v.len()).unwrap_or(0),
-            forwardlinks: graph.forwardlinks.get(&entry_id).map(|v| v.len()).unwrap_or(0),
+            backlinks: graph.backlinks.get(&entry_id).map(std::vec::Vec::len).unwrap_or(0),
+            forwardlinks: graph.forwardlinks.get(&entry_id).map(std::vec::Vec::len).unwrap_or(0),
         })
     })
     .await

--- a/src-tauri/src/commands/knowledge_meta.rs
+++ b/src-tauri/src/commands/knowledge_meta.rs
@@ -286,7 +286,7 @@ pub fn knowledge_meta_patch(
         let entry = writer
             .snapshot
             .pages
-            .entry(entry_id.clone())
+            .entry(entry_id)
             .or_insert_with(PageMeta::default);
         if entry.created_at.is_none() {
             entry.created_at = Some(now.clone());

--- a/src-tauri/src/commands/log.rs
+++ b/src-tauri/src/commands/log.rs
@@ -90,7 +90,7 @@ pub async fn append_pinned_log(org: String, entry_json: String) -> Result<(), St
             .map_err(|e| e.to_string())?;
         // Strip any newlines in the entry so each line is one entry.
         let single = entry_json.replace('\n', " ");
-        writeln!(f, "{}", single).map_err(|e| e.to_string())?;
+        writeln!(f, "{single}").map_err(|e| e.to_string())?;
         Ok(())
     })
     .await
@@ -164,7 +164,7 @@ pub async fn append_project_log(project: String, entry_json: String) -> Result<(
                 .open(&path)
                 .map_err(|e| e.to_string())?;
             let single = entry_json.replace('\n', " ");
-            writeln!(f, "{}", single).map_err(|e| e.to_string())?;
+            writeln!(f, "{single}").map_err(|e| e.to_string())?;
         }
         // Soft-cap: if the file grew past the limit, keep the most recent bytes
         // starting at a line boundary.

--- a/src-tauri/src/commands/memory_delta.rs
+++ b/src-tauri/src/commands/memory_delta.rs
@@ -68,28 +68,44 @@ pub fn classify(delta: &SessionDelta, session_id: &str, agent: &str) -> Vec<RawE
         }
 
         // A finished tool call that mutates a file → file_changed (on Completed
-        // only; dedup-by-path in the fold collapses repeats).
+        // only; dedup-by-path in the fold collapses repeats). Classification
+        // and path extraction are the checkpoint crate's — the one place that
+        // already solved both per agent family (#67): the native agent's tool
+        // name is a human title ("Edit src/foo.rs"), which the old
+        // exact-string matcher never matched, and its files ride the ACP
+        // `locations`, which the old singular-key probe never read — so
+        // Atlas Agent's edits silently produced no cross-agent memory at all.
         SessionDelta::ToolCallUpserted { tool_call, .. } => {
             if tool_call.status != ToolCallStatus::Completed {
                 return Vec::new();
             }
-            if !is_file_mutation(&tool_call.tool_name) {
+            let name = atlas_checkpoint::tools::canonical_name(
+                Some(&tool_call.tool_name),
+                tool_call.title.as_deref(),
+                tool_call.kind.as_deref(),
+                &tool_call.arguments,
+            );
+            if !name.writes_files() {
                 return Vec::new();
             }
-            let Some(path) = extract_path(&tool_call.arguments) else {
-                return Vec::new();
-            };
             let summary = tool_call
                 .title
                 .clone()
                 .unwrap_or_else(|| tool_call.tool_name.clone());
-            vec![RawEvent {
+            atlas_checkpoint::tools::extract_paths(
+                &tool_call.locations,
+                &[],
+                &tool_call.arguments,
+            )
+            .into_iter()
+            .map(|path| RawEvent {
                 agent: agent.to_string(),
                 session_id: session_id.to_string(),
                 kind: EventKind::FileChanged,
                 key: path.clone(),
                 payload: serde_json::json!({ "path": path, "summary": redact(&cap(&summary)) }),
-            }]
+            })
+            .collect()
         }
 
         // A completed assistant message → conservative keyword scan for explicit
@@ -142,29 +158,6 @@ fn scan_assistant_text(content: &str, session_id: &str, agent: &str) -> Vec<RawE
         }
     }
     out
-}
-
-fn is_file_mutation(tool_name: &str) -> bool {
-    let n = tool_name.to_lowercase();
-    n == "edit"
-        || n == "write"
-        || n == "create"
-        || n.contains("str_replace")
-        || n.contains("create_file")
-        || n.contains("apply_patch")
-        || n.contains("multiedit")
-}
-
-/// Pull a file path out of common tool-argument shapes.
-fn extract_path(args: &serde_json::Value) -> Option<String> {
-    for key in ["file_path", "path", "filePath", "target_file", "file"] {
-        if let Some(p) = args.get(key).and_then(|v| v.as_str()) {
-            if !p.trim().is_empty() {
-                return Some(p.to_string());
-            }
-        }
-    }
-    None
 }
 
 fn cap(s: &str) -> String {
@@ -241,6 +234,41 @@ fn looks_secret(tok: &str) -> bool {
 mod tests {
     use super::*;
     use atlas_agent_wire::PlanEntry;
+
+    fn native_edit_delta() -> SessionDelta {
+        SessionDelta::ToolCallUpserted {
+            message_id: "m1".into(),
+            tool_call: atlas_agent_wire::ToolCall {
+                id: "call-1".into(),
+                tool_name: "Edit src/foo.rs (+1 more)".into(),
+                title: Some("Edit src/foo.rs (+1 more)".into()),
+                kind: Some("edit".into()),
+                status: ToolCallStatus::Completed,
+                arguments: serde_json::json!({ "paths": ["src/foo.rs", "src/bar.rs"] }),
+                result: None,
+                locations: vec![
+                    serde_json::json!({ "path": "src/foo.rs" }),
+                    serde_json::json!({ "path": "src/bar.rs" }),
+                ],
+                raw_output: None,
+                content_blocks: vec![],
+            },
+        }
+    }
+
+    /// Issue #67: the native agent titles its edit call "Edit src/foo.rs" and
+    /// carries the files in ACP `locations` — no exact-string tool name, no
+    /// singular path key. The old matcher saw neither, so Atlas Agent's edits
+    /// never produced a `file_changed` and cross-agent memory silently
+    /// excluded the native agent. Every edited file gets its own event.
+    #[test]
+    fn a_native_agent_edit_reaches_shared_memory() {
+        let evs = classify(&native_edit_delta(), "s1", "cersei");
+        assert_eq!(evs.len(), 2, "one file_changed per edited file");
+        assert!(evs.iter().all(|e| e.kind == EventKind::FileChanged));
+        assert_eq!(evs[0].key, "src/foo.rs");
+        assert_eq!(evs[1].key, "src/bar.rs");
+    }
 
     fn plan_delta() -> SessionDelta {
         SessionDelta::PlanUpdated {

--- a/src-tauri/src/commands/memory_indexer.rs
+++ b/src-tauri/src/commands/memory_indexer.rs
@@ -283,14 +283,13 @@ impl MemoryRegistry {
 
                 // The persisted codebase index, when it exists.
                 let codebase_index = Path::new(cwd).join(".atlas").join("codebase-index");
-                if codebase_index.is_dir() {
-                    if w
+                if codebase_index.is_dir()
+                    && w
                         .watch(&codebase_index, notify::RecursiveMode::Recursive)
                         .is_ok()
                     {
                         watched_any = true;
                     }
-                }
 
                 if watched_any {
                     self.watchers.insert(cwd.to_string(), w);

--- a/src-tauri/src/commands/memory_pack.rs
+++ b/src-tauri/src/commands/memory_pack.rs
@@ -57,7 +57,7 @@ pub fn curate_pack(mut docs: Vec<MemoryDoc>) -> Option<String> {
         return None;
     }
     // Newest first — the most recent conventions/decisions matter most.
-    docs.sort_by(|a, b| b.timestamp_ms.cmp(&a.timestamp_ms));
+    docs.sort_by_key(|doc| std::cmp::Reverse(doc.timestamp_ms));
 
     let mut body = String::new();
     let mut count = 0usize;
@@ -85,8 +85,7 @@ pub fn curate_pack(mut docs: Vec<MemoryDoc>) -> Option<String> {
     }
     let footer = format!("({} memories · {} chars)", count, body.trim_end().len());
     Some(format!(
-        "--- PROJECT MEMORY ---\n{}{}\n--- END PROJECT MEMORY ---",
-        body, footer
+        "--- PROJECT MEMORY ---\n{body}{footer}\n--- END PROJECT MEMORY ---"
     ))
 }
 
@@ -145,7 +144,7 @@ pub fn parse_handoff_turns(jsonl: &str, max_turns: usize) -> Vec<(String, String
             Ok(v) => v,
             Err(_) => continue,
         };
-        if v.get("isSidechain").and_then(|x| x.as_bool()) == Some(true) {
+        if v.get("isSidechain").and_then(serde_json::Value::as_bool) == Some(true) {
             continue;
         }
         match v.get("type").and_then(|t| t.as_str()).unwrap_or("") {
@@ -234,8 +233,7 @@ fn format_turns(turns: &[(String, String)]) -> String {
 /// Wrap a raw handoff body in the labelled block with an attribution footer.
 pub fn wrap_handoff(body: &str, turn_count: usize, attribution: &str) -> String {
     format!(
-        "--- RECENT SESSION ---\n{}\n(last {} turns · {})\n--- END RECENT SESSION ---",
-        body, turn_count, attribution
+        "--- RECENT SESSION ---\n{body}\n(last {turn_count} turns · {attribution})\n--- END RECENT SESSION ---"
     )
 }
 

--- a/src-tauri/src/commands/memory_timeline.rs
+++ b/src-tauri/src/commands/memory_timeline.rs
@@ -169,7 +169,7 @@ pub async fn memory_timeline(
         });
     }
     sessions.retain(|s| s.ts_ms > 0);
-    sessions.sort_by(|a, b| a.ts_ms.cmp(&b.ts_ms));
+    sessions.sort_by_key(|a| a.ts_ms);
 
     let mut memory: Vec<TimelineMemory> = docs
         .into_iter()
@@ -182,7 +182,7 @@ pub async fn memory_timeline(
             ts_ms: d.timestamp_ms,
         })
         .collect();
-    memory.sort_by(|a, b| a.ts_ms.cmp(&b.ts_ms));
+    memory.sort_by_key(|a| a.ts_ms);
 
     let result = MemoryTimeline {
         branches,
@@ -226,7 +226,7 @@ pub async fn memory_timeline_cached(project_path: String) -> Result<Option<Memor
 
 fn build_git(path: &str) -> Result<(Vec<TimelineBranch>, Vec<TimelineCommit>), String> {
     let refs = git_refs_compute(path)?;
-    let current = refs.head_ref.clone();
+    let current = refs.head_ref;
 
     // Local branches with their tip commit time (unix seconds), for ordering.
     let out = Command::new("git")

--- a/src-tauri/src/commands/mention_search.rs
+++ b/src-tauri/src/commands/mention_search.rs
@@ -431,7 +431,7 @@ pub async fn mention_search(
     for scored in [files, folders, symbols_res, knowledge_res, repos, branches] {
         all.extend(scored);
     }
-    all.sort_by(|a, b| b.0.cmp(&a.0));
+    all.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     let mut per_kind: HashMap<&'static str, usize> = HashMap::new();
     let mut out: Vec<MentionResult> = Vec::new();
     for (_, m) in all {
@@ -496,7 +496,7 @@ fn rank_files(query: &str, files: Vec<(String, PathBuf)>) -> Vec<(u32, MentionRe
             pattern.score(utf, &mut matcher).map(|s| (s, (rel, abs)))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(PER_KIND_LIMIT)
@@ -533,7 +533,7 @@ fn rank_folders(
             pattern.score(utf, &mut matcher).map(|s| (s, (rel, abs)))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(PER_KIND_LIMIT)
@@ -566,7 +566,7 @@ fn rank_repos(query: &str, rows: Vec<ClonedRepo>) -> Vec<(u32, MentionResult)> {
             pattern.score(utf, &mut matcher).map(|s| (s, r))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(PER_KIND_LIMIT)
@@ -612,7 +612,7 @@ fn rank_branches(query: &str, refs: GitRefs) -> Vec<(u32, MentionResult)> {
             pattern.score(utf, &mut matcher).map(|s| (s, r))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(PER_KIND_LIMIT)
@@ -655,7 +655,7 @@ fn rank_symbols(query: &str, symbols: Vec<SymbolInput>) -> Vec<(u32, MentionResu
             pattern.score(utf, &mut matcher).map(|sc| (sc, s))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(PER_KIND_LIMIT)
@@ -710,7 +710,7 @@ fn rank_knowledge(query: &str, entries: Vec<KnowledgeInput>) -> Vec<(u32, Mentio
             pattern.score(utf, &mut matcher).map(|s| (s, e, folder))
         })
         .collect();
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     scored
         .into_iter()
         .take(PER_KIND_LIMIT)

--- a/src-tauri/src/commands/modelchat.rs
+++ b/src-tauri/src/commands/modelchat.rs
@@ -125,7 +125,7 @@ fn persist_byok_usage(app: &AppHandle, provider: &str, model: &str, input: u64, 
         "outputTokens": output,
         "costUsd": cost,
     });
-    let line = format!("{}\n", entry);
+    let line = format!("{entry}\n");
     if let Some(dir) = path.parent() {
         let _ = std::fs::create_dir_all(dir);
     }

--- a/src-tauri/src/commands/models_pricing.rs
+++ b/src-tauri/src/commands/models_pricing.rs
@@ -66,8 +66,8 @@ fn parse_catalog(v: &serde_json::Value) -> BTreeMap<String, ModelPrice> {
         };
         for (mid, mval) in models {
             let cost = mval.get("cost");
-            let input = cost.and_then(|c| c.get("input")).and_then(|x| x.as_f64());
-            let output = cost.and_then(|c| c.get("output")).and_then(|x| x.as_f64());
+            let input = cost.and_then(|c| c.get("input")).and_then(serde_json::Value::as_f64);
+            let output = cost.and_then(|c| c.get("output")).and_then(serde_json::Value::as_f64);
             if let (Some(input), Some(output)) = (input, output) {
                 let price = ModelPrice { input, output };
                 out.insert(format!("{pid}/{mid}"), price.clone());

--- a/src-tauri/src/commands/session_chat.rs
+++ b/src-tauri/src/commands/session_chat.rs
@@ -152,7 +152,7 @@ fn count_checkpoints(detail: &SessionDetail) -> usize {
 /// Entries arrive ordered, so this is one pass: accumulate a run, and when a
 /// Checkpoint closes it, keep the run if that Checkpoint was selected.
 fn scope_to_checkpoints(entries: &[TimelineEntry], shas: &[String]) -> Vec<TimelineEntry> {
-    let selected: HashSet<&str> = shas.iter().map(|s| s.as_str()).collect();
+    let selected: HashSet<&str> = shas.iter().map(std::string::String::as_str).collect();
     let mut out: Vec<TimelineEntry> = Vec::new();
     let mut run: Vec<TimelineEntry> = Vec::new();
 
@@ -685,7 +685,7 @@ fn searchable(entry: &TimelineEntry) -> String {
 fn tokenize(text: &str) -> Vec<String> {
     text.split(|c: char| !c.is_alphanumeric() && c != '_')
         .filter(|t| t.len() > 1)
-        .map(|t| t.to_ascii_lowercase())
+        .map(str::to_ascii_lowercase)
         .collect()
 }
 

--- a/src-tauri/src/commands/shared_memory.rs
+++ b/src-tauri/src/commands/shared_memory.rs
@@ -757,6 +757,6 @@ mod tests {
         e.session_id = "abc".into();
         e.agent = "codex".into();
         let s = fold_events(vec![e]);
-        assert_eq!(s.session_agents.get("abc").map(|x| x.as_str()), Some("codex"));
+        assert_eq!(s.session_agents.get("abc").map(std::string::String::as_str), Some("codex"));
     }
 }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -875,6 +875,8 @@ struct LedgerEntry {
 
 /// `skip_serializing_if` predicate: a `Skill` kind is the implicit default and is
 /// never written to the ledger JSON.
+// The reference is serde's contract for `skip_serializing_if`, not a choice.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_skill_kind(kind: &ComponentKind) -> bool {
     *kind == ComponentKind::Skill
 }
@@ -1720,7 +1722,7 @@ fn reconcile(root: &Path, scope: &str, home: &Path) -> Result<ReconcileView, Str
                     // No canonical twin → external (or external-conflict).
                     ("external".to_string(), None)
                 }
-            } else if !entry_meta.is_some() {
+            } else if entry_meta.is_none() {
                 // Nothing on disk for this tool.
                 if !detected {
                     ("absent".to_string(), None)
@@ -1988,11 +1990,9 @@ pub async fn agents_list_skill_targets(
     project_path: Option<String>,
 ) -> Result<Vec<AgentTarget>, String> {
     let root = root_for(&scope, project_path.as_deref())?;
-    Ok(
-        tokio::task::spawn_blocking(move || list_targets(&root, &scope))
+    tokio::task::spawn_blocking(move || list_targets(&root, &scope))
             .await
-            .map_err(|e| e.to_string())?,
-    )
+            .map_err(|e| e.to_string())
 }
 
 // ── Tauri commands (Control Plane) ───────────────────────────────────────────────
@@ -2004,11 +2004,9 @@ pub async fn tools_list(
     project_path: Option<String>,
 ) -> Result<Vec<AgentTarget>, String> {
     let root = root_for(&scope, project_path.as_deref())?;
-    Ok(
-        tokio::task::spawn_blocking(move || list_targets(&root, &scope))
+    tokio::task::spawn_blocking(move || list_targets(&root, &scope))
             .await
-            .map_err(|e| e.to_string())?,
-    )
+            .map_err(|e| e.to_string())
 }
 
 /// Build the reconciled skill × tool matrix for a scope.
@@ -2127,7 +2125,7 @@ fn repo_name_from_source(source: &str) -> String {
     source
         .trim()
         .trim_end_matches('/')
-        .rsplit(|c| c == '/' || c == ':')
+        .rsplit(['/', ':'])
         .next()
         .unwrap_or(source)
         .trim_end_matches(".git")

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -114,7 +114,7 @@ pub async fn terminal_create(
             // output is a reliable carrier for the change — and hanging the
             // check here costs one ioctl per emitted chunk and NOTHING while
             // the terminal sits idle, unlike a polling timer per session.
-            if let Some(raw) = probe.as_ref().and_then(|p| p.is_raw()) {
+            if let Some(raw) = probe.as_ref().and_then(atlas_terminal::TtyModeProbe::is_raw) {
                 if last_raw != Some(raw) {
                     last_raw = Some(raw);
                     let _ = app_handle.emit(
@@ -379,7 +379,7 @@ const SHELL_BUILTINS: &[&str] = &[
 
 fn scan_commands() -> Vec<String> {
     use std::collections::BTreeSet;
-    let mut set: BTreeSet<String> = SHELL_BUILTINS.iter().map(|s| s.to_string()).collect();
+    let mut set: BTreeSet<String> = SHELL_BUILTINS.iter().map(std::string::ToString::to_string).collect();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -299,7 +299,7 @@ pub fn update_ignore(
         guard.settings.updater_ignored_version = Some(version);
         guard.clone()
     };
-    let app2 = app.clone();
+    let app2 = app;
     std::thread::spawn(move || {
         if let Err(e) = AppState::save(&app2, &snapshot) {
             tracing::warn!(target: "atlas::updater", "save ignored version failed: {e}");
@@ -634,7 +634,7 @@ fn stage_from_dmg(app: &AppHandle, dmg: &Path, dir: &Path, version: &str) -> Res
 fn stage_from_mount(mount_point: &Path, dir: &Path) -> Result<PathBuf, String> {
     let src_app = std::fs::read_dir(mount_point)
         .map_err(|e| format!("read mount: {e}"))?
-        .filter_map(|e| e.ok())
+        .filter_map(std::result::Result::ok)
         .map(|e| e.path())
         .find(|p| p.extension().map(|x| x == "app").unwrap_or(false))
         .ok_or_else(|| "no .app found in the update DMG".to_string())?;
@@ -851,7 +851,7 @@ fn current_app_bundle() -> Result<PathBuf, String> {
         .parent() // MacOS
         .and_then(|p| p.parent()) // Contents
         .and_then(|p| p.parent()) // Atlas.app
-        .map(|p| p.to_path_buf())
+        .map(std::path::Path::to_path_buf)
         .ok_or_else(|| "could not resolve app bundle path".to_string())?;
     if app.extension().map(|x| x == "app").unwrap_or(false) {
         Ok(app)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -288,6 +288,7 @@ pub fn run() {
             commands::auth::auth_sign_in,
             commands::auth::auth_cancel_sign_in,
             commands::auth::auth_sign_out,
+            commands::auth::auth_set_active_org,
             commands::auth::auth_create_org,
             commands::auth::auth_check_org_slug,
             commands::auth::auth_list_members,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,7 +79,7 @@ pub fn run() {
         // Custom menu: replaces the default Window ▸ Close (Cmd+W) with a
         // "Close Tab" item so Cmd+W in a focused embedded browser webview closes
         // the tab instead of tearing down the window. See `menu.rs`.
-        .menu(|handle| menu::build(handle))
+        .menu(menu::build)
         .on_menu_event(|app, event| {
             if event.id() == menu::CLOSE_TAB_ID {
                 use tauri::Emitter;
@@ -106,7 +106,7 @@ pub fn run() {
             // Pre-load the Rust-owned `AppState` (currentProject + recents)
             // before the webview starts loading — paid in parallel with the
             // WebView framework init, ~1ms on warm cache.
-            let mut loaded = AppState::load(&app.handle());
+            let mut loaded = AppState::load(app.handle());
             // Device-stable telemetry identity, owned by Rust in its own file.
             // It used to live in `state.json` as `telemetry_anon_id`, where every
             // settings save wiped it (the frontend payload omitted the field and
@@ -114,14 +114,14 @@ pub fn run() {
             // new PostHog person on every save. An install upgrading from that
             // era ADOPTS its existing id here rather than forking a new person.
             let (device, is_new_device) =
-                telemetry::device::load_or_create(&app.handle(), loaded.telemetry_anon_id.as_deref());
+                telemetry::device::load_or_create(app.handle(), loaded.telemetry_anon_id.as_deref());
             let device_id = device.device_id.clone();
-            let device_id_source = device.source.clone();
+            let device_id_source = device.source;
             // Mirror it back into `state.json` so the two agree and a downgrade
             // still finds an id. `AppStatePatch` now stops the frontend wiping it.
             if loaded.telemetry_anon_id.as_deref() != Some(device_id.as_str()) {
                 loaded.telemetry_anon_id = Some(device_id.clone());
-                let _ = AppState::save(&app.handle(), &loaded);
+                let _ = AppState::save(app.handle(), &loaded);
             }
             let telemetry_enabled = loaded.settings.share_telemetry;
             let app_state: AppStateHandle = Arc::new(Mutex::new(loaded));
@@ -130,7 +130,7 @@ pub fn run() {
             // Opt-in product telemetry. Inert unless the user has enabled it AND
             // a PostHog key resolves (env / telemetry.json / build-time default).
             let (telemetry, flush_rx) =
-                telemetry::TelemetryClient::new(&app.handle(), device_id, telemetry_enabled);
+                telemetry::TelemetryClient::new(app.handle(), device_id, telemetry_enabled);
             app.manage(telemetry.clone());
             if let Some(rx) = flush_rx {
                 let tclient = telemetry.clone();
@@ -154,7 +154,7 @@ pub fn run() {
                         .payload()
                         .downcast_ref::<&str>()
                         .copied()
-                        .or_else(|| info.payload().downcast_ref::<String>().map(|s| s.as_str()))
+                        .or_else(|| info.payload().downcast_ref::<String>().map(std::string::String::as_str))
                         .unwrap_or("panic");
                     tclient.capture_panic_blocking(serde_json::json!({
                         "location": location,
@@ -173,10 +173,10 @@ pub fn run() {
                 }),
             );
 
-            commands::agents::install_manager(&app.handle());
+            commands::agents::install_manager(app.handle());
             // Silent background refresh of model pricing from models.dev — first
             // launch populates the cache; later launches update only on change.
-            commands::models_pricing::refresh_in_background(&app.handle());
+            commands::models_pricing::refresh_in_background(app.handle());
             // Auto-update: clean up any staged update that already took effect,
             // then run a non-blocking background check + a periodic re-check. The
             // download/verify/stage happens silently; the user is only prompted
@@ -191,7 +191,7 @@ pub fn run() {
                     .app_config_dir()
                     .unwrap_or_else(|_| std::path::PathBuf::from("."));
                 app.manage(commands::auth::AuthState::new(config_dir));
-                commands::auth::restore_on_launch(&app.handle());
+                commands::auth::restore_on_launch(app.handle());
 
                 // Seed the Organisation every event is attributed to, from the
                 // state we just loaded. The app has an active org from its first
@@ -229,9 +229,9 @@ pub fn run() {
                     }));
             }
 
-            commands::updater::init_on_startup(&app.handle());
-            commands::updater::check_in_background(&app.handle());
-            commands::updater::spawn_periodic(&app.handle());
+            commands::updater::init_on_startup(app.handle());
+            commands::updater::check_in_background(app.handle());
+            commands::updater::spawn_periodic(app.handle());
 
             // Background memory indexer (Step 4): a single owned Tokio task drains
             // a bounded queue and indexes each open project's corpus into its

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -64,7 +64,12 @@ import { openSettingsSection } from "@/features/settings/lib/open-settings";
 import { ComposerOptionsPill } from "./composer-options-pill";
 import { FeaturedAgentOffers } from "./featured-agent-offers";
 import { RetryPill } from "./retry-pill";
-import { QUALITY_LADDER, exceedsBudget, targetDimensions } from "../lib/image-policy";
+import {
+  QUALITY_LADDER,
+  aggregateExceedsBudget,
+  exceedsBudget,
+  targetDimensions,
+} from "../lib/image-policy";
 import { ComposerAddMenu } from "./composer-add-menu";
 import type { GithubRepo } from "@/features/github/types";
 import { imageMimeFromPath } from "@/lib/byok/model-capabilities";
@@ -148,6 +153,12 @@ async function downscaleAttachment(image: ImageAttachment): Promise<ImageAttachm
     canvas.height = height;
     const ctx = canvas.getContext("2d");
     if (!ctx) return image;
+    // A fresh canvas is transparent and JPEG has no alpha channel, so
+    // transparent pixels composite to BLACK — a macOS window capture (rounded
+    // corners, drop shadow, routinely over budget) came out with black
+    // corners and a black halo (#71). Paint the ground white first.
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, width, height);
     ctx.drawImage(bitmap, 0, 0, width, height);
     bitmap.close?.();
 
@@ -1163,6 +1174,25 @@ export function MessageInput({
   useEffect(() => {
     if (!imageSupported) setStagedImages([]);
   }, [imageSupported]);
+
+  // The per-image budget is per image only: several in-budget attachments
+  // plus the prompt, tools and history can still blow the gateway's body cap
+  // (#71). The gateway's 413 stays the backstop — this is the warning the
+  // user is owed BEFORE pressing send, once per crossing, cleared when they
+  // remove enough to fit again.
+  const stagedOverAggregateBudget = aggregateExceedsBudget(
+    stagedImages.map((img) => img.dataBase64.length),
+  );
+  const warnedAggregateRef = useRef(false);
+  useEffect(() => {
+    if (stagedOverAggregateBudget && !warnedAggregateRef.current) {
+      warnedAggregateRef.current = true;
+      toast.warning(
+        "These attachments together are near the 2 MB request limit — the send may be refused. Consider removing one.",
+      );
+    }
+    if (!stagedOverAggregateBudget) warnedAggregateRef.current = false;
+  }, [stagedOverAggregateBudget]);
 
   // "+" menu → "Add files or photos". The Tauri dialog hands back real
   // paths (a browser file input wouldn't), which is what makes the routing

--- a/src/features/chat/lib/image-policy.test.ts
+++ b/src/features/chat/lib/image-policy.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  AGGREGATE_IMAGE_BUDGET_BYTES,
   BODY_CAP_BYTES,
   MAX_EDGE_PX,
   PER_IMAGE_BUDGET_BYTES,
+  aggregateExceedsBudget,
   encodedSize,
   exceedsBudget,
   targetDimensions,
@@ -58,5 +60,15 @@ describe("image sizing policy (D15c)", () => {
     // The case this exists for: a 4 MB retina screenshot, ~5.3 MB once base64
     // encoded, against a 2 MB cap.
     expect(exceedsBudget(encodedSize(4 * 1024 * 1024))).toBe(true);
+  });
+
+  it("warns when in-budget attachments together would still blow the cap", () => {
+    // The per-image budget is per image only: four images each exactly on
+    // budget total a full body cap before a byte of prompt, tools or history
+    // is counted (#71). Three fit under the aggregate line; four do not.
+    const onBudget = PER_IMAGE_BUDGET_BYTES;
+    expect(aggregateExceedsBudget([onBudget, onBudget, onBudget])).toBe(false);
+    expect(aggregateExceedsBudget([onBudget, onBudget, onBudget, onBudget])).toBe(true);
+    expect(AGGREGATE_IMAGE_BUDGET_BYTES).toBeLessThan(BODY_CAP_BYTES);
   });
 });

--- a/src/features/chat/lib/image-policy.ts
+++ b/src/features/chat/lib/image-policy.ts
@@ -86,3 +86,20 @@ export function exceedsBudget(base64Length: number): boolean {
  * gateway refuses outright.
  */
 export const QUALITY_LADDER = [0.85, 0.7, 0.55, 0.4] as const;
+
+/**
+ * What all staged attachments together may occupy.
+ *
+ * The per-image budget is enforced per image only, so four in-budget
+ * attachments plus the prompt, the tool schemas and the conversation so far
+ * could still guarantee a `413` (#71). Three quarters of the cap leaves the
+ * last quarter for everything that isn't an image — the same share one image
+ * gets. The gateway stays the backstop; crossing this line is a warning owed
+ * to the user before they press send, not a refusal.
+ */
+export const AGGREGATE_IMAGE_BUDGET_BYTES = (BODY_CAP_BYTES * 3) / 4;
+
+/** Whether the staged attachments together are likely to blow the body cap. */
+export function aggregateExceedsBudget(base64Lengths: number[]): boolean {
+  return base64Lengths.reduce((total, n) => total + n, 0) > AGGREGATE_IMAGE_BUDGET_BYTES;
+}

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -34,6 +34,7 @@ import { defaultAgentForNewSession } from "../lib/default-agent";
 import { loadCachedContextUsage, saveCachedContextUsage } from "../lib/context-usage-cache";
 import { saveCerseiModelPref, saveCerseiEffort } from "../lib/cersei-model-pref";
 import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
 import { extractPlanMarkdown, type PlanRecord } from "../lib/plans";
 import { extractNextSteps } from "../lib/next-steps";
 import {
@@ -134,31 +135,67 @@ function aggregateTurnFiles(tools: Record<string, TurnFile>): TurnFile[] {
  * No-op until the session is bound (the create-time setMode in chat-panel
  * covers the not-yet-bound case).
  */
-function pushPermissionModeToAgent(state: ChatState, sessionId: string): void {
+function pushPermissionModeToAgent(
+  state: ChatState,
+  sessionId: string,
+  previousMode?: ClaudePermissionMode,
+): void {
   const session = state.sessions[sessionId];
   if (!session?.acpAgentId || !session.acpSessionId) return;
   if (session.agentType !== "claude-code") return;
+  const pushed = session.claudePermissionMode ?? "default";
   void invoke("agents_set_mode", {
     key: { agent_id: session.acpAgentId, session_id: session.acpSessionId },
-    modeId: session.claudePermissionMode ?? "default",
-  }).catch((err) => console.warn("agents_set_mode failed:", err));
+    modeId: pushed,
+  }).catch((err) => {
+    console.warn("agents_set_mode failed:", err);
+    revertRefusedMode(sessionId, err, (sess) => {
+      if (sess.claudePermissionMode === pushed && previousMode !== undefined) {
+        sess.claudePermissionMode = previousMode;
+      }
+    });
+  });
 }
 
 /** Push a generic ACP session mode (Codex's read-only / auto / full-access)
  *  to its bound agent. Agent-agnostic sibling of `pushPermissionModeToAgent`.
  *  No-op until the session is bound. */
-function pushAcpModeToAgent(state: ChatState, sessionId: string): void {
+function pushAcpModeToAgent(state: ChatState, sessionId: string, previousMode?: string): void {
   const session = state.sessions[sessionId];
   if (!session?.acpAgentId || !session.acpSessionId || !session.acpCurrentMode) return;
   // Only push ids this session's agent actually advertised. A mode carried over
-  // from another agent is rejected (`invalidParams`), and the actor rolls its
-  // optimistic flip back — which reads as a picker that silently does nothing.
+  // from another agent is rejected (`invalidParams`) before it is ever pushed.
   const modes = session.acpAvailableModes ?? [];
   if (modes.length > 0 && !modes.some((m) => m.id === session.acpCurrentMode)) return;
+  const pushed = session.acpCurrentMode;
   void invoke("agents_set_mode", {
     key: { agent_id: session.acpAgentId, session_id: session.acpSessionId },
-    modeId: session.acpCurrentMode,
-  }).catch((err) => console.warn("agents_set_mode failed:", err));
+    modeId: pushed,
+  }).catch((err) => {
+    console.warn("agents_set_mode failed:", err);
+    revertRefusedMode(sessionId, err, (sess) => {
+      if (sess.acpCurrentMode === pushed && previousMode !== undefined) {
+        sess.acpCurrentMode = previousMode;
+      }
+    });
+  });
+}
+
+/** The agent refused a mode change the picker already shows (the flip is
+ *  optimistic). Leaving the label on the refused mode is the picker lying —
+ *  the native agent refuses mid-turn switches precisely because the running
+ *  turn keeps the permissions it started with (#61) — so roll the label back
+ *  (unless the user has since picked something else) and say why. */
+function revertRefusedMode(
+  sessionId: string,
+  err: unknown,
+  revert: (sess: ChatSession) => void,
+): void {
+  useChatStore.setState((s) => {
+    const sess = s.sessions[sessionId];
+    if (sess) revert(sess);
+  });
+  toast.error(typeof err === "string" ? err : String(err));
 }
 
 /** Hydrate the per-agent persisted mode preference (last explicit pick) into
@@ -957,10 +994,12 @@ export const useChatStore = createSelectors(
           }),
         cycleClaudePermissionMode: (sessionId) => {
           let next: ClaudePermissionMode | undefined;
+          let previous: ClaudePermissionMode | undefined;
           set((s) => {
             const session = s.sessions[sessionId];
             if (!session) return;
             const cur = session.claudePermissionMode ?? "default";
+            previous = cur;
             const i = CLAUDE_PERMISSION_MODES.indexOf(cur);
             next = CLAUDE_PERMISSION_MODES[(i + 1) % CLAUDE_PERMISSION_MODES.length];
             session.claudePermissionMode = next;
@@ -969,7 +1008,7 @@ export const useChatStore = createSelectors(
           // "default" means "defer to the CLI's own configured default" —
           // cycling back to it DROPS the persisted pick rather than storing it.
           if (next) saveLastModePref("claude-code", next === "default" ? null : next);
-          pushPermissionModeToAgent(get(), sessionId);
+          pushPermissionModeToAgent(get(), sessionId, previous);
         },
         hydrateClaudePermissionMode: (sessionId, mode) =>
           set((s) => {
@@ -979,6 +1018,7 @@ export const useChatStore = createSelectors(
             session.claudePermissionModeExplicit = false;
           }),
         setClaudePermissionMode: (sessionId, mode) => {
+          const previous = get().sessions[sessionId]?.claudePermissionMode ?? "default";
           set((s) => {
             const session = s.sessions[sessionId];
             if (session) {
@@ -987,7 +1027,7 @@ export const useChatStore = createSelectors(
             }
           });
           saveLastModePref("claude-code", mode === "default" ? null : mode);
-          pushPermissionModeToAgent(get(), sessionId);
+          pushPermissionModeToAgent(get(), sessionId, previous);
         },
         setAcpModes: (sessionId, currentMode, availableModes, sourceAgentType) => {
           const at = get().sessions[sessionId]?.agentType;
@@ -1037,6 +1077,7 @@ export const useChatStore = createSelectors(
             if (session) session.acpModesPending = pending;
           }),
         setAcpMode: (sessionId, modeId) => {
+          const previous = get().sessions[sessionId]?.acpCurrentMode;
           set((s) => {
             const session = s.sessions[sessionId];
             if (session) {
@@ -1049,7 +1090,7 @@ export const useChatStore = createSelectors(
           // or installed — keeps its own record.
           const at = get().sessions[sessionId]?.agentType;
           if (at && at !== "claude-code") saveLastModePref(at, modeId);
-          pushAcpModeToAgent(get(), sessionId);
+          pushAcpModeToAgent(get(), sessionId, previous);
         },
         clearElicitation: (sessionId) =>
           set((s) => {

--- a/src/features/organisations/lib/org-switch.ts
+++ b/src/features/organisations/lib/org-switch.ts
@@ -8,6 +8,7 @@ import {
   scheduleAppStateSave,
 } from "@/features/project/stores/project-store";
 import { toast } from "sonner";
+import { invoke } from "@tauri-apps/api/core";
 import { auth } from "@/features/auth/lib/auth-api";
 import { useAuthStore } from "@/features/auth/stores/auth-store";
 import { useOrgStore } from "../stores/org-store";
@@ -100,6 +101,22 @@ export async function switchOrg(id: string): Promise<void> {
     //    re-points analytics attribution (see `syncOrgTelemetry`), so events
     //    from here on are filed under the incoming org.
     orgActions.setActiveOrganisation(id);
+
+    //    The switch must reach the BACKEND too (#73): every gateway request
+    //    reads the active org from the Rust auth snapshot, so a frontend-only
+    //    switch keeps billing — and entitlement-checking — the previous org,
+    //    which is how an unentitled org appeared to work. Awaited, so the
+    //    first message sent in the new org cannot race the write. A
+    //    local-only org (no remoteId) clears the choice: attribution falls
+    //    back the way the auth store documents (web-set value, else first
+    //    server org).
+    try {
+      await invoke("auth_set_active_org", { orgId: target.remoteId ?? null });
+    } catch (err) {
+      // Signed out (nothing to bill) or transient — the switch itself must
+      // not be aborted over attribution; the next sign-in rewrites it.
+      console.warn("auth_set_active_org failed:", err);
+    }
 
     //    Re-scope the activity console the same way: drop the outgoing org's
     //    buffered entries and load the incoming org's pins. Without this the

--- a/tests/cargo-workspace.test.ts
+++ b/tests/cargo-workspace.test.ts
@@ -225,11 +225,6 @@ describe("dev-profile opt-levels survive the move into the workspace", () => {
     );
   });
 
-  // Scoped to Atlas's own members on purpose. The vendored engine (#42) is
-  // deliberately NOT given per-member opt-level stanzas: it is quarantined, on
-  // no runtime path until the seam is rewired (#45), and paying opt-level 1 on
-  // ~600k LOC would slow every dev build for a runtime benefit nothing can yet
-  // collect. Revisit in #45, when the engine starts doing work.
   it("restates opt-level 1 for every member the `*` override no longer reaches", () => {
     const missing: string[] = [];
     for (const rel of expectedMembers()) {
@@ -245,6 +240,29 @@ describe("dev-profile opt-levels survive the move into the workspace", () => {
       );
       if (!stanza.test(rootSrc())) missing.push(name);
     }
+    expect(missing).toEqual([]);
+  });
+
+  // The exemption this test replaced — "the vendored engine is quarantined, on
+  // no runtime path until the seam is rewired (#45); revisit in #45" — expired
+  // when #45 and #54 landed: the engine now runs on every dev turn, and at the
+  // profile's opt-level 0 it was ~600k LOC of streaming, rollout I/O,
+  // sandboxing and apply-patch running unoptimized on the hottest path (#65).
+  it("restates opt-level 1 for the vendored engine members too", () => {
+    const vendored = workspaceList("members").filter((m) => m.startsWith("vendor/codex/"));
+    expect(vendored.length, "member-list parser health").toBeGreaterThan(50);
+    const missing: string[] = [];
+    for (const rel of vendored) {
+      const name = packageName(path.join(REPO_ROOT, rel, "Cargo.toml"));
+      const stanza = new RegExp(
+        `^\\s*\\[profile\\.dev\\.package\\.(?:"${escapeForRegExp(name)}"|${escapeForRegExp(name)})\\]\\s*$` +
+          `(?:(?!^\\s*\\[)[\\s\\S])*?opt-level\\s*=\\s*1`,
+        "m",
+      );
+      if (!stanza.test(rootSrc())) missing.push(name);
+    }
+    // A new vendored member gets a stanza in the block the root manifest
+    // keeps for them (#65) — the `"*"` override cannot reach members.
     expect(missing).toEqual([]);
   });
 

--- a/tests/cersei-containment.test.ts
+++ b/tests/cersei-containment.test.ts
@@ -27,17 +27,11 @@ import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-/** Manifests that may declare cersei dependencies today: the protocol-free
- *  atlas-cersei wrapper, the in-process native agent built on it, the app crate
- *  (which carries the vendored `cersei-provider` UTF-8 compile guard), and the
- *  workspace root (which owns the two `[patch.crates-io]` vendor overrides —
- *  the only manifest cargo honors a patch table in). */
-const ALLOWED_CERSEI_MANIFESTS = new Set([
-  "Cargo.toml",
-  "crates/atlas-cersei/Cargo.toml",
-  "crates/atlas-native-agent/Cargo.toml",
-  "src-tauri/Cargo.toml",
-]);
+/** Manifests that may still declare cersei-named dependencies. The Cersei
+ *  path is deleted (#54): no manifest should, and the set is empty — kept (and
+ *  the walker with it) so a reintroduced `cersei-*` dependency anywhere fails
+ *  this suite instead of quietly resolving from crates.io. */
+const ALLOWED_CERSEI_MANIFESTS = new Set<string>([]);
 
 /** A dependency-shaped cersei line: `cersei = …`, `cersei-agent = { … }`, and
  *  the `[patch.crates-io]` vendored overrides. Comment lines don't count —

--- a/tests/codex-no-phone-home.test.ts
+++ b/tests/codex-no-phone-home.test.ts
@@ -180,3 +180,33 @@ describe("the ChatGPT analytics client is gone", () => {
     expect(manifest).not.toMatch(/^\s*reqwest/m);
   });
 });
+
+describe("the Sentry feedback uploader is gone", () => {
+  it("has no Sentry DSN", () => {
+    // The fourth phone-home path (#63): `codex-feedback` shipped a hardcoded
+    // ingest DSN and built a client around it inside `upload_feedback` — a
+    // path the in-process app-server would honour on a `feedback/upload`
+    // request. The key is split so this file is not itself a hit.
+    const dsn = ["ae32ed50620d7a", "7792c1ce5df38b3e3e"].join("");
+    expect(filesMatching(new RegExp(dsn))).toEqual([]);
+    expect(filesMatching(/o33249\.ingest/)).toEqual([]);
+  });
+
+  it("parses no DSN and builds no Sentry client", () => {
+    expect(codeMatching(/Dsn::from_str|sentry::init/)).toEqual([]);
+  });
+});
+
+describe("no telemetry ingest marker anywhere in vendored code", () => {
+  // The removals above are point checks against sites already known. The
+  // fourth path (#63) shipped precisely because only known sites were
+  // asserted: the guard could not fail on one it had never heard of. This is
+  // the structural half — any ingest-service marker in vendored CODE fails
+  // here (comments explaining a removal don't count), so a fifth site fails
+  // rather than passes.
+  it("matches no known telemetry vendor", () => {
+    const markers =
+      /sentry\.io|statsig|posthog\.com|segment\.io|datadoghq|bugsnag|honeycomb\.io|o33249/i;
+    expect(codeMatching(markers)).toEqual([]);
+  });
+});

--- a/tests/vendor-licensing.test.ts
+++ b/tests/vendor-licensing.test.ts
@@ -128,6 +128,18 @@ describe("§4(a) and §4(d) — the licence and NOTICE reach recipients", () => 
 });
 
 describe("§4(b) — modified files say they were modified", () => {
+  it("has the history it needs — a shallow clone cannot run this suite", () => {
+    // On a depth-1 clone the oldest commit touching vendor/codex IS HEAD, so
+    // the diff against it is empty and the rule below holds vacuously. Name
+    // the cause here so the next person reads it instead of the symptom (#58).
+    expect(
+      vendoringCommit(),
+      "vendoringCommit() resolved to HEAD — this is a shallow clone " +
+        "(actions/checkout defaults to fetch-depth: 1). Check out with " +
+        "fetch-depth: 0 so the vendoring fork point is reachable.",
+    ).not.toBe(git("rev-parse", "HEAD").trim());
+  });
+
   it("finds the modification set (parser health)", () => {
     // If this returned nothing, the rule below would hold vacuously forever.
     expect(modifiedVendoredFiles().length).toBeGreaterThan(5);

--- a/vendor/codex/codex-api/src/atlas_chat/org.rs
+++ b/vendor/codex/codex-api/src/atlas_chat/org.rs
@@ -52,8 +52,16 @@ pub fn current_org() -> Option<String> {
 mod tests {
     use super::*;
 
+    /// Every test here writes the one global `ORG_SOURCE`, and cargo runs
+    /// tests concurrently by default — unserialised, the loser reads the
+    /// winner's source and the suite flakes with the schedule (#64). One
+    /// lock, taken first in each test; `into_inner` so one panicking test
+    /// does not poison the rest.
+    static ORG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn no_source_means_personal_attribution() {
+        let _serialised = ORG_TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         // Not an error: a caller with no org grant is the contract's
         // `org_none` case, and the header is simply absent.
         *ORG_SOURCE.write().unwrap_or_else(std::sync::PoisonError::into_inner) = None;
@@ -62,6 +70,7 @@ mod tests {
 
     #[test]
     fn the_source_is_consulted_per_call_so_an_org_switch_takes_effect() {
+        let _serialised = ORG_TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         // The whole reason this is a callback and not a config value: the user
         // can switch org mid-session, and the *next* request must bill the new
         // one.
@@ -78,6 +87,7 @@ mod tests {
 
     #[test]
     fn an_empty_org_id_is_absent_rather_than_a_malformed_header() {
+        let _serialised = ORG_TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         set_org_source(Arc::new(|| Some(String::new())));
         assert_eq!(current_org(), None);
     }

--- a/vendor/codex/codex-api/src/atlas_chat/org.rs
+++ b/vendor/codex/codex-api/src/atlas_chat/org.rs
@@ -34,14 +34,14 @@ static ORG_SOURCE: RwLock<Option<OrgSource>> = RwLock::new(None);
 /// Installs the host's org source. A later call replaces the earlier one,
 /// which is also what lets each test bring its own.
 pub fn set_org_source(source: OrgSource) {
-    *ORG_SOURCE.write().unwrap_or_else(|p| p.into_inner()) = Some(source);
+    *ORG_SOURCE.write().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(source);
 }
 
 /// The paying org for a request being built now, if the host declared one.
 pub fn current_org() -> Option<String> {
     let source = ORG_SOURCE
         .read()
-        .unwrap_or_else(|p| p.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .clone()?;
     // An empty id is no org: sending `Atlas-Org:` with nothing in it is a
     // malformed header, not a personal request.
@@ -56,7 +56,7 @@ mod tests {
     fn no_source_means_personal_attribution() {
         // Not an error: a caller with no org grant is the contract's
         // `org_none` case, and the header is simply absent.
-        *ORG_SOURCE.write().unwrap_or_else(|p| p.into_inner()) = None;
+        *ORG_SOURCE.write().unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         assert_eq!(current_org(), None);
     }
 
@@ -68,11 +68,11 @@ mod tests {
         let org = Arc::new(std::sync::Mutex::new(Some("org_a".to_string())));
         let reader = org.clone();
         set_org_source(Arc::new(move || {
-            reader.lock().unwrap_or_else(|p| p.into_inner()).clone()
+            reader.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
         }));
         assert_eq!(current_org().as_deref(), Some("org_a"));
 
-        *org.lock().unwrap_or_else(|p| p.into_inner()) = Some("org_b".to_string());
+        *org.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some("org_b".to_string());
         assert_eq!(current_org().as_deref(), Some("org_b"));
     }
 

--- a/vendor/codex/codex-api/src/atlas_chat/sse.rs
+++ b/vendor/codex/codex-api/src/atlas_chat/sse.rs
@@ -322,6 +322,19 @@ async fn process_chat_sse(
             Ok(chunk) => chunk,
             Err(err) => {
                 debug!(error = %err, "failed to parse a chat.completion.chunk");
+                // Recorded, not skipped: whatever this frame carried is gone,
+                // so the turn can no longer honestly be reported complete —
+                // "no error signalled" has to keep implying "nothing was
+                // lost", or `[DONE]` becomes the header's short success from
+                // the inside (#59). Kept scanning so a gateway error frame
+                // that follows can overwrite this with its own diagnosis,
+                // which is strictly better than "a frame was unreadable".
+                if stream_error.is_none() {
+                    stream_error = Some(ApiError::Stream(format!(
+                        "the model stream carried a frame this client could \
+                         not read ({err}), so the answer may be incomplete"
+                    )));
+                }
                 continue;
             }
         };

--- a/vendor/codex/codex-api/src/atlas_chat/sse_tests.rs
+++ b/vendor/codex/codex-api/src/atlas_chat/sse_tests.rs
@@ -95,10 +95,7 @@ fn completion(
 }
 
 fn error_of(events: &[Result<ResponseEvent, ApiError>]) -> Option<&ApiError> {
-    events.iter().find_map(|event| match event {
-        Err(err) => Some(err),
-        _ => None,
-    })
+    events.iter().find_map(|event| event.as_ref().err())
 }
 
 #[test]

--- a/vendor/codex/codex-api/src/atlas_chat/sse_tests.rs
+++ b/vendor/codex/codex-api/src/atlas_chat/sse_tests.rs
@@ -428,16 +428,67 @@ fn a_turn_with_no_usage_chunk_still_completes() {
 }
 
 #[test]
-fn an_unparseable_frame_is_skipped_rather_than_killing_the_turn() {
-    // Gateways emit keepalives and comments. Treating one as fatal would end
-    // turns for no reason; treating a *missing sentinel* as fine would not.
+fn an_unparseable_frame_poisons_the_turn_rather_than_vanishing() {
+    // This test used to assert the opposite — that the frame is skipped and
+    // the turn completes — on the theory that gateways emit keepalives. They
+    // do, but as SSE *comments*, which the eventsource layer never surfaces
+    // as data; a data frame this client cannot read carried something, and
+    // whatever it carried is gone. Reporting the turn complete anyway is the
+    // header's "short success", the exact outcome the withheld-`[DONE]` rule
+    // exists to prevent — one layer up from the decoder (#59).
     let events = tokio_test::block_on(play(&[
         "{not json",
         &text_delta("still here"),
         FINISH_STOP,
         "[DONE]",
     ]));
-    assert_eq!(assistant_text(&events).as_deref(), Some("still here"));
+    // The content that did arrive still streams — it was really delivered —
+    // but the close reports an error, not a complete answer.
+    assert_eq!(deltas(&events), "still here");
+    assert!(
+        completion(&events).is_none(),
+        "a stream with a lost frame must not report a completed turn",
+    );
+    let Some(err) = error_of(&events) else {
+        panic!("a lost frame is an error at close");
+    };
+    assert!(
+        err.to_string().contains("could not read"),
+        "the error should say what happened: {err}",
+    );
+}
+
+#[test]
+fn an_explicit_null_where_a_default_is_declared_is_a_lost_frame_too() {
+    // `#[serde(default)]` covers a *missing* key, not a present-but-null one:
+    // `{"choices":null}` fails the chunk parse. The failure mode must be the
+    // same as any other unreadable frame — recorded, surfaced at close —
+    // because it is silent by construction otherwise.
+    let events = tokio_test::block_on(play(&[
+        r#"{"id":"c1","choices":null}"#,
+        FINISH_STOP,
+        "[DONE]",
+    ]));
+    assert!(completion(&events).is_none());
+    assert!(error_of(&events).is_some());
+}
+
+#[test]
+fn a_gateway_error_frame_still_wins_over_a_lost_frame_diagnosis() {
+    // The gateway's own diagnosis is strictly better than "a frame here was
+    // unreadable". When both happen, the user sees the gateway's message.
+    let events = tokio_test::block_on(play(&[
+        "{not json",
+        r#"{"error":{"message":"quota exhausted","code":"usage_limit_reached"}}"#,
+        "[DONE]",
+    ]));
+    let Some(err) = error_of(&events) else {
+        panic!("an error frame is an error");
+    };
+    assert!(
+        err.to_string().contains("quota exhausted"),
+        "the gateway's own diagnosis wins: {err}",
+    );
 }
 
 #[test]

--- a/vendor/codex/codex-api/src/atlas_gateway.rs
+++ b/vendor/codex/codex-api/src/atlas_gateway.rs
@@ -91,11 +91,21 @@ struct GatewayError {
 /// The gateway sets `1` for a concurrency refusal and `60` for the per-minute
 /// limit. Absent or unparseable falls back to 60: the longer of the two, since
 /// retrying too soon against a rate limit earns another one.
+///
+/// Clamped at 60 either way (#68): the value is slept verbatim downstream,
+/// and a *parseable* absurd one — `Retry-After: 86400` from an intervening
+/// CDN or WAF, whose 429 reaches this arm because `classify` falls back
+/// gracefully on a non-envelope body — would stall the turn for hours behind
+/// "Reconnecting…". 60 is the longest interval the gateway documents, and the
+/// same bound the connection-retry branch already enforces; a source that
+/// really wants a longer wait will answer the retry with another 429.
 fn retry_after(header: Option<&str>) -> Duration {
+    const LONGEST_DOCUMENTED: Duration = Duration::from_secs(60);
     header
         .and_then(|v| v.trim().parse::<u64>().ok())
         .map(Duration::from_secs)
-        .unwrap_or(Duration::from_secs(60))
+        .unwrap_or(LONGEST_DOCUMENTED)
+        .min(LONGEST_DOCUMENTED)
 }
 
 fn cap_detail(err: &GatewayError) -> String {
@@ -331,6 +341,19 @@ mod tests {
         assert!(matches!(d, Disposition::RetryAfter { delay, .. } if delay == Duration::from_secs(60)));
         let d = classify(StatusCode::TOO_MANY_REQUESTS, &body("rate_limited", "x"), Some("garbage"));
         assert!(matches!(d, Disposition::RetryAfter { delay, .. } if delay == Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn an_absurd_retry_after_is_clamped_rather_than_slept() {
+        // A parseable value is honoured downstream verbatim, so a CDN's
+        // `Retry-After: 86400` would stall the turn for a day behind
+        // "Reconnecting…" (#68). 60 is the longest interval the gateway
+        // documents; nothing may wait longer on this header's say-so.
+        let d = classify(StatusCode::TOO_MANY_REQUESTS, &body("rate_limited", "x"), Some("86400"));
+        assert!(matches!(d, Disposition::RetryAfter { delay, .. } if delay == Duration::from_secs(60)));
+        // The documented short interval still passes through untouched.
+        let d = classify(StatusCode::TOO_MANY_REQUESTS, &body("rate_limited", "x"), Some("1"));
+        assert!(matches!(d, Disposition::RetryAfter { delay, .. } if delay == Duration::from_secs(1)));
     }
 
     #[test]

--- a/vendor/codex/codex-api/src/endpoint/chat_completions.rs
+++ b/vendor/codex/codex-api/src/endpoint/chat_completions.rs
@@ -79,11 +79,10 @@ impl<T: HttpTransport> ChatCompletionsClient<T> {
         // switch org mid-session and the next request must bill the new one.
         // Absent = personal attribution, per the contract.
         let mut extra_headers = extra_headers;
-        if let Some(org) = crate::atlas_chat::org::current_org() {
-            if let Ok(value) = HeaderValue::from_str(&org) {
+        if let Some(org) = crate::atlas_chat::org::current_org()
+            && let Ok(value) = HeaderValue::from_str(&org) {
                 extra_headers.insert("atlas-org", value);
             }
-        }
 
         let stream_response = self
             .session

--- a/vendor/codex/feedback/src/lib.rs
+++ b/vendor/codex/feedback/src/lib.rs
@@ -1,3 +1,4 @@
+// Modified by Atlas from upstream OpenAI Codex (Apache-2.0). See CONTEXT.md.
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::collections::btree_map::Entry;
@@ -8,7 +9,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Duration;
 
 use anyhow::Result;
 use anyhow::anyhow;
@@ -38,9 +38,11 @@ pub const CODEX_APP_DIRECTORY_CACHE_ATTACHMENT_FILENAME: &str = "codex-app-direc
 /// Filename used for the Windows sandbox log feedback attachment.
 pub const WINDOWS_SANDBOX_LOG_ATTACHMENT_FILENAME: &str = "windows-sandbox.log";
 const DEFAULT_MAX_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
-const SENTRY_DSN: &str =
-    "https://ae32ed50620d7a7792c1ce5df38b3e3e@o33249.ingest.us.sentry.io/4510195390611458";
-const UPLOAD_TIMEOUT_SECS: u64 = 10;
+// Upstream carried `SENTRY_DSN` and `UPLOAD_TIMEOUT_SECS` here — a hardcoded
+// ingest endpoint that `upload_feedback` built a Sentry client around. Removed
+// by Atlas (#63): the fourth phone-home path, reachable through the in-process
+// app-server's `feedback/upload` request even though Atlas ships no feedback
+// UI. `upload_feedback` refuses now instead of exfiltrating logs.
 const FEEDBACK_TAGS_TARGET: &str = "feedback_tags";
 const MAX_FEEDBACK_TAGS: usize = 64;
 
@@ -353,7 +355,9 @@ impl RingBuffer {
 }
 
 pub struct FeedbackSnapshot {
+    #[allow(dead_code)] // read only by the removed upload path (#63)
     bytes: Vec<u8>,
+    #[allow(dead_code)]
     tags: BTreeMap<String, String>,
     feedback_diagnostics: FeedbackDiagnostics,
     pub thread_id: String,
@@ -420,77 +424,20 @@ impl FeedbackSnapshot {
     }
 
     /// Upload feedback to Sentry with optional attachments.
-    pub fn upload_feedback(&self, options: FeedbackUploadOptions<'_>) -> Result<()> {
-        use std::str::FromStr;
-        use std::sync::Arc;
-
-        use sentry::Client;
-        use sentry::ClientOptions;
-        use sentry::protocol::Envelope;
-        use sentry::protocol::EnvelopeItem;
-        use sentry::protocol::Event;
-        use sentry::protocol::Level;
-        use sentry::transports::DefaultTransportFactory;
-        use sentry::types::Dsn;
-
-        // Build Sentry client
-        let client = Client::from_config(ClientOptions {
-            dsn: Some(Dsn::from_str(SENTRY_DSN).map_err(|e| anyhow!("invalid DSN: {e}"))?),
-            transport: Some(Arc::new(DefaultTransportFactory {})),
-            ..Default::default()
-        });
-
-        let tags = self.upload_tags(
-            options.classification,
-            options.reason,
-            options.tags,
-            options.session_source.as_ref(),
-        );
-
-        let level = match options.classification {
-            "bug" | "bad_result" | "safety_check" => Level::Error,
-            _ => Level::Info,
-        };
-
-        let mut envelope = Envelope::new();
-        let title = format!(
-            "[{}]: Codex session {}",
-            display_classification(options.classification),
-            self.thread_id
-        );
-
-        let mut event = Event {
-            level,
-            message: Some(title.clone()),
-            tags,
-            ..Default::default()
-        };
-        if let Some(r) = options.reason {
-            use sentry::protocol::Exception;
-            use sentry::protocol::Values;
-
-            event.exception = Values::from(vec![Exception {
-                ty: title,
-                value: Some(r.to_string()),
-                ..Default::default()
-            }]);
-        }
-        envelope.add_item(EnvelopeItem::Event(event));
-
-        for attachment in self.feedback_attachments(
-            options.include_logs,
-            options.extra_attachments,
-            options.extra_attachment_paths,
-            options.logs_override,
-        ) {
-            envelope.add_item(EnvelopeItem::Attachment(attachment));
-        }
-
-        client.send_envelope(envelope);
-        client.flush(Some(Duration::from_secs(UPLOAD_TIMEOUT_SECS)));
-        Ok(())
+    ///
+    /// Removed by Atlas (#63). Upstream built a Sentry client around a
+    /// hardcoded ingest DSN here and shipped the user's logs to it; the
+    /// in-process app-server honours a `feedback/upload` request, so the path
+    /// was live even with no feedback UI in front of it. The signature stays
+    /// so the request processor compiles; the answer is an error, never a
+    /// silent success — a caller must not believe an upload happened.
+    pub fn upload_feedback(&self, _options: FeedbackUploadOptions<'_>) -> Result<()> {
+        Err(anyhow!("feedback upload is removed in Atlas"))
     }
 
+    // Fed only the removed `upload_feedback` (#63); kept, with its tests,
+    // as the record of what an upload carried.
+    #[allow(dead_code)]
     fn upload_tags(
         &self,
         classification: &str,
@@ -540,6 +487,7 @@ impl FeedbackSnapshot {
         tags
     }
 
+    #[allow(dead_code)]
     fn feedback_attachments(
         &self,
         include_logs: bool,
@@ -622,6 +570,7 @@ impl FeedbackSnapshot {
     }
 }
 
+#[allow(dead_code)]
 fn display_classification(classification: &str) -> String {
     match classification {
         "bug" => "Bug".to_string(),


### PR DESCRIPTION
Follow-up to #210, on the same branch, freshly merged with `0.3.1` (`d1eaf361`). Twenty-one commits: every finding from the deep review of #210, two clusters found in live testing, and the merge.

## The deep-review fix pass (17 findings, one commit each)

All six blocking findings and all eleven non-blocking ones from the #210 deep review, each red-verified where a test could exist:

**Blocking**
- **Resume duplicates** — reopening a pre-cutover conversation rebinds the history row to the engine's new id instead of minting a duplicate sidebar row per reopen (`e68e17f3`)
- **Lost Stop** — a stop pressed during the `turn/start` round trip is recorded and honoured the moment the turn id exists; one-press cancel test, both interleavings unit-pinned (`0ab78d7e`)
- **Licensing guard in CI** — `fetch-depth: 0` plus an assertion naming the shallow-clone cause; reproduced red on a depth-1 clone (`7e41df71`)
- **Silent SSE truncation** — a chunk the client cannot parse poisons the turn instead of vanishing under `[DONE]` (`8e4bfade`)
- **Dead lint table** — all 19 first-party crates opt into `[workspace.lints]`; the `#54` cfg-outage class now fails builds (probe-verified); ~240 violations swept; `unwrap_used`/`expect_used` staged out with the staging documented; CI gains plain-clippy for src-tauri and every matrix crate (`4585a39c`)
- **Mid-turn mode switch** — refused with the reason while a turn runs (the engine keeps the frozen turn context); the picker rolls back on refusal instead of displaying a control that isn't in force; mutation-checked (`8a3af9c7`)

**Non-blocking** — sign-out drops the engine connection so the cached access JWT dies with it; the fourth phone-home path (Sentry DSN in codex-feedback) removed plus a structural telemetry-marker guard; a CI job for the Atlas-authored codex-api dialect (221 tests, previously running nowhere) with the org-test race serialized; native edits reaching cross-agent memory; `Retry-After` clamped at the gateway's documented 60s; approval-delivery failures logged; `--locked` on CI cargo; transparent-PNG downscale fix plus an aggregate attachment budget warning; the vendored members at dev opt-level 1 (engine suite ~55s → ~24s); sink session state bounded by live sessions; stale Cersei docs corrected.

## Found in live testing

- **Org-scoped billing** (`4f29488a`) — the desktop org switcher was frontend-only: every gateway request billed the web-active/first org regardless of the selection, which is why an unentitled org appeared to work. The switch now writes the active org through a new `auth_set_active_org` command (local-only; the server's `set-active` stays untouched), awaited so the first message in the new org cannot race it.
- **Timeline alignment for Atlas Agent** (`7ca039d9`, `c03a1265`) — the sink ignored the engine's `thread/tokenUsage/updated` (so the one agent reporting a real input/output split showed no consumption) and flattened edit diffs to text (so checkpoints had no patch to show or restore). Both now flow; both red-verified at the sink seam.

## The merge (`39766399`)

One conflict, `projector.rs`: upstream's ATL-225 sweep wins verbatim, restated in the closure idiom the lint table enforces; the handful of new upstream closures the now-live denies flagged got the same one-line treatment.

## Verification

1037 frontend tests, the full 19-crate Rust battery (80 suites), and first-party clippy — all green after the merge. Still human-gated, unchanged from #210: the live entitled-account turn and the observed outbound-traffic/402 checks.