### PR TITLE
build: rlib-only app crate, thin LTO, one cargo cache, content-aware dist sync

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,30 @@
+# The Tauri CLI exports MACOSX_DEPLOYMENT_TARGET (from
+# bundle.macOS.minimumSystemVersion) when it drives cargo, and 72 native build
+# scripts declare `rerun-if-env-changed` on it. Without this file a plain
+# `cargo build --release` and `tauri build` had disjoint caches inside one
+# target/: alternating them with nothing changed recompiled 186 crates and cost
+# 21m36s (measured 2026-09-04, docs/research/build-performance.md, R3), and it
+# is why target/release had grown to 69 GB of variants cargo never collects.
+#
+# The value must equal what the CLI sets, which is why it is checked against
+# tauri.conf.json in tests/cargo-workspace.test.ts rather than trusted here.
+# Deliberately not `force`: if the CLI ever disagrees, its value wins and the
+# contract test fails loudly instead of the build silently diverging.
+#
+# REMOVE_UNUSED_COMMANDS is deliberately NOT set here, though the research doc
+# proposed it. Verified on Tauri CLI 2.11.1 by running `tauri build` with a
+# fake `--runner` that dumps its environment: the CLI passes exactly one
+# variable, MACOSX_DEPLOYMENT_TARGET, and never sets REMOVE_UNUSED_COMMANDS.
+# Setting it here does not align the two caches — it un-aligns them, and worse,
+# `tauri-utils::acl::build::generate_allowed_commands` treats the variable's
+# mere presence as "prune every command no capability allows", so it silently
+# changed what the shipped binary exposes.
+#
+# One difference therefore remains and cannot be expressed as config: the CLI
+# invokes cargo as `cargo build --bins --features tauri/custom-protocol
+# --release` from src-tauri/, and that extra feature re-resolves `tauri` and the
+# six tauri-plugin-* crates. A plain `cargo build --release -p atlas` still
+# recompiles those eight crates plus the app. `cargo check`/`cargo test` are
+# unaffected; release builds go through `bun run build:app` (the CLI) only.
+[env]
+MACOSX_DEPLOYMENT_TARGET = "11.0"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,11 +20,19 @@
 # mere presence as "prune every command no capability allows", so it silently
 # changed what the shipped binary exposes.
 #
-# One difference therefore remains and cannot be expressed as config: the CLI
-# invokes cargo as `cargo build --bins --features tauri/custom-protocol
-# --release` from src-tauri/, and that extra feature re-resolves `tauri` and the
-# six tauri-plugin-* crates. A plain `cargo build --release -p atlas` still
-# recompiles those eight crates plus the app. `cargo check`/`cargo test` are
-# unaffected; release builds go through `bun run build:app` (the CLI) only.
+# One difference remains and cannot be expressed as config, because it is a
+# cargo *argument* rather than an env var: the CLI invokes cargo as
+# `cargo build --bins --features tauri/custom-protocol --release`, and that
+# feature re-resolves `tauri` and the six tauri-plugin-* crates. So a plain
+# `cargo build --release -p atlas` recompiles those eight plus the app (16
+# rustc invocations), while
+#
+#   cargo build --release -p atlas --features tauri/custom-protocol
+#
+# is a complete cache hit against `bun run build:app` — 0 rustc invocations,
+# verified 2026-09-04. `custom-protocol` cannot simply become a default
+# feature: it makes tauri serve the embedded assets instead of the dev server,
+# which is why the CLI adds it on release builds only. `cargo check`, `cargo
+# test` and `tauri dev` are unaffected by any of this.
 [env]
 MACOSX_DEPLOYMENT_TARGET = "11.0"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ bun.lockb
 
 # Build output
 dist/
+# Staging dir for scripts/build-frontend.mjs (content-aware sync into dist/).
+dist-next/
 target/
 
 # IDE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -658,17 +658,20 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev 
 [patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "4fffad30fe373adbdcffab9545e9e9bf4f2fc19f" }
 
