### PR TITLE
Config-driven settings: a validated, self-documenting config.toml in ~/.config/atlas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ skills-lock.json
 !docs/atlas-agent-codex-port-spec.md
 !docs/research/*.md
 !docs/reference/*.md
+# The bundled `atlas-self-configure` skill's content — `include_str!`'d into
+# the binary at compile time (`commands/skills.rs`), so it has to ship from a
+# fresh clone the same way the vendored Codex prompts below do.
+!src-tauri/resources/**/*.md
 graphify-out/
 # Local-only working folders (plans/specs + helper scripts)
 plans/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,26 +34,70 @@ patch from the Settings UI or an agent preserves comments, key order, and any
 key Atlas doesn't recognize. Chosen over JSON (no comments) and YAML
 (ambiguous scalar parsing for a file humans and agents both hand-edit).
 
+Atlas writes the file **self-documenting**: a header, then a comment above
+every key giving what it does, its default, and any constraint on its value.
+Those comments come from `SETTINGS_DOCS` in `state/atlas_config.rs` — the same
+table `unknown_keys_in` uses to decide what Atlas recognizes — so they can't
+drift from what validation accepts.
+
+That is deliberate, and it's why the bundled `atlas-self-configure` skill
+carries no key table of its own: an agent reads the real file and gets a
+schema that matches the build in front of it, instead of a copy in a skill
+that was projected into `~/.agents/skills` at some earlier version. The
+`settings_docs_cover_every_setting` and
+`the_self_configure_skill_defers_to_the_files_own_comments` tests hold both
+halves of that in place.
+
+A generated file looks like this (abridged — every key gets the same
+treatment):
+
 ```toml
+# Atlas configuration.
+#
+# Every user-facing Atlas preference lives here. Edit this file by hand or use
+# Settings — both write to it, and Atlas picks up external edits live, with no
+# restart needed for any key below.
+#
+# Your comments, formatting, and any keys Atlas doesn't recognize survive its
+# own writes. An invalid value is rejected whole: Atlas keeps running on the
+# last settings that loaded cleanly, shows the error in Settings, and leaves
+# this file exactly as you wrote it.
+
+# Format version of this file. Atlas manages it; leave it alone.
 schemaVersion = 1
 
 [settings]
+
+# Add `.atlas/` to each opened git project's .gitignore, creating the
+# file if needed. No-op on non-git projects. (default: true)
 autoAddAtlasGitignore = true
-enableAtlasLogs = true
-showHiddenFiles = true
+
+# Interface zoom, where 1.0 is 100%. Also driven by Cmd +/-/0.
+# Must be a number between 0.5 and 2.0. (default: 1.0)
 uiScale = 1.0
-shareTelemetry = true
-linkTelemetryToAccount = true
-embeddingModelId = "all-MiniLM-L6-v2"
-codeEditorTheme = "atlas"
-atlasTheme = "atlas-black"
+
+# Next-step suggestion chips in the agent chat's per-turn card.
+# Exactly "agent" or "off", nothing else. (default: "agent")
 adaptiveSuggestions = "agent"
-gitBlameInline = true
-autoUpdate = true
-# updaterIgnoredVersion is absent unless a version was ignored — TOML has no
-# null, so "unset" means the key doesn't appear at all.
+
+# updaterIgnoredVersion: a release you chose to skip in the update
+# prompt. Absent unless one was ignored — TOML has no null, so "unset"
+# means the key simply isn't here. Delete the line to clear it; never
+# write an empty string.
+
+# Chat composer send gesture. true = Enter sends and Shift+Enter
+# inserts a newline; false = only Cmd/Ctrl+Enter sends. Cmd/Ctrl+Enter
+# sends either way. (default: true)
 enterToSend = true
 ```
+
+Note `updaterIgnoredVersion`: a key that serializes to nothing still gets its
+comment, carried down onto the next key that is present. Otherwise the one key
+whose *absence* carries meaning would be the one key nothing explains.
+
+Comments are only ever written into a file Atlas generates — first migration,
+or "Recreate defaults". Atlas never injects them into a file a user or agent
+wrote; `toml_edit` just preserves whatever comments are already there.
 
 ## Schema
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,219 @@
+# Atlas configuration (`config.toml`)
+
+Reference for Atlas's user-facing preferences file. Written for both humans
+hand-editing the file and agents using the `atlas-self-configure` skill
+(`src-tauri/resources/skills/atlas-self-configure/SKILL.md`) — the skill's
+key table is a copy of the one below, and both are compiled into the test
+binary via `include_str!` so a Rust test (`every_known_setting_key_is_*` in
+`state/atlas_config.rs`) fails the build the moment either one drops a key;
+see [Testing](#testing).
+
+- **Source of truth (Rust):** `src-tauri/src/state/atlas_config.rs`
+  (schema, defaults, validation, migration) and
+  `src-tauri/src/commands/atlas_config.rs` (Tauri commands + file watcher).
+- **Frontend wrapper:** `src/features/settings/lib/atlas-config-api.ts`.
+- **Design context:** GitHub issue #64.
+
+## Location
+
+| Platform | Path |
+|---|---|
+| macOS | `~/Library/Application Support/dev.atlas.ide/config.toml` |
+| Linux | `~/.config/dev.atlas.ide/config.toml` |
+| Windows | `%APPDATA%\dev.atlas.ide\config.toml` |
+
+Resolved exclusively through Tauri's `app.path().app_config_dir()` — never
+hard-code an OS-specific path in application code; call
+`ConfigManager::config_path` (Rust) or the `get_atlas_config_info` command
+(frontend/agents) instead.
+
+## Format
+
+TOML, edited through `toml_edit` rather than reserialized wholesale, so a
+patch from the Settings UI or an agent preserves comments, key order, and any
+key Atlas doesn't recognize. Chosen over JSON (no comments) and YAML
+(ambiguous scalar parsing for a file humans and agents both hand-edit).
+
+```toml
+schemaVersion = 1
+
+[settings]
+autoAddAtlasGitignore = true
+enableAtlasLogs = true
+showHiddenFiles = true
+uiScale = 1.0
+shareTelemetry = true
+linkTelemetryToAccount = true
+embeddingModelId = "all-MiniLM-L6-v2"
+codeEditorTheme = "atlas"
+atlasTheme = "atlas-black"
+adaptiveSuggestions = "agent"
+gitBlameInline = true
+autoUpdate = true
+# updaterIgnoredVersion is absent unless a version was ignored — TOML has no
+# null, so "unset" means the key doesn't appear at all.
+enterToSend = true
+```
+
+## Schema
+
+| Key | Type | Default | Validation |
+|---|---|---|---|
+| `autoAddAtlasGitignore` | boolean | `true` | — |
+| `enableAtlasLogs` | boolean | `true` | — |
+| `showHiddenFiles` | boolean | `true` | — |
+| `uiScale` | number | `1.0` | finite, `0.5`–`2.0` inclusive |
+| `shareTelemetry` | boolean | `true` | — |
+| `linkTelemetryToAccount` | boolean | `true` | — |
+| `embeddingModelId` | string | `"all-MiniLM-L6-v2"` | non-empty |
+| `codeEditorTheme` | string | `"atlas"` | non-empty (not checked against the frontend theme catalog — see [Non-goals](#non-goals-for-validation)) |
+| `atlasTheme` | string | `"atlas-black"` | non-empty (same caveat) |
+| `adaptiveSuggestions` | `"agent"` \| `"off"` | `"agent"` | exactly one of these two strings |
+| `gitBlameInline` | boolean | `true` | — |
+| `autoUpdate` | boolean | `true` | — |
+| `updaterIgnoredVersion` | string, or absent | absent | — |
+| `enterToSend` | boolean | `true` | — |
+
+Any other key under `[settings]` is left on disk untouched and reported as an
+`unknownKeys` entry in `get_atlas_config_info` — never treated as an error,
+never deleted.
+
+### Non-goals for validation
+
+`codeEditorTheme`/`atlasTheme` are checked for non-emptiness, not membership
+in the frontend's theme catalogs (`src/features/theme/themes.ts`,
+`src/features/editor/themes/themes.ts`). Duplicating that catalog into Rust
+would create a second list that has to stay in sync with the frontend one —
+trading one drift bug for another. An unrecognized-but-well-formed theme id
+is accepted here and handled the same way the frontend already handles one
+from a newer Atlas version.
+
+## Schema versioning
+
+`config.toml`'s `schemaVersion` is independent of `state.json`'s
+`AppState::SCHEMA_VERSION` — the two files describe different domains and
+evolve on separate timelines. Current: `CONFIG_SCHEMA_VERSION = 1`
+(`state/atlas_config.rs`).
+
+- A file with a *lower* version is meant to run through sequential, idempotent
+  migrations, the same pattern `AppState::migrate()` already uses for
+  `state.json`. **Not yet implemented as code** — `CONFIG_SCHEMA_VERSION` is
+  still `1`, so there is nothing to migrate from today; a real v1→v2 bump is
+  what will exercise this path for the first time. Field-level
+  `#[serde(default = ...)]` already covers the common case (a new key added
+  within v1) without needing a version bump at all.
+- A file with a *higher* version than this Atlas build supports is rejected
+  outright — last-known-good settings stay active, the file is left alone.
+  (This is what happens when a newer Atlas version's config is opened by an
+  older build.)
+
+## Precedence and scope
+
+```
+compiled defaults  <  validated config.toml
+```
+
+Global only. There is no project-level override and no durable UI/session
+layer — a Settings UI change **is** a `config.toml` write, immediately.
+"Project scope" is explicitly out of scope for this design; a future project-
+level preference would need its own design (ownership, eligible keys,
+location, precedence), not silent inheritance of this mechanism.
+
+## Loading, validation, and failure behavior
+
+Every read — cold start, a UI patch, an external edit picked up by the
+watcher — validates the **complete candidate** before it replaces anything.
+A malformed or invalid file never partially applies and never gets
+auto-repaired, renamed, or overwritten by Atlas on its own:
+
+- **Cold start, file missing:** normal (pre-migration, or the user deleted
+  it on purpose) — served compiled defaults, `status: "ok"`.
+- **Cold start, file malformed:** served compiled defaults in memory,
+  `status: "usingDefaults"` with the parse/validation error. The file itself
+  is never touched.
+- **Hot reload (external edit) is malformed:** the previous, already-
+  validated settings stay effective, `status: "usingLastKnownGood"` with the
+  error. The malformed file is left exactly as written.
+- **A UI/agent patch would produce an invalid candidate:** rejected outright
+  (`update_atlas_settings` returns an error); nothing is written.
+- **A UI/agent patch arrives while the on-disk file is currently
+  malformed:** also rejected — a patch is never allowed to paper over a
+  file it didn't validate first.
+
+The only path allowed to overwrite a malformed (or just unwanted) file is
+"Recreate defaults" (`reset_atlas_config`), which backs the previous content
+up to `config.toml.bak-<unix-seconds>` next to it before writing fresh
+defaults.
+
+## Live reload
+
+Atlas watches `config.toml`'s parent directory (not the file itself — an
+atomic save replaces the inode) and re-validates on any change. Every
+setting in the schema is hot-reloadable; none requires a restart. A
+successful reload emits `atlas:config-changed` with the new settings and a
+`generation` counter; a rejected one emits `atlas:config-error` without
+changing anything.
+
+## Writing
+
+The Settings UI and any agent both write through the same
+read-modify-validate-atomic-write path:
+
+1. Re-read the file from disk (closes the race with a concurrent external
+   edit).
+2. Merge only the changed key(s) into the parsed document via `toml_edit` —
+   every other key, comment, and ordering is left untouched.
+3. Validate the complete resulting candidate.
+4. Write to a uniquely-named temp file in the same directory, then rename it
+   over `config.toml` (atomic; a crash mid-write can't leave a torn file).
+
+The Settings UI additionally passes an `expectedGeneration` — a stale value
+(something else changed the file first) is reported back as a conflict
+rather than silently overwritten.
+
+## Migration from `state.json`
+
+Before issue #64, these settings lived in `state.json`'s `AppState.settings`
+(schema v3 and earlier). On first launch after upgrading:
+
+1. `state.json` is bumped to schema v4, which adds
+   `settingsConfigMigrated: bool`.
+2. If `config.toml` doesn't exist yet and the marker is `false`, the legacy
+   `settings` object is extracted field-by-field (a value that doesn't parse
+   is skipped, not fatal to the rest) and written as the new `config.toml`.
+3. The marker is then set `true` — this is what stops Atlas from
+   resurrecting stale `state.json` settings if the user later deletes
+   `config.toml` on purpose.
+
+One extra field, `adaptiveSuggestions`, existed on the frontend but had no
+Rust-side counterpart before this migration; it's now part of the schema
+above, closing that drift. Legacy values `"parse"`/`"llm"` (from before it
+was a closed enum) normalize to `"agent"` during migration only — the live
+schema accepts only `"agent"` or `"off"`.
+
+## What's explicitly NOT in this file
+
+- **API keys / credentials.** Atlas doesn't store these itself at all — see
+  `src-tauri/src/commands/byok.rs`; they live in the user's shell profile.
+- **Telemetry identity** (`device.json`) and the **self-hosted PostHog
+  override** (`telemetry.json`) — deliberately separate files. Their split
+  from coarse settings writes fixed a real bug (a settings save used to wipe
+  the telemetry anonymous id); folding them back in would reverse that fix.
+  `shareTelemetry`/`linkTelemetryToAccount` (the on/off preferences) stay in
+  `config.toml` — only the identity/override files are excluded.
+- **Session history, transcripts, per-project `.atlas/` state.** File-backed,
+  but not a "setting," and out of scope until an explicit ownership design
+  says otherwise.
+- **Any "is a credential configured" presence flag.** Even a boolean is
+  security-sensitive derived state; the BYOK UI computes availability at
+  runtime from the environment instead of persisting it here.
+
+## Testing
+
+- Rust: `src-tauri/src/state/atlas_config.rs` (`#[cfg(test)] mod tests`) —
+  defaults, missing-key fallback, comment/unknown-key preservation across a
+  patch, invalid values, unsupported future schema, malformed cold-start and
+  hot-reload behavior, generation conflicts, reset/backup, and the legacy
+  migration extraction (including the `adaptiveSuggestions` normalization).
+- Rust: `src-tauri/src/state/app_state.rs` — a legacy `settings` key in
+  `state.json` doesn't break parsing of the rest of the file.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -140,6 +140,24 @@ auto-repaired, renamed, or overwritten by Atlas on its own:
   malformed:** also rejected — a patch is never allowed to paper over a
   file it didn't validate first.
 
+Any status other than `"ok"` reaches the user as a banner at the top of
+Settings → General, with "Open config" and "Recreate defaults" beside it.
+Both the boot-time status (carried on `bootstrap_app_state`'s
+`configStatus`) and later hot-reload failures (`atlas:config-error`) land
+there, so a config that failed to load at startup can't quietly serve
+defaults — including flipping `shareTelemetry` back on — without saying so.
+
+A file that exists but cannot be *read* at all (permissions, a transient I/O
+fault) is treated as `"usingDefaults"`, not as an absent file — as is a
+config directory that can't be resolved, and a migration write that fails.
+The distinction matters for migration: see below.
+
+"Defaults" there means *compiled* defaults only once migration has been
+recorded. Before that, a broken or unwritable `config.toml` falls back to the
+legacy `state.json` settings instead, so the user keeps their real
+preferences (their telemetry opt-out included) for the session rather than
+silently reverting while those preferences sit unused on disk.
+
 The only path allowed to overwrite a malformed (or just unwanted) file is
 "Recreate defaults" (`reset_atlas_config`), which backs the previous content
 up to `config.toml.bak-<unix-seconds>` next to it before writing fresh
@@ -164,12 +182,25 @@ read-modify-validate-atomic-write path:
 2. Merge only the changed key(s) into the parsed document via `toml_edit` —
    every other key, comment, and ordering is left untouched.
 3. Validate the complete resulting candidate.
-4. Write to a uniquely-named temp file in the same directory, then rename it
-   over `config.toml` (atomic; a crash mid-write can't leave a torn file).
+4. Re-check that the file still holds exactly the content step 1 read. If it
+   moved, the merge base is stale: nothing is written and the whole sequence
+   restarts on the fresh content (up to three times, then the write is
+   refused with "config.toml is being written by something else"). This
+   narrows — it cannot fully close, short of an advisory file lock — the
+   window between the re-read and the swap, in which a concurrent external
+   edit would otherwise be clobbered along with its comments.
+5. Write to a uniquely-named temp file in the same directory, `fsync` it,
+   then rename it over `config.toml` and `fsync` the directory. The sync
+   before the rename is what makes the atomicity real: without it the rename
+   can reach disk ahead of the bytes it points at, so power loss just after
+   "Settings saved" could leave an empty or half-written file. Temp files are
+   removed on every failure path rather than left beside the real config.
 
 The Settings UI additionally passes an `expectedGeneration` — a stale value
-(something else changed the file first) is reported back as a conflict
-rather than silently overwritten.
+(something else changed the file first) is reported back as a conflict. The
+store adopts the fresh generation and retries the same patch, up to three
+attempts in total, before surfacing an error; one retry wasn't enough to
+survive a burst of rapid changes (dragging the zoom slider, say).
 
 ## Migration from `state.json`
 
@@ -184,6 +215,28 @@ Before issue #64, these settings lived in `state.json`'s `AppState.settings`
 3. The marker is then set `true` — this is what stops Atlas from
    resurrecting stale `state.json` settings if the user later deletes
    `config.toml` on purpose.
+
+The marker is set **only** once `config.toml` demonstrably holds the
+settings: it either loaded cleanly or was just created. If the file exists
+but is malformed or unreadable, migration is deliberately left unrecorded,
+because `state.json`'s `settings` object is still the only surviving copy of
+the user's preferences at that point.
+
+That copy is protected from the other end too. The typed `AppState` has no
+`settings` field any more, so serializing it over `state.json` wholesale
+would delete the legacy object — and `state.json` gets saved for reasons
+that have nothing to do with settings (a rotated telemetry id, a workspace
+change). `AppState::save` therefore merges over whatever the file already
+holds rather than replacing it, and drops the legacy `settings` key only
+once `settingsConfigMigrated` is `true`. It writes through a uniquely-named
+temp file, `fsync`ed before the rename, for the same reasons `config.toml`
+does.
+
+And the preserved copy is actually used: while the marker is `false` and
+`config.toml` is unreadable, unparseable, or couldn't be written, those
+legacy settings become the effective ones. "Recreate defaults" still writes
+compiled defaults — that is what the button says — so it discards them; the
+banner offers "Open config" first for exactly that reason.
 
 One extra field, `adaptiveSuggestions`, existed on the frontend but had no
 Rust-side counterpart before this migration; it's now part of the schema
@@ -215,5 +268,10 @@ schema accepts only `"agent"` or `"off"`.
   patch, invalid values, unsupported future schema, malformed cold-start and
   hot-reload behavior, generation conflicts, reset/backup, and the legacy
   migration extraction (including the `adaptiveSuggestions` normalization).
+  Also: the compare-and-swap that refuses a write on a stale base, temp-file
+  cleanup, external-edit adoption (generation bump + dedup on re-read),
+  `ConfigStatus`'s wire shape, and that a malformed or unreadable
+  `config.toml` never reports migration as done.
 - Rust: `src-tauri/src/state/app_state.rs` — a legacy `settings` key in
-  `state.json` doesn't break parsing of the rest of the file.
+  `state.json` doesn't break parsing of the rest of the file, survives a save
+  made before migration is recorded, and is dropped once it is.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,16 +16,37 @@ see [Testing](#testing).
 
 ## Location
 
-| Platform | Path |
-|---|---|
-| macOS | `~/Library/Application Support/dev.atlas.ide/config.toml` |
-| Linux | `~/.config/dev.atlas.ide/config.toml` |
-| Windows | `%APPDATA%\dev.atlas.ide\config.toml` |
+```
+~/.config/atlas/config.toml
+```
 
-Resolved exclusively through Tauri's `app.path().app_config_dir()` — never
-hard-code an OS-specific path in application code; call
-`ConfigManager::config_path` (Rust) or the `get_atlas_config_info` command
-(frontend/agents) instead.
+The same path on every platform, and `$XDG_CONFIG_HOME/atlas/config.toml`
+when that variable is set to an absolute path. A relative value is ignored
+rather than resolved against the cwd — a GUI app launched from Finder has an
+arbitrary one.
+
+Deliberately **not** Tauri's `app_config_dir()`, which on macOS is
+`~/Library/Application Support/dev.atlas.ide/`. This file exists to be opened
+and hand-edited, by a person or an agent, and a path they can type is part of
+that; a bundle id buried under `Application Support` is not. Zed makes the same
+call for the same reason (`~/.config/zed/settings.json` on macOS), and it puts
+Atlas's config beside every other tool a developer already keeps in
+`~/.config`.
+
+This is a split, not a move. Everything else Atlas persists stays in the
+platform data directory, because none of it is a document anyone should be
+editing:
+
+| Stays in `app_config_dir()` | Why |
+|---|---|
+| `state.json` | Workspaces, recents, orgs — machine-managed. |
+| `device.json` | Telemetry identity; see the exclusions below. |
+| `telemetry.json` | Self-hosted PostHog override. |
+| `models-pricing.json`, `byok-usage.jsonl` | Caches. |
+| `session-chat/`, comms state | Session data. |
+
+In application code, call `ConfigManager::config_path()` (Rust) or the
+`get_atlas_config_info` command (frontend) rather than rebuilding the path.
 
 ## Format
 

--- a/scripts/clean-atlas-config.sh
+++ b/scripts/clean-atlas-config.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Wipe all local Atlas app data for a true first-run (macOS).
-# Removes app support, caches, WebKit state, and preferences for both the
-# current bundle id (dev.atlas.ide) and the legacy `atlas` name. Does NOT
+# Removes ~/.config/atlas (config.toml), app support, caches, WebKit state,
+# and preferences for both the current bundle id (dev.atlas.ide) and the
+# legacy `atlas` name. Does NOT
 # touch the repo, build artifacts, or any agent CLI credentials (~/.claude etc).
 set -euo pipefail
 
@@ -12,6 +13,7 @@ fi
 
 removed=0
 for d in \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/atlas" \
   "$HOME/Library/Application Support/dev.atlas.ide" \
   "$HOME/Library/Caches/atlas" \
   "$HOME/Library/Caches/dev.atlas.ide" \

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -143,6 +143,13 @@ futures = "0.3"
 ignore = "0.4"
 notify = "8"
 notify-debouncer-full = "0.6"
+# `config.toml` (issue #64): `toml_edit` edits the on-disk document
+# key-by-key so a UI/skill patch preserves comments, ordering and unknown
+# keys instead of reserializing the whole file; `toml` (serde-based) does
+# the typed parse/validate pass. Both pinned versions already exist in the
+# workspace lockfile via vendored deps, so this adds no new resolution.
+toml_edit = "0.24.0"
+toml = "0.9.5"
 # Per-cwd engine registry map for the background memory indexer
 # (`commands::memory_indexer`). Same 6.x already used by the workspace crates.
 dashmap = "6"

--- a/src-tauri/resources/skills/atlas-self-configure/SKILL.md
+++ b/src-tauri/resources/skills/atlas-self-configure/SKILL.md
@@ -16,89 +16,73 @@ without touching anything else Atlas persists.
 - Windows: `%APPDATA%\dev.atlas.ide\config.toml`
 
 Editing that file is the supported mechanism, and the only one available to
-you: Atlas's own config commands are IPC endpoints reachable from its UI, not
+you: Atlas's config commands are IPC endpoints reachable from its own UI, not
 agent tools. Atlas watches the file and validates every change you make (see
-step 7 below), so a direct edit is a first-class way in — not a workaround.
+step 6 below), so a direct edit is a first-class way in — not a workaround.
 
 If the file does not exist yet, Atlas hasn't created it (a fresh install
 before first launch, or the user deleted it). Do not create one speculatively
 — report that to the user instead of guessing at defaults.
 
-## The schema
+## The schema is in the file
 
-```toml
-schemaVersion = 1
+Atlas writes a comment above every key: what it does, its default, and any
+constraint on its value — a numeric range, an exact set of allowed strings,
+"must not be empty". **Read those comments and follow them.** They are
+generated from the same table Atlas validates against, so they cannot drift
+from what it will actually accept.
 
-[settings]
-autoAddAtlasGitignore = true
-enableAtlasLogs = true
-showHiddenFiles = true
-uiScale = 1.0
-shareTelemetry = true
-linkTelemetryToAccount = true
-embeddingModelId = "all-MiniLM-L6-v2"
-codeEditorTheme = "atlas"
-atlasTheme = "atlas-black"
-adaptiveSuggestions = "agent"
-gitBlameInline = true
-autoUpdate = true
-# updaterIgnoredVersion is absent unless the user has ignored a specific
-# version — TOML has no null, so "unset" means the key isn't there at all.
-enterToSend = true
-```
+Do not work from a schema you remember, or from one you saw in another
+project. The file in front of you is authoritative, and it is the only thing
+guaranteed to match the Atlas build the user is running.
 
-| Key | Type | Default | Meaning |
-|---|---|---|---|
-| `autoAddAtlasGitignore` | boolean | `true` | Adds `.atlas/` to a project's `.gitignore` on open. |
-| `enableAtlasLogs` | boolean | `true` | Records Atlas-internal events into the Logs panel. |
-| `showHiddenFiles` | boolean | `true` | Shows dotfiles in the file explorer. |
-| `uiScale` | number | `1.0` | Interface zoom. **Must be between 0.5 and 2.0.** |
-| `shareTelemetry` | boolean | `true` | Anonymous product telemetry opt-out switch. |
-| `linkTelemetryToAccount` | boolean | `true` | Attribute telemetry to the signed-in account instead of the anonymous device id. |
-| `embeddingModelId` | string | `"all-MiniLM-L6-v2"` | Selected on-device embedding model id. **Must not be empty.** |
-| `codeEditorTheme` | string | `"atlas"` | Code editor color theme id. **Must not be empty.** |
-| `atlasTheme` | string | `"atlas-black"` | Atlas interface theme id. **Must not be empty.** |
-| `adaptiveSuggestions` | `"agent"` \| `"off"` | `"agent"` | Next-step suggestion chips in chat. Exactly one of these two strings — nothing else. |
-| `gitBlameInline` | boolean | `true` | Inline git blame in the editor. |
-| `autoUpdate` | boolean | `true` | Auto-update master switch. |
-| `updaterIgnoredVersion` | string, or the key absent | absent | A version the user chose to skip. Set the key to clear it back to "nothing ignored" by removing the line entirely — do not write an empty string. |
-| `enterToSend` | boolean | `true` | Chat composer send gesture. |
+Two things the comments won't spell out:
 
-Any key not in this table is left alone by Atlas (preserved, surfaced as a
-diagnostic) — never delete a key you don't recognize.
+- **A key that isn't there.** Some settings mean "unset" by being absent —
+  TOML has no null. The comment for such a key sits above whichever key
+  follows it, so read the whole `[settings]` block, not just the lines with
+  values on them. To clear one of these, delete its line; never write an
+  empty string.
+- **A key Atlas doesn't recognize.** It's preserved untouched and reported to
+  the user as a diagnostic. Never delete a key you don't recognize.
 
 ## Making a change
 
-1. **Read the whole file first.** You need to see existing comments and
-   formatting so your edit doesn't disturb them.
-2. **Explain what you're about to change** to the user before writing:
-   the key, its current value, the new value, and what it actually does
-   (from the table above) — don't silently flip a setting.
-3. **Change only the one line (or few lines) you mean to change.** Leave
-   every other key, comment, and blank line exactly as it was. Do not
-   reformat, reorder, or re-indent the rest of the file.
-4. **Validate the value yourself before writing:**
-   - `uiScale` must be a finite number in `[0.5, 2.0]`.
-   - `adaptiveSuggestions` must be exactly `"agent"` or `"off"`.
-   - String fields (`embeddingModelId`, `codeEditorTheme`, `atlasTheme`) must
-     not be empty.
-   - To clear `updaterIgnoredVersion`, remove the line; don't write `""`.
+1. **Read the whole file first.** You need its comments and formatting to
+   avoid disturbing them, and you need the target key's comment to know what
+   a valid value even is.
+2. **Explain what you're about to change** to the user before writing: the
+   key, its current value, the new value, and what it does — quoting the
+   file's own comment. Don't silently flip a setting.
+3. **Change only the line (or few lines) you mean to change.** Leave every
+   other key, comment, and blank line exactly as it was — including the
+   comment above the key you're editing, which is Atlas's to rewrite, not
+   yours. Do not reformat, reorder, or re-indent anything:
+
+   ```diff
+    # Inline git blame — a dim author/age/summary annotation trailing the
+    # active line in the editor. (default: true)
+   -someSetting = true
+   +someSetting = false
+   ```
+4. **Validate the value against that key's comment before writing.** If the
+   comment states a range or a fixed set of values and the user asked for
+   something outside it, say so and stop; don't write it and let Atlas reject
+   it.
 5. **Write atomically:** write your edited content to a new file in the
    *same directory* (e.g. `config.toml.tmp.<random>`), then rename/move it
-   over `config.toml`. Never edit the file in place or write directly to
-   `config.toml` — a crash or a concurrent Atlas reload mid-write must never
-   leave a half-written file behind.
-6. **Re-read the file after writing** to confirm your change landed as
-   expected.
-7. Atlas does its own full validation pass whenever it notices the file
-   changed (this happens live, no restart required for any setting above).
-   If your edit was invalid despite step 4, Atlas rejects it entirely and
-   keeps running on the last good settings — but the *file* stays as you
-   wrote it, and while it is invalid Atlas refuses every settings write from
-   its own UI too, until someone fixes the file or uses "Recreate defaults"
-   (which overwrites it, keeping a `.bak-<unix-seconds>` copy). So an invalid
-   write is not free: report it to the user and offer to restore the content
-   you read in step 1, rather than trying to "fix" the file further yourself.
+   over `config.toml`. Never edit in place — a crash or a concurrent Atlas
+   reload mid-write must not leave a half-written file behind.
+6. **Re-read the file after writing** to confirm your change landed.
+
+Atlas re-validates the whole file whenever it notices a change, live, no
+restart. An invalid edit is rejected entirely and Atlas keeps running on the
+last good settings — but the file stays as you wrote it, and while it's
+invalid Atlas also refuses every settings write from its own UI, until someone
+repairs it or uses "Recreate defaults" (which overwrites it, keeping a
+`.bak-<unix-seconds>` copy). So a bad write is not free: report it and offer to
+restore the exact content you read in step 1, rather than trying to patch your
+way out.
 
 ## What this skill must never touch
 
@@ -115,25 +99,3 @@ diagnostic) — never delete a key you don't recognize.
 
 If a request needs any of the above, say so plainly and stop — it's out of
 scope for this skill, not something to work around.
-
-## Examples
-
-**Turn off a boolean** (`gitBlameInline`):
-```diff
--gitBlameInline = true
-+gitBlameInline = false
-```
-
-**Change an enum** (`adaptiveSuggestions`):
-```diff
--adaptiveSuggestions = "agent"
-+adaptiveSuggestions = "off"
-```
-
-**Change a bounded number** (`uiScale`, requesting 150%):
-```diff
--uiScale = 1.0
-+uiScale = 1.5
-```
-(Reject a request for e.g. `3.0` — out of the `[0.5, 2.0]` range; tell the
-user the valid range instead of writing it anyway.)

--- a/src-tauri/resources/skills/atlas-self-configure/SKILL.md
+++ b/src-tauri/resources/skills/atlas-self-configure/SKILL.md
@@ -15,10 +15,10 @@ without touching anything else Atlas persists.
 - Linux: `~/.config/dev.atlas.ide/config.toml`
 - Windows: `%APPDATA%\dev.atlas.ide\config.toml`
 
-If you are the Atlas native agent and have a `get_atlas_config_info` tool
-available, prefer it — it returns the exact resolved path plus the current
-validated settings, generation number, and any load error, without you
-having to guess at platform conventions or race a concurrent write.
+Editing that file is the supported mechanism, and the only one available to
+you: Atlas's own config commands are IPC endpoints reachable from its UI, not
+agent tools. Atlas watches the file and validates every change you make (see
+step 7 below), so a direct edit is a first-class way in — not a workaround.
 
 If the file does not exist yet, Atlas hasn't created it (a fresh install
 before first launch, or the user deleted it). Do not create one speculatively
