### PR TITLE
test: compare manifest paths with forward slashes in the codex quarantine suite

### DIFF
--- a/tests/codex-quarantine.test.ts
+++ b/tests/codex-quarantine.test.ts
@@ -142,7 +142,10 @@ describe("nothing that ships depends on the vendored engine", () => {
   it("no Atlas crate declares a codex dependency", () => {
     const offenders = atlasManifests()
       .filter((m) => CODEX_DEP.test(uncommented(read(m))))
-      .map((m) => path.relative(REPO_ROOT, m))
+      // Forward slashes regardless of host: `path.relative` answers with the
+      // native separator, and on Windows `cratestlas-native-agent\Cargo.toml`
+      // misses the allowlist above and the seam is reported as an offender.
+      .map((m) => path.relative(REPO_ROOT, m).split(path.sep).join("/"))
       .filter((rel) => !ALLOWED_CODEX_CONSUMERS.has(rel));
     expect(
       offenders,


### PR DESCRIPTION
### What?

`tests/codex-quarantine.test.ts` › *no Atlas crate declares a codex dependency* fails on Windows: the one manifest that is allowed to depend on the engine (`crates/atlas-native-agent/Cargo.toml`) is reported as an offender. This normalises the relative path to forward slashes before the allowlist lookup.

### Why?

`path.relative(REPO_ROOT, m)` answers with the host separator, so on Windows the seam comes back as `crates\atlas-native-agent\Cargo.toml`, which is not in `ALLOWED_CODEX_CONSUMERS` (`crates/atlas-native-agent/Cargo.toml`). The other suites in `tests/` already compare names rather than paths, so this was the only one tripping — the rest of `bun run test` is green on Windows apart from the timezone fixture in #222.

CONTRIBUTING lists Windows testing as the place help goes furthest; this is one of the things in the way of a green `bun run test` there.

### How?

`.split(path.sep).join("/")` on the relative path, with a comment saying why. No change on macOS/Linux where `path.sep` is already `/`.

Verified on Windows 11 (Bun 1.3.14), `bun run test tests/codex-quarantine.test.ts`:

- before: `1 failed | 8 passed` — `expected [ "crates\atlas-native-agent\Cargo.toml" ] to deeply equal []`
- after: `9 passed`

`bun run lint`, `bun run format:check`, `bun run typecheck` clean.

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it — this is the test; the before/after above is the evidence, reproducible on any Windows checkout
- [ ] You've run the app and used the change in a window — test-only change