-# Release profile — Atlas previously shipped with Cargo defaults
-# (lto = false, codegen-units = 16, no strip), which means the bundled .app
-# binary was substantially larger and slower than necessary.
-#
-# Trade-off: `bun run build:app` link time roughly doubles on clean builds
-# (~30 s → ~60–90 s). Dev (`tauri dev`) is unaffected — these are
-# release-only settings.
+# Release profile. Thin LTO, not fat: measured 2026-09-04 on an M4 Pro at
+# 422af792 (docs/research/build-performance.md) fat LTO's final link is a
+# 12-minute single-threaded unit that reruns on every rebuild — one-file touch
+# 14m59s, clean 23m05s — for a binary 19 MB smaller. Thin LTO at the same
+# codegen-units, same tree: touch 4m16s, clean 8m14s, 170 MB vs 151 MB.
+# Nothing upstream of that unit can shorten it; making the inputs cheaper to
+# produce (codegen-units = 16 on the dependencies) made the fat merge *worse*,
+# 38 minutes for the link alone. `codegen-units = 1` stays: raising it buys
+# ~50 s per touch for +74 MB of binary (thin/cgu16 measured 243 MB).
+# Before flipping this back to "fat", measure — the research doc has the method.
 [profile.release]
 codegen-units = 1   # Single codegen unit → better cross-function inlining
-lto = "fat"         # Fat LTO: maximum cross-crate dead-code elimination +
-                    # inlining (smaller binary; ~2× link time vs thin)
+lto = "thin"        # Thin LTO: cross-crate inlining and DCE in parallel, per
+                    # codegen unit, instead of one serial whole-program merge
 strip = "symbols"   # Smaller .app bundle, faster dyld load
 panic = "unwind"    # REQUIRED — three independent `catch_unwind` guards depend on
                     # it, so this survived the local-LLM removal:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "tauri": "tauri",
     "dev:app": "node scripts/with-posthog-env.mjs tauri dev",
     "build:app": "node scripts/with-posthog-env.mjs tauri build --bundles app",
-    "build:app:fast": "CARGO_TARGET_DIR=\"$PWD/target/fast\" CARGO_PROFILE_RELEASE_LTO=thin CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 node scripts/with-posthog-env.mjs tauri build --bundles app",
     "build:app:dmg": "bash scripts/build-dmg.sh arm",
     "build:app:dmg:arm": "bash scripts/build-dmg.sh arm",
     "build:app:dmg:intel": "bash scripts/build-dmg.sh intel",