@@ -93,9 +93,12 @@ diagnostic) — never delete a key you don't recognize.
 7. Atlas does its own full validation pass whenever it notices the file
    changed (this happens live, no restart required for any setting above).
    If your edit was invalid despite step 4, Atlas rejects it entirely and
-   keeps running on the last good settings — report that to the user rather
-   than trying to "fix" the file further yourself; ask them what they
-   actually want instead.
+   keeps running on the last good settings — but the *file* stays as you
+   wrote it, and while it is invalid Atlas refuses every settings write from
+   its own UI too, until someone fixes the file or uses "Recreate defaults"
+   (which overwrites it, keeping a `.bak-<unix-seconds>` copy). So an invalid
+   write is not free: report it to the user and offer to restore the content
+   you read in step 1, rather than trying to "fix" the file further yourself.
 
 ## What this skill must never touch
 

--- a/src-tauri/resources/skills/atlas-self-configure/SKILL.md
+++ b/src-tauri/resources/skills/atlas-self-configure/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: atlas-self-configure
+description: Inspect and safely update Atlas user preferences through Atlas's config.toml.
+---
+
+# Atlas self-configure
+
+Atlas's user-facing preferences live in one human-editable file,
+`config.toml`. This skill is how you (an agent) read and change it safely —
+without touching anything else Atlas persists.
+
+## Where the file lives
+
+- macOS: `~/Library/Application Support/dev.atlas.ide/config.toml`
+- Linux: `~/.config/dev.atlas.ide/config.toml`
+- Windows: `%APPDATA%\dev.atlas.ide\config.toml`
+
+If you are the Atlas native agent and have a `get_atlas_config_info` tool
+available, prefer it — it returns the exact resolved path plus the current
+validated settings, generation number, and any load error, without you
+having to guess at platform conventions or race a concurrent write.
+
+If the file does not exist yet, Atlas hasn't created it (a fresh install
+before first launch, or the user deleted it). Do not create one speculatively
+— report that to the user instead of guessing at defaults.
+
+## The schema
+
+```toml
+schemaVersion = 1
+
+[settings]
+autoAddAtlasGitignore = true
+enableAtlasLogs = true
+showHiddenFiles = true
+uiScale = 1.0
+shareTelemetry = true
+linkTelemetryToAccount = true
+embeddingModelId = "all-MiniLM-L6-v2"
+codeEditorTheme = "atlas"
+atlasTheme = "atlas-black"
+adaptiveSuggestions = "agent"
+gitBlameInline = true
+autoUpdate = true
+# updaterIgnoredVersion is absent unless the user has ignored a specific
+# version — TOML has no null, so "unset" means the key isn't there at all.
+enterToSend = true
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `autoAddAtlasGitignore` | boolean | `true` | Adds `.atlas/` to a project's `.gitignore` on open. |
+| `enableAtlasLogs` | boolean | `true` | Records Atlas-internal events into the Logs panel. |
+| `showHiddenFiles` | boolean | `true` | Shows dotfiles in the file explorer. |
+| `uiScale` | number | `1.0` | Interface zoom. **Must be between 0.5 and 2.0.** |
+| `shareTelemetry` | boolean | `true` | Anonymous product telemetry opt-out switch. |
+| `linkTelemetryToAccount` | boolean | `true` | Attribute telemetry to the signed-in account instead of the anonymous device id. |
+| `embeddingModelId` | string | `"all-MiniLM-L6-v2"` | Selected on-device embedding model id. **Must not be empty.** |
+| `codeEditorTheme` | string | `"atlas"` | Code editor color theme id. **Must not be empty.** |
+| `atlasTheme` | string | `"atlas-black"` | Atlas interface theme id. **Must not be empty.** |
+| `adaptiveSuggestions` | `"agent"` \| `"off"` | `"agent"` | Next-step suggestion chips in chat. Exactly one of these two strings — nothing else. |
+| `gitBlameInline` | boolean | `true` | Inline git blame in the editor. |
+| `autoUpdate` | boolean | `true` | Auto-update master switch. |
+| `updaterIgnoredVersion` | string, or the key absent | absent | A version the user chose to skip. Set the key to clear it back to "nothing ignored" by removing the line entirely — do not write an empty string. |
+| `enterToSend` | boolean | `true` | Chat composer send gesture. |
+
+Any key not in this table is left alone by Atlas (preserved, surfaced as a
+diagnostic) — never delete a key you don't recognize.
+
+## Making a change
+
+1. **Read the whole file first.** You need to see existing comments and
+   formatting so your edit doesn't disturb them.
+2. **Explain what you're about to change** to the user before writing:
+   the key, its current value, the new value, and what it actually does
+   (from the table above) — don't silently flip a setting.
+3. **Change only the one line (or few lines) you mean to change.** Leave
+   every other key, comment, and blank line exactly as it was. Do not
+   reformat, reorder, or re-indent the rest of the file.
+4. **Validate the value yourself before writing:**
+   - `uiScale` must be a finite number in `[0.5, 2.0]`.
+   - `adaptiveSuggestions` must be exactly `"agent"` or `"off"`.
+   - String fields (`embeddingModelId`, `codeEditorTheme`, `atlasTheme`) must
+     not be empty.
+   - To clear `updaterIgnoredVersion`, remove the line; don't write `""`.
+5. **Write atomically:** write your edited content to a new file in the
+   *same directory* (e.g. `config.toml.tmp.<random>`), then rename/move it
+   over `config.toml`. Never edit the file in place or write directly to
+   `config.toml` — a crash or a concurrent Atlas reload mid-write must never
+   leave a half-written file behind.
+6. **Re-read the file after writing** to confirm your change landed as
+   expected.
+7. Atlas does its own full validation pass whenever it notices the file
+   changed (this happens live, no restart required for any setting above).
+   If your edit was invalid despite step 4, Atlas rejects it entirely and
+   keeps running on the last good settings — report that to the user rather
+   than trying to "fix" the file further yourself; ask them what they
+   actually want instead.
+
+## What this skill must never touch
+
+- API keys, tokens, or any credential — Atlas doesn't store these in a file
+  it owns at all; they live in the user's own shell profile. Never write
+  secrets into `config.toml`.
+- `state.json`, `device.json`, `telemetry.json` — separate files with
+  separate ownership; not in scope for this skill.
+- The user's shell profile (`~/.zshrc` and similar).
+- Atlas's own binary, packages, or update mechanism. "Self-configure" means
+  preferences only, never self-update.
+- Session history, transcripts, or any per-project `.atlas/` state — none of
+  that is a "setting."
+
+If a request needs any of the above, say so plainly and stop — it's out of
+scope for this skill, not something to work around.
+
+## Examples
+
+**Turn off a boolean** (`gitBlameInline`):
+```diff
+-gitBlameInline = true
++gitBlameInline = false
+```
+
+**Change an enum** (`adaptiveSuggestions`):
+```diff
+-adaptiveSuggestions = "agent"
++adaptiveSuggestions = "off"
+```
+
+**Change a bounded number** (`uiScale`, requesting 150%):
+```diff
+-uiScale = 1.0
++uiScale = 1.5
+```
+(Reject a request for e.g. `3.0` — out of the `[0.5, 2.0]` range; tell the
+user the valid range instead of writing it anyway.)

--- a/src-tauri/resources/skills/atlas-self-configure/SKILL.md
+++ b/src-tauri/resources/skills/atlas-self-configure/SKILL.md
@@ -11,9 +11,13 @@ without touching anything else Atlas persists.
 
 ## Where the file lives
 
-- macOS: `~/Library/Application Support/dev.atlas.ide/config.toml`
-- Linux: `~/.config/dev.atlas.ide/config.toml`
-- Windows: `%APPDATA%\dev.atlas.ide\config.toml`
+```
+~/.config/atlas/config.toml
+```
+
+The same path on every platform. If `$XDG_CONFIG_HOME` is set to an absolute
+path, it's `$XDG_CONFIG_HOME/atlas/config.toml` instead — check that variable
+before assuming.
 
 Editing that file is the supported mechanism, and the only one available to
 you: Atlas's config commands are IPC endpoints reachable from its own UI, not

--- a/src-tauri/src/commands/app_state.rs
+++ b/src-tauri/src/commands/app_state.rs
@@ -1,15 +1,39 @@
 //! Tauri command surface for the Rust-owned `AppState`.
 
+use serde::Serialize;
 use tauri::{AppHandle, State};
 
-use crate::state::{AppState, AppStateHandle, AppStatePatch};
+use crate::state::{AppSettings, AppState, AppStateHandle, AppStatePatch, AtlasConfigHandle};
 
-/// One-shot bootstrap: returns the full `AppState` snapshot. Called by the
-/// frontend exactly once on app mount, before any UI that depends on
-/// `currentProject` / `recentProjects` renders.
+/// Bootstrap response: `AppState` (workspaces/recents/orgs) plus the
+/// `config.toml`-sourced settings snapshot, combined into one payload so the
+/// frontend pays a single IPC round trip at boot. The two remain separately
+/// stored/versioned on the Rust side — this struct exists only at the wire
+/// boundary, matching the issue #64 design record's "bootstrap may combine
+/// state and config for latency; they still don't share a source of truth".
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapPayload {
+    #[serde(flatten)]
+    pub state: AppState,
+    pub settings: AppSettings,
+    pub config_generation: u64,
+}
+
+/// One-shot bootstrap: returns the full `AppState` snapshot plus the current
+/// settings. Called by the frontend exactly once on app mount, before any UI
+/// that depends on `currentProject` / `recentProjects` / settings renders.
 #[tauri::command]
-pub fn bootstrap_app_state(state: State<'_, AppStateHandle>) -> AppState {
-    state.lock().clone()
+pub fn bootstrap_app_state(
+    state: State<'_, AppStateHandle>,
+    config: State<'_, AtlasConfigHandle>,
+) -> BootstrapPayload {
+    let config_guard = config.lock();
+    BootstrapPayload {
+        state: state.lock().clone(),
+        settings: config_guard.effective().clone(),
+        config_generation: config_guard.generation(),
+    }
 }
 
 /// Merge a frontend save into the in-memory snapshot and persist it to disk.

--- a/src-tauri/src/commands/app_state.rs
+++ b/src-tauri/src/commands/app_state.rs
@@ -3,7 +3,9 @@
 use serde::Serialize;
 use tauri::{AppHandle, State};
 
-use crate::state::{AppSettings, AppState, AppStateHandle, AppStatePatch, AtlasConfigHandle};
+use crate::state::{
+    AppSettings, AppState, AppStateHandle, AppStatePatch, AtlasConfigHandle, ConfigStatus,
+};
 
 /// Bootstrap response: `AppState` (workspaces/recents/orgs) plus the
 /// `config.toml`-sourced settings snapshot, combined into one payload so the
@@ -18,6 +20,13 @@ pub struct BootstrapPayload {
     pub state: AppState,
     pub settings: AppSettings,
     pub config_generation: u64,
+    /// Whether `config.toml` actually loaded. This is the ONLY signal the UI
+    /// gets at boot that the file on disk is broken and the settings on
+    /// screen are Atlas's defaults rather than the user's — computed since
+    /// #64 but, until now, reachable only through `get_atlas_config_info`,
+    /// which nothing called. A malformed config silently reverted every
+    /// preference (`shareTelemetry` back to ON included) with no banner.
+    pub config_status: ConfigStatus,
 }
 
 /// One-shot bootstrap: returns the full `AppState` snapshot plus the current
@@ -33,6 +42,7 @@ pub fn bootstrap_app_state(
         state: state.lock().clone(),
         settings: config_guard.effective().clone(),
         config_generation: config_guard.generation(),
+        config_status: config_guard.status().clone(),
     }
 }
 

--- a/src-tauri/src/commands/atlas_config.rs
+++ b/src-tauri/src/commands/atlas_config.rs
@@ -154,6 +154,13 @@ pub fn start_watcher(app: &AppHandle, handle: AtlasConfigHandle) {
             None => return,
         }
     };
+    // The watch target must exist before `notify` can watch it. `bootstrap`
+    // normally creates it on the way in (writing the file creates the dir),
+    // but not if that write failed — and unlike the old Application Support
+    // location, `~/.config/atlas` is a directory nothing else creates.
+    if let Err(e) = std::fs::create_dir_all(&watch_dir) {
+        tracing::warn!(target: "atlas::config", "could not create {}: {e}", watch_dir.display());
+    }
     let config_file_name = crate::state::atlas_config::CONFIG_FILE_NAME.to_string();
     let app = app.clone();
 

--- a/src-tauri/src/commands/atlas_config.rs
+++ b/src-tauri/src/commands/atlas_config.rs
@@ -20,33 +20,11 @@ use crate::state::{
 use crate::telemetry::TelemetryClient;
 
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase", tag = "status")]
-pub enum ConfigStatusWire {
-    Ok,
-    UsingLastKnownGood { error: String },
-    UsingDefaults { error: String },
-}
-
-impl From<&ConfigStatus> for ConfigStatusWire {
-    fn from(status: &ConfigStatus) -> Self {
-        match status {
-            ConfigStatus::Ok => ConfigStatusWire::Ok,
-            ConfigStatus::UsingLastKnownGood { error } => {
-                ConfigStatusWire::UsingLastKnownGood { error: error.clone() }
-            }
-            ConfigStatus::UsingDefaults { error } => {
-                ConfigStatusWire::UsingDefaults { error: error.clone() }
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigInfo {
     pub path: String,
     pub schema_version: u32,
-    pub status: ConfigStatusWire,
+    pub status: ConfigStatus,
     pub effective_settings: AppSettings,
     pub generation: u64,
     pub unknown_keys: Vec<String>,
@@ -61,7 +39,7 @@ pub fn get_atlas_config_info(state: State<'_, AtlasConfigHandle>) -> ConfigInfo 
     ConfigInfo {
         path: guard.path().to_string_lossy().into_owned(),
         schema_version: crate::state::atlas_config::CONFIG_SCHEMA_VERSION,
-        status: guard.status().into(),
+        status: guard.status().clone(),
         effective_settings: guard.effective().clone(),
         generation: guard.generation(),
         unknown_keys: guard.unknown_keys().to_vec(),
@@ -146,6 +124,12 @@ pub fn notify_settings_changed(app: &AppHandle, settings: &AppSettings, generati
     if let Some(client) = app.try_state::<Arc<TelemetryClient>>() {
         client.set_enabled(settings.share_telemetry);
     }
+    // 3. re-apply `linkTelemetryToAccount`. It is read by
+    //    `commands::auth::sync_identity`, which otherwise only runs on an auth
+    //    *transition* — so without this, turning account linkage off while
+    //    signed in left PostHog attributing events to the account until the
+    //    next sign-out, which is the opposite of what the toggle says.
+    crate::commands::auth::resync_telemetry_identity(app, settings.link_telemetry_to_account);
 }
 
 fn emit_error(app: &AppHandle, error: &ConfigError) {

--- a/src-tauri/src/commands/atlas_config.rs
+++ b/src-tauri/src/commands/atlas_config.rs
@@ -1,0 +1,226 @@
+//! Tauri command surface + file watcher for `config.toml` (issue #64).
+//!
+//! Pairs with `state::atlas_config`, which owns the actual parsing/
+//! validation/migration logic — this module is the thin IPC + filesystem-
+//! watching layer on top, mirroring the `commands::app_state` /
+//! `state::app_state` split.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use notify::RecursiveMode;
+use notify_debouncer_full::new_debouncer;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use crate::state::{
+    AppSettings, AtlasConfigHandle, ConfigError, ConfigSnapshot, ConfigStatus, SettingsPatch,
+    UpdateOutcome,
+};
+use crate::telemetry::TelemetryClient;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum ConfigStatusWire {
+    Ok,
+    UsingLastKnownGood { error: String },
+    UsingDefaults { error: String },
+}
+
+impl From<&ConfigStatus> for ConfigStatusWire {
+    fn from(status: &ConfigStatus) -> Self {
+        match status {
+            ConfigStatus::Ok => ConfigStatusWire::Ok,
+            ConfigStatus::UsingLastKnownGood { error } => {
+                ConfigStatusWire::UsingLastKnownGood { error: error.clone() }
+            }
+            ConfigStatus::UsingDefaults { error } => {
+                ConfigStatusWire::UsingDefaults { error: error.clone() }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigInfo {
+    pub path: String,
+    pub schema_version: u32,
+    pub status: ConfigStatusWire,
+    pub effective_settings: AppSettings,
+    pub generation: u64,
+    pub unknown_keys: Vec<String>,
+}
+
+/// UI-hydration snapshot of `config.toml` — used both by the standalone
+/// `get_atlas_config_info` call and folded into `bootstrap_app_state` for a
+/// single boot round-trip (see `commands::app_state::bootstrap_app_state`).
+#[tauri::command]
+pub fn get_atlas_config_info(state: State<'_, AtlasConfigHandle>) -> ConfigInfo {
+    let guard = state.lock();
+    ConfigInfo {
+        path: guard.path().to_string_lossy().into_owned(),
+        schema_version: crate::state::atlas_config::CONFIG_SCHEMA_VERSION,
+        status: guard.status().into(),
+        effective_settings: guard.effective().clone(),
+        generation: guard.generation(),
+        unknown_keys: guard.unknown_keys().to_vec(),
+    }
+}
+
+/// Apply a partial settings change from the Settings UI. `expected_generation`
+/// is the generation the UI last saw — a mismatch means something else (an
+/// external edit, a hot reload) changed the file first; the write is refused
+/// and the caller gets the actual latest snapshot back to reconcile against,
+/// same idea as `save_app_state`'s "never blindly overwrite" (`app_state.rs`)
+/// applied to a file editable from outside the app.
+///
+/// The parse/validate/write itself runs on a blocking thread — CLAUDE.md:
+/// "every blocking operation ... must run inside `tokio::task::spawn_blocking`
+/// — the Tauri command runtime is shared with the UI's IPC channel." Unlike
+/// `save_app_state` (which fires the disk write after replying, since the
+/// frontend doesn't need the result), the caller here needs the validated
+/// outcome back, so this awaits the blocking task rather than detaching it.
+#[tauri::command]
+pub async fn update_atlas_settings(
+    patch: SettingsPatch,
+    expected_generation: u64,
+    app: AppHandle,
+    state: State<'_, AtlasConfigHandle>,
+) -> Result<UpdateOutcome, String> {
+    let handle = state.inner().clone();
+    let outcome = tokio::task::spawn_blocking(move || handle.lock().apply_patch(&patch, Some(expected_generation)))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+    if let UpdateOutcome::Applied { ref settings, generation } = outcome {
+        notify_settings_changed(&app, settings, generation);
+    }
+    Ok(outcome)
+}
+
+/// "Recreate defaults" — the sole action authorized to overwrite a malformed
+/// (or just unwanted) `config.toml`. Backs up whatever was there first. See
+/// `update_atlas_settings` for why this runs on a blocking thread.
+#[tauri::command]
+pub async fn reset_atlas_config(app: AppHandle, state: State<'_, AtlasConfigHandle>) -> Result<ConfigSnapshot, String> {
+    let handle = state.inner().clone();
+    let snapshot = tokio::task::spawn_blocking(move || handle.lock().reset())
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+    notify_settings_changed(&app, &snapshot.settings, snapshot.generation);
+    Ok(snapshot)
+}
+
+/// "Open config" — reveal `config.toml` in the OS default editor, for the
+/// Settings UI's error-recovery actions and for a user who just wants to
+/// hand-edit it.
+#[tauri::command]
+pub fn open_atlas_config(app: AppHandle, state: State<'_, AtlasConfigHandle>) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+    let path = state.lock().path().to_string_lossy().into_owned();
+    app.opener().open_path(path, None::<&str>).map_err(|e| e.to_string())
+}
+
+/// The one thing every committer of a new settings snapshot must do —
+/// whichever of the four paths produced it (a UI patch, `reset`, a hot
+/// reload, or an internal Rust-side write from `commands::models`/
+/// `commands::updater` via `state::atlas_config::update`):
+///
+/// 1. tell the frontend (`atlas:config-changed`), so its mirrored
+///    `settings`/`configGeneration` never goes stale — a stale generation on
+///    the frontend is exactly what turns its next legitimate edit into a
+///    spurious `Conflict`;
+/// 2. re-sync the live telemetry opt-in gate. `TelemetryClient::enabled` is a
+///    cached flag, not read fresh from settings per event; without this, a
+///    `shareTelemetry` change that didn't come from the Settings UI's own
+///    toggle handler (an external edit, the self-configure skill, "Recreate
+///    defaults") would leave telemetry emitting — or silently gated off —
+///    out of sync with what the file says until restart.
+pub fn notify_settings_changed(app: &AppHandle, settings: &AppSettings, generation: u64) {
+    let _ = app.emit(
+        "atlas:config-changed",
+        serde_json::json!({ "settings": settings, "generation": generation }),
+    );
+    if let Some(client) = app.try_state::<Arc<TelemetryClient>>() {
+        client.set_enabled(settings.share_telemetry);
+    }
+}
+
+fn emit_error(app: &AppHandle, error: &ConfigError) {
+    let _ = app.emit("atlas:config-error", serde_json::json!({ "error": error.to_string() }));
+}
+
+/// Watch `config.toml`'s parent directory (atomic saves replace the file's
+/// inode, so watching the file itself misses the swap) and hot-reload on any
+/// change. A valid external edit replaces the effective settings and notifies
+/// the frontend; a malformed one is reported without touching anything —
+/// `ConfigManager::reload_from_disk` already enforces both halves of that,
+/// this is just wiring its result to Tauri events.
+///
+/// Leaks the debouncer into a background thread for the process lifetime —
+/// there is exactly one `config.toml`, unlike the per-workspace git watcher,
+/// so there is nothing to ever tear this down for.
+pub fn start_watcher(app: &AppHandle, handle: AtlasConfigHandle) {
+    let watch_dir = {
+        let guard = handle.lock();
+        match guard.path().parent() {
+            Some(dir) => dir.to_path_buf(),
+            None => return,
+        }
+    };
+    let config_file_name = crate::state::atlas_config::CONFIG_FILE_NAME.to_string();
+    let app = app.clone();
+
+    std::thread::spawn(move || {
+        let handle_for_cb = handle.clone();
+        let app_for_cb = app.clone();
+        let file_name_for_cb = config_file_name.clone();
+        let debouncer = new_debouncer(
+            Duration::from_millis(200),
+            None,
+            move |result: notify_debouncer_full::DebounceEventResult| {
+                let Ok(events) = result else {
+                    return;
+                };
+                let touches_config = events.iter().any(|e| {
+                    e.paths.iter().any(|p| {
+                        p.file_name().map(|n| n.to_string_lossy() == file_name_for_cb.as_str()).unwrap_or(false)
+                    })
+                });
+                if !touches_config {
+                    return;
+                }
+                let mut guard = handle_for_cb.lock();
+                match guard.reload_from_disk() {
+                    Ok(true) => {
+                        let settings = guard.effective().clone();
+                        let generation = guard.generation();
+                        drop(guard);
+                        notify_settings_changed(&app_for_cb, &settings, generation);
+                    }
+                    Ok(false) => {} // self-write echo or no-op — nothing to do
+                    Err(e) => {
+                        drop(guard);
+                        tracing::warn!(target: "atlas::config", "external config.toml edit rejected: {e}");
+                        emit_error(&app_for_cb, &e);
+                    }
+                }
+            },
+        );
+        let Ok(mut debouncer) = debouncer else {
+            tracing::warn!(target: "atlas::config", "failed to start config.toml watcher");
+            return;
+        };
+        if let Err(e) = debouncer.watch(&watch_dir, RecursiveMode::NonRecursive) {
+            tracing::warn!(target: "atlas::config", "failed to watch {}: {e}", watch_dir.display());
+            return;
+        }
+        // Park forever, keeping the debouncer (and its OS-level watch) alive
+        // for the life of the process.
+        loop {
+            std::thread::sleep(Duration::from_secs(3600));
+        }
+    });
+}

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -88,12 +88,7 @@ fn sync_identity(app: &AppHandle, snapshot: &AuthSnapshot) {
             active_org_id,
         } => {
             // Honour the user's choice to keep analytics off their account.
-            if !app
-                .state::<crate::state::AppStateHandle>()
-                .lock()
-                .settings
-                .link_telemetry_to_account
-            {
+            if !crate::state::atlas_config::read(app).link_telemetry_to_account {
                 tel.reset_identity();
                 return;
             }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -60,7 +60,7 @@ impl AuthState {
 /// because of that: a signed-in relaunch is covered for free, and no future
 /// transition can forget to update who events are attributed to.
 fn broadcast(app: &AppHandle, snapshot: AuthSnapshot) {
-    sync_identity(app, &snapshot);
+    sync_identity(app, &snapshot, crate::state::atlas_config::read(app).link_telemetry_to_account);
     // Team chat's socket follows the active Organisation, and every transition
     // that can change it — launch restore, sign-in, sign-out, `set_active_org`
     // — passes through here. Hooking the funnel rather than each call site is
@@ -79,7 +79,24 @@ fn broadcast(app: &AppHandle, snapshot: AuthSnapshot) {
 /// alone: the next successful validation broadcasts a snapshot that has `user`,
 /// and resetting in the gap would bounce attribution back to the device for no
 /// reason.
-fn sync_identity(app: &AppHandle, snapshot: &AuthSnapshot) {
+/// Re-apply the current auth snapshot to the telemetry identity after
+/// `linkTelemetryToAccount` changed.
+///
+/// [`sync_identity`] only ever runs on an auth transition, but that setting
+/// gates it from the settings side and can flip with no transition at all —
+/// so `commands::atlas_config::notify_settings_changed` calls this on every
+/// committed settings change. The flag is passed in rather than read here
+/// because that caller already holds the freshly committed snapshot, and
+/// reaching back into the config mutex from a path that may be running under
+/// it is how a deadlock gets written.
+pub fn resync_telemetry_identity(app: &AppHandle, link_to_account: bool) {
+    if let Some(state) = app.try_state::<AuthState>() {
+        let snapshot = state.core().snapshot();
+        sync_identity(app, &snapshot, link_to_account);
+    }
+}
+
+fn sync_identity(app: &AppHandle, snapshot: &AuthSnapshot, link_to_account: bool) {
     let tel = telemetry(app);
     match snapshot {
         AuthSnapshot::SignedIn {
@@ -88,7 +105,7 @@ fn sync_identity(app: &AppHandle, snapshot: &AuthSnapshot) {
             active_org_id,
         } => {
             // Honour the user's choice to keep analytics off their account.
-            if !crate::state::atlas_config::read(app).link_telemetry_to_account {
+            if !link_to_account {
                 tel.reset_identity();
                 return;
             }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod agent_transcript;
 pub mod agents;
 pub mod app_state;
+pub mod atlas_config;
 pub mod browser;
 pub mod byok;
 pub mod cli;

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::memory_indexer::MemoryRegistry;
-use crate::state::app_state::AppStateHandle;
 
 /// Embedding models all expose the same three sentence-transformer files; only the
 /// source repo differs.
@@ -135,11 +134,7 @@ pub fn model_dir_for(app: &AppHandle, id: &str) -> Result<PathBuf, String> {
 }
 
 pub fn selected_embedding_id(app: &AppHandle) -> String {
-    app.state::<AppStateHandle>()
-        .lock()
-        .settings
-        .embedding_model_id
-        .clone()
+    crate::state::atlas_config::read(app).embedding_model_id
 }
 
 /// Whether every file for `id` exists on disk. Uses the catalog's file list; for an
@@ -348,19 +343,30 @@ pub async fn model_select(
         return Err("Download the model before selecting it.".into());
     }
 
-    let state = app.state::<AppStateHandle>();
     let mut needs_reindex = false;
-    {
-        let mut s = state.lock();
-        match entry.kind {
-            ModelKind::Embedding => {
-                if s.settings.embedding_model_id != id {
-                    s.settings.embedding_model_id = id.clone();
-                    needs_reindex = true;
-                }
+    match entry.kind {
+        ModelKind::Embedding => {
+            if crate::state::atlas_config::read(&app).embedding_model_id != id {
+                let patch = crate::state::SettingsPatch {
+                    embedding_model_id: Some(id.clone()),
+                    ..Default::default()
+                };
+                // Off the async runtime thread — this touches the filesystem.
+                let app_for_write = app.clone();
+                let snapshot = tokio::task::spawn_blocking(move || {
+                    crate::state::atlas_config::update(&app_for_write, patch)
+                })
+                .await
+                .map_err(|e| e.to_string())?
+                .map_err(|e| format!("save settings: {e}"))?;
+                crate::commands::atlas_config::notify_settings_changed(
+                    &app,
+                    &snapshot.settings,
+                    snapshot.generation,
+                );
+                needs_reindex = true;
             }
         }
-        crate::state::app_state::AppState::save(&app, &s).map_err(|e| format!("save settings: {e}"))?;
     }
 
     // Drop cached models so the next call loads the newly selected one.

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -3808,16 +3808,14 @@ mod tests {
     use super::*;
 
     fn tmp_root() -> PathBuf {
+        // UUID rather than a nanosecond timestamp: two threads in the same
+        // `cargo test` run landed on the same directory often enough to be
+        // observed (see `tmp_root_isolated` below, which was added to dodge
+        // exactly this), and a collision means one test deletes another's
+        // fixture mid-assertion. Fixing the shared helper removes the flake
+        // for every test that uses it, not just the bundled-skill ones.
         let mut p = std::env::temp_dir();
-        let uniq = format!(
-            "atlas-skills-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        );
-        p.push(uniq);
+        p.push(format!("atlas-skills-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&p).unwrap();
         // Make both v1 tools "detected".
         fs::create_dir_all(p.join(".claude")).unwrap();
@@ -3825,13 +3823,9 @@ mod tests {
         p
     }
 
-    /// `tmp_root()` suffixed with a UUID. The bundled-skill tests below don't
-    /// need the `.claude`/`.codex` detection dirs, and running many of them
-    /// concurrently made `tmp_root()`'s nanosecond-timestamp uniqueness
-    /// collide often enough to be observed in practice (two threads landing
-    /// on the same directory, one test's `ensure_bundled_skills_at` write
-    /// racing another's fixture setup) — this closes that without touching
-    /// the shared helper other tests already depend on.
+    /// `tmp_root()` without the `.claude`/`.codex` detection dirs — the
+    /// bundled-skill tests below assert on the canonical store itself and
+    /// don't want either tool to register as detected.
     fn tmp_root_isolated() -> PathBuf {
         let p = std::env::temp_dir().join(format!("atlas-skills-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&p).unwrap();
@@ -5177,6 +5171,40 @@ mod tests {
         let entry = skills.iter().find(|s| s.name == BUNDLED_SKILL_NAME).expect("bundled skill is discoverable");
         assert!(entry.managed);
         assert_eq!(entry.scope, "global");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    /// Issue #64's acceptance criteria name the skill's *projection*, not just
+    /// its discoverability: "a managed global `self-configure` skill is
+    /// available for supported Atlas agents". Discoverability was covered;
+    /// actually landing it in a tool's skills dir was not.
+    #[test]
+    fn bundled_skill_projects_into_a_supported_tool() {
+        let root = tmp_root_isolated();
+        ensure_bundled_skills_at(&root);
+
+        for tool in ["claude-code", "codex"] {
+            let def = tool_def(tool).expect("tool is in the registry");
+            project(&root, def, "global", BUNDLED_SKILL_NAME, false)
+                .unwrap_or_else(|e| panic!("projecting into {tool} failed: {e}"));
+
+            let link = tool_link_path(&root, def, "global", BUNDLED_SKILL_NAME);
+            let projected = fs::read_to_string(link.join("SKILL.md"))
+                .unwrap_or_else(|e| panic!("{tool} projection has no readable SKILL.md: {e}"));
+            assert_eq!(projected, ATLAS_SELF_CONFIGURE_SKILL_MD);
+
+            // And the ledger knows about it, which is what `reconcile` reads to
+            // report the skill as projected rather than as external drift.
+            let ledger = read_ledger(&root);
+            assert!(
+                ledger
+                    .projections
+                    .get(BUNDLED_SKILL_NAME)
+                    .is_some_and(|per_tool| per_tool.contains_key(def.id)),
+                "{tool} projection was not recorded in the ledger"
+            );
+        }
 
         fs::remove_dir_all(&root).ok();
     }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -568,6 +568,86 @@ fn migrate_legacy_skills(root: &Path) {
     }
 }
 
+// ── Bundled skills (issue #64) ──────────────────────────────────────────────
+
+/// Content of the Atlas-owned `atlas-self-configure` skill, compiled into the
+/// binary so installing/upgrading it needs no separate resource-bundling
+/// config — it's just a string embedded at build time.
+const ATLAS_SELF_CONFIGURE_SKILL_MD: &str =
+    include_str!("../../resources/skills/atlas-self-configure/SKILL.md");
+
+/// Name of the one bundled skill Atlas ships today. A second one would want
+/// this generalized into a table; not done speculatively for a list of one.
+const BUNDLED_SKILL_NAME: &str = "atlas-self-configure";
+
+/// Sidecar file recording the hash of the bundled content Atlas itself last
+/// wrote, so a later upgrade can tell "the user never touched this" (safe to
+/// overwrite with the new bundled version) apart from "the user edited this"
+/// (must not clobber their changes — surface drift instead).
+const BUNDLED_HASH_FILE: &str = ".bundled-hash";
+
+fn sha256_hex(content: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(content.as_bytes());
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Install or upgrade the bundled `atlas-self-configure` skill into the
+/// canonical **global** store (`~/.agents/skills/atlas-self-configure`), so
+/// it's discoverable through the exact same `list_skills`/`skills_project`
+/// machinery as any other managed skill — no second delivery path.
+///
+/// Idempotent and safe to call on every launch:
+/// - Missing entirely → write it fresh.
+/// - Present, and its content hash matches the last hash *this function*
+///   recorded → the user never touched it since; safe to overwrite with
+///   whatever this build ships (a normal version upgrade).
+/// - Present, but the hash doesn't match (or the sidecar is missing/
+///   unreadable) → treat as user-modified and leave it alone entirely,
+///   including not touching the sidecar, so the next launch keeps re-
+///   detecting the drift rather than adopting the user's edit as "new
+///   baseline" behind their back.
+///
+/// Global-only, matching the design record: no per-project duplicate.
+pub fn ensure_bundled_skills() {
+    let Some(home) = home_dir() else {
+        return;
+    };
+    ensure_bundled_skills_at(&home);
+}
+
+/// The root-parameterized core of `ensure_bundled_skills`, split out so tests
+/// can point it at a temp dir instead of the real `$HOME` — mirrors every
+/// other function in this file (`root_for`, `skills_base`, `project`, ...)
+/// taking `root: &Path` rather than resolving it internally.
+fn ensure_bundled_skills_at(root: &Path) {
+    let dir = skills_base(root).join(BUNDLED_SKILL_NAME);
+    let skill_md = dir.join("SKILL.md");
+    let hash_file = dir.join(BUNDLED_HASH_FILE);
+    let bundled_hash = sha256_hex(ATLAS_SELF_CONFIGURE_SKILL_MD);
+
+    if skill_md.exists() {
+        let recorded_hash = fs::read_to_string(&hash_file).ok();
+        let on_disk_matches_recorded = fs::read_to_string(&skill_md)
+            .ok()
+            .zip(recorded_hash.as_deref())
+            .map(|(disk, recorded)| sha256_hex(&disk) == recorded.trim())
+            .unwrap_or(false);
+        if !on_disk_matches_recorded {
+            // User-modified (or a pre-#64 install with no sidecar yet) —
+            // never overwrite silently.
+            return;
+        }
+    }
+
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    if fs::write(&skill_md, ATLAS_SELF_CONFIGURE_SKILL_MD).is_ok() {
+        let _ = fs::write(&hash_file, &bundled_hash);
+    }
+}
+
 /// Sanitize a skill name into a safe single path segment.
 ///
 /// - lowercase; `[^a-z0-9._]+` → `-`; collapse runs; strip leading/trailing
@@ -3745,6 +3825,19 @@ mod tests {
         p
     }
 
+    /// `tmp_root()` suffixed with a UUID. The bundled-skill tests below don't
+    /// need the `.claude`/`.codex` detection dirs, and running many of them
+    /// concurrently made `tmp_root()`'s nanosecond-timestamp uniqueness
+    /// collide often enough to be observed in practice (two threads landing
+    /// on the same directory, one test's `ensure_bundled_skills_at` write
+    /// racing another's fixture setup) — this closes that without touching
+    /// the shared helper other tests already depend on.
+    fn tmp_root_isolated() -> PathBuf {
+        let p = std::env::temp_dir().join(format!("atlas-skills-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
     #[test]
     fn sanitize_lowercases_and_replaces_spaces() {
         assert_eq!(sanitize_name("My Cool Skill").unwrap(), "my-cool-skill");
@@ -5054,6 +5147,87 @@ mod tests {
         assert!(ship.path.ends_with("commands/ship.md"));
         assert!(Path::new(&ship.path).is_file());
 
+        fs::remove_dir_all(&root).ok();
+    }
+
+    // ── ensure_bundled_skills_at (issue #64) ────────────────────────────
+
+    #[test]
+    fn bundled_skill_is_installed_fresh_into_the_canonical_store() {
+        let root = tmp_root_isolated();
+        ensure_bundled_skills_at(&root);
+
+        let dir = skills_base(&root).join(BUNDLED_SKILL_NAME);
+        let installed = fs::read_to_string(dir.join("SKILL.md")).unwrap();
+        assert_eq!(installed, ATLAS_SELF_CONFIGURE_SKILL_MD);
+        assert!(installed.contains("name: atlas-self-configure"));
+
+        let recorded_hash = fs::read_to_string(dir.join(BUNDLED_HASH_FILE)).unwrap();
+        assert_eq!(recorded_hash.trim(), sha256_hex(ATLAS_SELF_CONFIGURE_SKILL_MD));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn bundled_skill_appears_as_a_managed_global_skill() {
+        let root = tmp_root_isolated();
+        ensure_bundled_skills_at(&root);
+
+        let skills = list_skills(&root, "global").expect("list_skills succeeds");
+        let entry = skills.iter().find(|s| s.name == BUNDLED_SKILL_NAME).expect("bundled skill is discoverable");
+        assert!(entry.managed);
+        assert_eq!(entry.scope, "global");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn reinstalling_is_idempotent_when_nothing_touched_it() {
+        let root = tmp_root_isolated();
+        ensure_bundled_skills_at(&root);
+        let dir = skills_base(&root).join(BUNDLED_SKILL_NAME);
+        let first_pass = fs::read_to_string(dir.join("SKILL.md")).unwrap();
+
+        // Simulates the next app launch on the same (unmodified) install.
+        ensure_bundled_skills_at(&root);
+        let second_pass = fs::read_to_string(dir.join("SKILL.md")).unwrap();
+
+        assert_eq!(first_pass, second_pass);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_user_edited_skill_is_never_silently_overwritten() {
+        let root = tmp_root_isolated();
+        ensure_bundled_skills_at(&root);
+        let dir = skills_base(&root).join(BUNDLED_SKILL_NAME);
+        let skill_md = dir.join("SKILL.md");
+
+        // The user (or an agent, via the ordinary skills-edit surface) hand-
+        // edits the canonical copy — its hash no longer matches the sidecar.
+        fs::write(&skill_md, "user-modified content").unwrap();
+
+        ensure_bundled_skills_at(&root);
+
+        assert_eq!(fs::read_to_string(&skill_md).unwrap(), "user-modified content");
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_skill_with_no_hash_sidecar_is_treated_as_user_owned() {
+        // Covers a pre-#64 install (or any external drop-in) that has a
+        // SKILL.md at this exact canonical path but no `.bundled-hash` —
+        // absence of the sidecar must fail closed (never overwrite), not
+        // open.
+        let root = tmp_root_isolated();
+        let dir = skills_base(&root).join(BUNDLED_SKILL_NAME);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), "hand-authored, no sidecar").unwrap();
+
+        ensure_bundled_skills_at(&root);
+
+        assert_eq!(fs::read_to_string(dir.join("SKILL.md")).unwrap(), "hand-authored, no sidecar");
+        assert!(!dir.join(BUNDLED_HASH_FILE).exists());
         fs::remove_dir_all(&root).ok();
     }
 }

--- a/src-tauri/src/commands/telemetry.rs
+++ b/src-tauri/src/commands/telemetry.rs
@@ -17,9 +17,16 @@ pub fn telemetry_config(client: State<'_, Arc<TelemetryClient>>) -> TelemetryCon
     client.config()
 }
 
-/// Flip the live opt-in gate (mirrors the persisted `share_telemetry` setting,
-/// which the frontend saves via `save_app_state`). Records a single
-/// opt-in/opt-out event at the boundary.
+/// Flip the live opt-in gate directly. Records a single opt-in/opt-out event
+/// at the boundary.
+///
+/// Kept for completeness/tests, but no longer the only path that keeps this
+/// in sync with the persisted `shareTelemetry` setting: every committer of a
+/// new `config.toml` snapshot (a Settings UI change, `reset_atlas_config`, an
+/// external edit picked up by the watcher, or an internal Rust-side write)
+/// already calls `commands::atlas_config::notify_settings_changed`, which
+/// re-syncs this gate itself — so `shareTelemetry` stays live-accurate no
+/// matter which of those paths changed it, not just the Settings toggle.
 #[tauri::command]
 pub fn telemetry_set_enabled(enabled: bool, client: State<'_, Arc<TelemetryClient>>) {
     client.set_enabled(enabled);

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -49,7 +49,6 @@ const DL_PARALLEL_MIN: u64 = 4 * 1024 * 1024;
 /// Flush accumulated bytes to disk once a segment buffers this much.
 const DL_WRITE_CHUNK: usize = 1024 * 1024;
 
-use crate::state::{AppState, AppStateHandle};
 use crate::telemetry::{RemoteUpdateConfig, TelemetryClient};
 
 /// The running app's version (compile-time). Compared against the remote value.
@@ -154,12 +153,8 @@ fn is_newer(remote: &str, current: &str) -> bool {
 }
 
 fn read_settings(app: &AppHandle) -> (bool, Option<String>) {
-    let state = app.state::<AppStateHandle>();
-    let guard = state.lock();
-    (
-        guard.settings.auto_update,
-        guard.settings.updater_ignored_version.clone(),
-    )
+    let settings = crate::state::atlas_config::read(app);
+    (settings.auto_update, settings.updater_ignored_version)
 }
 
 async fn fetch_remote(app: &AppHandle) -> Option<RemoteUpdateConfig> {
@@ -289,22 +284,18 @@ pub fn update_state(app: AppHandle, state: State<'_, UpdaterState>) -> UpdaterSn
 
 /// Persist a "don't prompt for this version again" choice.
 #[tauri::command]
-pub fn update_ignore(
-    version: String,
-    app: AppHandle,
-    state: State<'_, AppStateHandle>,
-) -> Result<(), String> {
-    let snapshot = {
-        let mut guard = state.lock();
-        guard.settings.updater_ignored_version = Some(version);
-        guard.clone()
+pub async fn update_ignore(version: String, app: AppHandle) -> Result<(), String> {
+    let patch = crate::state::SettingsPatch {
+        updater_ignored_version: Some(Some(version)),
+        ..Default::default()
     };
-    let app2 = app;
-    std::thread::spawn(move || {
-        if let Err(e) = AppState::save(&app2, &snapshot) {
-            tracing::warn!(target: "atlas::updater", "save ignored version failed: {e}");
-        }
-    });
+    // Off the async runtime thread — this touches the filesystem.
+    let app_for_write = app.clone();
+    let snapshot = tokio::task::spawn_blocking(move || crate::state::atlas_config::update(&app_for_write, patch))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+    crate::commands::atlas_config::notify_settings_changed(&app, &snapshot.settings, snapshot.generation);
     Ok(())
 }
 
@@ -715,12 +706,7 @@ pub fn apply_on_exit(app: &AppHandle) {
     if !is_newer(&m.version, CURRENT_VERSION) {
         return;
     }
-    let ignored = app
-        .state::<AppStateHandle>()
-        .lock()
-        .settings
-        .updater_ignored_version
-        .clone();
+    let ignored = crate::state::atlas_config::read(app).updater_ignored_version;
     if ignored.as_deref() == Some(m.version.as_str()) {
         return;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,8 +128,12 @@ pub fn run() {
             }
             // Pre-load the Rust-owned `AppState` (currentProject + recents)
             // before the webview starts loading — paid in parallel with the
-            // WebView framework init, ~1ms on warm cache.
-            let mut loaded = AppState::load(app.handle());
+            // WebView framework init, ~1ms on warm cache. `legacy_settings_raw`
+            // is the old `settings` object exactly as it appeared in a
+            // pre-#64 `state.json`, if any — `AppState` no longer has that
+            // field, so it's carried separately for the one-time migration
+            // below rather than being silently dropped by serde.
+            let (mut loaded, legacy_settings_raw) = AppState::load(app.handle());
             // Device-stable telemetry identity, owned by Rust in its own file.
             // It used to live in `state.json` as `telemetry_anon_id`, where every
             // settings save wiped it (the frontend payload omitted the field and
@@ -140,15 +144,41 @@ pub fn run() {
                 telemetry::device::load_or_create(app.handle(), loaded.telemetry_anon_id.as_deref());
             let device_id = device.device_id.clone();
             let device_id_source = device.source;
-            // Mirror it back into `state.json` so the two agree and a downgrade
-            // still finds an id. `AppStatePatch` now stops the frontend wiping it.
-            if loaded.telemetry_anon_id.as_deref() != Some(device_id.as_str()) {
+            let telemetry_id_changed = loaded.telemetry_anon_id.as_deref() != Some(device_id.as_str());
+            if telemetry_id_changed {
                 loaded.telemetry_anon_id = Some(device_id.clone());
+            }
+
+            // `config.toml` (issue #64): user preferences move out of
+            // `state.json.settings` into their own validated, human-editable
+            // file. `bootstrap` imports the legacy settings exactly once,
+            // guarded by `settings_config_migrated` so a user who later
+            // deletes `config.toml` on purpose never gets it silently
+            // resurrected from stale `state.json` data.
+            let migration =
+                state::atlas_config::bootstrap(app.handle(), loaded.settings_config_migrated, legacy_settings_raw);
+            let migration_marker_changed = migration.mark_migrated && !loaded.settings_config_migrated;
+            if migration_marker_changed {
+                loaded.settings_config_migrated = true;
+            }
+            let telemetry_enabled = migration.manager.effective().share_telemetry;
+            let atlas_config: state::AtlasConfigHandle = Arc::new(Mutex::new(migration.manager));
+            app.manage(atlas_config.clone());
+            commands::atlas_config::start_watcher(app.handle(), atlas_config);
+
+            // Mirror the (possibly updated) telemetry id + migration marker
+            // back into `state.json` so both agree and a downgrade still
+            // finds them. `AppStatePatch` stops the frontend wiping either.
+            if telemetry_id_changed || migration_marker_changed {
                 let _ = AppState::save(app.handle(), &loaded);
             }
-            let telemetry_enabled = loaded.settings.share_telemetry;
             let app_state: AppStateHandle = Arc::new(Mutex::new(loaded));
             app.manage(app_state);
+
+            // Bundled `atlas-self-configure` skill (issue #64): install/
+            // upgrade it into the canonical global skills store so it's
+            // discoverable the same way any other managed skill is.
+            commands::skills::ensure_bundled_skills();
 
             // Opt-in product telemetry. Inert unless the user has enabled it AND
             // a PostHog key resolves (env / telemetry.json / build-time default).
@@ -539,6 +569,10 @@ pub fn run() {
             commands::log::clear_project_log,
             commands::app_state::bootstrap_app_state,
             commands::app_state::save_app_state,
+            commands::atlas_config::get_atlas_config_info,
+            commands::atlas_config::update_atlas_settings,
+            commands::atlas_config::reset_atlas_config,
+            commands::atlas_config::open_atlas_config,
             commands::telemetry::telemetry_config,
             commands::telemetry::telemetry_set_enabled,
             commands::telemetry::telemetry_set_org,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,7 +156,7 @@ pub fn run() {
             // deletes `config.toml` on purpose never gets it silently
             // resurrected from stale `state.json` data.
             let migration =
-                state::atlas_config::bootstrap(app.handle(), loaded.settings_config_migrated, legacy_settings_raw);
+                state::atlas_config::bootstrap(loaded.settings_config_migrated, legacy_settings_raw);
             let migration_marker_changed = migration.mark_migrated && !loaded.settings_config_migrated;
             if migration_marker_changed {
                 loaded.settings_config_migrated = true;

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -22,7 +22,14 @@ use tauri::{AppHandle, Manager};
 /// (`organisations`/`active_organisation_id`, plus `org_id` on each
 /// workspace/group). v2 payloads are migrated by wrapping all existing
 /// workspaces in a default local "Personal" org.
-pub const SCHEMA_VERSION: u32 = 3;
+///
+/// v4 removed `AppSettings` from this struct entirely (issue #64) — user
+/// preferences now live in their own validated `config.toml`
+/// (`crate::state::atlas_config`). `settings_config_migrated` records whether
+/// that one-time export already happened, so a user who deletes `config.toml`
+/// afterward gets fresh defaults rather than a silent re-import of whatever
+/// was last in `state.json`.
+pub const SCHEMA_VERSION: u32 = 4;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -139,13 +146,16 @@ pub struct AppState {
     pub organisations: Vec<Organisation>,
     #[serde(default)]
     pub active_organisation_id: Option<String>,
-    #[serde(default)]
-    pub settings: AppSettings,
     /// Stable anonymous id for opt-in product telemetry (PostHog `distinct_id`).
     /// Generated once on first launch (see `lib.rs` setup); never contains PII.
     /// `None` on old `state.json` files — backfilled + persisted at startup.
     #[serde(default)]
     pub telemetry_anon_id: Option<String>,
+    /// Whether the one-time `state.json.settings` → `config.toml` export
+    /// (issue #64) has already run. See the `SCHEMA_VERSION` doc for why this
+    /// can't just be "does config.toml exist".
+    #[serde(default)]
+    pub settings_config_migrated: bool,
     #[serde(default = "default_version")]
     pub version: u32,
 }
@@ -181,8 +191,6 @@ pub struct AppStatePatch {
     pub organisations: Vec<Organisation>,
     #[serde(default)]
     pub active_organisation_id: Option<String>,
-    #[serde(default)]
-    pub settings: AppSettings,
 }
 
 impl Default for AppState {
@@ -195,8 +203,8 @@ impl Default for AppState {
             active_workspace_id: None,
             organisations: Vec::new(),
             active_organisation_id: None,
-            settings: AppSettings::default(),
             telemetry_anon_id: None,
+            settings_config_migrated: false,
             version: SCHEMA_VERSION,
         }
     }
@@ -340,133 +348,6 @@ impl AppState {
     }
 }
 
-/// User-facing toggles surfaced in Settings → General.
-///
-/// New fields MUST be `#[serde(default = "…")]` or have an obvious zero
-/// value so old `state.json` files (written before the field existed)
-/// load cleanly.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AppSettings {
-    /// On project open, ensure `.atlas/` is listed in the project's
-    /// `.gitignore` (creating the file if needed). No-op on non-git
-    /// projects. Default ON because Atlas writes caches / state into
-    /// `.atlas/` that don't belong in version control.
-    #[serde(default = "default_true")]
-    pub auto_add_atlas_gitignore: bool,
-    /// Record Atlas-internal events (sign-in, agent start/finish,
-    /// browser/file open, etc.) into the Logs panel under the `atlas`
-    /// source. Default ON so early users can share their logs without
-    /// flipping a flag first.
-    #[serde(default = "default_true")]
-    pub enable_atlas_logs: bool,
-    /// Show dotfiles / dot-directories (e.g. `.git`, `.atlas`, `.env`) in
-    /// the explorer file tree. Default ON so nothing is silently hidden;
-    /// users who want a cleaner tree can turn it off.
-    #[serde(default = "default_true")]
-    pub show_hidden_files: bool,
-    /// Global interface zoom (1.0 == 100%). Applied via the native WebView zoom
-    /// on the frontend (⌘+/⌘-/⌘0); persisted so it survives relaunch.
-    #[serde(default = "default_ui_scale")]
-    pub ui_scale: f32,
-    /// Anonymous product telemetry (PostHog). Default **ON** (opt-out, like
-    /// VS Code / Zed) — privacy-preserving metadata only; the user can turn it
-    /// off anytime in Settings → General. Gates both the Rust emitter and the
-    /// frontend `posthog-js` crash reporter. Still inert unless a key resolves.
-    /// See `crate::telemetry`.
-    #[serde(default = "default_true")]
-    pub share_telemetry: bool,
-    /// Attribute telemetry to the signed-in Atlas account (PostHog `$identify`),
-    /// rather than keeping it on the anonymous per-device person. Default **ON**,
-    /// and irrelevant while signed out or while `share_telemetry` is off — both
-    /// gate this. Turning it off calls `reset_identity`, so subsequent events go
-    /// back to the device person; it does not un-merge what PostHog has already
-    /// attributed. See `crate::telemetry`.
-    #[serde(default = "default_true")]
-    pub link_telemetry_to_account: bool,
-    /// Selected on-device **embedding** model id (== its dir name under
-    /// `app_data/models/`). Drives `memory_graph::model_dir` and every embedding
-    /// consumer via the shared provider. Switching it wipes + rebuilds the
-    /// per-project memory index (different model = different vector space).
-    /// See `crate::commands::models`.
-    #[serde(default = "default_embedding_model")]
-    pub embedding_model_id: String,
-    /// Code-editor color theme id (see `src/features/editor/themes`). Drives the
-    /// CodeMirror editor, the diff viewer and the source-control diff views on
-    /// the frontend; persisted so it survives relaunch.
-    #[serde(default = "default_code_editor_theme")]
-    pub code_editor_theme: String,
-    /// Atlas interface-theme id (see `src/features/theme/themes`). Swaps the
-    /// whole dark UI palette on the frontend — independent of the editor syntax
-    /// theme; persisted so it survives relaunch.
-    #[serde(default = "default_atlas_theme")]
-    pub atlas_theme: String,
-    /// Inline Git blame in the code editor — a dim author / age / commit
-    /// summary annotation trailing the active line. Default ON; when off the
-    /// editor doesn't even load the extension (no blame IPC).
-    #[serde(default = "default_true")]
-    pub git_blame_inline: bool,
-    /// Auto-update master switch. When ON (default), every startup runs a
-    /// non-blocking check against PostHog remote config and prompts if a newer
-    /// version is available. See `crate::commands::updater`.
-    #[serde(default = "default_true")]
-    pub auto_update: bool,
-    /// A version the user chose to "Ignore" in the update prompt — the startup
-    /// check won't re-prompt for exactly this version. `None` = nothing ignored.
-    #[serde(default)]
-    pub updater_ignored_version: Option<String>,
-    /// Chat composer send gesture. Default ON: Enter sends, Shift+Enter inserts
-    /// a newline (Slack/Discord/ChatGPT convention). OFF: only Cmd/Ctrl+Enter
-    /// sends, matching Atlas's original behavior. Cmd/Ctrl+Enter always sends
-    /// regardless of this setting. See `src/features/chat/components/chat-input.tsx`.
-    #[serde(default = "default_true")]
-    pub enter_to_send: bool,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-/// Default code-editor theme — the historical monochrome "atlas" look.
-pub fn default_code_editor_theme() -> String {
-    "atlas".to_string()
-}
-
-/// Default Atlas interface theme — the historical AMOLED-black look.
-pub fn default_atlas_theme() -> String {
-    "atlas-black".to_string()
-}
-
-/// Default embedding model — the historical `all-MiniLM-L6-v2` dir, so existing
-/// installs keep using their already-downloaded model with no migration.
-pub fn default_embedding_model() -> String {
-    "all-MiniLM-L6-v2".to_string()
-}
-
-fn default_ui_scale() -> f32 {
-    1.0
-}
-
-impl Default for AppSettings {
-    fn default() -> Self {
-        Self {
-            auto_add_atlas_gitignore: true,
-            enable_atlas_logs: true,
-            show_hidden_files: true,
-            ui_scale: default_ui_scale(),
-            share_telemetry: true,
-            link_telemetry_to_account: true,
-            embedding_model_id: default_embedding_model(),
-            code_editor_theme: default_code_editor_theme(),
-            atlas_theme: default_atlas_theme(),
-            git_blame_inline: true,
-            auto_update: true,
-            updater_ignored_version: None,
-            enter_to_send: true,
-        }
-    }
-}
-
 /// Thread-safe handle registered as Tauri managed state.
 pub type AppStateHandle = Arc<Mutex<AppState>>;
 
