### PR TITLE
ci: cover atlas-comms in the crate matrix and clear its clippy denies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           - crate: atlas-checkpoint
             clippy: true
           - crate: atlas-codeindex
+          - crate: atlas-comms
           - crate: atlas-embed
           - crate: atlas-git
           - crate: atlas-gitdiff

--- a/crates/atlas-comms/src/manager.rs
+++ b/crates/atlas-comms/src/manager.rs
@@ -573,7 +573,7 @@ impl CommsManager {
         );
 
         let row = LocalMessage {
-            message: message.clone(),
+            message,
             client_msg_id: Some(client_msg_id.clone()),
             status: SendStatus::Sending,
             deleted: false,
@@ -1438,7 +1438,7 @@ mod tests {
             assert!(row.deleted);
             assert!(row.message.body.is_empty());
             // A rail must never point at something that is gone.
-            assert!(s.pins.get("c1").is_none_or(|rail| rail.is_empty()));
+            assert!(s.pins.get("c1").is_none_or(Vec::is_empty));
         });
     }
 

--- a/crates/atlas-comms/src/state.rs
+++ b/crates/atlas-comms/src/state.rs
@@ -219,7 +219,7 @@ pub fn apply_frame(
                 return Vec::new();
             };
             let optimistic_id = optimistic_id(&client_msg_id);
-            let conv_id = sent.conv_id.clone();
+            let conv_id = sent.conv_id;
 
             // The optimistic row may already have been replaced by a
             // `message.new` from our own other device; if so there is nothing


### PR DESCRIPTION
### What?

Adds `atlas-comms` to the CI crate matrix and clears the three workspace-lint-table clippy denies the crate carries. This is what has been failing the **frontend** and **app (src-tauri)** jobs on every push to `0.3.1` since `6d2cd890` ("chat WIP") — both were green at #218 (`787d652a`), see [run 33493190945](https://github.com/pacifio/atlas/actions/runs/33493190945) vs [run 33666867294](https://github.com/pacifio/atlas/actions/runs/33666867294).

### Why?

`crates/atlas-comms` landed without a matrix entry, so:

- `tests/ci-coverage.test.ts` › *runs the tests of every crate in the repository* fails with `expected [ 'atlas-comms' ] to deeply equal []` → **frontend job red**, and the crate's own tests have never run in CI.
- The app job's "Clippy (workspace lint table)" step checks `atlas-comms` as a dependency of `src-tauri`, and the lib carries two `redundant_clone` denies (`manager.rs:576`, `state.rs:222`) → `could not compile atlas-comms (lib) due to 2 previous errors` → **app job red**.
- Adding the matrix entry alone would have turned the new job red on a third deny only `--all-targets` sees: `redundant_closure_for_method_calls` in the crate's unit tests (`manager.rs:1441`, `is_none_or(|rail| rail.is_empty())`).

### How?

- `ci.yml`: `- crate: atlas-comms` in the matrix (alphabetical, after `atlas-codeindex`). No `clippy: true` — that's the opt-in `-D warnings` gate and I'd rather the maintainers flip it once they've seen it clean under current stable.
- `manager.rs:576`: `message: message.clone()` → `message` (last use).
- `state.rs:222`: `let conv_id = sent.conv_id.clone()` → `let conv_id = sent.conv_id` (`sent` was just removed from the map and is not used again).
- `manager.rs:1441`: `is_none_or(|rail| rail.is_empty())` → `is_none_or(Vec::is_empty)`.

No behaviour change. `atlas-native-agent`'s `engine_turn` failures are separate and pre-date this (they were already red at #218); not touched here.

Verified locally (Windows 11, `cargo 1.95` — CI uses current stable, so the deny set may differ slightly; the three above are the ones in the CI log):

```
cd crates/atlas-comms
cargo clippy --locked --all-targets           # before: 1 error (redundant closure, manager.rs:1441); after: clean
cargo clippy --locked --all-targets -- -D warnings   # after: clean
cargo test --locked                            # 4 + 17 + 8 passed
bun run test tests/ci-coverage.test.ts         # before: 1 failed; after: 5 passed
```

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it — `tests/ci-coverage.test.ts` is the test for the matrix entry and fails without it; the clippy fixes are gated by the lint table itself
- [ ] You've run the app and used the change in a window — no app behaviour touched