--- a/scripts/build-frontend.mjs
+++ b/scripts/build-frontend.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * `beforeBuildCommand` for `tauri build`: typecheck, build the frontend, and
+ * then sync the result into `dist/` **by content**.
+ *
+ * Why not just `bun run build`: `tauri-build` prints
+ * `cargo:rerun-if-changed=<frontendDist>` for the whole `dist/` directory
+ * (tauri-build/src/codegen/context.rs). `vite build` empties and rewrites
+ * `dist/` on every run, so every `tauri build` dirtied the app crate's build
+ * script and recompiled the lib, the bin and the LTO link even when nothing
+ * had changed — measured 2026-09-04 at 15m16s for a no-op build
+ * (docs/research/build-performance.md, R4).
+ *
+ * Vite's output is content-hashed and deterministic, so only the mtimes were
+ * actually changing. This script builds into `dist-next/` and copies across
+ * only the files whose bytes differ, deletes the ones that disappeared, and
+ * leaves everything else — mtimes included — alone. An unchanged frontend
+ * therefore leaves `dist/` untouched, `rerun-if-changed` stays satisfied, and
+ * a Rust-only rebuild no longer pays for a frontend it did not change.
+ *
+ * `bun run build` keeps doing the plain `tsc && vite build` for CI and for
+ * anyone iterating on the frontend alone.
+ */
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  existsSync,
+  unlinkSync,
+  rmdirSync,
+} from "node:fs";
+import { delimiter, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = join(root, "dist");
+const NEXT = join(root, "dist-next");
+
+/** Run a command from the repo root, inheriting stdio; exit on failure. */
+function run(cmd, args) {
+  const env = { ...process.env };
+  env.PATH = `${join(root, "node_modules", ".bin")}${delimiter}${env.PATH ?? ""}`;
+  const label = [cmd, ...args].join(" ");
+  console.log(`[build-frontend] ${label}`);
+  const result = spawnSync(cmd, args, {
+    stdio: "inherit",
+    cwd: root,
+    env,
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) {
+    console.error(`[build-frontend] failed: ${label}`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+/** Every file under `dir`, as paths relative to it (POSIX-ish, sorted). */
+function listFiles(dir) {
+  const out = [];
+  const walk = (abs) => {
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      const child = join(abs, entry.name);
+      if (entry.isDirectory()) walk(child);
+      else if (entry.isFile()) out.push(relative(dir, child));
+    }
+  };
+  if (existsSync(dir)) walk(dir);
+  return out.sort();
+}
+
+function sameBytes(a, b) {
+  // Size first: it settles almost every changed file without reading either.
+  try {
+    if (statSync(a).size !== statSync(b).size) return false;
+  } catch {
+    return false;
+  }
+  const digest = (p) => createHash("sha256").update(readFileSync(p)).digest("hex");
+  return digest(a) === digest(b);
+}
+
+/** Remove directories left empty after deletions, deepest first. */
+function pruneEmptyDirs(dir) {
+  const walk = (abs) => {
+    let empty = true;
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!walk(join(abs, entry.name))) empty = false;
+      } else {
+        empty = false;
+      }
+    }
+    if (empty && abs !== dir) rmdirSync(abs);
+    return empty;
+  };
+  if (existsSync(dir)) walk(dir);
+}
+
+// 1. Typecheck. `tsconfig.json` only — the test config is not part of the
+//    shipped bundle and `bun run typecheck` covers it in the PR gates.
+run("bunx", ["tsc", "--noEmit", "-p", "tsconfig.json"]);
+
+// 2. Build into a staging directory so `dist/` is never emptied.
+rmSync(NEXT, { recursive: true, force: true });
+run("bunx", ["vite", "build", "--outDir", "dist-next", "--emptyOutDir"]);
+
+// 3. Content-aware sync into `dist/`.
+mkdirSync(DIST, { recursive: true });
+const next = listFiles(NEXT);
+if (next.length === 0) {
+  console.error("[build-frontend] vite produced no files in dist-next/ — refusing to sync");
+  process.exit(1);
+}
+const nextSet = new Set(next);
+
+let copied = 0;
+for (const rel of next) {
+  const from = join(NEXT, rel);
+  const to = join(DIST, rel);
+  if (sameBytes(from, to)) continue;
+  mkdirSync(dirname(to), { recursive: true });
+  copyFileSync(from, to);
+  copied += 1;
+}
+
+let removed = 0;
+for (const rel of listFiles(DIST)) {
+  if (nextSet.has(rel)) continue;
+  unlinkSync(join(DIST, rel));
+  removed += 1;
+}
+pruneEmptyDirs(DIST);
+
+rmSync(NEXT, { recursive: true, force: true });
+
+const unchanged = next.length - copied;
+console.log(
+  `[build-frontend] dist/: ${copied} written, ${removed} deleted, ${unchanged} unchanged ` +
+    `(unchanged files keep their mtime, so tauri-build's rerun-if-changed stays satisfied)`,
+);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,19 @@ edition = "2021"
 
 [lib]
 name = "atlas_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+# rlib only. `staticlib`/`cdylib` are the Tauri mobile template's crate types
+# (a native shell loads the app as a library); Atlas ships a macOS binary via
+# main.rs → atlas_lib::run(). They are not free: a lib that emits a staticlib
+# needs object code from every dependency, so cargo compiled all ~1,150 of
+# them with machine code AND bitcode and fat LTO optimised everything twice,
+# and this unit wrote a 1.7 GB libatlas_lib.a on every rebuild. Measured
+# 2026-09-04 (docs/research/build-performance.md): with the fat profile this
+# change alone took a clean build from 22m46s to 18m34s and cut 14% of total
+# CPU; under the thin profile that replaced it (see the root Cargo.toml) a
+# clean build is 8m14s at 422af792. No trade-off — nothing consumes the
+# staticlib or the cdylib. Restore the two crate types only with a real
+# iOS/Android target in gen/.
+crate-type = ["rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
     "beforeDevCommand": "bun run dev",
-    "beforeBuildCommand": "bun run build"
+    "beforeBuildCommand": "node scripts/build-frontend.mjs"
   },
   "app": {
     "macOSPrivateApi": true,

--- a/tests/cargo-workspace.test.ts
+++ b/tests/cargo-workspace.test.ts
@@ -281,6 +281,19 @@ describe("dev-profile opt-levels survive the move into the workspace", () => {
   });
 });
 