@@ -485,7 +366,6 @@ impl AppState {
         self.active_workspace_id = p.active_workspace_id;
         self.organisations = p.organisations;
         self.active_organisation_id = p.active_organisation_id;
-        self.settings = p.settings;
         self.version = SCHEMA_VERSION;
         // `telemetry_anon_id` (and anything Rust adds later) is deliberately
         // NOT assigned here. See the `AppStatePatch` doc.
@@ -502,16 +382,25 @@ impl AppState {
     /// before the webview opens — the cost is one `fs::read_to_string` of a
     /// few-KB JSON file (~1 ms on warm cache). Returns `Self::default()` on
     /// any I/O or parse failure so a corrupt file never blocks app launch.
-    pub fn load(app: &AppHandle) -> Self {
+    ///
+    /// Also returns the raw `settings` object, if any, exactly as it appeared
+    /// in the file — the typed `AppState` no longer has a `settings` field
+    /// (issue #64) so `serde_json` would otherwise silently drop it on the
+    /// floor as an unrecognized key. The caller feeds this to
+    /// `atlas_config::bootstrap` for the one-time `config.toml` export.
+    pub fn load(app: &AppHandle) -> (Self, Option<serde_json::Value>) {
         let Some(path) = Self::path(app) else {
-            return Self::default();
+            return (Self::default(), None);
         };
         let Ok(raw) = std::fs::read_to_string(&path) else {
-            return Self::default();
+            return (Self::default(), None);
         };
+        let legacy_settings = serde_json::from_str::<serde_json::Value>(&raw)
+            .ok()
+            .and_then(|v| v.get("settings").cloned());
         let mut state: AppState = serde_json::from_str(&raw).unwrap_or_default();
         state.migrate();
-        state
+        (state, legacy_settings)
     }
 
     /// Atomic write — `state.json.tmp` then `rename` so a crash mid-write
@@ -551,8 +440,7 @@ mod tests {
             "activeWorkspaceId": null,
             "organisations": [],
             "activeOrganisationId": null,
-            "settings": { "shareTelemetry": false },
-            "version": 3,
+            "version": 4,
         }))
         .expect("frontend payload deserializes as a patch")
     }
