### PR TITLE
build(memory): build usearch without numkong on Windows

### DIFF
--- a/crates/atlas-memory/Cargo.toml
+++ b/crates/atlas-memory/Cargo.toml
@@ -20,7 +20,9 @@ uuid = { version = "1", features = ["v4"] }
 # `embedding::EmbeddingError`.
 thiserror = "2"
 # The persistent HNSW vector index — has native save/load/remove (hard deletes).
-usearch = "2.25.3"
+# Declared per target below: usearch's default `numkong` feature pulls in a C
+# kernel library that does not compile under MSVC, and this crate is the only
+# thing that keeps Atlas from building on Windows because of it.
 # On-device MiniLM embedder (384-d, CPU). The `MiniLmProvider` wraps this.
 atlas-embed = { path = "../atlas-embed" }
 
@@ -30,6 +32,18 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
+
+[target.'cfg(not(windows))'.dependencies]
+usearch = "2.25.3"
+
+# MSVC cannot compile `numkong` 7.x (usearch's default SIMD backend):
+# `include/numkong/cast/serial.h` fails with C2059/C2065 on every dispatch
+# unit, and 7.8.2 fares no better. Without the feature usearch falls back to
+# its own portable kernels (`USEARCH_USE_NUMKONG=0`), which do build there —
+# slower distance math, same index format, same API. Drop this stanza once
+# a numkong release builds under MSVC.
+[target.'cfg(windows)'.dependencies]
+usearch = { version = "2.25.3", default-features = false }
 
 # The workspace lint table is only real for members that opt in —
 # without this stanza it is dead configuration (#60).


### PR DESCRIPTION
### What?

`crates/atlas-memory/Cargo.toml`: declare `usearch` per target, so that on Windows it is built with `default-features = false` (no `numkong`). Nothing changes on macOS/Linux, and `Cargo.lock` is untouched (features are not part of the lockfile; `--locked` stays valid).

### Why?

MSVC cannot compile **numkong** 7.x, which is usearch 2.25's default SIMD backend. `cargo check -p atlas-memory` on Windows 11 / VS 2026 (MSVC 14.51) dies in numkong's build script:

```
error: failed to run custom build command for `numkong v7.7.0`
  error occurred in cc-rs: command did not execute successfully (status code exit code: 2): "...\cl.exe" ... "-c" "c/numkong.c"
```

cc-rs only forwards stderr, so the actual errors are invisible in the cargo output; running the same `cl.exe` line by hand shows a cascade starting at `include/numkong/cast/serial.h(884): error C2059: syntax error: 'if'`, then `C2065 'sign_bit' undeclared`, `C2099 initializer is not a constant`, … on every `dispatch_*.c` unit. numkong **7.8.2** (current) fails the same way, so this is not something a lock bump fixes. The crate's own `build.rs` passes `-std:c99`, which MSVC does not know (`D9002` ignoring unknown option) — the header relies on something that flag was meant to enable.

`atlas-memory` is the only workspace member that pulls usearch in, and this is the first hard stop for `cargo check -p atlas` on Windows — everything CONTRIBUTING lists under "Linux and Windows testing" is behind it.

### How?

usearch's `numkong` feature is what enables the C backend; without it usearch compiles its own portable kernels (`USEARCH_USE_NUMKONG=0` in its build script) — same index file format, same Rust API, just slower distance math on Windows until numkong builds under MSVC. Two target-specific tables replace the one plain line, with a comment saying when to drop the stanza.

**Verification** (Windows 11, `cargo 1.95`, MSVC 14.51):

- before: `cargo check --locked -p atlas-memory` → numkong build failure above.
- after: `cargo check --locked -p atlas-memory` → clean. Linking the test binary then hits `LNK2038 RuntimeLibrary MT_StaticRelease vs MD_DynamicRelease` in `esaxx-rs` — that is `tokenizers`' `esaxx_fast` default feature via `atlas-embed`, which #98 already addresses (its item 3). With #98's esaxx change applied locally on top of this PR, `cargo test -p atlas-memory` on Windows → **51 + 36 passed, 0 failed**. I have deliberately not included that change here since #98 owns it.
- `bun run test tests/cargo-workspace.test.ts tests/cargo-deps-unification.test.ts` → 24 passed (the manifest-shape guards).
- macOS/Linux: the `cfg(not(windows))` table is byte-for-byte the previous declaration, so nothing to re-verify there beyond CI.

Full Windows build/test report (what else is in the way after this) in the accompanying issue.

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it — a build fix; the "test" is `cargo check -p atlas-memory` on a Windows/MSVC host, failing before and passing after as above
- [ ] You've run the app and used the change in a window — the app still does not build on Windows for reasons outside this crate (see issue); verified at crate level