+describe("the app crate emits one crate type", () => {
+  // `staticlib`/`cdylib` are the Tauri mobile template's defaults and there is
+  // no mobile target here. A lib emitting a staticlib forces cargo to compile
+  // every dependency with object code *and* bitcode, so LTO optimises the whole
+  // graph twice and the lib unit writes a 1.7 GB archive nothing loads —
+  // measured 2026-09-04, docs/research/build-performance.md (R2).
+  it("the app lib is an rlib only (staticlib/cdylib double every dependency's codegen)", () => {
+    expect(read(path.join(REPO_ROOT, "src-tauri", "Cargo.toml"))).toMatch(
+      /^\s*crate-type\s*=\s*\["rlib"\]\s*$/m,
+    );
+  });
+});
+
 describe("the build scripts follow the target dir into the workspace", () => {
   /**
    * A workspace moves cargo's output from `src-tauri/target/` to the root's

--- a/tests/cargo-workspace.test.ts
+++ b/tests/cargo-workspace.test.ts
@@ -300,6 +300,62 @@ describe("the app crate emits one crate type", () => {
   });
 });
 
+describe("plain cargo and the Tauri CLI agree on the deployment target", () => {
+  /**
+   * The Tauri CLI exports `MACOSX_DEPLOYMENT_TARGET` (from
+   * `bundle.macOS.minimumSystemVersion`) when it drives cargo, and 72 native
+   * build scripts `rerun-if-env-changed` on it. When `.cargo/config.toml` does
+   * not set the same value, `cargo check` / `cargo test` and `tauri build` have
+   * disjoint caches inside one `target/`: alternating them with nothing changed
+   * recompiled 186 crates and cost 21m36s (measured 2026-09-04,
+   * docs/research/build-performance.md, R3).
+   *
+   * Checked against the tauri config rather than a literal, because a bump to
+   * `minimumSystemVersion` that forgets this file silently reintroduces the
+   * split cache.
+   *
+   * `REMOVE_UNUSED_COMMANDS` is asserted *absent*, against the research doc's
+   * proposal: verified on CLI 2.11.1 (a `tauri build --runner` that dumps its
+   * environment) the CLI never sets it, so setting it here splits the cache the
+   * other way — and `tauri-utils`' `generate_allowed_commands` reads its mere
+   * presence as "prune every command no capability allows", quietly changing
+   * what the shipped binary exposes.
+   */
+  const CARGO_CONFIG = path.join(REPO_ROOT, ".cargo", "config.toml");
+
+  const envTable = (): string => {
+    const src = uncommented(read(CARGO_CONFIG));
+    const block = src.match(/^\s*\[env\]\s*$((?:(?!^\s*\[)[\s\S])*)/m);
+    if (!block) throw new Error("no [env] table in .cargo/config.toml");
+    return block[1];
+  };
+
+  it("exists at the repository root", () => {
+    expect(existsSync(CARGO_CONFIG), "no .cargo/config.toml").toBe(true);
+  });
+
+  it("sets MACOSX_DEPLOYMENT_TARGET to the bundle's minimumSystemVersion", () => {
+    const conf = JSON.parse(read(path.join(REPO_ROOT, "src-tauri", "tauri.conf.json")));
+    const minimum = conf?.bundle?.macOS?.minimumSystemVersion;
+    expect(typeof minimum, "tauri.conf.json has no bundle.macOS.minimumSystemVersion").toBe(
+      "string",
+    );
+    const declared = envTable().match(/^\s*MACOSX_DEPLOYMENT_TARGET\s*=\s*"([^"]+)"/m);
+    expect(declared, "no MACOSX_DEPLOYMENT_TARGET in .cargo/config.toml [env]").not.toBeNull();
+    expect(declared?.[1]).toBe(minimum);
+  });
+
+  it("does not set REMOVE_UNUSED_COMMANDS", () => {
+    expect(envTable()).not.toMatch(/REMOVE_UNUSED_COMMANDS/);
+  });
+
+  it("does not force any value over the CLI's", () => {
+    // `force = true` would override what the CLI exports instead of matching
+    // it — the split cache would come back silently, in the other direction.
+    expect(envTable()).not.toMatch(/force\s*=\s*true/);
+  });
+});
+
 describe("the build scripts follow the target dir into the workspace", () => {
   /**
    * A workspace moves cargo's output from `src-tauri/target/` to the root's

--- a/tests/cargo-workspace.test.ts
+++ b/tests/cargo-workspace.test.ts
@@ -43,8 +43,8 @@ const ROOT_MANIFEST = path.join(REPO_ROOT, "Cargo.toml");
  * template binary that `commands::knowledge_export` compiles on demand at
  * runtime, and it carries its own `[profile.release]` (`panic = "abort"`,
  * thin LTO). Profiles are workspace-global, so joining the workspace would
- * silently rebuild it under the app's fat-LTO/unwind profile. Excluded so its
- * build stays byte-for-byte what it is today.
+ * silently rebuild it under the app's unwind profile. Excluded so its build
+ * stays byte-for-byte what it is today.
  */
 const EXCLUDED_CRATE_DIRS = new Set(["atlas-kb-server"]);
 
@@ -271,13 +271,19 @@ describe("dev-profile opt-levels survive the move into the workspace", () => {
     expect(src).toMatch(/^\s*\[profile\.release\]/m);
     for (const setting of [
       /codegen-units\s*=\s*1/,
-      /lto\s*=\s*"fat"/,
+      /lto\s*=\s*"thin"/,
       /strip\s*=\s*"symbols"/,
       /panic\s*=\s*"unwind"/,
       /opt-level\s*=\s*3/,
     ]) {
       expect(src).toMatch(setting);
     }
+    // Asserted absent, not merely unasserted: fat LTO's final link is a
+    // 12-minute single-threaded unit that reruns on every rebuild, for a
+    // binary 19 MB smaller (measured 2026-09-04 — clean 23m05s vs 8m14s,
+    // touch 14m59s vs 4m16s; docs/research/build-performance.md). Whoever
+    // wants it back measures first.
+    expect(src).not.toMatch(/lto\s*=\s*"fat"/);
   });
 });
 