@@ -571,8 +459,6 @@ mod tests {
         state.apply_patch(frontend_payload());
 
         assert_eq!(state.telemetry_anon_id.as_deref(), Some("device-uuid"));
-        // ...while the frontend-owned half really was applied.
-        assert!(!state.settings.share_telemetry);
     }
 
     /// A patch with unknown/extra keys (an older or newer frontend) still parses,
@@ -591,20 +477,25 @@ mod tests {
         assert_eq!(state.version, SCHEMA_VERSION);
     }
 
-    /// The retired built-in toggle is gone from `AppSettings` (ADR-0002:
-    /// nothing ships that can be switched off), but a user's `state.json` may
-    /// still carry the key. Their OTHER settings must survive it.
-    ///
-    /// `enter_to_send` is the probe precisely because its default is `true`:
-    /// reading `false` back proves the file was parsed, not that `load` fell
-    /// through to `AppState::default()` — which is what a strict deserializer
-    /// would have done, silently resetting every setting the user had.
+    /// `AppState` no longer has a `settings` field at all (issue #64) — user
+    /// preferences live in `config.toml` now. A `state.json` written by an
+    /// older Atlas build still carries a `settings` object; `serde_json`
+    /// silently drops unrecognized keys for structs without
+    /// `deny_unknown_fields`, so this must parse cleanly and leave every other
+    /// field intact rather than erroring or resetting anything. What happens
+    /// to that dropped value is `AppState::load`'s job (it re-parses the raw
+    /// JSON separately to recover it for migration) and
+    /// `atlas_config::settings_from_legacy_json`'s job (extracting it into
+    /// `AppSettings`) — both tested on their own.
     #[test]
-    fn a_retired_key_in_state_json_does_not_reset_the_other_settings() {
+    fn a_legacy_settings_key_in_state_json_does_not_break_parsing() {
         let state: AppState = serde_json::from_value(serde_json::json!({
-            "settings": { "disabledBuiltinAgents": ["kilo"], "enterToSend": false }
+            "settings": { "disabledBuiltinAgents": ["kilo"], "enterToSend": false },
+            "recentProjects": [
+                { "name": "demo", "path": "/tmp/demo", "lastOpened": "2024-01-01T00:00:00Z" }
+            ],
         }))
-        .expect("an older state file parses");
-        assert!(!state.settings.enter_to_send);
+        .expect("an older state file parses even with the retired settings key present");
+        assert_eq!(state.recent_projects.len(), 1);
     }
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -3,7 +3,7 @@
 //! JS side via `#[serde(rename_all = "camelCase")]` so the frontend can use
 //! the deserialized payload verbatim.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -403,9 +403,55 @@ impl AppState {
         (state, legacy_settings)
     }
 
-    /// Atomic write — `state.json.tmp` then `rename` so a crash mid-write
-    /// can never leave a torn JSON file behind.
+    /// Merge `state` over whatever `state.json` already holds, rather than
+    /// replacing the file wholesale.
+    ///
+    /// The typed `AppState` deliberately has no `settings` field any more
+    /// (issue #64), so `to_string_pretty(state)` DROPS the legacy `settings`
+    /// object — the very thing `atlas_config::bootstrap` still needs whenever
+    /// migration hasn't succeeded yet. A save triggered for some unrelated
+    /// reason (a rotated telemetry id, say) would then destroy the user's only
+    /// surviving copy of their preferences. Merging preserves it, and any
+    /// other key an older or newer build writes, for exactly the reason
+    /// `config.toml` patches preserve unknown TOML keys.
+    ///
+    /// Once migration IS recorded as done the legacy copy has served its
+    /// purpose and is dropped, so `state.json` doesn't carry a stale shadow of
+    /// `config.toml` forever.
+    fn merged_for_save(path: &Path, state: &AppState) -> serde_json::Result<serde_json::Value> {
+        let mut merged = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+            .filter(serde_json::Value::is_object)
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+
+        let fresh = serde_json::to_value(state)?;
+        if let (Some(dst), Some(src)) = (merged.as_object_mut(), fresh.as_object()) {
+            for (k, v) in src {
+                dst.insert(k.clone(), v.clone());
+            }
+            if state.settings_config_migrated {
+                dst.remove("settings");
+            }
+        }
+        Ok(merged)
+    }
+
+    /// Atomic write — a uniquely-named temp file then `rename`, so a crash
+    /// mid-write can never leave a torn JSON file behind.
+    ///
+    /// The temp name carries a UUID rather than being the fixed
+    /// `state.json.tmp`: saves overlap in practice (the boot-time telemetry-id
+    /// / migration-marker write against the frontend's debounced flush), and
+    /// two of them sharing one temp path can interleave into exactly the torn
+    /// file the rename is supposed to prevent. That matters more since
+    /// [`Self::merged_for_save`] made this a read-modify-write, and because
+    /// this file holds the only copy of the legacy settings until migration
+    /// succeeds. `sync_all` before the rename is what makes the atomicity
+    /// real — otherwise the rename can reach disk ahead of its bytes.
     pub fn save(app: &AppHandle, state: &AppState) -> std::io::Result<()> {
+        use std::io::Write;
+
         let Some(path) = Self::path(app) else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -415,12 +461,26 @@ impl AppState {
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }
-        let tmp = path.with_extension("json.tmp");
-        let raw = serde_json::to_string_pretty(state).map_err(|e| {
+        let tmp = path.with_extension(format!("json.tmp.{}", uuid::Uuid::new_v4()));
+        let merged = Self::merged_for_save(&path, state).map_err(|e| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
         })?;
-        std::fs::write(&tmp, raw)?;
-        std::fs::rename(tmp, path)?;
+        let raw = serde_json::to_string_pretty(&merged).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+        })?;
+        let written = (|| -> std::io::Result<()> {
+            let mut f = std::fs::File::create(&tmp)?;
+            f.write_all(raw.as_bytes())?;
+            f.sync_all()
+        })();
+        if let Err(e) = written {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e);
+        }
+        if let Err(e) = std::fs::rename(&tmp, &path) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e);
+        }
         Ok(())
     }
 }
