### PR TITLE
fix(agent-servers): merge PATH extras with the platform separator

### DIFF
--- a/crates/atlas-agent-servers/src/host_env.rs
+++ b/crates/atlas-agent-servers/src/host_env.rs
@@ -4,6 +4,9 @@
 //! It belongs with the transport because it exists entirely for the benefit of
 //! the child process an [`AcpConnection`](crate::AcpConnection) spawns.
 
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
 /// Startup-time host environment fix-ups for the ACP agent process.
 ///
 /// Two concrete problems this addresses:
@@ -62,6 +65,12 @@ fn enrich_path() {
 /// init, etc.) can't hang app startup — on timeout we fall back to the
 /// hardcoded extras already applied in `apply_cheap_path_extras`.
 fn merge_login_shell_path() {
+    // A login-shell probe is a Unix idea: Windows has no `$SHELL` (and no
+    // `kill` for the timeout path below), and a GUI process there already
+    // inherits the user's full PATH.
+    if !cfg!(unix) {
+        return;
+    }
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
 
     // `probe_shell` runs `-lic` — login AND interactive, so both
@@ -109,12 +118,16 @@ fn apply_cheap_path_extras() {
         // (interactive-only) — deterministic backstop for the shell probe.
         extras.push(format!("{home}/.opencode/bin"));
     }
-    extras.push("/opt/homebrew/bin".into());
-    extras.push("/opt/homebrew/sbin".into());
-    extras.push("/usr/local/bin".into());
-    extras.push("/usr/local/sbin".into());
-    extras.push("/usr/bin".into());
-    extras.push("/bin".into());
+    // The system-wide guesses are Unix directories; on Windows they would only
+    // pad PATH with entries that exist nowhere.
+    if cfg!(unix) {
+        extras.push("/opt/homebrew/bin".into());
+        extras.push("/opt/homebrew/sbin".into());
+        extras.push("/usr/local/bin".into());
+        extras.push("/usr/local/sbin".into());
+        extras.push("/usr/bin".into());
+        extras.push("/bin".into());
+    }
     prepend_to_path(&extras);
 }
 
@@ -153,22 +166,8 @@ fn nvm_path_walk() {
 }
 
 fn prepend_to_path(extras: &[String]) {
-    let base = std::env::var("PATH").unwrap_or_default();
-    let mut path_parts: Vec<String> = if base.is_empty() {
-        Vec::new()
-    } else {
-        base.split(':').map(String::from).collect()
-    };
-
-    // Prepend extras (in reverse so the first listed wins after all inserts),
-    // skipping anything already on PATH.
-    for extra in extras.iter().rev() {
-        if !path_parts.iter().any(|p| p == extra) {
-            path_parts.insert(0, extra.clone());
-        }
-    }
-
-    let new_path = path_parts.join(":");
+    let base = std::env::var_os("PATH").unwrap_or_default();
+    let new_path = prepend_entries(&base, extras);
     // SAFETY: every caller runs at boot on the main thread, inside
     // `sanitize_host_env`, before any threads spawn child processes — the
     // post-boot mutators were removed (managed-node registration now injects
@@ -178,6 +177,37 @@ fn prepend_to_path(extras: &[String]) {
     }
 }
 
+/// `extras` ahead of `base`, each at most once, in the platform's own PATH
+/// syntax.
+///
+/// `split_paths`/`join_paths` rather than `':'`: Windows separates entries with
+/// `;` and every entry carries a drive-letter colon, so splitting on `':'`
+/// shredded `C:\Windows\system32;C:\Windows` into `C`, `\Windows\system32;C`,
+/// `\Windows`, the dedupe never matched anything, and the `':'` rejoin glued the
+/// extras onto the first inherited entry — which then no longer resolved.
+fn prepend_entries(base: &OsStr, extras: &[String]) -> OsString {
+    // An unset or empty PATH splits into one empty entry, which would rejoin
+    // as a trailing separator; treat it as no entries.
+    let mut parts: Vec<PathBuf> = if base.is_empty() {
+        Vec::new()
+    } else {
+        std::env::split_paths(base).collect()
+    };
+
+    // Prepend extras (in reverse so the first listed wins after all inserts),
+    // skipping anything already on PATH.
+    for extra in extras.iter().rev() {
+        let extra = PathBuf::from(extra);
+        if !parts.contains(&extra) {
+            parts.insert(0, extra);
+        }
+    }
+
+    // `join_paths` refuses an entry that itself contains the separator. None
+    // of ours do; if the inherited PATH somehow does, keep it as it was rather
+    // than lose it.
+    std::env::join_paths(parts).unwrap_or_else(|_| base.to_os_string())
+}
 
 /// Run `$SHELL -lic <script>` with an OWNED timeout: on expiry the probe child
 /// is killed (so its reader thread exits promptly) instead of being abandoned
@@ -219,5 +249,83 @@ fn probe_shell(
                 .status();
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::path::PathBuf;
+
+    use super::prepend_entries;
+
+    /// A PATH as the platform actually hands it over — drive letters and `;`
+    /// on Windows, `:`-separated absolute paths elsewhere.
+    fn inherited() -> Vec<PathBuf> {
+        if cfg!(windows) {
+            vec![r"C:\Windows\system32".into(), r"C:\Windows".into()]
+        } else {
+            vec!["/usr/bin".into(), "/bin".into()]
+        }
+    }
+
+    fn extra() -> String {
+        if cfg!(windows) {
+            r"C:\Users\me\.bun\bin".to_string()
+        } else {
+            "/home/me/.bun/bin".to_string()
+        }
+    }
+
+    fn entries(path: &OsStr) -> Vec<PathBuf> {
+        std::env::split_paths(path).collect()
+    }
+
+    #[test]
+    fn extras_go_in_front_and_every_inherited_entry_survives() {
+        let base = std::env::join_paths(inherited()).unwrap();
+
+        let merged = prepend_entries(&base, &[extra()]);
+
+        let mut expected = vec![PathBuf::from(extra())];
+        expected.extend(inherited());
+        assert_eq!(
+            entries(&merged),
+            expected,
+            "the merge must use the platform separator: splitting a Windows PATH on ':' \
+             shreds every drive-letter entry, and the rejoin glues the extras onto the first"
+        );
+    }
+
+    #[test]
+    fn an_extra_already_on_path_is_not_added_again() {
+        let base = std::env::join_paths(inherited()).unwrap();
+        let already = inherited()[1].to_string_lossy().into_owned();
+
+        let merged = prepend_entries(&base, &[already]);
+
+        assert_eq!(entries(&merged), inherited());
+    }
+
+    #[test]
+    fn the_first_listed_extra_wins() {
+        let base = std::env::join_paths(inherited()).unwrap();
+        let first = extra();
+        let second = inherited()[0].to_string_lossy().into_owned();
+
+        let merged = prepend_entries(&base, &[first.clone(), second]);
+
+        // `second` is already inherited, so it is not duplicated — and `first`
+        // still lands ahead of everything.
+        let mut expected = vec![PathBuf::from(first)];
+        expected.extend(inherited());
+        assert_eq!(entries(&merged), expected);
+    }
+
+    #[test]
+    fn an_empty_path_becomes_just_the_extras() {
+        let merged = prepend_entries(OsStr::new(""), &[extra()]);
+
+        assert_eq!(entries(&merged), vec![PathBuf::from(extra())]);
     }
 }


### PR DESCRIPTION
### What?

`crates/atlas-agent-servers/src/host_env.rs` — the boot-time PATH enrichment split and rejoined `PATH` on `':'`. That is only the separator on Unix. This switches the merge to `std::env::split_paths` / `join_paths`, extracts it into a pure `prepend_entries` with tests, and skips the two parts of the enrichment that are Unix by construction (the Homebrew/`/usr` guesses and the `$SHELL -lic` probe) on other platforms.

### Why?

On Windows the separator is `;` and every entry carries a drive-letter colon, so `C:\Windows\system32;C:\Windows` came apart as `C`, `\Windows\system32;C`, `\Windows`. Two consequences:

- the dedupe never matched anything (no fragment equals a real directory), and
- the `':'` rejoin glued every extra onto the *first* inherited entry: `C:\Users\me\.bun\bin:C:\Windows\system32;C:\Windows`. Windows then reads the first entry as one directory that doesn't exist, so whatever was first on the user's PATH silently stops resolving for the rest of the process — and every ACP agent spawned after boot inherits that PATH (`AcpConnection::stdio` passes the process env through).

CONTRIBUTING names "PATH resolution" as the first thing Windows testing should look at; this is the boot-time half of it.

### How?

- `prepend_entries(base: &OsStr, extras: &[String]) -> OsString`: `split_paths` → dedupe as `PathBuf`s → `join_paths`. Empty/unset PATH is treated as no entries (it otherwise splits into one empty entry and rejoins with a trailing separator). If `join_paths` refuses (an inherited entry containing the separator — nothing we add does), the PATH is left as it was rather than lost.
- `prepend_to_path` now reads `var_os("PATH")` and just applies the result; the `SAFETY` note on the `set_var` stays where it was.
- `apply_cheap_path_extras`: the `/opt/homebrew/*`, `/usr/local/*`, `/usr/bin`, `/bin` guesses only on `cfg!(unix)` — on Windows they exist nowhere. The `$HOME`-relative ones stay (Git Bash / MSYS users do have `HOME`).
- `merge_login_shell_path`: early return unless `cfg!(unix)` — there is no `$SHELL` on Windows, the timeout path shells out to `kill -9`, and a GUI process there already inherits the user's full PATH.

No change in behaviour on macOS/Linux beyond the merge going through `split_paths`/`join_paths`, which produce the same `':'`-joined string there.

**Verification** (Windows 11, `cargo 1.95`; CI uses current stable):

Four tests in `host_env::tests`. Run against the *old* logic (temporarily lifted verbatim into `prepend_entries`) they fail on Windows with the exact shape described above:

```
test host_env::tests::extras_go_in_front_and_every_inherited_entry_survives ... FAILED
  left: ["C:\Users\me\.bun\bin:C:\Windows\system32", "C:\Windows"]
 right: ["C:\Users\me\.bun\bin", "C:\Windows\system32", "C:\Windows"]
test host_env::tests::an_extra_already_on_path_is_not_added_again ... FAILED
  left: ["C:\Windows:C:\Windows\system32", "C:\Windows"]
 right: ["C:\Windows\system32", "C:\Windows"]
test host_env::tests::the_first_listed_extra_wins ... FAILED
test result: FAILED. 1 passed; 3 failed
```

With the fix: `cargo test --locked -p atlas-agent-servers --lib` → 16 passed (12 existing + 4 new). On Unix the same tests exercise the `':'` form and pass before and after — the Windows failure is the one this change is for, so the honest statement is: the tests prove the regression only on a Windows runner.

`cargo clippy --locked --all-targets -- -D warnings` (this crate is `clippy: true` in CI) is clean for `src/`. It reports one pre-existing `collapsible_match` in `tests/connect.rs:540` under clippy 1.95 that CI's 1.98 does not flag; not touched here. `rustfmt --check` clean on the file.

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it — see above; fails on Windows only, by the nature of the bug
- [ ] You've run the app and used the change in a window — the app does not currently build on Windows (`numkong` does not compile under MSVC; separate report), so this is verified at the crate level only