### PR DESCRIPTION
## Why

`bun run build:app` cost 15–23 minutes per run, including runs where nothing changed. Four configuration facts, not the size of the Rust graph, accounted for it (full write-up with measurements and method: `docs/research/build-performance.md`, in the tree but gitignored):

1. **Fat LTO** — a 12-minute single-threaded whole-program link that reran on every rebuild, for a binary ~20 MB smaller.
2. **`crate-type = ["staticlib", "cdylib", "rlib"]`** on the app crate (the Tauri *mobile* template default, with no mobile target) forced every dependency to compile with object code *and* bitcode, so LTO optimised the graph twice, and wrote a 1.7 GB `libatlas_lib.a` per rebuild.
3. **Plain cargo and the Tauri CLI had disjoint caches** — the CLI exports `MACOSX_DEPLOYMENT_TARGET`, which 72 native build scripts `rerun-if-env-changed` on.
4. **`dist/` is a Rust build input** — `tauri-build` declares `rerun-if-changed` on it and `vite build` rewrote it every time, so the app crate recompiled on every `tauri build`.

## What changed

- `src-tauri/Cargo.toml`: `crate-type = ["rlib"]`.
- Root `Cargo.toml`: `lto = "thin"` (`codegen-units = 1`, `panic = "unwind"`, `opt-level = 3`, `strip` unchanged). `build:app:fast` script removed from `package.json` — its env-var profile flips are what filled `target/` with dead variants.
- New `.cargo/config.toml` with `[env] MACOSX_DEPLOYMENT_TARGET = "11.0"` (= `bundle.macOS.minimumSystemVersion`). **Not** `REMOVE_UNUSED_COMMANDS`: the CLI never sets it, and `tauri-utils` treats its presence as "prune every command no capability allows".
- New `scripts/build-frontend.mjs` as `beforeBuildCommand`: `tsc --noEmit`, `vite build` into `dist-next/`, then copy only files whose bytes differ into `dist/`. Unchanged frontend → no Rust work. `bun run build` is unchanged for CI and frontend-only use.
- `tests/cargo-workspace.test.ts`: guards for the crate type, the thin/not-fat profile, the env value matching `tauri.conf.json`, and the absence of `REMOVE_UNUSED_COMMANDS`.

## Measured (M4 Pro, commit 422af792, this branch)

| scenario | before | after |
|---|---|---|
| clean `bun run build:app` | 23m05s | 9m03s |
| no-change `bun run build:app` | 15m16s | 9.4 s (0 `Compiling`) |
| one-file touch, cargo | 14m59s | 4m16s |
| binary | 151 MB | 172.7 MB |

One wrinkle: the first no-change rebuild right after a `cargo clean --release` recompiles the app crate once more (4m41s) because `tauri-build`'s first `OUT_DIR` fingerprint is stale by construction; every rebuild after that is the 9 s row.

The one thing the config cannot express: the CLI passes `--features tauri/custom-protocol`, which re-resolves `tauri` and the six plugins. `cargo build --release -p atlas --features tauri/custom-protocol` is a full cache hit against `build:app`; a bare `cargo build --release` is not. `cargo check`, `cargo test` and `tauri dev` are unaffected.

## Verification

- `bun run lint && bun run format:check && bun run typecheck && bun run test` (57 files, 1,086 tests) — green
- `cargo check --workspace` — green
- `bun run build:app` ×3 after `cargo clean --release`: 9m03s → 4m41s (one-shot) → 9.4 s
- `cargo build --release -p atlas --features tauri/custom-protocol -v`: 0 `Running` lines
- `bun run test:rust` not run (full workspace test-profile compile)

**Still owed before release:** a runtime comparison of a thin-LTO build against the last fat release (cold launch, one streaming session). The profile change is one word to reverse if it shows anything.

Note for reviewers: `CLAUDE.md` is gitignored, so its rewritten "Build cost" section does not travel with this PR; the same content is in the research doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ssYTTgFqBuF8nuZYn2pUL
