### PR TITLE
test(comms): pin the midnight-boundary fixture to local time

### DIFF
--- a/src/features/comms/lib/derive.test.ts
+++ b/src/features/comms/lib/derive.test.ts
@@ -105,10 +105,15 @@ describe("groupMessages", () => {
   it("breaks the stack across midnight so the day divider can render", () => {
     // The divider is drawn BETWEEN groups. Two messages minutes apart either
     // side of midnight used to stay in one group, which suppressed it entirely.
+    //
+    // Local-time components, not a UTC string: `crossesDay` compares local
+    // calendar dates, so a fixture pinned to UTC midnight only straddles a day
+    // when the machine's zone IS UTC — anywhere else both instants land on the
+    // same date and the assertion fails.
     const groups = groupMessages(
       [
-        msg({ id: "m1", created_at: Date.parse("2026-08-31T23:59:00.000Z") }),
-        msg({ id: "m2", created_at: Date.parse("2026-09-01T00:01:00.000Z") }),
+        msg({ id: "m1", created_at: new Date(2026, 7, 31, 23, 59).getTime() }),
+        msg({ id: "m2", created_at: new Date(2026, 8, 1, 0, 1).getTime() }),
       ],
       "u_b",
     );


### PR DESCRIPTION
### What?

`src/features/comms/lib/derive.test.ts` › `groupMessages` › *breaks the stack across midnight so the day divider can render* fails on any machine whose timezone is not UTC. This builds the two fixture instants from local-time components instead of UTC strings.

### Why?

`crossesDay` (and `isNewDay`) compare **local** calendar dates via `toDateString()`. The fixture pinned the messages to `2026-08-31T23:59Z` and `2026-09-01T00:01Z`, which only straddle midnight when the machine's zone *is* UTC. Anywhere else both instants land on the same local date — Seoul sees 08:59 and 09:01 on Sep 1, Los Angeles sees 16:59 and 17:01 on Aug 31 — so the two messages stay in one group and the assertion fails. CI's `ubuntu-latest` runners are UTC, which is why the suite is green there and red on a developer's laptop.

### How?

`new Date(2026, 7, 31, 23, 59)` / `new Date(2026, 8, 1, 0, 1)` — the boundary is now local midnight wherever the test runs, which is exactly what the code under test compares against. Comment added next to the fixture so the next person doesn't "fix" it back to an ISO string.

Verified with `TZ=<zone> bun run test src/features/comms/lib/derive.test.ts`:

| zone | before | after |
|---|---|---|
| `Asia/Seoul` (this machine) | 1 failed / 19 passed | 20 passed |
| `America/Los_Angeles` | 1 failed / 19 passed | 20 passed |
| `UTC` | 20 passed | 20 passed |
| `Pacific/Kiritimati` (UTC+14) | — | 20 passed |

`bun run lint`, `bun run format:check`, `bun run typecheck` clean. Platform: Windows 11, Bun 1.3.14 — but nothing here is platform-specific.

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it — this *is* the test; it fails before in every non-UTC zone, see table
- [ ] You've run the app and used the change in a window — test-only change, no app behaviour touched