@@ -428,6 +488,82 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tmp_state_path() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("atlas-state-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("state.json")
+    }
+
+    fn state_file_with_legacy_settings(path: &Path) {
+        std::fs::write(
+            path,
+            serde_json::json!({
+                "version": 1,
+                "recentProjects": [],
+                "settings": { "enterToSend": false, "gitBlameInline": false },
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    /// The typed `AppState` has no `settings` field any more (issue #64), so
+    /// serializing it over `state.json` wholesale silently DELETES the legacy
+    /// settings object. While `settings_config_migrated` is still false that
+    /// object is the only surviving copy of the user's preferences —
+    /// `config.toml` either doesn't exist yet or couldn't be read — and a save
+    /// fired for an entirely unrelated reason (a rotated telemetry id) must
+    /// not destroy it.
+    #[test]
+    fn a_save_before_migration_preserves_the_legacy_settings() {
+        let path = tmp_state_path();
+        state_file_with_legacy_settings(&path);
+
+        let state = AppState { settings_config_migrated: false, ..AppState::default() };
+        let merged = AppState::merged_for_save(&path, &state).unwrap();
+
+        assert_eq!(
+            merged.get("settings").and_then(|s| s.get("enterToSend")),
+            Some(&serde_json::json!(false)),
+            "the legacy settings must survive a save made for an unrelated reason"
+        );
+    }
+
+    /// ...and once migration IS recorded, the legacy copy has served its
+    /// purpose: drop it rather than carrying a stale shadow of `config.toml`
+    /// in `state.json` forever.
+    #[test]
+    fn a_save_after_migration_drops_the_legacy_settings() {
+        let path = tmp_state_path();
+        state_file_with_legacy_settings(&path);
+
+        let state = AppState { settings_config_migrated: true, ..AppState::default() };
+        let merged = AppState::merged_for_save(&path, &state).unwrap();
+
+        assert!(merged.get("settings").is_none(), "a migrated state.json keeps no settings shadow");
+    }
+
+    /// Merging must not resurrect stale values for keys the struct owns — the
+    /// fresh state always wins on its own fields.
+    #[test]
+    fn merging_lets_the_live_state_win_on_its_own_fields() {
+        let path = tmp_state_path();
+        std::fs::write(
+            &path,
+            serde_json::json!({ "version": 1, "settingsConfigMigrated": false, "recentProjects": [
+                { "name": "old", "path": "/old", "lastOpened": "then" }
+            ]})
+            .to_string(),
+        )
+        .unwrap();
+
+        let state = AppState { settings_config_migrated: true, ..AppState::default() };
+        let merged = AppState::merged_for_save(&path, &state).unwrap();
+
+        assert_eq!(merged["settingsConfigMigrated"], serde_json::json!(true));
+        assert_eq!(merged["recentProjects"], serde_json::json!([]));
+    }
 
     /// Exactly the payload `buildAppStatePayload()` sends — note the absence of
     /// `telemetryAnonId`, which is the whole point.

--- a/src-tauri/src/state/atlas_config.rs
+++ b/src-tauri/src/state/atlas_config.rs
@@ -202,22 +202,122 @@ impl Default for AppSettings {
 /// The full set of keys `AppSettings` knows about, in wire (camelCase) form.
 /// Used to flag anything else in `[settings]` as an unknown key — preserved
 /// on disk and surfaced as a diagnostic, never treated as an error.
-const KNOWN_SETTINGS_KEYS: &[&str] = &[
-    "autoAddAtlasGitignore",
-    "enableAtlasLogs",
-    "showHiddenFiles",
-    "uiScale",
-    "shareTelemetry",
-    "linkTelemetryToAccount",
-    "embeddingModelId",
-    "codeEditorTheme",
-    "atlasTheme",
-    "adaptiveSuggestions",
-    "gitBlameInline",
-    "autoUpdate",
-    "updaterIgnoredVersion",
-    "enterToSend",
+/// Preamble written above `schemaVersion` in every `config.toml` Atlas
+/// generates.
+const CONFIG_HEADER: &str = "\
+# Atlas configuration.
+#
+# Every user-facing Atlas preference lives here. Edit this file by hand or use
+# Settings — both write to it, and Atlas picks up external edits live, with no
+# restart needed for any key below.
+#
+# Your comments, formatting, and any keys Atlas doesn't recognize survive its
+# own writes. An invalid value is rejected whole: Atlas keeps running on the
+# last settings that loaded cleanly, shows the error in Settings, and leaves
+# this file exactly as you wrote it.
+";
+
+const SCHEMA_VERSION_DOC: &str = "\
+
+# Format version of this file. Atlas manages it; leave it alone.
+";
+
+/// camelCase key → the comment written directly above it in a generated
+/// `config.toml`.
+///
+/// This is the schema documentation. The `atlas-self-configure` skill
+/// deliberately carries no copy of it: the agent reads the real file, which
+/// explains itself, rather than a table that can drift from the code. A key
+/// missing an entry here therefore ships undocumented —
+/// `settings_docs_cover_every_setting` fails the build if that happens.
+///
+/// Order matches `AppSettings`' field order, and so the generated file's. That
+/// matters for a key that serializes to nothing (`updaterIgnoredVersion` when
+/// unset): its comment is carried down onto the next key that IS present,
+/// rather than dropped.
+const SETTINGS_DOCS: &[(&str, &str)] = &[
+    (
+        "autoAddAtlasGitignore",
+        "# Add `.atlas/` to each opened git project's .gitignore, creating the\n\
+         # file if needed. No-op on non-git projects. (default: true)",
+    ),
+    (
+        "enableAtlasLogs",
+        "# Record Atlas-internal events (sign-in, agent lifecycle, file and\n\
+         # browser opens) into the Logs panel. (default: true)",
+    ),
+    (
+        "showHiddenFiles",
+        "# Show dotfiles and dot-directories in the explorer file tree.\n\
+         # (default: true)",
+    ),
+    (
+        "uiScale",
+        "# Interface zoom, where 1.0 is 100%. Also driven by Cmd +/-/0.\n\
+         # Must be a number between 0.5 and 2.0. (default: 1.0)",
+    ),
+    (
+        "shareTelemetry",
+        "# Anonymous product telemetry. Opt-OUT: on by default, coarse metadata\n\
+         # only, never file contents or prompts. See TELEMETRY.md.\n\
+         # (default: true)",
+    ),
+    (
+        "linkTelemetryToAccount",
+        "# Attribute telemetry to your signed-in Atlas account instead of the\n\
+         # anonymous per-device id. Irrelevant while signed out, or while\n\
+         # shareTelemetry is false — both gate it. (default: true)",
+    ),
+    (
+        "embeddingModelId",
+        "# On-device embedding model, named by its directory. Normally managed\n\
+         # for you by the Local Model Manager. Must not be empty.\n\
+         # (default: \"all-MiniLM-L6-v2\")",
+    ),
+    (
+        "codeEditorTheme",
+        "# Code-editor colour theme id — themes code syntax in the editor and\n\
+         # both diff views. Must not be empty. (default: \"atlas\")",
+    ),
+    (
+        "atlasTheme",
+        "# Atlas interface theme id — repaints the whole UI palette, separately\n\
+         # from codeEditorTheme. Must not be empty. (default: \"atlas-black\")",
+    ),
+    (
+        "adaptiveSuggestions",
+        "# Next-step suggestion chips in the agent chat's per-turn card.\n\
+         # Exactly \"agent\" or \"off\", nothing else. (default: \"agent\")",
+    ),
+    (
+        "gitBlameInline",
+        "# Inline git blame — a dim author/age/summary annotation trailing the\n\
+         # active line in the editor. (default: true)",
+    ),
+    (
+        "autoUpdate",
+        "# Check for a newer signed Atlas release on startup and prompt when one\n\
+         # is available. (default: true)",
+    ),
+    (
+        "updaterIgnoredVersion",
+        "# updaterIgnoredVersion: a release you chose to skip in the update\n\
+         # prompt. Absent unless one was ignored — TOML has no null, so \"unset\"\n\
+         # means the key simply isn't here. Delete the line to clear it; never\n\
+         # write an empty string.",
+    ),
+    (
+        "enterToSend",
+        "# Chat composer send gesture. true = Enter sends and Shift+Enter\n\
+         # inserts a newline; false = only Cmd/Ctrl+Enter sends. Cmd/Ctrl+Enter\n\
+         # sends either way. (default: true)",
+    ),
 ];
+
+/// Every key Atlas recognizes under `[settings]`, in file order.
+fn known_settings_keys() -> impl Iterator<Item = &'static str> {
+    SETTINGS_DOCS.iter().map(|(key, _)| *key)
+}
 
 /// One field failed semantic validation. Structural validation only —
 /// deliberately NOT a full theme-id/embedding-model-id catalog membership
@@ -292,14 +392,98 @@ fn unknown_keys_in(document: &toml_edit::DocumentMut) -> Vec<String> {
     table
         .iter()
         .map(|(k, _)| k.to_string())
-        .filter(|k| !KNOWN_SETTINGS_KEYS.contains(&k.as_str()))
+        .filter(|k| !known_settings_keys().any(|known| known == k.as_str()))
         .collect()
 }
 
 fn document_for(settings: &AppSettings) -> toml_edit::DocumentMut {
     let file = AtlasConfigFile { schema_version: CONFIG_SCHEMA_VERSION, settings: settings.clone() };
     let text = toml::to_string_pretty(&file).expect("AppSettings always serializes to TOML");
-    text.parse().expect("freshly-generated TOML always parses")
+    annotate(&text).parse().expect("freshly-generated TOML always parses")
+}
+
+/// Interleave [`CONFIG_HEADER`] and [`SETTINGS_DOCS`] into freshly generated
+/// TOML, so the file Atlas writes explains itself.
+///
+/// Done on the text rather than through `toml_edit`'s decor API for one
+/// reason: a key can be missing from the output entirely (`updaterIgnoredVersion`
+/// serializes to nothing when unset, since TOML has no null), and there is no
+/// decor to hang its comment on. Walking `SETTINGS_DOCS` in order alongside
+/// the generated lines lets an absent key's comment fall through onto the next
+/// key that is present, which is exactly where a reader looking for it will be.
+///
+/// Only ever applied to output this module just generated — never to a file a
+/// user or agent wrote. Comments already in such a file are preserved by
+/// `toml_edit` on patch, and none are ever injected into it.
+fn annotate(generated: &str) -> String {
+    let mut out = String::with_capacity(generated.len() * 3);
+    out.push_str(CONFIG_HEADER);
+
+    let mut docs = SETTINGS_DOCS.iter().peekable();
+    // Comments for keys that serialized to nothing, waiting for the next key
+    // that did.
+    let mut carried: Vec<&str> = Vec::new();
+
+    for line in generated.lines() {
+        // A key line, not the `[settings]` header or a blank: it has an `=`,
+        // and something before it. Getting this wrong once meant `[settings]`
+        // was read as a key, which drained every remaining doc entry into
+        // `carried` and dumped all of them at the bottom of the file.
+        let Some(assigned) = line
+            .split_once('=')
+            .map(|(key, _)| key.trim())
+            .filter(|key| !key.is_empty())
+        else {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        };
+
+        if assigned == "schemaVersion" {
+            out.push_str(SCHEMA_VERSION_DOC);
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        // Advance to this key's entry, collecting the comments of any keys it
+        // skipped past (those didn't make it into the output).
+        while docs.peek().is_some_and(|(key, _)| *key != assigned) {
+            let (_, comment) = docs.next().expect("peeked");
+            carried.push(comment);
+        }
+        let Some((_, comment)) = docs.next() else {
+            // Not a documented key (the `[settings]` header, a blank line, or
+            // something new that `settings_docs_cover_every_setting` will
+            // catch) — pass it through untouched.
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        };
+
+        out.push('\n');
+        for skipped in carried.drain(..) {
+            out.push_str(skipped);
+            out.push('\n');
+        }
+        out.push_str(comment);
+        out.push('\n');
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    // Any documented keys after the last one that was emitted.
+    for (_, comment) in docs {
+        out.push('\n');
+        out.push_str(comment);
+        out.push('\n');
+    }
+    for comment in carried {
+        out.push('\n');
+        out.push_str(comment);
+        out.push('\n');
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1360,8 +1544,8 @@ someFutureKey = \"left alone\"
     // `docs/reference/configuration.md` explicitly claims every schema key
     // appears in both itself and the bundled skill. Compiled in via
     // `include_str!` (not read from disk at test time) so this fails the
-    // build the moment either document drifts from `KNOWN_SETTINGS_KEYS`,
-    // the same way the rest of this crate's `include_str!`'d resources do.
+    // build the moment either document drifts from `SETTINGS_DOCS`, the same
+    // way the rest of this crate's `include_str!`'d resources do.
 
     const CONFIGURATION_DOC: &str = include_str!("../../../docs/reference/configuration.md");
     const SELF_CONFIGURE_SKILL: &str =
@@ -1369,7 +1553,7 @@ someFutureKey = \"left alone\"
 
     #[test]
     fn every_known_setting_key_is_documented_in_the_configuration_reference() {
-        for key in KNOWN_SETTINGS_KEYS {
+        for key in known_settings_keys() {
             assert!(CONFIGURATION_DOC.contains(key), "docs/reference/configuration.md is missing `{key}`");
         }
     }
@@ -1604,13 +1788,79 @@ someFutureKey = \"left alone\"
         assert!(temp_files_beside(&path).is_empty());
     }
 
+    /// The generated file is the schema documentation now — the skill points
+    /// agents at the comments rather than carrying its own copy of the key
+    /// table. So the guard that used to check SKILL.md checks the emitted file
+    /// instead: a key with no `SETTINGS_DOCS` entry would ship undocumented and
+    /// leave an agent with nothing to read.
     #[test]
-    fn every_known_setting_key_is_covered_by_the_self_configure_skill() {
-        for key in KNOWN_SETTINGS_KEYS {
+    fn settings_docs_cover_every_setting() {
+        let rendered = document_for(&AppSettings::default()).to_string();
+        for key in known_settings_keys() {
+            let documented = SETTINGS_DOCS
+                .iter()
+                .find(|(k, _)| *k == key)
+                .is_some_and(|(_, comment)| comment.contains(key) || !comment.trim().is_empty());
+            assert!(documented, "`{key}` has no SETTINGS_DOCS comment");
+        }
+        // And every one of those comments actually reaches the file.
+        for (_, comment) in SETTINGS_DOCS {
+            let first = comment.lines().next().expect("comments are non-empty");
             assert!(
-                SELF_CONFIGURE_SKILL.contains(key),
-                "the atlas-self-configure SKILL.md is missing `{key}`"
+                rendered.contains(first.trim()),
+                "this comment never made it into config.toml: {first}"
             );
         }
+    }
+
+    /// The skill must NOT re-document the keys — that duplication is what the
+    /// comments replaced, and a stale copy is worse than none. It should still
+    /// tell the agent where the file is.
+    #[test]
+    fn the_self_configure_skill_defers_to_the_files_own_comments() {
+        let named: Vec<_> =
+            known_settings_keys().filter(|key| SELF_CONFIGURE_SKILL.contains(*key)).collect();
+        // A worked example may name a key or two; a table of them is the
+        // duplication the file's own comments replaced, and a stale copy of
+        // the schema is worse for an agent than no copy at all.
+        assert!(
+            named.len() < 4,
+            "SKILL.md is re-documenting the schema instead of deferring to config.toml: {named:?}"
+        );
+        assert!(SELF_CONFIGURE_SKILL.contains(CONFIG_FILE_NAME));
+    }
+
+    /// A key absent from the generated output (`updaterIgnoredVersion` when
+    /// unset — TOML has no null) must still get its comment into the file,
+    /// carried down onto the next key that IS present. Otherwise the one key
+    /// whose *absence* is meaningful is the one nothing explains.
+    #[test]
+    fn a_key_that_serializes_to_nothing_still_gets_documented() {
+        let rendered = document_for(&AppSettings::default()).to_string();
+        assert!(
+            !rendered.contains("updaterIgnoredVersion ="),
+            "unset means the key is absent, not written as a sentinel"
+        );
+        assert!(
+            rendered.contains("# updaterIgnoredVersion:"),
+            "its comment must survive even though the key didn't"
+        );
+        // Sitting immediately above the key that follows it in field order.
+        let comment_at = rendered.find("# updaterIgnoredVersion:").unwrap();
+        let next_key_at = rendered.find("enterToSend =").unwrap();
+        assert!(comment_at < next_key_at);
+    }
+
+    /// The annotated file must still be a valid, loadable config — comments
+    /// are decoration, not a second schema.
+    #[test]
+    fn the_annotated_file_round_trips() {
+        let path = tmp_config_path();
+        let settings = AppSettings { ui_scale: 1.25, enter_to_send: false, ..Default::default() };
+        let rendered = document_for(&settings).to_string();
+
+        let mgr = ConfigManager::from_raw(path, &rendered).expect("the generated file parses");
+        assert_eq!(mgr.effective(), &settings);
+        assert!(mgr.unknown_keys().is_empty(), "comments must not read as unknown keys");
     }
 }

--- a/src-tauri/src/state/atlas_config.rs
+++ b/src-tauri/src/state/atlas_config.rs
@@ -46,6 +46,12 @@ pub const CONFIG_SCHEMA_VERSION: u32 = 1;
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
 
+/// How many times [`ConfigManager::apply_patch`] rebuilds its patch when an
+/// external write lands inside the merge-then-swap window. Three is enough to
+/// ride out an editor's own save (which is itself usually a rename) without
+/// letting a runaway writer block the UI indefinitely.
+const CAS_ATTEMPTS: usize = 3;
+
 /// Mirrors `MIN_SCALE`/`MAX_SCALE` in
 /// `src/features/settings/lib/ui-scale.ts` — kept in sync manually since the
 /// frontend clamp and this validation gate the same field from two ends.
@@ -306,6 +312,10 @@ pub enum ConfigError {
     Parse(String),
     Invalid(ValidationIssue),
     UnsupportedVersion(u32),
+    /// `CAS_ATTEMPTS` consecutive attempts each found the file rewritten
+    /// between the merge and the swap. Nothing was written — retrying is
+    /// safe, which is what the message tells the user to do.
+    Busy,
 }
 
 impl std::fmt::Display for ConfigError {
@@ -319,6 +329,10 @@ impl std::fmt::Display for ConfigError {
             ConfigError::UnsupportedVersion(v) => write!(
                 f,
                 "config.toml has schemaVersion {v}, newer than this Atlas build supports ({CONFIG_SCHEMA_VERSION}) — it was likely created by a newer Atlas version"
+            ),
+            ConfigError::Busy => write!(
+                f,
+                "config.toml is being written by something else — nothing was changed; try again"
             ),
         }
     }
@@ -547,7 +561,13 @@ pub fn settings_from_legacy_json(raw: Option<&serde_json::Value>) -> AppSettings
 // ConfigManager
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq)]
+/// Serialized straight to the frontend (`ConfigInfo.status`,
+/// `BootstrapPayload.configStatus`) — `tag = "status"` matches the
+/// discriminated union in `atlas-config-api.ts`. Deriving `Serialize` here
+/// rather than mirroring the enum into a separate wire type in
+/// `commands::atlas_config` keeps one definition of the three states.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
 pub enum ConfigStatus {
     Ok,
     /// A hot-reload (external edit) failed; `effective` still holds the
@@ -680,7 +700,24 @@ impl ConfigManager {
             // File genuinely absent — the normal pre-first-write state, not
             // an error. `bootstrap` below is what decides whether that's
             // "needs migration" or "already migrated, stay on defaults".
-            Err(_) => Self::in_memory_defaults(path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Self::in_memory_defaults(path),
+            // Anything else (permissions, a transient I/O fault, a directory
+            // where the file should be) is a *failure to read*, not an
+            // absence. Serving defaults is still right at runtime — boot must
+            // never block on this — but the status MUST say so, because
+            // `bootstrap_at` keys the "the legacy state.json settings are
+            // now redundant" decision off it. Reporting `Ok` here is what let
+            // an unreadable config silently retire the user's only surviving
+            // copy of their preferences.
+            Err(e) => {
+                tracing::warn!(
+                    target: "atlas::config",
+                    "config.toml could not be read, serving defaults in memory (file left untouched): {e}"
+                );
+                let mut mgr = Self::in_memory_defaults(path);
+                mgr.status = ConfigStatus::UsingDefaults { error: format!("could not read config.toml: {e}") };
+                mgr
+            }
         }
     }
 
@@ -721,6 +758,18 @@ impl ConfigManager {
     /// between an external edit and this write); rejects outright rather than
     /// clobbering if that re-read finds a malformed file.
     ///
+    /// The re-read and the rename are not one atomic step — an external
+    /// editor (or the `atlas-self-configure` skill) can still write in the
+    /// gap, and that write would be clobbered along with its comments and
+    /// unknown keys. Short of taking an advisory file lock, the best
+    /// available answer is to re-check the file immediately before the swap
+    /// and, if it moved, rebuild the patch on the fresh content and try
+    /// again — bounded by [`CAS_ATTEMPTS`], after which the write is refused
+    /// with [`ConfigError::Busy`] rather than spinning forever. Note that
+    /// `Busy` is only reachable for `expected_generation: None` callers: with
+    /// `Some(g)`, the retry's `reload_from_disk` adopts the intervening write
+    /// and bumps the generation, so the second pass reports `Conflict`.
+    ///
     /// `expected_generation`: `None` for internal Rust-side callers
     /// (`commands::updater`, `commands::models`) that only ever race the
     /// filesystem, never a second in-app editor — always applies, matching
@@ -733,14 +782,30 @@ impl ConfigManager {
         patch: &SettingsPatch,
         expected_generation: Option<u64>,
     ) -> Result<UpdateOutcome, ConfigError> {
+        for _ in 0..CAS_ATTEMPTS {
+            if let Some(outcome) = self.try_apply_patch(patch, expected_generation)? {
+                return Ok(outcome);
+            }
+        }
+        Err(ConfigError::Busy)
+    }
+
+    /// One compare-and-swap attempt. `Ok(None)` means the file changed
+    /// underneath us between the re-read and the swap and nothing was
+    /// written — the caller retries against the new content.
+    fn try_apply_patch(
+        &mut self,
+        patch: &SettingsPatch,
+        expected_generation: Option<u64>,
+    ) -> Result<Option<UpdateOutcome>, ConfigError> {
         self.reload_from_disk()?;
 
         if let Some(expected) = expected_generation {
             if expected != self.generation {
-                return Ok(UpdateOutcome::Conflict {
+                return Ok(Some(UpdateOutcome::Conflict {
                     settings: self.effective.clone(),
                     generation: self.generation,
-                });
+                }));
             }
         }
 
@@ -753,7 +818,9 @@ impl ConfigManager {
         doc["schemaVersion"] = toml_edit::value(i64::from(CONFIG_SCHEMA_VERSION));
 
         let text = doc.to_string();
-        write_atomic(&self.path, &text).map_err(|e| ConfigError::Io(e.to_string()))?;
+        if !self.write_if_unchanged(&text)? {
+            return Ok(None);
+        }
 
         self.document = doc;
         self.unknown_keys = unknown_keys_in(&self.document);
@@ -762,7 +829,26 @@ impl ConfigManager {
         self.generation += 1;
         self.status = ConfigStatus::Ok;
 
-        Ok(UpdateOutcome::Applied { settings: candidate, generation: self.generation })
+        Ok(Some(UpdateOutcome::Applied { settings: candidate, generation: self.generation }))
+    }
+
+    /// Swap `text` in only if the file still holds exactly the content this
+    /// patch was merged against (`last_raw`). `Ok(false)` = it moved, so the
+    /// merge base is stale and nothing was written.
+    ///
+    /// A missing file is not "moved" — that's the pre-first-write state, and
+    /// writing is precisely what should happen. Any other read error is
+    /// surfaced rather than guessed past.
+    fn write_if_unchanged(&self, text: &str) -> Result<bool, ConfigError> {
+        match fs::read_to_string(&self.path) {
+            Ok(now) if now != self.last_raw => return Ok(false),
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+                return Err(ConfigError::Io(e.to_string()));
+            }
+            _ => {}
+        }
+        write_atomic(&self.path, text).map_err(|e| ConfigError::Io(e.to_string()))?;
+        Ok(true)
     }
 
     /// The sole path allowed to overwrite a malformed (or just unwanted)
@@ -811,6 +897,8 @@ impl ConfigManager {
 /// writes, migration, and any external tooling can never collide on one
 /// fixed `.tmp` name), flushed then renamed over the target.
 fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
     if let Some(dir) = path.parent() {
         fs::create_dir_all(dir)?;
     }
@@ -820,8 +908,35 @@ fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
         .unwrap_or_else(|| CONFIG_FILE_NAME.to_string());
     let unique = format!("{file_name}.tmp.{}", uuid::Uuid::new_v4());
     let tmp = path.with_file_name(unique);
-    fs::write(&tmp, contents)?;
-    fs::rename(&tmp, path)
+
+    // `sync_all` before the rename, not just `fs::write`: without it the
+    // rename can reach the disk ahead of the bytes it points at, so power
+    // loss just after the UI said "saved" can leave config.toml pointing at
+    // an empty or half-written inode. On the failure paths the temp file is
+    // removed rather than left as litter next to the real config.
+    let written = (|| -> std::io::Result<()> {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.sync_all()
+    })();
+    if let Err(e) = written {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+
+    // Make the rename itself durable. Best-effort: some filesystems refuse to
+    // open a directory for sync, and that is not worth failing an otherwise
+    // successful write over.
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
 }
 
 /// Thread-safe handle registered as Tauri managed state, mirroring
@@ -870,10 +985,11 @@ pub fn update(app: &AppHandle, patch: SettingsPatch) -> Result<ConfigSnapshot, C
 pub struct MigrationOutcome {
     pub manager: ConfigManager,
     /// Whether the caller should persist `settings_config_migrated = true`
-    /// into `state.json` (v4) after this call. Always `true` once this
-    /// returns — either the config already existed, or it was just created —
-    /// the only remaining question is whether the *caller* still needs to
-    /// write that fact down.
+    /// into `state.json` (v4) after this call. `true` once `config.toml`
+    /// demonstrably holds the settings — it either loaded cleanly or was
+    /// just created. Deliberately `false` when the file exists but could not
+    /// be read or parsed: the legacy `state.json.settings` is still the only
+    /// copy in that case and must survive until a real config does.
     pub mark_migrated: bool,
 }
 
@@ -883,7 +999,14 @@ pub fn bootstrap(
     legacy_settings_raw: Option<serde_json::Value>,
 ) -> MigrationOutcome {
     let Some(path) = ConfigManager::config_path(app) else {
-        return MigrationOutcome { manager: ConfigManager::load(app), mark_migrated: false };
+        // No resolvable config dir at all (no $HOME / no %APPDATA%). Defaults
+        // keep the app usable, but this is a failure and must reach the
+        // banner rather than passing for a healthy load.
+        let mut manager = ConfigManager::load(app);
+        manager.status = ConfigStatus::UsingDefaults {
+            error: "could not resolve the Atlas config directory".to_string(),
+        };
+        return MigrationOutcome { manager, mark_migrated: false };
     };
     bootstrap_at(path, marker_already_set, legacy_settings_raw)
 }
@@ -902,7 +1025,26 @@ fn bootstrap_at(
         // into it, whether this is the first time we've seen it (a v3->v4
         // upgrade that lands after a user hand-authored config.toml, or a
         // manual restore) or the Nth.
-        return MigrationOutcome { manager: ConfigManager::load_at(path), mark_migrated: true };
+        let mut manager = ConfigManager::load_at(path);
+        // ...but only report migration as done if that file could actually be
+        // READ. While it is malformed or unreadable, `state.json.settings` is
+        // still the only surviving copy of the user's preferences; setting
+        // the marker here would let `AppState::save` drop it (the typed
+        // `AppState` has no `settings` field any more), turning a recoverable
+        // bad file into permanent data loss.
+        let mark_migrated = matches!(manager.status(), ConfigStatus::Ok);
+        if !mark_migrated && !marker_already_set {
+            // The file is present but unusable, so migration never ran and
+            // `state.json.settings` is still the user's real configuration.
+            // Serve THAT rather than compiled defaults: keeping the legacy
+            // copy alive (see `AppState::save`) is only half the guarantee —
+            // the other half is honouring it while the file is broken, or the
+            // user still spends the whole session on defaults with, say,
+            // telemetry back on. The broken file itself is left untouched.
+            manager.effective = settings_from_legacy_json(legacy_settings_raw.as_ref());
+            manager.document = document_for(&manager.effective);
+        }
+        return MigrationOutcome { manager, mark_migrated };
     }
 
     // No file yet. Import from legacy state exactly once, ever.
@@ -912,11 +1054,21 @@ fn bootstrap_at(
         settings_from_legacy_json(legacy_settings_raw.as_ref())
     };
 
-    match ConfigManager::create_fresh_with(path.clone(), settings) {
+    match ConfigManager::create_fresh_with(path.clone(), settings.clone()) {
         Ok(manager) => MigrationOutcome { manager, mark_migrated: true },
         Err(e) => {
             tracing::warn!(target: "atlas::config", "failed to write migrated config.toml: {e}");
-            MigrationOutcome { manager: ConfigManager::load_at(path), mark_migrated: false }
+            // The file was never created, so `load_at` will take its
+            // "genuinely absent" branch and report `Ok` — which would hide a
+            // real failure behind a healthy status and drop the legacy
+            // settings we just computed. Serve those settings in memory and
+            // flag the write failure instead.
+            let mut manager = ConfigManager::load_at(path);
+            manager.effective = settings;
+            manager.document = document_for(&manager.effective);
+            manager.status =
+                ConfigStatus::UsingDefaults { error: format!("could not write config.toml: {e}") };
+            MigrationOutcome { manager, mark_migrated: false }
         }
     }
 }
@@ -1220,6 +1372,236 @@ someFutureKey = \"left alone\"
         for key in KNOWN_SETTINGS_KEYS {
             assert!(CONFIGURATION_DOC.contains(key), "docs/reference/configuration.md is missing `{key}`");
         }
+    }
+
+    /// `MIN_UI_SCALE`/`MAX_UI_SCALE` are duplicated in `ui-scale.ts`, which
+    /// clamps the same field from the frontend end. Nothing but this test
+    /// stops the two drifting apart, and drift means the UI happily offers a
+    /// zoom level Rust then rejects (or vice versa).
+    #[test]
+    fn ui_scale_bounds_match_the_frontend_clamp() {
+        const UI_SCALE_TS: &str = include_str!("../../../src/features/settings/lib/ui-scale.ts");
+        assert!(
+            UI_SCALE_TS.contains(&format!("export const MIN_SCALE = {MIN_UI_SCALE:.1};")),
+            "ui-scale.ts MIN_SCALE has drifted from MIN_UI_SCALE ({MIN_UI_SCALE})"
+        );
+        assert!(
+            UI_SCALE_TS.contains(&format!("export const MAX_SCALE = {MAX_UI_SCALE:.1};")),
+            "ui-scale.ts MAX_SCALE has drifted from MAX_UI_SCALE ({MAX_UI_SCALE})"
+        );
+    }
+
+    /// `ConfigStatus` serializes straight to the frontend now that the
+    /// mirrored `ConfigStatusWire` is gone; this pins the exact discriminated
+    /// union `atlas-config-api.ts` destructures.
+    #[test]
+    fn config_status_serializes_as_the_frontend_union() {
+        assert_eq!(
+            serde_json::to_value(ConfigStatus::Ok).unwrap(),
+            serde_json::json!({ "status": "ok" })
+        );
+        assert_eq!(
+            serde_json::to_value(ConfigStatus::UsingDefaults { error: "boom".into() }).unwrap(),
+            serde_json::json!({ "status": "usingDefaults", "error": "boom" })
+        );
+        assert_eq!(
+            serde_json::to_value(ConfigStatus::UsingLastKnownGood { error: "boom".into() }).unwrap(),
+            serde_json::json!({ "status": "usingLastKnownGood", "error": "boom" })
+        );
+    }
+
+    /// A file that exists but cannot be PARSED must not be reported as a
+    /// completed migration: `state.json.settings` is still the only surviving
+    /// copy of the user's preferences at that point, and the marker is what
+    /// authorizes `AppState::save` to drop it.
+    #[test]
+    fn a_malformed_existing_config_does_not_report_migration_done() {
+        let path = tmp_config_path();
+        fs::write(&path, "this is not { valid toml").unwrap();
+        let legacy = serde_json::json!({ "enterToSend": false, "gitBlameInline": false });
+
+        let outcome = bootstrap_at(path, false, Some(legacy));
+
+        assert!(
+            !outcome.mark_migrated,
+            "a malformed config.toml must not retire the legacy settings"
+        );
+        assert!(matches!(outcome.manager.status(), ConfigStatus::UsingDefaults { .. }));
+        // Boot never blocks: something usable is always effective. Which
+        // settings those are is the subject of
+        // `a_broken_config_falls_back_to_the_legacy_settings_not_compiled_defaults`.
+        assert!(!outcome.manager.effective().enter_to_send);
+    }
+
+    /// The same guarantee for a file that cannot be READ at all (here: a
+    /// directory sitting where the config should be — deterministic on every
+    /// platform and every uid, unlike a chmod-based test). This is the case
+    /// `load_at` used to fold into "file absent" and report as healthy.
+    #[test]
+    fn an_unreadable_existing_config_does_not_report_migration_done() {
+        let path = tmp_config_path();
+        fs::create_dir_all(&path).unwrap();
+
+        let outcome = bootstrap_at(path, false, Some(serde_json::json!({ "enterToSend": false })));
+
+        assert!(
+            !outcome.mark_migrated,
+            "an unreadable config.toml must not retire the legacy settings"
+        );
+        assert!(
+            matches!(outcome.manager.status(), ConfigStatus::UsingDefaults { .. }),
+            "an unreadable file must be flagged, not reported as Ok"
+        );
+    }
+
+    /// Preserving `state.json.settings` is only half the guarantee — while the
+    /// file is broken those settings must actually be in EFFECT, or the user
+    /// spends the session on compiled defaults (telemetry back on) with their
+    /// real preferences sitting unused on disk.
+    #[test]
+    fn a_broken_config_falls_back_to_the_legacy_settings_not_compiled_defaults() {
+        let path = tmp_config_path();
+        fs::write(&path, "this is not { valid toml").unwrap();
+        let legacy = serde_json::json!({ "shareTelemetry": false, "uiScale": 1.25 });
+
+        let outcome = bootstrap_at(path, false, Some(legacy));
+
+        assert!(!outcome.mark_migrated);
+        assert!(!outcome.manager.effective().share_telemetry, "the user's opt-out must survive");
+        assert_eq!(outcome.manager.effective().ui_scale, 1.25);
+        assert!(matches!(outcome.manager.status(), ConfigStatus::UsingDefaults { .. }));
+    }
+
+    /// ...but only before migration is recorded. Once the marker is set, the
+    /// legacy object is stale by definition and must not be resurrected.
+    #[test]
+    fn a_broken_config_after_migration_does_not_resurrect_legacy_settings() {
+        let path = tmp_config_path();
+        fs::write(&path, "this is not { valid toml").unwrap();
+        let legacy = serde_json::json!({ "shareTelemetry": false });
+
+        let outcome = bootstrap_at(path, true, Some(legacy));
+
+        assert!(
+            outcome.manager.effective().share_telemetry,
+            "a post-migration boot must not read state.json.settings again"
+        );
+    }
+
+    /// The healthy path still marks migration done, so the two tests above
+    /// can't be satisfied by simply never setting the marker.
+    #[test]
+    fn a_readable_existing_config_reports_migration_done() {
+        let path = tmp_config_path();
+        fs::write(&path, "schemaVersion = 1\n\n[settings]\nenterToSend = false\n").unwrap();
+
+        let outcome = bootstrap_at(path, false, None);
+
+        assert!(outcome.mark_migrated);
+        assert_eq!(outcome.manager.status(), &ConfigStatus::Ok);
+        assert!(!outcome.manager.effective().enter_to_send);
+    }
+
+    /// The external-edit half of the round trip: a valid edit made outside
+    /// Atlas is adopted wholesale and advances the generation, which is what
+    /// the frontend mirrors so its next write isn't a spurious conflict.
+    #[test]
+    fn reload_adopts_a_valid_external_edit_and_bumps_the_generation() {
+        let path = tmp_config_path();
+        let mut mgr =
+            ConfigManager::create_fresh_with(path.clone(), AppSettings::default()).unwrap();
+        let before = mgr.generation();
+        assert!(mgr.effective().git_blame_inline);
+
+        fs::write(
+            &path,
+            "schemaVersion = 1\n\n# hand-written\n[settings]\ngitBlameInline = false\nuiScale = 1.25\n",
+        )
+        .unwrap();
+
+        assert!(mgr.reload_from_disk().unwrap(), "a changed, valid file is adopted");
+        assert!(!mgr.effective().git_blame_inline);
+        assert_eq!(mgr.effective().ui_scale, 1.25);
+        assert_eq!(mgr.generation(), before + 1);
+        assert_eq!(mgr.status(), &ConfigStatus::Ok);
+
+        // Idempotent: re-reading the same bytes is a no-op, not another bump.
+        assert!(!mgr.reload_from_disk().unwrap());
+        assert_eq!(mgr.generation(), before + 1);
+    }
+
+    /// The compare-and-swap that guards the merge-then-rename window: if the
+    /// file moved since the base this patch was computed against, the write is
+    /// refused outright rather than clobbering the other writer's content
+    /// (comments and unknown keys included).
+    #[test]
+    fn a_write_whose_base_went_stale_is_refused_rather_than_clobbering() {
+        let path = tmp_config_path();
+        let mgr = ConfigManager::create_fresh_with(path.clone(), AppSettings::default()).unwrap();
+
+        // Simulate the racing writer landing inside the window: disk now holds
+        // something `mgr.last_raw` doesn't know about.
+        let external =
+            "schemaVersion = 1\n\n# someone else's comment\n[settings]\nenterToSend = false\n";
+        fs::write(&path, external).unwrap();
+
+        assert!(
+            !mgr.write_if_unchanged("schemaVersion = 1\n").unwrap(),
+            "a stale base must refuse to write"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            external,
+            "the other writer's content survives untouched"
+        );
+    }
+
+    /// ...and the same call writes when the base IS current, so the guard
+    /// can't be satisfied by refusing everything.
+    #[test]
+    fn a_write_on_a_current_base_goes_through() {
+        let path = tmp_config_path();
+        let mgr = ConfigManager::create_fresh_with(path.clone(), AppSettings::default()).unwrap();
+
+        let text = "schemaVersion = 1\n\n[settings]\nenterToSend = false\n";
+        assert!(mgr.write_if_unchanged(text).unwrap());
+        assert_eq!(fs::read_to_string(&path).unwrap(), text);
+    }
+
+    fn temp_files_beside(path: &Path) -> Vec<String> {
+        fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp."))
+            .collect()
+    }
+
+    /// `write_atomic` must not leave its `.tmp.<uuid>` sibling behind when the
+    /// swap FAILS — that's the path that used to litter, since the success
+    /// path renames the temp away by construction. A directory sitting at the
+    /// destination makes the rename fail deterministically.
+    #[test]
+    fn a_failed_atomic_write_cleans_up_its_temp_file() {
+        let path = tmp_config_path();
+        fs::create_dir_all(&path).unwrap();
+
+        assert!(write_atomic(&path, "schemaVersion = 1\n").is_err(), "renaming onto a dir fails");
+        assert!(
+            temp_files_beside(&path).is_empty(),
+            "a failed write left litter: {:?}",
+            temp_files_beside(&path)
+        );
+    }
+
+    /// ...and the success path both lands the content and leaves nothing.
+    #[test]
+    fn a_successful_atomic_write_lands_the_content_and_leaves_nothing() {
+        let path = tmp_config_path();
+        write_atomic(&path, "schemaVersion = 1\n").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "schemaVersion = 1\n");
+        assert!(temp_files_beside(&path).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/state/atlas_config.rs
+++ b/src-tauri/src/state/atlas_config.rs
@@ -1,7 +1,7 @@
 //! `AtlasConfig` — the human- and agent-editable settings file.
 //!
 //! Replaces `AppState.settings` (formerly the `settings` object inside
-//! `state.json`). Lives at `<app_config_dir>/config.toml`: TOML rather than
+//! `state.json`). Lives at `~/.config/atlas/config.toml`: TOML rather than
 //! JSON specifically so the file can carry comments, and so a patch (from the
 //! Settings UI or the `atlas-self-configure` skill) can preserve them —
 //! `toml_edit` edits the document key-by-key instead of reserializing the
@@ -45,6 +45,11 @@ use tauri::{AppHandle, Manager};
 pub const CONFIG_SCHEMA_VERSION: u32 = 1;
 
 pub const CONFIG_FILE_NAME: &str = "config.toml";
+
+/// Directory under `~/.config` (or `$XDG_CONFIG_HOME`) holding
+/// [`CONFIG_FILE_NAME`]. Named for the product, not the bundle id: a path a
+/// user types should read `atlas`, not `dev.atlas.ide`.
+pub const CONFIG_DIR_NAME: &str = "atlas";
 
 /// How many times [`ConfigManager::apply_patch`] rebuilds its patch when an
 /// external write lands inside the merge-then-swap window. Three is enough to
@@ -217,8 +222,7 @@ const CONFIG_HEADER: &str = "\
 # this file exactly as you wrote it.
 ";
 
-const SCHEMA_VERSION_DOC: &str = "\
-
+const SCHEMA_VERSION_DOC: &str = "
 # Format version of this file. Atlas manages it; leave it alone.
 ";
 
@@ -795,8 +799,8 @@ pub struct ConfigManager {
 }
 
 impl ConfigManager {
-    pub fn config_path(app: &AppHandle) -> Option<PathBuf> {
-        app.path().app_config_dir().ok().map(|d| d.join(CONFIG_FILE_NAME))
+    pub fn config_path() -> Option<PathBuf> {
+        config_root().map(|d| d.join(CONFIG_FILE_NAME))
     }
 
     pub fn path(&self) -> &Path {
@@ -860,16 +864,15 @@ impl ConfigManager {
     /// Never blocks boot — malformed or missing content degrades to
     /// `AppSettings::default()`, exactly like `AppState::load`'s existing
     /// `unwrap_or_default()` behavior for `state.json`.
-    pub fn load(app: &AppHandle) -> Self {
-        let Some(path) = Self::config_path(app) else {
+    pub fn load() -> Self {
+        let Some(path) = Self::config_path() else {
             return Self::in_memory_defaults(PathBuf::from(CONFIG_FILE_NAME));
         };
         Self::load_at(path)
     }
 
     /// The path-only half of `load` — split out so `bootstrap_at` (and its
-    /// tests) can exercise the real cold-start behavior without needing a
-    /// live `AppHandle`/`app_config_dir` to resolve a path from.
+    /// tests) can exercise the real cold-start behavior against a temp dir.
     fn load_at(path: PathBuf) -> Self {
         match fs::read_to_string(&path) {
             Ok(raw) => Self::from_raw(path.clone(), &raw).unwrap_or_else(|e| {
@@ -1123,6 +1126,43 @@ fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// `~/.config/atlas/` — deliberately NOT Tauri's `app_config_dir()`, which on
+/// macOS is `~/Library/Application Support/dev.atlas.ide/`.
+///
+/// `config.toml` is meant to be opened, read and hand-edited, by a person or
+/// by an agent; a path they can type is part of that, and a bundle id buried
+/// under `Application Support` is not. Zed makes the same call for the same
+/// reason (`~/.config/zed/settings.json` on macOS), and it puts Atlas's config
+/// beside every other tool a developer already keeps under `~/.config`.
+///
+/// This is a split, not a move: everything else Atlas persists —
+/// `state.json`, `device.json`, `telemetry.json`, the models-pricing cache,
+/// session chat — stays in the platform data directory. Those are
+/// machine-managed state, not documents, and nobody should be editing them.
+fn config_root() -> Option<PathBuf> {
+    let xdg = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+    let home = dirs::home_dir().or_else(|| std::env::var_os("HOME").map(PathBuf::from));
+    config_root_from(xdg.as_deref(), home.as_deref())
+}
+
+/// The decision itself, taking its inputs rather than reading the environment,
+/// so it can be tested without racing every other test in the process over
+/// `set_var`.
+///
+/// `$XDG_CONFIG_HOME` wins when it is set to an absolute path — the convention
+/// everywhere the variable means anything, and how a user relocates config for
+/// every other tool they run. A relative value is ignored rather than resolved
+/// against the cwd: the cwd of a GUI app launched from Finder is arbitrary,
+/// and writing config into it would be worse than falling back.
+fn config_root_from(xdg: Option<&Path>, home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(xdg) = xdg {
+        if xdg.is_absolute() {
+            return Some(xdg.join(CONFIG_DIR_NAME));
+        }
+    }
+    home.map(|home| home.join(".config").join(CONFIG_DIR_NAME))
+}
+
 /// Thread-safe handle registered as Tauri managed state, mirroring
 /// `AppStateHandle`'s shape.
 pub type AtlasConfigHandle = Arc<Mutex<ConfigManager>>;
@@ -1178,15 +1218,14 @@ pub struct MigrationOutcome {
 }
 
 pub fn bootstrap(
-    app: &AppHandle,
     marker_already_set: bool,
     legacy_settings_raw: Option<serde_json::Value>,
 ) -> MigrationOutcome {
-    let Some(path) = ConfigManager::config_path(app) else {
+    let Some(path) = ConfigManager::config_path() else {
         // No resolvable config dir at all (no $HOME / no %APPDATA%). Defaults
         // keep the app usable, but this is a failure and must reach the
         // banner rather than passing for a healthy load.
-        let mut manager = ConfigManager::load(app);
+        let mut manager = ConfigManager::load();
         manager.status = ConfigStatus::UsingDefaults {
             error: "could not resolve the Atlas config directory".to_string(),
         };
@@ -1196,9 +1235,8 @@ pub fn bootstrap(
 }
 
 /// The actual migration decision, split out from `bootstrap` so it's
-/// testable against a real temp-dir path without needing a live `AppHandle`
-/// to resolve one from — `ConfigManager::config_path` requires a running
-/// Tauri app, which `#[cfg(test)]` here has no way to construct.
+/// testable against a real temp-dir path rather than whatever
+/// `config_root()` resolves to on the machine running the tests.
 fn bootstrap_at(
     path: PathBuf,
     marker_already_set: bool,
@@ -1268,6 +1306,53 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("atlas-config-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&dir).unwrap();
         dir.join(CONFIG_FILE_NAME)
+    }
+
+    // ── config_root (issue #64 follow-up: ~/.config/atlas, not the bundle id) ──
+
+    #[test]
+    fn config_lives_under_dot_config_atlas_not_the_bundle_id() {
+        let home = PathBuf::from("/Users/someone");
+        let root = config_root_from(None, Some(&home)).expect("a home resolves a root");
+
+        assert_eq!(root, PathBuf::from("/Users/someone/.config/atlas"));
+        assert_eq!(root.join(CONFIG_FILE_NAME), PathBuf::from("/Users/someone/.config/atlas/config.toml"));
+        // The whole point: nothing here reads `dev.atlas.ide`.
+        assert!(!root.to_string_lossy().contains("dev.atlas.ide"));
+        assert!(!root.to_string_lossy().contains("Application Support"));
+    }
+
+    /// `$XDG_CONFIG_HOME` is how a user relocates config for every other tool
+    /// they run; honouring it is the price of living in `~/.config`.
+    #[test]
+    fn an_absolute_xdg_config_home_wins() {
+        let xdg = PathBuf::from("/elsewhere/cfg");
+        let home = PathBuf::from("/Users/someone");
+
+        let root = config_root_from(Some(&xdg), Some(&home)).unwrap();
+
+        assert_eq!(root, PathBuf::from("/elsewhere/cfg/atlas"));
+    }
+
+    /// A relative `$XDG_CONFIG_HOME` is ignored rather than resolved against
+    /// the cwd — a GUI app launched from Finder has an arbitrary one, and
+    /// writing config into it is worse than falling back to `$HOME`.
+    #[test]
+    fn a_relative_xdg_config_home_is_ignored() {
+        let xdg = PathBuf::from("relative/cfg");
+        let home = PathBuf::from("/Users/someone");
+
+        let root = config_root_from(Some(&xdg), Some(&home)).unwrap();
+
+        assert_eq!(root, PathBuf::from("/Users/someone/.config/atlas"));
+    }
+
+    /// No home and no usable XDG: there is nowhere to put it, and `load`
+    /// degrades to in-memory defaults rather than inventing a path.
+    #[test]
+    fn no_home_and_no_xdg_resolves_nothing() {
+        assert_eq!(config_root_from(None, None), None);
+        assert_eq!(config_root_from(Some(&PathBuf::from("rel")), None), None);
     }
 
     #[test]

--- a/src-tauri/src/state/atlas_config.rs
+++ b/src-tauri/src/state/atlas_config.rs
@@ -1,0 +1,1234 @@
+//! `AtlasConfig` — the human- and agent-editable settings file.
+//!
+//! Replaces `AppState.settings` (formerly the `settings` object inside
+//! `state.json`). Lives at `<app_config_dir>/config.toml`: TOML rather than
+//! JSON specifically so the file can carry comments, and so a patch (from the
+//! Settings UI or the `atlas-self-configure` skill) can preserve them —
+//! `toml_edit` edits the document key-by-key instead of reserializing the
+//! whole thing the way a JSON round-trip would.
+//!
+//! Two representations are kept in sync inside [`ConfigManager`]:
+//!   - `document` (`toml_edit::DocumentMut`) — the actual on-disk text,
+//!     mutated key-by-key so untouched comments/formatting/unknown keys
+//!     survive a patch.
+//!   - `effective` ([`AppSettings`]) — the typed, validated snapshot every
+//!     other module reads. Derived from `document` by round-tripping through
+//!     `toml` (cheap; this file is a few hundred bytes).
+//!
+//! Validation is all-or-nothing: a candidate document is parsed and validated
+//! in full before it ever replaces `effective` or touches disk. A malformed
+//! external edit — or a bad patch — never displaces the last-known-good state,
+//! and this module never repairs/renames/overwrites a malformed file on its
+//! own; [`ConfigManager::reset`] is the sole authorized "recreate defaults"
+//! path, and it backs up whatever was there first.
+//!
+//! Scope (see the issue #64 design record): only the preferences that used to
+//! live in `AppState.settings` move here. Telemetry identity (`device.json`),
+//! the self-hosted PostHog override (`telemetry.json`), and BYOK (the user's
+//! shell profile) are deliberately untouched — their separation from
+//! coarse-write settings state already fixed a real bug (see
+//! `crate::telemetry::device`) or was never Atlas-owned to begin with.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Deserializer, Serialize};
+use tauri::{AppHandle, Manager};
+
+/// Schema version of `config.toml` itself — independent of `state.json`'s
+/// `AppState::SCHEMA_VERSION`. The two files describe different domains and
+/// evolve on their own timelines; coupling them would make "what does version
+/// N mean" ambiguous.
+pub const CONFIG_SCHEMA_VERSION: u32 = 1;
+
+pub const CONFIG_FILE_NAME: &str = "config.toml";
+
+/// Mirrors `MIN_SCALE`/`MAX_SCALE` in
+/// `src/features/settings/lib/ui-scale.ts` — kept in sync manually since the
+/// frontend clamp and this validation gate the same field from two ends.
+pub const MIN_UI_SCALE: f32 = 0.5;
+pub const MAX_UI_SCALE: f32 = 2.0;
+
+// ---------------------------------------------------------------------------
+// AppSettings
+// ---------------------------------------------------------------------------
+
+/// Adaptive next-step suggestion chips in the agent chat's per-turn card.
+/// Strict on the live config file (`agent` | `off` only) — the legacy
+/// `"parse"`/`"llm"` values only ever existed in old `state.json` payloads
+/// and are normalized to `Agent` once, during migration
+/// (see [`adaptive_suggestions_from_legacy`]), not accepted ongoing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AdaptiveSuggestions {
+    Agent,
+    Off,
+}
+
+impl Default for AdaptiveSuggestions {
+    fn default() -> Self {
+        Self::Agent
+    }
+}
+
+/// User-facing toggles surfaced in Settings → General. Moved out of
+/// `state.json`'s `AppState.settings` (issue #64) into its own validated,
+/// human-editable `config.toml`.
+///
+/// New fields MUST be `#[serde(default = "…")]` or have an obvious zero value
+/// so older `config.toml` files (written before the field existed) load
+/// cleanly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppSettings {
+    /// On project open, ensure `.atlas/` is listed in the project's
+    /// `.gitignore` (creating the file if needed). No-op on non-git
+    /// projects. Default ON because Atlas writes caches / state into
+    /// `.atlas/` that don't belong in version control.
+    #[serde(default = "default_true")]
+    pub auto_add_atlas_gitignore: bool,
+    /// Record Atlas-internal events (sign-in, agent start/finish,
+    /// browser/file open, etc.) into the Logs panel under the `atlas`
+    /// source. Default ON so early users can share their logs without
+    /// flipping a flag first.
+    #[serde(default = "default_true")]
+    pub enable_atlas_logs: bool,
+    /// Show dotfiles / dot-directories (e.g. `.git`, `.atlas`, `.env`) in
+    /// the explorer file tree. Default ON so nothing is silently hidden;
+    /// users who want a cleaner tree can turn it off.
+    #[serde(default = "default_true")]
+    pub show_hidden_files: bool,
+    /// Global interface zoom (1.0 == 100%). Applied via the native WebView zoom
+    /// on the frontend (⌘+/⌘-/⌘0); persisted so it survives relaunch.
+    #[serde(default = "default_ui_scale")]
+    pub ui_scale: f32,
+    /// Anonymous product telemetry (PostHog). Default **ON** (opt-out, like
+    /// VS Code / Zed) — privacy-preserving metadata only; the user can turn it
+    /// off anytime in Settings → General. Gates both the Rust emitter and the
+    /// frontend `posthog-js` crash reporter. Still inert unless a key resolves.
+    /// See `crate::telemetry`.
+    #[serde(default = "default_true")]
+    pub share_telemetry: bool,
+    /// Attribute telemetry to the signed-in Atlas account (PostHog `$identify`),
+    /// rather than keeping it on the anonymous per-device person. Default **ON**,
+    /// and irrelevant while signed out or while `share_telemetry` is off — both
+    /// gate this. See `crate::telemetry`.
+    #[serde(default = "default_true")]
+    pub link_telemetry_to_account: bool,
+    /// Selected on-device **embedding** model id (== its dir name under
+    /// `app_data/models/`). Drives `memory_graph::model_dir` and every embedding
+    /// consumer via the shared provider. See `crate::commands::models`.
+    #[serde(default = "default_embedding_model")]
+    pub embedding_model_id: String,
+    /// Code-editor color theme id (see `src/features/editor/themes`).
+    #[serde(default = "default_code_editor_theme")]
+    pub code_editor_theme: String,
+    /// Atlas interface-theme id (see `src/features/theme/themes`).
+    #[serde(default = "default_atlas_theme")]
+    pub atlas_theme: String,
+    /// "agent" (default) asks the coding agent to end each reply with a hidden
+    /// `<next_steps>` block; "off" disables it.
+    #[serde(default)]
+    pub adaptive_suggestions: AdaptiveSuggestions,
+    /// Inline Git blame in the code editor. Default ON; when off the editor
+    /// doesn't even load the extension (no blame IPC).
+    #[serde(default = "default_true")]
+    pub git_blame_inline: bool,
+    /// Auto-update master switch. See `crate::commands::updater`.
+    #[serde(default = "default_true")]
+    pub auto_update: bool,
+    /// A version the user chose to "Ignore" in the update prompt. `None` =
+    /// nothing ignored. Absent from the TOML file rather than written as a
+    /// sentinel empty string — TOML has no native null, and an absent key is
+    /// the idiomatic way to express "unset".
+    #[serde(default)]
+    pub updater_ignored_version: Option<String>,
+    /// Chat composer send gesture. Default ON: Enter sends, Shift+Enter
+    /// inserts a newline. Cmd/Ctrl+Enter always sends regardless.
+    #[serde(default = "default_true")]
+    pub enter_to_send: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+pub fn default_code_editor_theme() -> String {
+    "atlas".to_string()
+}
+
+pub fn default_atlas_theme() -> String {
+    "atlas-black".to_string()
+}
+
+pub fn default_embedding_model() -> String {
+    "all-MiniLM-L6-v2".to_string()
+}
+
+pub fn default_ui_scale() -> f32 {
+    1.0
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            auto_add_atlas_gitignore: true,
+            enable_atlas_logs: true,
+            show_hidden_files: true,
+            ui_scale: default_ui_scale(),
+            share_telemetry: true,
+            link_telemetry_to_account: true,
+            embedding_model_id: default_embedding_model(),
+            code_editor_theme: default_code_editor_theme(),
+            atlas_theme: default_atlas_theme(),
+            adaptive_suggestions: AdaptiveSuggestions::default(),
+            git_blame_inline: true,
+            auto_update: true,
+            updater_ignored_version: None,
+            enter_to_send: true,
+        }
+    }
+}
+
+/// The full set of keys `AppSettings` knows about, in wire (camelCase) form.
+/// Used to flag anything else in `[settings]` as an unknown key — preserved
+/// on disk and surfaced as a diagnostic, never treated as an error.
+const KNOWN_SETTINGS_KEYS: &[&str] = &[
+    "autoAddAtlasGitignore",
+    "enableAtlasLogs",
+    "showHiddenFiles",
+    "uiScale",
+    "shareTelemetry",
+    "linkTelemetryToAccount",
+    "embeddingModelId",
+    "codeEditorTheme",
+    "atlasTheme",
+    "adaptiveSuggestions",
+    "gitBlameInline",
+    "autoUpdate",
+    "updaterIgnoredVersion",
+    "enterToSend",
+];
+
+/// One field failed semantic validation. Structural validation only —
+/// deliberately NOT a full theme-id/embedding-model-id catalog membership
+/// check: that catalog is frontend-owned (`src/features/theme/themes.ts`,
+/// `src/features/editor/themes/themes.ts`) and duplicating it into Rust would
+/// create a second place both lists must stay in sync, trading one drift bug
+/// (the `adaptiveSuggestions` gap this issue fixes) for another. Garbage
+/// (empty/non-finite) is still rejected; an unrecognized-but-well-formed id
+/// is accepted and left for the frontend to fall back on, same as it does
+/// today for a theme id from a newer Atlas version.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationIssue {
+    pub key: &'static str,
+    pub message: String,
+}
+
+pub fn validate(settings: &AppSettings) -> Result<(), ValidationIssue> {
+    if !settings.ui_scale.is_finite()
+        || settings.ui_scale < MIN_UI_SCALE
+        || settings.ui_scale > MAX_UI_SCALE
+    {
+        return Err(ValidationIssue {
+            key: "uiScale",
+            message: format!(
+                "must be a finite number between {MIN_UI_SCALE} and {MAX_UI_SCALE}, got {}",
+                settings.ui_scale
+            ),
+        });
+    }
+    if settings.embedding_model_id.trim().is_empty() {
+        return Err(ValidationIssue {
+            key: "embeddingModelId",
+            message: "must not be empty".to_string(),
+        });
+    }
+    if settings.code_editor_theme.trim().is_empty() {
+        return Err(ValidationIssue {
+            key: "codeEditorTheme",
+            message: "must not be empty".to_string(),
+        });
+    }
+    if settings.atlas_theme.trim().is_empty() {
+        return Err(ValidationIssue {
+            key: "atlasTheme",
+            message: "must not be empty".to_string(),
+        });
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// On-disk document shape
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AtlasConfigFile {
+    #[serde(default = "default_config_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    settings: AppSettings,
+}
+
+fn default_config_schema_version() -> u32 {
+    CONFIG_SCHEMA_VERSION
+}
+
+fn unknown_keys_in(document: &toml_edit::DocumentMut) -> Vec<String> {
+    let Some(table) = document.get("settings").and_then(|i| i.as_table()) else {
+        return Vec::new();
+    };
+    table
+        .iter()
+        .map(|(k, _)| k.to_string())
+        .filter(|k| !KNOWN_SETTINGS_KEYS.contains(&k.as_str()))
+        .collect()
+}
+
+fn document_for(settings: &AppSettings) -> toml_edit::DocumentMut {
+    let file = AtlasConfigFile { schema_version: CONFIG_SCHEMA_VERSION, settings: settings.clone() };
+    let text = toml::to_string_pretty(&file).expect("AppSettings always serializes to TOML");
+    text.parse().expect("freshly-generated TOML always parses")
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigError {
+    Io(String),
+    Parse(String),
+    Invalid(ValidationIssue),
+    UnsupportedVersion(u32),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::Io(e) => write!(f, "{e}"),
+            ConfigError::Parse(e) => write!(f, "config.toml is not valid TOML: {e}"),
+            ConfigError::Invalid(issue) => {
+                write!(f, "config.toml: `{}` {}", issue.key, issue.message)
+            }
+            ConfigError::UnsupportedVersion(v) => write!(
+                f,
+                "config.toml has schemaVersion {v}, newer than this Atlas build supports ({CONFIG_SCHEMA_VERSION}) — it was likely created by a newer Atlas version"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+// ---------------------------------------------------------------------------
+// Patch (partial update from the UI, the self-configure skill's writes go
+// straight to disk and are picked up by the watcher instead of this path)
+// ---------------------------------------------------------------------------
+
+/// Deserializes a JSON field into `Option<Option<T>>`: key absent stays
+/// `None` (untouched, via `#[serde(default)]` on the field), key present
+/// (even as `null`) becomes `Some(inner)`. A plain `Option<T>` can't tell
+/// "don't touch this field" apart from "clear it" — both arrive as an absent
+/// key vs. `null` on the wire, but `#[serde(default)]` alone collapses both
+/// to `None`. Only used for `updater_ignored_version`, the one field where
+/// clearing (`Some(None)`) is a real, distinct action from leaving it alone.
+fn deserialize_double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
+}
+
+/// A partial settings update — every field optional so a UI/skill edit can
+/// touch exactly the key it means to change, leaving everything else (and
+/// its comments/formatting) alone.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsPatch {
+    pub auto_add_atlas_gitignore: Option<bool>,
+    pub enable_atlas_logs: Option<bool>,
+    pub show_hidden_files: Option<bool>,
+    pub ui_scale: Option<f32>,
+    pub share_telemetry: Option<bool>,
+    pub link_telemetry_to_account: Option<bool>,
+    pub embedding_model_id: Option<String>,
+    pub code_editor_theme: Option<String>,
+    pub atlas_theme: Option<String>,
+    pub adaptive_suggestions: Option<AdaptiveSuggestions>,
+    pub git_blame_inline: Option<bool>,
+    pub auto_update: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub updater_ignored_version: Option<Option<String>>,
+    pub enter_to_send: Option<bool>,
+}
+
+impl SettingsPatch {
+    fn apply_to(&self, settings: &mut AppSettings) {
+        if let Some(v) = self.auto_add_atlas_gitignore {
+            settings.auto_add_atlas_gitignore = v;
+        }
+        if let Some(v) = self.enable_atlas_logs {
+            settings.enable_atlas_logs = v;
+        }
+        if let Some(v) = self.show_hidden_files {
+            settings.show_hidden_files = v;
+        }
+        if let Some(v) = self.ui_scale {
+            settings.ui_scale = v;
+        }
+        if let Some(v) = self.share_telemetry {
+            settings.share_telemetry = v;
+        }
+        if let Some(v) = self.link_telemetry_to_account {
+            settings.link_telemetry_to_account = v;
+        }
+        if let Some(v) = &self.embedding_model_id {
+            settings.embedding_model_id = v.clone();
+        }
+        if let Some(v) = &self.code_editor_theme {
+            settings.code_editor_theme = v.clone();
+        }
+        if let Some(v) = &self.atlas_theme {
+            settings.atlas_theme = v.clone();
+        }
+        if let Some(v) = self.adaptive_suggestions {
+            settings.adaptive_suggestions = v;
+        }
+        if let Some(v) = self.git_blame_inline {
+            settings.git_blame_inline = v;
+        }
+        if let Some(v) = self.auto_update {
+            settings.auto_update = v;
+        }
+        if let Some(v) = &self.updater_ignored_version {
+            settings.updater_ignored_version = v.clone();
+        }
+        if let Some(v) = self.enter_to_send {
+            settings.enter_to_send = v;
+        }
+    }
+
+    /// Mutate only the touched keys of `doc["settings"]` — everything else
+    /// (comments, ordering, unknown keys, untouched values) is left exactly
+    /// as `toml_edit` parsed it.
+    fn write_into(&self, doc: &mut toml_edit::DocumentMut) {
+        if doc.get("settings").and_then(|i| i.as_table()).is_none() {
+            doc["settings"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        let table = doc["settings"].as_table_mut().expect("just ensured settings is a table");
+
+        macro_rules! set_bool {
+            ($field:ident, $key:literal) => {
+                if let Some(v) = self.$field {
+                    table[$key] = toml_edit::value(v);
+                }
+            };
+        }
+        set_bool!(auto_add_atlas_gitignore, "autoAddAtlasGitignore");
+        set_bool!(enable_atlas_logs, "enableAtlasLogs");
+        set_bool!(show_hidden_files, "showHiddenFiles");
+        set_bool!(share_telemetry, "shareTelemetry");
+        set_bool!(link_telemetry_to_account, "linkTelemetryToAccount");
+        set_bool!(git_blame_inline, "gitBlameInline");
+        set_bool!(auto_update, "autoUpdate");
+        set_bool!(enter_to_send, "enterToSend");
+
+        if let Some(v) = self.ui_scale {
+            table["uiScale"] = toml_edit::value(f64::from(v));
+        }
+        if let Some(v) = &self.embedding_model_id {
+            table["embeddingModelId"] = toml_edit::value(v.as_str());
+        }
+        if let Some(v) = &self.code_editor_theme {
+            table["codeEditorTheme"] = toml_edit::value(v.as_str());
+        }
+        if let Some(v) = &self.atlas_theme {
+            table["atlasTheme"] = toml_edit::value(v.as_str());
+        }
+        if let Some(v) = self.adaptive_suggestions {
+            let s = match v {
+                AdaptiveSuggestions::Agent => "agent",
+                AdaptiveSuggestions::Off => "off",
+            };
+            table["adaptiveSuggestions"] = toml_edit::value(s);
+        }
+        if let Some(inner) = &self.updater_ignored_version {
+            match inner {
+                Some(v) => table["updaterIgnoredVersion"] = toml_edit::value(v.as_str()),
+                None => {
+                    table.remove("updaterIgnoredVersion");
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy migration (state.json.settings -> config.toml, one time)
+// ---------------------------------------------------------------------------
+
+/// Legacy `state.json` carried `adaptiveSuggestions` values from before it was
+/// a closed enum (`"parse"`, `"llm"`) — both meant "on" under the old
+/// free-form implementation. Anything except an exact `"off"` normalizes to
+/// `Agent`, matching that prior behavior; a missing/absent value also
+/// defaults to `Agent`, same as [`AppSettings::default`].
+fn adaptive_suggestions_from_legacy(raw: Option<&serde_json::Value>) -> AdaptiveSuggestions {
+    match raw.and_then(|v| v.as_str()) {
+        Some("off") => AdaptiveSuggestions::Off,
+        _ => AdaptiveSuggestions::Agent,
+    }
+}
+
+/// Extract an `AppSettings` from the raw JSON `settings` object of a legacy
+/// `state.json` (i.e. `AppState.settings` before it was removed). Field-by-
+/// field with a default fallback, deliberately not a single
+/// `serde_json::from_value::<AppSettings>` — that would hard-fail the whole
+/// struct the moment it hit the old free-form `adaptiveSuggestions` string,
+/// discarding every other perfectly-good legacy value along with it.
+pub fn settings_from_legacy_json(raw: Option<&serde_json::Value>) -> AppSettings {
+    let mut settings = AppSettings::default();
+    let Some(raw) = raw else {
+        return settings;
+    };
+
+    macro_rules! take_bool {
+        ($field:ident, $key:literal) => {
+            if let Some(v) = raw.get($key).and_then(serde_json::Value::as_bool) {
+                settings.$field = v;
+            }
+        };
+    }
+    take_bool!(auto_add_atlas_gitignore, "autoAddAtlasGitignore");
+    take_bool!(enable_atlas_logs, "enableAtlasLogs");
+    take_bool!(show_hidden_files, "showHiddenFiles");
+    take_bool!(share_telemetry, "shareTelemetry");
+    take_bool!(link_telemetry_to_account, "linkTelemetryToAccount");
+    take_bool!(git_blame_inline, "gitBlameInline");
+    take_bool!(auto_update, "autoUpdate");
+    take_bool!(enter_to_send, "enterToSend");
+
+    if let Some(v) = raw.get("uiScale").and_then(serde_json::Value::as_f64) {
+        let v = v as f32;
+        if v.is_finite() && (MIN_UI_SCALE..=MAX_UI_SCALE).contains(&v) {
+            settings.ui_scale = v;
+        }
+    }
+    if let Some(v) = raw.get("embeddingModelId").and_then(serde_json::Value::as_str) {
+        if !v.trim().is_empty() {
+            settings.embedding_model_id = v.to_string();
+        }
+    }
+    if let Some(v) = raw.get("codeEditorTheme").and_then(serde_json::Value::as_str) {
+        if !v.trim().is_empty() {
+            settings.code_editor_theme = v.to_string();
+        }
+    }
+    if let Some(v) = raw.get("atlasTheme").and_then(serde_json::Value::as_str) {
+        if !v.trim().is_empty() {
+            settings.atlas_theme = v.to_string();
+        }
+    }
+    if let Some(v) = raw.get("updaterIgnoredVersion").and_then(serde_json::Value::as_str) {
+        settings.updater_ignored_version = Some(v.to_string());
+    }
+    settings.adaptive_suggestions = adaptive_suggestions_from_legacy(raw.get("adaptiveSuggestions"));
+
+    settings
+}
+
+// ---------------------------------------------------------------------------
+// ConfigManager
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigStatus {
+    Ok,
+    /// A hot-reload (external edit) failed; `effective` still holds the
+    /// previous, in-process-validated settings.
+    UsingLastKnownGood { error: String },
+    /// Cold start found no valid file (missing or malformed); `effective` is
+    /// `AppSettings::default()`. The malformed file, if any, is left
+    /// untouched on disk.
+    UsingDefaults { error: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigSnapshot {
+    pub settings: AppSettings,
+    pub generation: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum UpdateOutcome {
+    /// The patch applied and was persisted.
+    Applied { settings: AppSettings, generation: u64 },
+    /// `expected_generation` was stale — nothing was written. `settings`
+    /// carries what's actually on disk now so the caller can reconcile.
+    Conflict { settings: AppSettings, generation: u64 },
+}
+
+#[derive(Debug)]
+pub struct ConfigManager {
+    path: PathBuf,
+    document: toml_edit::DocumentMut,
+    effective: AppSettings,
+    /// Raw bytes of the last content this manager itself considers current —
+    /// used both to dedup the file watcher's self-write echo and as the base
+    /// a patch re-reads before merging.
+    last_raw: String,
+    generation: u64,
+    status: ConfigStatus,
+    unknown_keys: Vec<String>,
+}
+
+impl ConfigManager {
+    pub fn config_path(app: &AppHandle) -> Option<PathBuf> {
+        app.path().app_config_dir().ok().map(|d| d.join(CONFIG_FILE_NAME))
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn effective(&self) -> &AppSettings {
+        &self.effective
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn status(&self) -> &ConfigStatus {
+        &self.status
+    }
+
+    pub fn unknown_keys(&self) -> &[String] {
+        &self.unknown_keys
+    }
+
+    fn in_memory_defaults(path: PathBuf) -> Self {
+        let settings = AppSettings::default();
+        let document = document_for(&settings);
+        Self {
+            path,
+            document,
+            effective: settings,
+            last_raw: String::new(),
+            generation: 0,
+            status: ConfigStatus::Ok,
+            unknown_keys: Vec::new(),
+        }
+    }
+
+    fn from_raw(path: PathBuf, raw: &str) -> Result<Self, ConfigError> {
+        let document: toml_edit::DocumentMut =
+            raw.parse().map_err(|e: toml_edit::TomlError| ConfigError::Parse(e.to_string()))?;
+        let text = document.to_string();
+        let file: AtlasConfigFile =
+            toml::from_str(&text).map_err(|e| ConfigError::Parse(e.to_string()))?;
+        if file.schema_version > CONFIG_SCHEMA_VERSION {
+            return Err(ConfigError::UnsupportedVersion(file.schema_version));
+        }
+        validate(&file.settings).map_err(ConfigError::Invalid)?;
+        let unknown_keys = unknown_keys_in(&document);
+        Ok(Self {
+            path,
+            document,
+            effective: file.settings,
+            last_raw: raw.to_string(),
+            generation: 0,
+            status: ConfigStatus::Ok,
+            unknown_keys,
+        })
+    }
+
+    /// Cold-start entry point: read whatever is on disk (or nothing) and
+    /// return a manager whose `effective` is always immediately usable.
+    /// Never blocks boot — malformed or missing content degrades to
+    /// `AppSettings::default()`, exactly like `AppState::load`'s existing
+    /// `unwrap_or_default()` behavior for `state.json`.
+    pub fn load(app: &AppHandle) -> Self {
+        let Some(path) = Self::config_path(app) else {
+            return Self::in_memory_defaults(PathBuf::from(CONFIG_FILE_NAME));
+        };
+        Self::load_at(path)
+    }
+
+    /// The path-only half of `load` — split out so `bootstrap_at` (and its
+    /// tests) can exercise the real cold-start behavior without needing a
+    /// live `AppHandle`/`app_config_dir` to resolve a path from.
+    fn load_at(path: PathBuf) -> Self {
+        match fs::read_to_string(&path) {
+            Ok(raw) => Self::from_raw(path.clone(), &raw).unwrap_or_else(|e| {
+                tracing::warn!(
+                    target: "atlas::config",
+                    "config.toml invalid at cold start, serving defaults in memory (file left untouched): {e}"
+                );
+                let mut mgr = Self::in_memory_defaults(path);
+                mgr.status = ConfigStatus::UsingDefaults { error: e.to_string() };
+                mgr
+            }),
+            // File genuinely absent — the normal pre-first-write state, not
+            // an error. `bootstrap` below is what decides whether that's
+            // "needs migration" or "already migrated, stay on defaults".
+            Err(_) => Self::in_memory_defaults(path),
+        }
+    }
+
+    /// Re-read disk. `Ok(true)` = adopted new (different, valid) content,
+    /// `Ok(false)` = unchanged or the file doesn't exist, `Err` = the file is
+    /// malformed. On the error path, `effective`/`document`/`last_raw` are
+    /// left completely untouched — that's what stops a bad external edit
+    /// from ever reaching them — but `status` DOES move to
+    /// `UsingLastKnownGood` so callers (the Settings UI, `get_atlas_config_info`)
+    /// can see that the on-disk file is currently broken even though the
+    /// in-memory settings are still the last good ones.
+    pub fn reload_from_disk(&mut self) -> Result<bool, ConfigError> {
+        let raw = match fs::read_to_string(&self.path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(ConfigError::Io(e.to_string())),
+        };
+        if raw == self.last_raw {
+            return Ok(false);
+        }
+        let fresh = match Self::from_raw(self.path.clone(), &raw) {
+            Ok(fresh) => fresh,
+            Err(e) => {
+                self.status = ConfigStatus::UsingLastKnownGood { error: e.to_string() };
+                return Err(e);
+            }
+        };
+        self.document = fresh.document;
+        self.effective = fresh.effective;
+        self.last_raw = fresh.last_raw;
+        self.unknown_keys = fresh.unknown_keys;
+        self.generation += 1;
+        self.status = ConfigStatus::Ok;
+        Ok(true)
+    }
+
+    /// Apply a partial update. Always re-reads disk first (closing the race
+    /// between an external edit and this write); rejects outright rather than
+    /// clobbering if that re-read finds a malformed file.
+    ///
+    /// `expected_generation`: `None` for internal Rust-side callers
+    /// (`commands::updater`, `commands::models`) that only ever race the
+    /// filesystem, never a second in-app editor — always applies, matching
+    /// their pre-existing last-write-wins semantics against the old
+    /// `AppStateHandle` mutex. `Some(g)` for the IPC command, which enforces
+    /// the optimistic check against a UI that may be editing a stale
+    /// snapshot.
+    pub fn apply_patch(
+        &mut self,
+        patch: &SettingsPatch,
+        expected_generation: Option<u64>,
+    ) -> Result<UpdateOutcome, ConfigError> {
+        self.reload_from_disk()?;
+
+        if let Some(expected) = expected_generation {
+            if expected != self.generation {
+                return Ok(UpdateOutcome::Conflict {
+                    settings: self.effective.clone(),
+                    generation: self.generation,
+                });
+            }
+        }
+
+        let mut candidate = self.effective.clone();
+        patch.apply_to(&mut candidate);
+        validate(&candidate).map_err(ConfigError::Invalid)?;
+
+        let mut doc = self.document.clone();
+        patch.write_into(&mut doc);
+        doc["schemaVersion"] = toml_edit::value(i64::from(CONFIG_SCHEMA_VERSION));
+
+        let text = doc.to_string();
+        write_atomic(&self.path, &text).map_err(|e| ConfigError::Io(e.to_string()))?;
+
+        self.document = doc;
+        self.unknown_keys = unknown_keys_in(&self.document);
+        self.effective = candidate.clone();
+        self.last_raw = text;
+        self.generation += 1;
+        self.status = ConfigStatus::Ok;
+
+        Ok(UpdateOutcome::Applied { settings: candidate, generation: self.generation })
+    }
+
+    /// The sole path allowed to overwrite a malformed (or just unwanted)
+    /// file: back up whatever is currently on disk, then atomically write
+    /// fresh defaults.
+    pub fn reset(&mut self) -> Result<ConfigSnapshot, ConfigError> {
+        if let Ok(existing) = fs::read_to_string(&self.path) {
+            let stamp = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+            let backup = self.path.with_file_name(format!("{CONFIG_FILE_NAME}.bak-{stamp}"));
+            let _ = fs::write(&backup, existing);
+        }
+        let settings = AppSettings::default();
+        let document = document_for(&settings);
+        let text = document.to_string();
+        write_atomic(&self.path, &text).map_err(|e| ConfigError::Io(e.to_string()))?;
+
+        self.document = document;
+        self.effective = settings.clone();
+        self.last_raw = text;
+        self.generation += 1;
+        self.status = ConfigStatus::Ok;
+        self.unknown_keys.clear();
+
+        Ok(ConfigSnapshot { settings, generation: self.generation })
+    }
+
+    /// Write a specific `AppSettings` as a brand-new file (migration's entry
+    /// point — there is no existing document to preserve yet).
+    fn create_fresh_with(path: PathBuf, settings: AppSettings) -> Result<Self, ConfigError> {
+        let document = document_for(&settings);
+        let text = document.to_string();
+        write_atomic(&path, &text).map_err(|e| ConfigError::Io(e.to_string()))?;
+        Ok(Self {
+            path,
+            document,
+            effective: settings,
+            last_raw: text,
+            generation: 0,
+            status: ConfigStatus::Ok,
+            unknown_keys: Vec::new(),
+        })
+    }
+}
+
+/// Atomic write: a unique temp file in the same directory (so distinct UI
+/// writes, migration, and any external tooling can never collide on one
+/// fixed `.tmp` name), flushed then renamed over the target.
+fn write_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| CONFIG_FILE_NAME.to_string());
+    let unique = format!("{file_name}.tmp.{}", uuid::Uuid::new_v4());
+    let tmp = path.with_file_name(unique);
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path)
+}
+
+/// Thread-safe handle registered as Tauri managed state, mirroring
+/// `AppStateHandle`'s shape.
+pub type AtlasConfigHandle = Arc<Mutex<ConfigManager>>;
+
+/// Convenience read for call sites that only need the current settings
+/// snapshot (e.g. gating a background task at startup, or the Local Model
+/// Manager checking the selected embedding model).
+pub fn read(app: &AppHandle) -> AppSettings {
+    app.state::<AtlasConfigHandle>().lock().effective().clone()
+}
+
+/// Apply a patch from Rust-internal code — e.g. the Local Model Manager
+/// persisting a model switch, or the updater persisting an ignored version.
+/// Always applies (no optimistic `expected_generation` check, so this never
+/// returns `Conflict`): these callers only ever race the filesystem, never a
+/// second in-app editor, matching the pre-#64 last-write-wins semantics
+/// against the old `AppStateHandle` mutex.
+///
+/// Returns the committed snapshot (settings + generation) rather than just
+/// `AppSettings` so the caller can hand both to
+/// `commands::atlas_config::notify_settings_changed` — without that, an
+/// internal write bumps `ConfigManager`'s generation on disk but the
+/// frontend's mirrored `configGeneration` goes stale, and the live telemetry
+/// gate (`TelemetryClient::enabled`) never re-syncs to a changed
+/// `shareTelemetry`.
+pub fn update(app: &AppHandle, patch: SettingsPatch) -> Result<ConfigSnapshot, ConfigError> {
+    let handle = app.state::<AtlasConfigHandle>();
+    let mut guard = handle.lock();
+    match guard.apply_patch(&patch, None)? {
+        UpdateOutcome::Applied { settings, generation }
+        | UpdateOutcome::Conflict { settings, generation } => Ok(ConfigSnapshot { settings, generation }),
+    }
+}
+
+/// Startup orchestration: decide whether `config.toml` needs to be created
+/// from a legacy `state.json.settings`, and return the manager either way.
+///
+/// `marker_already_set` is `AppState`'s `settings_config_migrated` flag (v4).
+/// It exists because "does `config.toml` exist" is NOT the same question as
+/// "has migration already happened" — a user can delete `config.toml` on
+/// purpose after migrating, and this must never resurrect the old
+/// `state.json` settings when that happens. The marker is what tells those
+/// two cases apart.
+pub struct MigrationOutcome {
+    pub manager: ConfigManager,
+    /// Whether the caller should persist `settings_config_migrated = true`
+    /// into `state.json` (v4) after this call. Always `true` once this
+    /// returns — either the config already existed, or it was just created —
+    /// the only remaining question is whether the *caller* still needs to
+    /// write that fact down.
+    pub mark_migrated: bool,
+}
+
+pub fn bootstrap(
+    app: &AppHandle,
+    marker_already_set: bool,
+    legacy_settings_raw: Option<serde_json::Value>,
+) -> MigrationOutcome {
+    let Some(path) = ConfigManager::config_path(app) else {
+        return MigrationOutcome { manager: ConfigManager::load(app), mark_migrated: false };
+    };
+    bootstrap_at(path, marker_already_set, legacy_settings_raw)
+}
+
+/// The actual migration decision, split out from `bootstrap` so it's
+/// testable against a real temp-dir path without needing a live `AppHandle`
+/// to resolve one from — `ConfigManager::config_path` requires a running
+/// Tauri app, which `#[cfg(test)]` here has no way to construct.
+fn bootstrap_at(
+    path: PathBuf,
+    marker_already_set: bool,
+    legacy_settings_raw: Option<serde_json::Value>,
+) -> MigrationOutcome {
+    if path.exists() {
+        // Config already exists — never merge stale `state.json` settings
+        // into it, whether this is the first time we've seen it (a v3->v4
+        // upgrade that lands after a user hand-authored config.toml, or a
+        // manual restore) or the Nth.
+        return MigrationOutcome { manager: ConfigManager::load_at(path), mark_migrated: true };
+    }
+
+    // No file yet. Import from legacy state exactly once, ever.
+    let settings = if marker_already_set {
+        AppSettings::default()
+    } else {
+        settings_from_legacy_json(legacy_settings_raw.as_ref())
+    };
+
+    match ConfigManager::create_fresh_with(path.clone(), settings) {
+        Ok(manager) => MigrationOutcome { manager, mark_migrated: true },
+        Err(e) => {
+            tracing::warn!(target: "atlas::config", "failed to write migrated config.toml: {e}");
+            MigrationOutcome { manager: ConfigManager::load_at(path), mark_migrated: false }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh `config.toml` path inside its own temp directory, so parallel
+    /// tests never collide and `write_atomic`'s `create_dir_all` has
+    /// somewhere real to write the sibling `.tmp.<uuid>` file.
+    fn tmp_config_path() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("atlas-config-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join(CONFIG_FILE_NAME)
+    }
+
+    #[test]
+    fn defaults_pass_validation() {
+        assert!(validate(&AppSettings::default()).is_ok());
+    }
+
+    #[test]
+    fn missing_keys_fall_back_to_defaults() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 1\n\n[settings]\nenterToSend = false\n";
+        let mgr = ConfigManager::from_raw(path, raw).expect("partial file parses");
+        assert!(!mgr.effective().enter_to_send);
+        // Every other field is absent from the file — must be the compiled default.
+        assert_eq!(mgr.effective().atlas_theme, default_atlas_theme());
+        assert_eq!(mgr.effective().ui_scale, default_ui_scale());
+        assert!(mgr.effective().auto_update);
+    }
+
+    #[test]
+    fn file_missing_entirely_serves_defaults_without_error() {
+        let dir = std::env::temp_dir().join(format!("atlas-config-test-{}", uuid::Uuid::new_v4()));
+        // Deliberately do NOT create the dir/file.
+        let path = dir.join(CONFIG_FILE_NAME);
+        let mgr = ConfigManager::in_memory_defaults(path);
+        assert_eq!(mgr.status(), &ConfigStatus::Ok);
+        assert_eq!(mgr.effective(), &AppSettings::default());
+    }
+
+    #[test]
+    fn patch_preserves_comments_and_unknown_keys() {
+        let path = tmp_config_path();
+        let raw = "\
+# a user's own comment, must survive every patch
+schemaVersion = 1
+
+[settings]
+enterToSend = true
+someFutureKey = \"left alone\"
+";
+        fs::write(&path, raw).unwrap();
+        let mut mgr = ConfigManager::from_raw(path.clone(), raw).unwrap();
+        assert_eq!(mgr.unknown_keys(), &["someFutureKey".to_string()]);
+
+        let patch = SettingsPatch { enter_to_send: Some(false), ..Default::default() };
+        let outcome = mgr.apply_patch(&patch, None).expect("patch applies");
+        match outcome {
+            UpdateOutcome::Applied { settings, generation } => {
+                assert!(!settings.enter_to_send);
+                assert_eq!(generation, 1);
+            }
+            UpdateOutcome::Conflict { .. } => panic!("no expected_generation was given"),
+        }
+
+        let on_disk = fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("# a user's own comment, must survive every patch"));
+        assert!(on_disk.contains("someFutureKey = \"left alone\""));
+        assert!(on_disk.contains("enterToSend = false"));
+    }
+
+    #[test]
+    fn invalid_ui_scale_is_rejected_and_does_not_touch_disk() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 1\n\n[settings]\nenterToSend = true\n";
+        fs::write(&path, raw).unwrap();
+        let mut mgr = ConfigManager::from_raw(path.clone(), raw).unwrap();
+
+        let patch = SettingsPatch { ui_scale: Some(99.0), ..Default::default() };
+        let err = mgr.apply_patch(&patch, None).expect_err("out-of-range scale must be rejected");
+        assert!(matches!(err, ConfigError::Invalid(ref issue) if issue.key == "uiScale"));
+
+        // Untouched: neither in-memory nor on disk.
+        assert_eq!(mgr.effective().ui_scale, default_ui_scale());
+        assert_eq!(fs::read_to_string(&path).unwrap(), raw);
+    }
+
+    #[test]
+    fn unsupported_future_schema_version_is_rejected() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 99\n\n[settings]\n";
+        let err = ConfigManager::from_raw(path, raw).expect_err("future schema must be rejected");
+        assert_eq!(err, ConfigError::UnsupportedVersion(99));
+    }
+
+    #[test]
+    fn malformed_syntax_at_cold_start_serves_defaults_and_leaves_file_alone() {
+        let path = tmp_config_path();
+        let raw = "this is not [ valid toml";
+        fs::write(&path, raw).unwrap();
+
+        // `ConfigManager::load` needs a real AppHandle, so exercise the same
+        // fallback it uses directly against `from_raw`.
+        let err = ConfigManager::from_raw(path.clone(), raw).expect_err("garbage TOML must error");
+        assert!(matches!(err, ConfigError::Parse(_)));
+        // The malformed file itself is never touched by a failed parse.
+        assert_eq!(fs::read_to_string(&path).unwrap(), raw);
+    }
+
+    #[test]
+    fn malformed_external_edit_is_rejected_and_last_known_good_survives() {
+        let path = tmp_config_path();
+        let good = "schemaVersion = 1\n\n[settings]\nenterToSend = true\n";
+        fs::write(&path, good).unwrap();
+        let mut mgr = ConfigManager::from_raw(path.clone(), good).unwrap();
+
+        // Simulate an external editor leaving the file mid-save / broken.
+        fs::write(&path, "not toml at all {{{").unwrap();
+
+        let patch = SettingsPatch { enter_to_send: Some(false), ..Default::default() };
+        let err = mgr.apply_patch(&patch, None).expect_err("must refuse to write over a malformed file");
+        assert!(matches!(err, ConfigError::Parse(_)));
+        // In-memory last-known-good is untouched.
+        assert!(mgr.effective().enter_to_send);
+        // The malformed file was never overwritten by the rejected patch.
+        assert_eq!(fs::read_to_string(&path).unwrap(), "not toml at all {{{");
+        // But the status now reflects the on-disk file being broken.
+        assert!(matches!(mgr.status(), ConfigStatus::UsingLastKnownGood { .. }));
+    }
+
+    #[test]
+    fn stale_generation_reports_conflict_without_writing() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 1\n\n[settings]\nenterToSend = true\n";
+        fs::write(&path, raw).unwrap();
+        let mut mgr = ConfigManager::from_raw(path.clone(), raw).unwrap();
+
+        let patch = SettingsPatch { enter_to_send: Some(false), ..Default::default() };
+        let outcome = mgr.apply_patch(&patch, Some(mgr.generation() + 1)).expect("conflict is not an error");
+        match outcome {
+            UpdateOutcome::Conflict { settings, generation } => {
+                assert!(settings.enter_to_send); // unchanged
+                assert_eq!(generation, mgr.generation());
+            }
+            UpdateOutcome::Applied { .. } => panic!("stale generation must not apply"),
+        }
+        assert_eq!(fs::read_to_string(&path).unwrap(), raw);
+    }
+
+    #[test]
+    fn reload_from_disk_dedups_identical_content() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 1\n\n[settings]\nenterToSend = true\n";
+        fs::write(&path, raw).unwrap();
+        let mut mgr = ConfigManager::from_raw(path, raw).unwrap();
+        let gen_before = mgr.generation();
+        assert_eq!(mgr.reload_from_disk().unwrap(), false);
+        assert_eq!(mgr.generation(), gen_before);
+    }
+
+    #[test]
+    fn reset_backs_up_and_rewrites_defaults() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 1\n\n[settings]\nenterToSend = false\n";
+        fs::write(&path, raw).unwrap();
+        let mut mgr = ConfigManager::from_raw(path.clone(), raw).unwrap();
+
+        let snapshot = mgr.reset().expect("reset always succeeds");
+        assert_eq!(snapshot.settings, AppSettings::default());
+        assert_eq!(fs::read_to_string(&path).unwrap(), mgr.last_raw);
+
+        // A backup of the pre-reset content exists somewhere alongside it.
+        let dir = path.parent().unwrap();
+        let has_backup = fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().starts_with("config.toml.bak-"));
+        assert!(has_backup, "reset() must back up the previous file before overwriting");
+    }
+
+    #[test]
+    fn legacy_migration_extracts_known_fields() {
+        let legacy = serde_json::json!({
+            "enterToSend": false,
+            "atlasTheme": "custom-theme",
+            "uiScale": 1.5,
+        });
+        let settings = settings_from_legacy_json(Some(&legacy));
+        assert!(!settings.enter_to_send);
+        assert_eq!(settings.atlas_theme, "custom-theme");
+        assert_eq!(settings.ui_scale, 1.5);
+        // Untouched fields keep their compiled defaults.
+        assert!(settings.auto_update);
+    }
+
+    #[test]
+    fn legacy_migration_normalizes_parse_and_llm_to_agent() {
+        for legacy_value in ["parse", "llm", "agent", "anything-else"] {
+            let legacy = serde_json::json!({ "adaptiveSuggestions": legacy_value });
+            let settings = settings_from_legacy_json(Some(&legacy));
+            assert_eq!(settings.adaptive_suggestions, AdaptiveSuggestions::Agent, "value: {legacy_value}");
+        }
+        let legacy = serde_json::json!({ "adaptiveSuggestions": "off" });
+        assert_eq!(settings_from_legacy_json(Some(&legacy)).adaptive_suggestions, AdaptiveSuggestions::Off);
+    }
+
+    #[test]
+    fn legacy_migration_defaults_missing_adaptive_to_agent() {
+        let settings = settings_from_legacy_json(None);
+        assert_eq!(settings.adaptive_suggestions, AdaptiveSuggestions::Agent);
+    }
+
+    #[test]
+    fn legacy_migration_ignores_out_of_range_ui_scale() {
+        let legacy = serde_json::json!({ "uiScale": 99.0 });
+        let settings = settings_from_legacy_json(Some(&legacy));
+        assert_eq!(settings.ui_scale, default_ui_scale());
+    }
+
+    // ── bootstrap_at (migration orchestration) ──────────────────────────
+
+    #[test]
+    fn bootstrap_first_run_imports_legacy_settings_and_marks_migrated() {
+        let path = tmp_config_path();
+        let legacy = serde_json::json!({ "enterToSend": false, "atlasTheme": "custom" });
+
+        let outcome = bootstrap_at(path.clone(), false, Some(legacy));
+
+        assert!(outcome.mark_migrated);
+        assert!(!outcome.manager.effective().enter_to_send);
+        assert_eq!(outcome.manager.effective().atlas_theme, "custom");
+        assert!(path.exists(), "bootstrap must actually write config.toml on first run");
+    }
+
+    #[test]
+    fn bootstrap_never_reimports_after_marker_is_set() {
+        let path = tmp_config_path();
+        let legacy = serde_json::json!({ "enterToSend": false });
+
+        // marker_already_set = true: even though config.toml doesn't exist
+        // yet, this must NOT be treated as a first run — the user deleted
+        // their config on purpose after already migrating once.
+        let outcome = bootstrap_at(path, true, Some(legacy));
+
+        assert!(outcome.mark_migrated);
+        assert_eq!(outcome.manager.effective(), &AppSettings::default());
+    }
+
+    #[test]
+    fn bootstrap_leaves_an_existing_config_untouched_regardless_of_legacy_data() {
+        let path = tmp_config_path();
+        let raw = "schemaVersion = 1\n\n[settings]\nenterToSend = false\n";
+        fs::write(&path, raw).unwrap();
+        let legacy = serde_json::json!({ "enterToSend": true, "atlasTheme": "should-never-appear" });
+
+        let outcome = bootstrap_at(path.clone(), false, Some(legacy));
+
+        assert!(outcome.mark_migrated);
+        // The existing file wins outright — legacy data is never merged in,
+        // not even for keys the existing file didn't set.
+        assert!(!outcome.manager.effective().enter_to_send);
+        assert_eq!(outcome.manager.effective().atlas_theme, default_atlas_theme());
+        assert_eq!(fs::read_to_string(&path).unwrap(), raw, "must not rewrite an existing config.toml");
+    }
+
+    #[test]
+    fn bootstrap_is_idempotent_across_repeated_calls() {
+        let path = tmp_config_path();
+        let legacy = serde_json::json!({ "enterToSend": false });
+
+        let first = bootstrap_at(path.clone(), false, Some(legacy.clone()));
+        assert!(first.mark_migrated);
+        let after_first = fs::read_to_string(&path).unwrap();
+
+        // Simulates the caller persisting `mark_migrated` and the process
+        // restarting: same call, but now with the marker set.
+        let second = bootstrap_at(path.clone(), true, Some(legacy));
+        assert!(second.mark_migrated);
+        assert_eq!(fs::read_to_string(&path).unwrap(), after_first, "a second bootstrap must not rewrite the file");
+        assert!(!second.manager.effective().enter_to_send);
+    }
+
+    // ── Cross-artifact key coverage ──────────────────────────────────────
+    //
+    // `docs/reference/configuration.md` explicitly claims every schema key
+    // appears in both itself and the bundled skill. Compiled in via
+    // `include_str!` (not read from disk at test time) so this fails the
+    // build the moment either document drifts from `KNOWN_SETTINGS_KEYS`,
+    // the same way the rest of this crate's `include_str!`'d resources do.
+
+    const CONFIGURATION_DOC: &str = include_str!("../../../docs/reference/configuration.md");
+    const SELF_CONFIGURE_SKILL: &str =
+        include_str!("../../resources/skills/atlas-self-configure/SKILL.md");
+
+    #[test]
+    fn every_known_setting_key_is_documented_in_the_configuration_reference() {
+        for key in KNOWN_SETTINGS_KEYS {
+            assert!(CONFIGURATION_DOC.contains(key), "docs/reference/configuration.md is missing `{key}`");
+        }
+    }
+
+    #[test]
+    fn every_known_setting_key_is_covered_by_the_self_configure_skill() {
+        for key in KNOWN_SETTINGS_KEYS {
+            assert!(
+                SELF_CONFIGURE_SKILL.contains(key),
+                "the atlas-self-configure SKILL.md is missing `{key}`"
+            );
+        }
+    }
+}

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -12,5 +12,10 @@
 //!   Windows: `%APPDATA%\dev.atlas.ide\state.json`
 
 pub mod app_state;
+pub mod atlas_config;
 
 pub use app_state::{AppState, AppStateHandle, AppStatePatch};
+pub use atlas_config::{
+    AppSettings, AtlasConfigHandle, ConfigError, ConfigSnapshot, ConfigStatus, SettingsPatch,
+    UpdateOutcome,
+};

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -22,6 +22,12 @@ import { applyEditorTheme } from "@/features/editor/themes/apply-editor-theme";
 import { DEFAULT_EDITOR_THEME_ID } from "@/features/editor/themes/themes";
 import { applyAtlasTheme } from "@/features/theme/apply-atlas-theme";
 import { DEFAULT_ATLAS_THEME_ID } from "@/features/theme/themes";
+import {
+  updateSettings as updateAtlasConfig,
+  onConfigChanged,
+  onConfigError,
+  type SettingsPatch,
+} from "@/features/settings/lib/atlas-config-api";
 
 interface Project {
   name: string;
@@ -124,7 +130,15 @@ export interface AppStateWire {
   /** The Organisation layer above workspaces (v3). */
   organisations?: Organisation[];
   activeOrganisationId?: string | null;
+  /** Sourced from `config.toml`, not `state.json` (issue #64) — folded into
+   *  this same bootstrap response for one round trip, but written back
+   *  through `update_atlas_settings`, never `save_app_state`. Optional only
+   *  because the bootstrap-failure fallback path constructs a payload by
+   *  hand without it; `hydrate` merges over `DEFAULT_SETTINGS` regardless. */
   settings?: AppSettings;
+  /** Optimistic-concurrency counter for `update_atlas_settings` — see
+   *  `atlas-config-api.ts`. */
+  configGeneration?: number;
   version: number;
 }
 
@@ -132,6 +146,14 @@ interface ProjectState {
   currentProject: Project | null;
   recentProjects: RecentProject[];
   settings: AppSettings;
+  /** The generation of `settings` currently reflected here — every
+   *  `updateSettings` call and every `atlas:config-changed` event advances
+   *  it. See `atlas-config-api.ts`. */
+  configGeneration: number;
+  /** Set when `config.toml` is currently malformed (external edit or a
+   *  rejected write) — `settings` still holds the last valid snapshot.
+   *  `null` when there's nothing to report. Settings UI surfaces this. */
+  configError: string | null;
   /** True until the Rust-side bootstrap returns. UI gates on this to keep
    *  the boot skeleton up rather than flashing an empty WelcomeScreen. */
   hydrated: boolean;
@@ -145,19 +167,40 @@ interface ProjectState {
     setActiveProject: (project: Project | null) => void;
     removeRecent: (path: string) => void;
     clearRecents: () => void;
+    /** Applies + persists a settings change through `config.toml`
+     *  (`update_atlas_settings`) — see `atlas-config-api.ts`. Optimistic:
+     *  the store updates immediately, then reconciles with whatever Rust
+     *  actually committed (a validation failure or a generation conflict
+     *  rolls the optimistic change back to the last-known-good snapshot). */
     updateSettings: (partial: Partial<AppSettings>) => void;
+    /** Dismiss the current `configError` banner without touching the file. */
+    clearConfigError: () => void;
     /** One-shot hydration from Rust. Called once on app boot. */
     hydrate: (payload: AppStateWire, opts?: { skipActiveSwitch?: boolean }) => void;
   };
 }
 
-// Debounced persistence: the Rust `save_app_state` command takes the full
-// `AppState` payload. Both `useProjectStore` (recents/settings) and
-// `useWorkspaceStore` (workspaces/groups/activeWorkspaceId) contribute to it,
-// so the save reads from both stores at flush time. Coalesced to ~500ms.
-/** Build the full `AppState` payload from every contributing store. Shared by
+/** The `AppStatePatch` shape `save_app_state` actually accepts — settings are
+ *  no longer part of it (issue #64: they persist through `config.toml` /
+ *  `update_atlas_settings` instead, see `updateSettings` below). */
+interface AppStatePatchWire {
+  currentProject: null;
+  recentProjects: RecentProject[];
+  workspaces: Workspace[];
+  groups: WorkspaceGroup[];
+  activeWorkspaceId: string | null;
+  organisations: Organisation[];
+  activeOrganisationId: string | null;
+}
+
+// Debounced persistence: the Rust `save_app_state` command takes the
+// workspaces/recents/orgs slice of `AppState`. Both `useProjectStore`
+// (recents) and `useWorkspaceStore` (workspaces/groups/activeWorkspaceId)
+// contribute to it, so the save reads from both stores at flush time.
+// Coalesced to ~500ms.
+/** Build the `AppStatePatch` payload from every contributing store. Shared by
  *  the debounced + immediate save paths so they never drift. */
-function buildAppStatePayload(): AppStateWire {
+function buildAppStatePayload(): AppStatePatchWire {
   const project = useProjectStore.getState();
   const ws = useWorkspaceStore.getState();
   const org = useOrgStore.getState();
@@ -169,8 +212,6 @@ function buildAppStatePayload(): AppStateWire {
     activeWorkspaceId: ws.activeWorkspaceId,
     organisations: org.organisations,
     activeOrganisationId: org.activeOrganisationId,
-    settings: project.settings,
-    version: 3,
   };
 }
 
@@ -308,11 +349,31 @@ export async function loadProjectStores(path: string): Promise<void> {
   }
 }
 
+/** Re-apply every settings-driven side effect whose value actually changed
+ *  between `previous` and `next`. Shared by `updateSettings` (both the
+ *  optimistic apply and the reconciled result), `hydrate`, and the
+ *  `atlas:config-changed` listener below — one path so a hot-reloaded
+ *  external edit re-applies UI scale/theme/explorer state exactly like a
+ *  UI-driven change does. */
+function applySettingsSideEffects(next: AppSettings, previous: AppSettings): void {
+  // Toggling hidden-files visibility must re-apply the explorer's dotfile
+  // filter immediately. `refresh()` reconciles the root and every expanded
+  // subtree, so the user's expansion state survives.
+  if (next.showHiddenFiles !== previous.showHiddenFiles) {
+    void useExplorerStore.getState().actions.refresh();
+  }
+  if (next.uiScale !== previous.uiScale) applyUiScale(next.uiScale);
+  if (next.codeEditorTheme !== previous.codeEditorTheme) applyEditorTheme(next.codeEditorTheme);
+  if (next.atlasTheme !== previous.atlasTheme) applyAtlasTheme(next.atlasTheme);
+}
+
 export const useProjectStore = createSelectors(
   create<ProjectState>()((set, get) => ({
     currentProject: null,
     recentProjects: [],
     settings: DEFAULT_SETTINGS,
+    configGeneration: 0,
+    configError: null,
     hydrated: false,
     actions: {
       openProject: async (path: string) => {
@@ -373,21 +434,62 @@ export const useProjectStore = createSelectors(
         scheduleAppStateSave();
       },
       updateSettings: (partial: Partial<AppSettings>) => {
-        set((s) => ({ settings: { ...s.settings, ...partial } }));
-        scheduleAppStateSave();
-        // Toggling hidden-files visibility must re-apply the explorer's
-        // dotfile filter immediately. `refresh()` reconciles the root and
-        // every expanded subtree, so the user's expansion state survives.
-        if (partial.showHiddenFiles !== undefined) {
-          void useExplorerStore.getState().actions.refresh();
-        }
-        if (partial.uiScale !== undefined) applyUiScale(partial.uiScale);
-        if (partial.codeEditorTheme !== undefined) applyEditorTheme(partial.codeEditorTheme);
-        if (partial.atlasTheme !== undefined) applyAtlasTheme(partial.atlasTheme);
+        // Optimistic: apply immediately so the control feels instant, then
+        // reconcile with whatever `config.toml` actually ends up holding.
+        // Rust validates the full candidate and can reject it outright, or —
+        // on a stale `configGeneration` — refuse to apply and return a
+        // Conflict instead (see `atlas-config-api.ts`). A generation can go
+        // stale without any UI involvement at all (an internal Rust-side
+        // write, e.g. the Local Model Manager persisting a model switch, or
+        // an external edit), so a Conflict here does NOT mean someone else
+        // wanted this same key — it just means the base this patch was
+        // computed against is out of date. Adopt the fresh generation and
+        // retry the original patch once; only surface an error if it
+        // conflicts again (an actual tight race, not just staleness).
+        const previous = get().settings;
+        const optimistic = { ...previous, ...partial };
+        set({ settings: optimistic });
+        applySettingsSideEffects(optimistic, previous);
+
+        const attempt = (generation: number, isRetry: boolean) => {
+          updateAtlasConfig(partial as SettingsPatch, generation)
+            .then((outcome) => {
+              if (outcome.kind === "conflict") {
+                if (isRetry) {
+                  console.warn("updateSettings: conflicted again after adopting latest generation");
+                  set({
+                    settings: outcome.settings,
+                    configGeneration: outcome.generation,
+                    configError:
+                      "Settings change conflicted with a concurrent edit — please try again.",
+                  });
+                  applySettingsSideEffects(outcome.settings, optimistic);
+                  return;
+                }
+                set({ configGeneration: outcome.generation });
+                attempt(outcome.generation, true);
+                return;
+              }
+              set({
+                settings: outcome.settings,
+                configGeneration: outcome.generation,
+                configError: null,
+              });
+              applySettingsSideEffects(outcome.settings, optimistic);
+            })
+            .catch((e) => {
+              console.warn("update_atlas_settings failed:", e);
+              set({ settings: previous, configError: String(e) });
+              applySettingsSideEffects(previous, optimistic);
+            });
+        };
+        attempt(get().configGeneration, false);
       },
+      clearConfigError: () => set({ configError: null }),
       hydrate: (payload: AppStateWire, opts?: { skipActiveSwitch?: boolean }) => {
-        // Merge with defaults so older state.json files (written before a new
-        // setting existed) get the modern default rather than `undefined`.
+        // Merge with defaults so an older/mid-migration response missing a
+        // brand-new key gets the modern default rather than `undefined` —
+        // belt-and-suspenders on top of Rust's own field-level defaulting.
         const settings: AppSettings = {
           ...DEFAULT_SETTINGS,
           ...payload.settings,
@@ -396,6 +498,8 @@ export const useProjectStore = createSelectors(
           currentProject: null,
           recentProjects: payload.recentProjects ?? [],
           settings,
+          configGeneration: payload.configGeneration ?? 0,
+          configError: null,
           hydrated: true,
         });
 
@@ -449,3 +553,22 @@ export const useProjectStore = createSelectors(
     },
   })),
 );
+
+// `config.toml` can change for reasons other than this window's own
+// `updateSettings` call: the Settings UI edited it in another window (not
+// currently possible — Atlas is single-window — but this is also what fires
+// for a `reset_atlas_config`), or an external editor / the
+// `atlas-self-configure` skill wrote to it directly. Both land here as a hot
+// reload; `applySettingsSideEffects` re-applies exactly the side effects that
+// actually changed, same as a UI-driven update.
+void onConfigChanged(({ settings, generation }) => {
+  const previous = useProjectStore.getState().settings;
+  useProjectStore.setState({ settings, configGeneration: generation, configError: null });
+  applySettingsSideEffects(settings, previous);
+});
+
+// A malformed external edit (or a write Rust rejected) — `settings` is
+// unchanged, this is purely "tell the user".
+void onConfigError((error) => {
+  useProjectStore.setState({ configError: error });
+});

--- a/src/features/project/stores/project-store.ts
+++ b/src/features/project/stores/project-store.ts
@@ -17,17 +17,23 @@ import { useOrgStore } from "@/features/organisations/stores/org-store";
 import type { Organisation } from "@/features/organisations/types";
 import { registerFlush } from "@/features/workspaces/lib/flush-registry";
 import { persistHashOf } from "@/features/workspaces/lib/workspace-snapshot";
-import { applyUiScale, DEFAULT_SCALE } from "@/features/settings/lib/ui-scale";
+import { applyUiScale } from "@/features/settings/lib/ui-scale";
 import { applyEditorTheme } from "@/features/editor/themes/apply-editor-theme";
-import { DEFAULT_EDITOR_THEME_ID } from "@/features/editor/themes/themes";
 import { applyAtlasTheme } from "@/features/theme/apply-atlas-theme";
-import { DEFAULT_ATLAS_THEME_ID } from "@/features/theme/themes";
 import {
   updateSettings as updateAtlasConfig,
+  resetConfig as resetAtlasConfig,
   onConfigChanged,
   onConfigError,
+  type ConfigStatus,
   type SettingsPatch,
 } from "@/features/settings/lib/atlas-config-api";
+import { DEFAULT_SETTINGS, type AppSettings } from "@/features/settings/lib/app-settings";
+
+// Re-exported because most of the app reaches for `AppSettings` through the
+// store it reads settings from; the definition itself belongs to the settings
+// feature (see `app-settings.ts`).
+export type { AppSettings };
 
 interface Project {
   name: string;
@@ -39,79 +45,6 @@ interface RecentProject {
   path: string;
   lastOpened: string;
 }
-
-/**
- * App-wide preferences surfaced in Settings → General. Mirrors
- * `src-tauri/src/state/app_state.rs:AppSettings`. Defaults declared on
- * both sides; if you add a field, default it both places.
- */
-export interface AppSettings {
-  /** Auto-add `.atlas/` to each opened git project's `.gitignore`. */
-  autoAddAtlasGitignore: boolean;
-  /** Record Atlas-internal events (sign-in, agent lifecycle, etc.) into
-   *  the Logs panel under the `atlas` source. */
-  enableAtlasLogs: boolean;
-  /** Show dotfiles / dot-directories in the explorer file tree. */
-  showHiddenFiles: boolean;
-  /** Global interface zoom (1 == 100%). Driven by the ⌘+/⌘-/⌘0 hotkeys;
-   *  applied via the native WebView zoom. */
-  uiScale: number;
-  /** Anonymous product telemetry (PostHog). Default ON (opt-out) — gates both
-   *  the Rust emitter and the frontend crash reporter. See
-   *  `src/features/telemetry`. */
-  shareTelemetry: boolean;
-  /** Attribute telemetry to the signed-in Atlas account rather than keeping it
-   *  on the anonymous per-device person. Default ON; irrelevant while signed out
-   *  or while `shareTelemetry` is off — both gate it. */
-  linkTelemetryToAccount: boolean;
-  /** Selected on-device embedding model id (== dir name). Managed by the Local
-   *  Model Manager; carried here so settings round-trips never clobber it. */
-  embeddingModelId: string;
-  /** Code-editor color theme id (see src/features/editor/themes). Drives the
-   *  CodeMirror editor, the diff viewer and the source-control diff views. */
-  codeEditorTheme: string;
-  /** Atlas interface-theme id (see src/features/theme/themes). Swaps the whole
-   *  dark UI palette — background, panels, text, borders and accent — while
-   *  keeping dark-theme primitives. Independent of `codeEditorTheme` (which only
-   *  themes code syntax). Default "atlas-black" = original AMOLED look. */
-  atlasTheme: string;
-  /** Adaptive next-step suggestion chips in the agent chat's per-turn card.
-   *  "agent" (default) asks the coding agent to end each reply with a hidden
-   *  `<next_steps>` block (uses the live session context, no BYOK); "off"
-   *  disables it. (Legacy "parse"/"llm" values are treated as enabled.) */
-  adaptiveSuggestions: "off" | "agent";
-  /** Inline Git blame in the code editor — dim author/age/summary annotation
-   *  trailing the active line. Off = the CodeMirror extension isn't loaded. */
-  gitBlameInline: boolean;
-  /** Auto-update master switch. ON (default) → every startup checks PostHog
-   *  remote config and prompts when a newer signed DMG is available. */
-  autoUpdate: boolean;
-  /** A version the user chose to "Ignore" in the update prompt; the startup
-   *  check won't re-prompt for exactly this version. */
-  updaterIgnoredVersion: string | null;
-  /** Chat composer send gesture. true (default) = Enter sends, Shift+Enter
-   *  inserts a newline (Slack/Discord/ChatGPT convention). false = only
-   *  Cmd/Ctrl+Enter sends, bare Enter always inserts a newline (the old
-   *  default). Cmd/Ctrl+Enter always sends regardless of this setting. */
-  enterToSend: boolean;
-}
-
-const DEFAULT_SETTINGS: AppSettings = {
-  autoAddAtlasGitignore: true,
-  enableAtlasLogs: true,
-  showHiddenFiles: true,
-  uiScale: DEFAULT_SCALE,
-  shareTelemetry: true,
-  linkTelemetryToAccount: true,
-  embeddingModelId: "all-MiniLM-L6-v2",
-  codeEditorTheme: DEFAULT_EDITOR_THEME_ID,
-  atlasTheme: DEFAULT_ATLAS_THEME_ID,
-  adaptiveSuggestions: "agent",
-  gitBlameInline: true,
-  autoUpdate: true,
-  updaterIgnoredVersion: null,
-  enterToSend: true,
-};
 
 /**
  * Wire shape returned by the Rust `bootstrap_app_state` command. Mirrors
@@ -139,6 +72,10 @@ export interface AppStateWire {
   /** Optimistic-concurrency counter for `update_atlas_settings` — see
    *  `atlas-config-api.ts`. */
   configGeneration?: number;
+  /** Whether `config.toml` actually loaded. Anything other than `ok` means
+   *  `settings` above are Atlas's defaults, not the user's. Optional only
+   *  because the bootstrap-failure fallback path builds a payload by hand. */
+  configStatus?: ConfigStatus;
   version: number;
 }
 
@@ -175,6 +112,12 @@ interface ProjectState {
     updateSettings: (partial: Partial<AppSettings>) => void;
     /** Dismiss the current `configError` banner without touching the file. */
     clearConfigError: () => void;
+    /** "Recreate defaults" — the one action allowed to overwrite a malformed
+     *  `config.toml` (Rust backs the old file up first). Owns the state write
+     *  AND the resulting side effects, which is why the Settings panel calls
+     *  this rather than reaching into `setState` itself. Rejects with the
+     *  underlying error so the caller can toast it. */
+    resetConfig: () => Promise<void>;
     /** One-shot hydration from Rust. Called once on app boot. */
     hydrate: (payload: AppStateWire, opts?: { skipActiveSwitch?: boolean }) => void;
   };
@@ -367,6 +310,19 @@ function applySettingsSideEffects(next: AppSettings, previous: AppSettings): voi
   if (next.atlasTheme !== previous.atlasTheme) applyAtlasTheme(next.atlasTheme);
 }
 
+/** How many times a settings write adopts the latest generation and retries
+ *  before giving up and telling the user. See `updateSettings`. */
+const SETTINGS_WRITE_ATTEMPTS = 3;
+
+/** Turn a boot-time `ConfigStatus` into the banner string, or `null` when the
+ *  file loaded cleanly. */
+function configErrorFrom(status: ConfigStatus | undefined): string | null {
+  if (!status || status.status === "ok") return null;
+  return status.status === "usingDefaults"
+    ? `config.toml could not be loaded, so Atlas is running on default settings — your saved preferences are not applied. ${status.error}`
+    : `config.toml is currently invalid; Atlas is running on the last settings that loaded cleanly. ${status.error}`;
+}
+
 export const useProjectStore = createSelectors(
   create<ProjectState>()((set, get) => ({
     currentProject: null,
@@ -444,19 +400,25 @@ export const useProjectStore = createSelectors(
         // an external edit), so a Conflict here does NOT mean someone else
         // wanted this same key — it just means the base this patch was
         // computed against is out of date. Adopt the fresh generation and
-        // retry the original patch once; only surface an error if it
-        // conflicts again (an actual tight race, not just staleness).
+        // retry the original patch; only surface an error once
+        // `SETTINGS_WRITE_ATTEMPTS` of them have conflicted in a row (an
+        // actual sustained race, not just staleness). A single retry wasn't
+        // enough: during a burst of rapid changes — dragging the zoom slider,
+        // say — a second unrelated write can land between the retry and its
+        // read, silently dropping the user's action.
         const previous = get().settings;
         const optimistic = { ...previous, ...partial };
         set({ settings: optimistic });
         applySettingsSideEffects(optimistic, previous);
 
-        const attempt = (generation: number, isRetry: boolean) => {
+        const attempt = (generation: number, attemptsLeft: number) => {
           updateAtlasConfig(partial as SettingsPatch, generation)
             .then((outcome) => {
               if (outcome.kind === "conflict") {
-                if (isRetry) {
-                  console.warn("updateSettings: conflicted again after adopting latest generation");
+                if (attemptsLeft <= 1) {
+                  console.warn(
+                    "updateSettings: still conflicting after adopting the latest generation",
+                  );
                   set({
                     settings: outcome.settings,
                     configGeneration: outcome.generation,
@@ -467,7 +429,7 @@ export const useProjectStore = createSelectors(
                   return;
                 }
                 set({ configGeneration: outcome.generation });
-                attempt(outcome.generation, true);
+                attempt(outcome.generation, attemptsLeft - 1);
                 return;
               }
               set({
@@ -483,9 +445,19 @@ export const useProjectStore = createSelectors(
               applySettingsSideEffects(previous, optimistic);
             });
         };
-        attempt(get().configGeneration, false);
+        attempt(get().configGeneration, SETTINGS_WRITE_ATTEMPTS);
       },
       clearConfigError: () => set({ configError: null }),
+      resetConfig: async () => {
+        const previous = get().settings;
+        const snapshot = await resetAtlasConfig();
+        set({
+          settings: snapshot.settings,
+          configGeneration: snapshot.generation,
+          configError: null,
+        });
+        applySettingsSideEffects(snapshot.settings, previous);
+      },
       hydrate: (payload: AppStateWire, opts?: { skipActiveSwitch?: boolean }) => {
         // Merge with defaults so an older/mid-migration response missing a
         // brand-new key gets the modern default rather than `undefined` —
@@ -499,7 +471,11 @@ export const useProjectStore = createSelectors(
           recentProjects: payload.recentProjects ?? [],
           settings,
           configGeneration: payload.configGeneration ?? 0,
-          configError: null,
+          // A `config.toml` that failed to load at startup is the one case the
+          // user cannot otherwise notice: every preference silently reads back
+          // as an Atlas default (`shareTelemetry` included). Rust computes the
+          // status at boot; hard-nulling it here is what kept it off screen.
+          configError: configErrorFrom(payload.configStatus),
           hydrated: true,
         });
 

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -36,7 +36,7 @@ import { useFeedbackStore } from "@/features/feedback/stores/feedback-store";
 import { updater } from "@/features/updater/lib/updater-api";
 import { useUpdaterStore } from "@/features/updater/stores/updater-store";
 import { useSettingsNav, type SettingsSection } from "../stores/settings-nav-store";
-import { openConfigFile, resetConfig } from "../lib/atlas-config-api";
+import { openConfigFile } from "../lib/atlas-config-api";
 
 const SECTIONS: Array<{
   id: SettingsSection;
@@ -187,7 +187,7 @@ interface CliStatus {
 function GeneralSettings() {
   const settings = useProjectStore.use.settings();
   const configError = useProjectStore.use.configError();
-  const { updateSettings, clearConfigError } = useProjectStore.use.actions();
+  const { updateSettings, clearConfigError, resetConfig } = useProjectStore.use.actions();
   const [cli, setCli] = useState<CliStatus | null>(null);
   const [installing, setInstalling] = useState(false);
   const [resettingConfig, setResettingConfig] = useState(false);
@@ -195,12 +195,11 @@ function GeneralSettings() {
   const recreateConfigDefaults = async () => {
     setResettingConfig(true);
     try {
-      const snapshot = await resetConfig();
-      useProjectStore.setState({
-        settings: snapshot.settings,
-        configGeneration: snapshot.generation,
-        configError: null,
-      });
+      // The store action owns both the state write and the resulting side
+      // effects (theme, zoom). Doing it here with `setState` raced the
+      // `atlas:config-changed` listener and skipped those side effects
+      // whenever this path won.
+      await resetConfig();
       toast.success("config.toml reset to defaults (previous file backed up alongside it)");
     } catch (e) {
       toast.error(`Reset failed: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/features/settings/components/settings-panel.tsx
+++ b/src/features/settings/components/settings-panel.tsx
@@ -36,6 +36,7 @@ import { useFeedbackStore } from "@/features/feedback/stores/feedback-store";
 import { updater } from "@/features/updater/lib/updater-api";
 import { useUpdaterStore } from "@/features/updater/stores/updater-store";
 import { useSettingsNav, type SettingsSection } from "../stores/settings-nav-store";
+import { openConfigFile, resetConfig } from "../lib/atlas-config-api";
 
 const SECTIONS: Array<{
   id: SettingsSection;
@@ -185,9 +186,28 @@ interface CliStatus {
 
 function GeneralSettings() {
   const settings = useProjectStore.use.settings();
-  const { updateSettings } = useProjectStore.use.actions();
+  const configError = useProjectStore.use.configError();
+  const { updateSettings, clearConfigError } = useProjectStore.use.actions();
   const [cli, setCli] = useState<CliStatus | null>(null);
   const [installing, setInstalling] = useState(false);
+  const [resettingConfig, setResettingConfig] = useState(false);
+
+  const recreateConfigDefaults = async () => {
+    setResettingConfig(true);
+    try {
+      const snapshot = await resetConfig();
+      useProjectStore.setState({
+        settings: snapshot.settings,
+        configGeneration: snapshot.generation,
+        configError: null,
+      });
+      toast.success("config.toml reset to defaults (previous file backed up alongside it)");
+    } catch (e) {
+      toast.error(`Reset failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setResettingConfig(false);
+    }
+  };
 
   // Model pricing (models.dev) — manual refresh + count for the picker.
   const pricingPrices = useModelPricingStore.use.prices();
@@ -243,6 +263,45 @@ function GeneralSettings() {
   return (
     <div className="space-y-6">
       <SectionTitle title="General" subtitle="Application preferences" />
+      {configError && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 space-y-2">
+          <p className="text-[12px] font-medium text-text-primary">
+            Atlas is using the last valid settings — config.toml has a problem
+          </p>
+          <p className="text-[11px] text-text-secondary font-mono break-all">{configError}</p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void openConfigFile()}
+              className={cn(
+                "h-7 rounded-md px-2.5 text-[11px] font-medium border border-border-default bg-bg-elevated",
+                "text-text-primary hover:bg-bg-hover transition-colors",
+              )}
+            >
+              Open config
+            </button>
+            <button
+              type="button"
+              onClick={() => void recreateConfigDefaults()}
+              disabled={resettingConfig}
+              className={cn(
+                "h-7 rounded-md px-2.5 text-[11px] font-medium border border-border-default bg-bg-elevated",
+                "text-text-primary hover:bg-bg-hover transition-colors",
+                "disabled:opacity-50 disabled:cursor-not-allowed",
+              )}
+            >
+              {resettingConfig ? "Resetting…" : "Recreate defaults"}
+            </button>
+            <button
+              type="button"
+              onClick={clearConfigError}
+              className="h-7 rounded-md px-2.5 text-[11px] font-medium text-text-secondary hover:text-text-primary transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
       <SettingRow
         label="Enter to send"
         description="Enter sends your message; Shift+Enter inserts a newline — the Slack/Discord/ChatGPT convention. Turn off to restore the old behavior, where only ⌘/Ctrl+Enter sends and Enter always inserts a newline. ⌘/Ctrl+Enter always sends either way."
@@ -295,9 +354,12 @@ function GeneralSettings() {
         <Toggle
           checked={settings.shareTelemetry}
           onChange={(next) => {
+            // Rust re-syncs the live gate itself on every settings commit
+            // (`notify_settings_changed`) — this only needs to flip the
+            // frontend-only `posthog-js` crash reporter, which Rust can't
+            // reach.
             updateSettings({ shareTelemetry: next });
             setTelemetryEnabled(next);
-            void invoke("telemetry_set_enabled", { enabled: next }).catch(() => {});
           }}
         />
       </SettingRow>

--- a/src/features/settings/lib/app-settings.ts
+++ b/src/features/settings/lib/app-settings.ts
@@ -1,0 +1,86 @@
+/**
+ * The `AppSettings` schema and its defaults.
+ *
+ * Lives in the settings feature (not the project store) because that is the
+ * domain that owns it: `atlas-config-api.ts` needs the type to describe its
+ * own IPC surface, and importing it back out of the project store — which in
+ * turn imports the api wrapper and runs listener registration at module scope
+ * — made the two modules a cycle.
+ */
+
+import { DEFAULT_SCALE } from "./ui-scale";
+import { DEFAULT_EDITOR_THEME_ID } from "@/features/editor/themes/themes";
+import { DEFAULT_ATLAS_THEME_ID } from "@/features/theme/themes";
+
+/**
+ * App-wide preferences surfaced in Settings → General. Mirrors
+ * `src-tauri/src/state/atlas_config.rs:AppSettings`. Defaults declared on
+ * both sides; if you add a field, default it both places.
+ */
+export interface AppSettings {
+  /** Auto-add `.atlas/` to each opened git project's `.gitignore`. */
+  autoAddAtlasGitignore: boolean;
+  /** Record Atlas-internal events (sign-in, agent lifecycle, etc.) into
+   *  the Logs panel under the `atlas` source. */
+  enableAtlasLogs: boolean;
+  /** Show dotfiles / dot-directories in the explorer file tree. */
+  showHiddenFiles: boolean;
+  /** Global interface zoom (1 == 100%). Driven by the ⌘+/⌘-/⌘0 hotkeys;
+   *  applied via the native WebView zoom. */
+  uiScale: number;
+  /** Anonymous product telemetry (PostHog). Default ON (opt-out) — gates both
+   *  the Rust emitter and the frontend crash reporter. See
+   *  `src/features/telemetry`. */
+  shareTelemetry: boolean;
+  /** Attribute telemetry to the signed-in Atlas account rather than keeping it
+   *  on the anonymous per-device person. Default ON; irrelevant while signed out
+   *  or while `shareTelemetry` is off — both gate it. */
+  linkTelemetryToAccount: boolean;
+  /** Selected on-device embedding model id (== dir name). Managed by the Local
+   *  Model Manager; carried here so settings round-trips never clobber it. */
+  embeddingModelId: string;
+  /** Code-editor color theme id (see src/features/editor/themes). Drives the
+   *  CodeMirror editor, the diff viewer and the source-control diff views. */
+  codeEditorTheme: string;
+  /** Atlas interface-theme id (see src/features/theme/themes). Swaps the whole
+   *  dark UI palette — background, panels, text, borders and accent — while
+   *  keeping dark-theme primitives. Independent of `codeEditorTheme` (which only
+   *  themes code syntax). Default "atlas-black" = original AMOLED look. */
+  atlasTheme: string;
+  /** Adaptive next-step suggestion chips in the agent chat's per-turn card.
+   *  "agent" (default) asks the coding agent to end each reply with a hidden
+   *  `<next_steps>` block (uses the live session context, no BYOK); "off"
+   *  disables it. (Legacy "parse"/"llm" values are treated as enabled.) */
+  adaptiveSuggestions: "off" | "agent";
+  /** Inline Git blame in the code editor — dim author/age/summary annotation
+   *  trailing the active line. Off = the CodeMirror extension isn't loaded. */
+  gitBlameInline: boolean;
+  /** Auto-update master switch. ON (default) → every startup checks PostHog
+   *  remote config and prompts when a newer signed DMG is available. */
+  autoUpdate: boolean;
+  /** A version the user chose to "Ignore" in the update prompt; the startup
+   *  check won't re-prompt for exactly this version. */
+  updaterIgnoredVersion: string | null;
+  /** Chat composer send gesture. true (default) = Enter sends, Shift+Enter
+   *  inserts a newline (Slack/Discord/ChatGPT convention). false = only
+   *  Cmd/Ctrl+Enter sends, bare Enter always inserts a newline (the old
+   *  default). Cmd/Ctrl+Enter always sends regardless of this setting. */
+  enterToSend: boolean;
+}
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  autoAddAtlasGitignore: true,
+  enableAtlasLogs: true,
+  showHiddenFiles: true,
+  uiScale: DEFAULT_SCALE,
+  shareTelemetry: true,
+  linkTelemetryToAccount: true,
+  embeddingModelId: "all-MiniLM-L6-v2",
+  codeEditorTheme: DEFAULT_EDITOR_THEME_ID,
+  atlasTheme: DEFAULT_ATLAS_THEME_ID,
+  adaptiveSuggestions: "agent",
+  gitBlameInline: true,
+  autoUpdate: true,
+  updaterIgnoredVersion: null,
+  enterToSend: true,
+};

--- a/src/features/settings/lib/atlas-config-api.ts
+++ b/src/features/settings/lib/atlas-config-api.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { AppSettings } from "@/features/project/stores/project-store";
+import type { AppSettings } from "./app-settings";
 
 /**
  * `config.toml` bridge — the validated, human/agent-editable settings file

--- a/src/features/settings/lib/atlas-config-api.ts
+++ b/src/features/settings/lib/atlas-config-api.ts
@@ -1,0 +1,78 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import type { AppSettings } from "@/features/project/stores/project-store";
+
+/**
+ * `config.toml` bridge — the validated, human/agent-editable settings file
+ * that replaced `AppState.settings` inside `state.json` (issue #64).
+ *
+ * Rust owns the schema, defaults, validation and persistence; this module is
+ * the thin `invoke`/`listen` wrapper isolating that IPC surface, per the
+ * repo's `lib/<domain>-api.ts` convention. `updateSettings` (below) is what
+ * every settings-changing UI action should call — never `invoke` these
+ * commands directly from a component.
+ */
+
+/** Every field optional — send only the keys actually changing. `null` for
+ *  `updaterIgnoredVersion` clears it; omitting the key leaves it untouched. */
+export type SettingsPatch = Partial<Omit<AppSettings, "updaterIgnoredVersion">> & {
+  updaterIgnoredVersion?: string | null;
+};
+
+export type ConfigStatus =
+  | { status: "ok" }
+  | { status: "usingLastKnownGood"; error: string }
+  | { status: "usingDefaults"; error: string };
+
+export interface ConfigInfo {
+  path: string;
+  schemaVersion: number;
+  status: ConfigStatus;
+  effectiveSettings: AppSettings;
+  generation: number;
+  unknownKeys: string[];
+}
+
+export type UpdateOutcome =
+  | { kind: "applied"; settings: AppSettings; generation: number }
+  | { kind: "conflict"; settings: AppSettings; generation: number };
+
+export function getConfigInfo(): Promise<ConfigInfo> {
+  return invoke<ConfigInfo>("get_atlas_config_info");
+}
+
+export function updateSettings(
+  patch: SettingsPatch,
+  expectedGeneration: number,
+): Promise<UpdateOutcome> {
+  return invoke<UpdateOutcome>("update_atlas_settings", { patch, expectedGeneration });
+}
+
+export function resetConfig(): Promise<{ settings: AppSettings; generation: number }> {
+  return invoke("reset_atlas_config");
+}
+
+export function openConfigFile(): Promise<void> {
+  return invoke("open_atlas_config");
+}
+
+interface ConfigChangedPayload {
+  settings: AppSettings;
+  generation: number;
+}
+
+/** Fires whenever `config.toml` changes for any reason other than the
+ *  current window's own successful `updateSettings` call, which already gets
+ *  the new snapshot back as that call's return value — the frontend's own
+ *  round trip, and this event, are two different delivery paths for the same
+ *  kind of change. */
+export function onConfigChanged(cb: (payload: ConfigChangedPayload) => void): Promise<UnlistenFn> {
+  return listen<ConfigChangedPayload>("atlas:config-changed", (e) => cb(e.payload));
+}
+
+/** Fires when an external edit (or a rejected patch) leaves `config.toml`
+ *  invalid — the file was NOT touched and the previous settings are still
+ *  effective; this is purely a "tell the user" signal. */
+export function onConfigError(cb: (error: string) => void): Promise<UnlistenFn> {
+  return listen<{ error: string }>("atlas:config-error", (e) => cb(e.payload.error));
+}


### PR DESCRIPTION
### What?

Moves every user-facing Atlas preference out of `state.json`'s `AppSettings` and into a validated, human- and agent-editable `~/.config/atlas/config.toml`, and ships the `atlas-self-configure` skill that teaches agents to edit it safely.

Four commits, meant to be read in order:

1. `315752fa` — the feature: the TOML schema, validation, migration, the Tauri command surface, the file watcher, the Settings UI wiring, and the bundled skill.
2. `8a393f52` — the review pass: closes a data-loss path, a telemetry-privacy gap, invisible startup errors, and several durability/race holes (detail below).
3. `c7a9efa4` — makes the generated file self-documenting and slims the skill accordingly.
4. `c636919c` — relocates the file to `~/.config/atlas/`.

### Why?

**The data-loss path is the one worth reviewing closely.** Three things collaborated: `load_at` mapped *every* `fs::read_to_string` error to healthy defaults with `status: Ok`, so an unreadable `config.toml` was indistinguishable from an absent one; `bootstrap_at` keyed "migration is done" off that; and `AppState::save` — serializing a struct that no longer has a `settings` field — then deleted the legacy `state.json.settings` on the next save made for any unrelated reason (a rotated telemetry id, a workspace change). A damaged `config.toml` destroyed the only surviving copy of the user's preferences. Now only `NotFound` counts as absent, the marker is set only once `config.toml` demonstrably holds the settings, `save` merges over the existing file, and while the file is broken those legacy settings are what's actually in effect rather than compiled defaults.

**`linkTelemetryToAccount` didn't take effect until the next auth transition**, so turning account linkage off while signed in kept attributing events to the account until sign-out — the opposite of what the toggle says. `sync_identity` now takes the flag as a parameter and every committed settings change re-applies it.

**Startup config errors were computed but unreachable.** `ConfigStatus` was only exposed through `get_atlas_config_info`, which had zero callers, and `hydrate` hard-set `configError` to `null`. A malformed config silently reverted every preference — `shareTelemetry` back to ON — with no banner. It now rides on `bootstrap_app_state`.

**The file explains itself.** The module doc said TOML was chosen over JSON "specifically so the file can carry comments," and then `document_for` wrote none. Generated files now carry a comment above every key — what it does, its default, its constraints — sourced from the same table validation uses, so they can't drift. That's what let the skill drop its own 14-row key table: an agent reads the real file and gets a schema matching the build in front of it, not a copy projected into `~/.agents/skills` at some earlier version.

**`~/.config/atlas/` rather than `app_config_dir()`.** `~/Library/Application Support/dev.atlas.ide/` is right for machine-managed state and wrong for a file whose whole point is that a person or an agent opens and edits it. Zed made the same call for the same reason. This is a split, not a move: `state.json`, `device.json`, `telemetry.json`, the caches and session-chat all stay in the platform data directory. `$XDG_CONFIG_HOME` wins when absolute.

No new top-level dependencies. Telemetry pipeline unchanged — `shareTelemetry` and `linkTelemetryToAccount` keep their opt-out semantics and the same coarse event set, so `TELEMETRY.md` needs no update; the only change is that the account-linkage preference now actually takes effect when you flip it.

### How?

- **Schema + validation** — `src-tauri/src/state/atlas_config.rs`. `SETTINGS_DOCS` is the single list of recognized keys *and* the source of the file's comments. Validation is all-or-nothing: a candidate is parsed and validated in full before it replaces anything, and this module never repairs, renames or overwrites a malformed file on its own — "Recreate defaults" is the sole authorized path, and it backs up first.
- **Writes** — `toml_edit` key-by-key, so comments, ordering and unrecognized keys survive a patch. The write re-checks the file immediately before the swap and rebuilds on fresh content rather than clobbering a concurrent external edit (bounded, then `ConfigError::Busy`). `write_atomic` fsyncs the temp file and the parent directory and cleans up on failure.
- **Live reload** — the watcher watches the parent directory, since an atomic save replaces the inode. Every setting is hot-reloadable.
- **Frontend** — `AppSettings` lives in `features/settings/lib/app-settings.ts`, which broke an import cycle with `atlas-config-api.ts`; a `resetConfig` store action replaced the Settings panel's direct `setState`, which raced the config-changed listener and skipped theme/zoom side effects.
- **Docs** — `docs/reference/configuration.md` covers location, schema, precedence, failure behaviour, the write path and the migration guarantees.

Fixes #64

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [x] You've run the app and used the change in a window

Notes for the reviewer:

- **CI is already red on `0.3.1`** and this PR inherits it. Three frontend tests fail — `cargo-workspace.test.ts`, `ci-coverage.test.ts`, `comms/lib/derive.test.ts` — and they fail identically on `origin/0.3.1` with this branch's changes absent (verified in a worktree at that ref). None of them are touched by this work.
- The two migration guards were confirmed to fail against the un-fixed code before being kept.
- No migration from the old `app_config_dir()` location, because nothing shipped ever wrote a `config.toml` — it first appears in `315752fa`, which is in no tag. Anyone who ran this branch locally before `c636919c` has a file at the old path that Atlas will now ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)