### PR TITLE
feat(chat): pace native-agent streaming with an adaptive per-session smoother

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useTerminalStore } from "@/features/terminal/stores/terminal-store";
 import { useProjectStore, type AppStateWire } from "@/features/project/stores/project-store";
 import { useChatStore } from "@/features/chat/stores/chat-store";
 import { listenAgents, resetAgentByAgentId } from "@/features/chat/lib/agents-api";
+import { StreamSmoother } from "@/features/chat/lib/stream-smoother";
 import type { PendingPermission } from "@/types/acp";
 import type { AgentDelta } from "@/types/agents";
 import { cycleChatAgent } from "@/features/chat/lib/switch-agent";
@@ -896,15 +897,7 @@ export function App() {
       }
     };
 
-    listenAgents((env) => {
-      if (cancelled) return;
-      if (
-        env.kind === "status" ||
-        env.kind === "message_appended" ||
-        env.kind === "turn_finished"
-      ) {
-        recordRecentChat(env.session_id);
-      }
+    const dispatchAgentDelta = (env: AgentDelta) => {
       const actions = useChatStore.getState().actions;
       switch (env.kind) {
         case "text_chunk":
@@ -1057,6 +1050,34 @@ export function App() {
           schedule();
           return;
       }
+    };
+
+    // Native-agent text arrives in provider-side bursts (~400-650 ms lumps —
+    // measured; see research/stream-smoothing.md). The smoother sits between
+    // the wire and the dispatch above and drips text/thinking chunks out at a
+    // steady rate, preserving wire order (non-text deltas barrier behind the
+    // text ahead of them). ACP sessions pass through untouched.
+    const isNativeAgentSession = (acpSessionId: string): boolean => {
+      for (const s of Object.values(useChatStore.getState().sessions)) {
+        if (s.acpSessionId === acpSessionId) return s.agentType === "cersei";
+      }
+      // Unknown session (delta raced ahead of the tab binding): don't smooth.
+      return false;
+    };
+    const smoother = new StreamSmoother(dispatchAgentDelta, {
+      shouldSmooth: isNativeAgentSession,
+    });
+
+    listenAgents((env) => {
+      if (cancelled) return;
+      if (
+        env.kind === "status" ||
+        env.kind === "message_appended" ||
+        env.kind === "turn_finished"
+      ) {
+        recordRecentChat(env.session_id);
+      }
+      smoother.ingest(env);
     }).then((un) => {
       if (cancelled) un();
       else unlisten = un;
@@ -1072,6 +1093,7 @@ export function App() {
 
     return () => {
       cancelled = true;
+      smoother.dispose();
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (backstopId !== null) clearTimeout(backstopId);
       window.removeEventListener("atlas:window-active", flushOnWake);

--- a/src/features/chat/lib/stream-smoother.test.ts
+++ b/src/features/chat/lib/stream-smoother.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { StreamSmoother } from "./stream-smoother";
+import type { AgentDelta } from "@/types/agents";
+
+/** Test fixture: collect everything the smoother hands downstream. */
+const makeSink = () => {
+  const out: AgentDelta[] = [];
+  const sink = (env: AgentDelta) => out.push(env);
+  return { out, sink };
+};
+
+const text = (delta: string, session = "s1", messageId = "m1"): AgentDelta => ({
+  kind: "text_chunk",
+  agent_id: "a1",
+  session_id: session,
+  message_id: messageId,
+  delta,
+});
+
+const thinking = (delta: string, session = "s1", messageId = "m1"): AgentDelta => ({
+  kind: "thinking_chunk",
+  agent_id: "a1",
+  session_id: session,
+  message_id: messageId,
+  delta,
+});
+
+const toolCall = (session = "s1"): AgentDelta => ({
+  kind: "tool_call_upserted",
+  agent_id: "a1",
+  session_id: session,
+  message_id: "m1",
+  tool_call: { id: "t1" } as never,
+});
+
+const finished = (stopReason = "end_turn", session = "s1"): AgentDelta =>
+  ({
+    kind: "turn_finished",
+    agent_id: "a1",
+    session_id: session,
+    stop_reason: stopReason,
+  }) as AgentDelta;
+
+const failed = (session = "s1"): AgentDelta =>
+  ({
+    kind: "turn_failed",
+    agent_id: "a1",
+    session_id: session,
+    error: "boom",
+  }) as AgentDelta;
+
+/** Concatenated text of every emitted chunk of `kind` for a session. */
+const emittedText = (out: AgentDelta[], kind = "text_chunk", session = "s1") =>
+  out
+    .filter((e) => e.kind === kind && e.session_id === session)
+    .map((e) => (e as { delta: string }).delta)
+    .join("");
+
+const TICK = 33;
+const LAG = 450;
+
+const makeSmoother = (sink: (env: AgentDelta) => void, smooth = () => true) =>
+  new StreamSmoother(sink, {
+    tickMs: TICK,
+    targetLagMs: LAG,
+    minCharsPerTick: 2,
+    shouldSmooth: smooth,
+  });
+
+describe("StreamSmoother", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("spreads a burst out over roughly the target lag instead of emitting it at once", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("x".repeat(450)));
+
+    // Nothing is emitted synchronously…
+    expect(emittedText(out)).toBe("");
+
+    // …after ~a third of the lag window, roughly a third has typed out.
+    vi.advanceTimersByTime(150);
+    const after150 = emittedText(out).length;
+    expect(after150).toBeGreaterThan(50);
+    expect(after150).toBeLessThan(320);
+
+    // The whole burst lands within a generous multiple of the target lag.
+    vi.advanceTimersByTime(LAG * 2);
+    expect(emittedText(out)).toBe("x".repeat(450));
+    s.dispose();
+  });
+
+  it("drains by elapsed time, so throttled (rare, long) ticks still keep pace", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("y".repeat(900)));
+    // Simulate WebKit-throttled timers: a single 1s gap between ticks must
+    // emit ~a full window's worth, not one tick's worth.
+    vi.advanceTimersByTime(1000);
+    expect(emittedText(out).length).toBeGreaterThan(500);
+    s.dispose();
+  });
+
+  it("lets an already-smooth stream through with only floor-rate latency", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    // 2 chars every 30 ms ≈ the floor rate: the queue should hover near empty.
+    for (let i = 0; i < 20; i++) {
+      s.ingest(text("ab"));
+      vi.advanceTimersByTime(30);
+    }
+    vi.advanceTimersByTime(200);
+    expect(emittedText(out)).toBe("ab".repeat(20));
+    s.dispose();
+  });
+
+  it("preserves wire order: a tool delta between two text runs waits for the first to finish", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("first-run-"));
+    s.ingest(toolCall());
+    s.ingest(text("second"));
+
+    vi.advanceTimersByTime(LAG * 3);
+    const kinds = out.map((e) => e.kind);
+    const toolAt = kinds.indexOf("tool_call_upserted");
+    expect(toolAt).toBeGreaterThan(0);
+    const before = out
+      .slice(0, toolAt)
+      .map((e) => (e as { delta?: string }).delta ?? "")
+      .join("");
+    expect(before).toBe("first-run-");
+    expect(emittedText(out)).toBe("first-run-second");
+    s.dispose();
+  });
+
+  it("holds turn_finished until the text tail has typed out", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("tail text that is still typing"));
+    s.ingest(finished());
+
+    vi.advanceTimersByTime(TICK * 2);
+    expect(out.some((e) => e.kind === "turn_finished")).toBe(false);
+
+    vi.advanceTimersByTime(LAG * 3);
+    expect(out[out.length - 1]?.kind).toBe("turn_finished");
+    expect(emittedText(out)).toBe("tail text that is still typing");
+    s.dispose();
+  });
+
+  it("flushes instantly on a cancelled turn", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("partial answer the user cancelled"));
+    s.ingest(finished("cancelled"));
+
+    // No timer advance: cancel must land synchronously.
+    expect(emittedText(out)).toBe("partial answer the user cancelled");
+    expect(out[out.length - 1]?.kind).toBe("turn_finished");
+    s.dispose();
+  });
+
+  it("flushes instantly on turn_failed", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("half an answer"));
+    s.ingest(failed());
+    expect(emittedText(out)).toBe("half an answer");
+    expect(out[out.length - 1]?.kind).toBe("turn_failed");
+    s.dispose();
+  });
+
+  it("passes everything through synchronously for sessions it should not smooth", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink, () => false);
+    s.ingest(text("immediate"));
+    s.ingest(toolCall());
+    expect(emittedText(out)).toBe("immediate");
+    expect(out[1]?.kind).toBe("tool_call_upserted");
+    s.dispose();
+  });
+
+  it("keeps thinking and text chunks apart and tags emissions with the right message_id", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(thinking("pondering...", "s1", "m1"));
+    s.ingest(text("answer", "s1", "m2"));
+    vi.advanceTimersByTime(LAG * 3);
+    expect(emittedText(out, "thinking_chunk")).toBe("pondering...");
+    expect(emittedText(out, "text_chunk")).toBe("answer");
+    for (const e of out) {
+      if (e.kind === "thinking_chunk") expect(e.message_id).toBe("m1");
+      if (e.kind === "text_chunk") expect(e.message_id).toBe("m2");
+    }
+    // Thinking (ingested first) must fully precede the text run.
+    const lastThinking = out.map((e) => e.kind).lastIndexOf("thinking_chunk");
+    const firstText = out.map((e) => e.kind).indexOf("text_chunk");
+    expect(lastThinking).toBeLessThan(firstText);
+    s.dispose();
+  });
+
+  it("never splits a surrogate pair", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("👍".repeat(200)));
+    vi.advanceTimersByTime(LAG * 3);
+    for (const e of out) {
+      if (e.kind !== "text_chunk") continue;
+      // Every emitted piece must itself be valid (no lone surrogates).
+      expect((e as { delta: string }).delta).not.toMatch(/[\uD800-\uDBFF]$|^[\uDC00-\uDFFF]/);
+    }
+    expect(emittedText(out)).toBe("👍".repeat(200));
+    s.dispose();
+  });
+
+  it("flushAll dumps every queue synchronously", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("aaa", "s1"));
+    s.ingest(text("bbb", "s2"));
+    s.flushAll();
+    expect(emittedText(out, "text_chunk", "s1")).toBe("aaa");
+    expect(emittedText(out, "text_chunk", "s2")).toBe("bbb");
+    s.dispose();
+  });
+
+  it("smooths independent sessions independently", () => {
+    const { out, sink } = makeSink();
+    const s = makeSmoother(sink);
+    s.ingest(text("1".repeat(300), "s1"));
+    s.ingest(text("2".repeat(4), "s2"));
+    vi.advanceTimersByTime(LAG * 3);
+    expect(emittedText(out, "text_chunk", "s1")).toBe("1".repeat(300));
+    expect(emittedText(out, "text_chunk", "s2")).toBe("2".repeat(4));
+    s.dispose();
+  });
+});

--- a/src/features/chat/lib/stream-smoother.ts
+++ b/src/features/chat/lib/stream-smoother.ts
@@ -1,0 +1,250 @@
+import type { AgentDelta } from "@/types/agents";
+
+/**
+ * Paces bursty streamed text so it types out steadily instead of landing in
+ * lumps.
+ *
+ * Why: the gateway forwards provider chunks faithfully, but Claude-via-Vertex
+ * *emits* in ~400–650 ms bursts (measured on the live endpoint, 2026-09-05 —
+ * see research/stream-smoothing.md). Every hop from engine to store is
+ * per-delta, so the lumps reach the UI intact. This is the one deliberate
+ * pacing stage, and it is presentation-only: it sits between the
+ * `atlas:agents` listener and the RAF batcher in App.tsx, so the Rust-side
+ * transcript record never sees it.
+ *
+ * Ordering contract (the same one the RAF buffer documents): deltas for a
+ * session leave in exactly the order they arrived. Text/thinking chunks are
+ * the only thing paced; every other delta becomes a *barrier* in the queue
+ * that passes only once the text ahead of it has drained. `turn_finished`
+ * rides as a barrier too, so the tail keeps typing after the turn ends and
+ * the idle flip lands last. Exceptions, all deliberate:
+ *  - `permission_request` / `permission_resolved` bypass entirely — the modal
+ *    must open on the next tick, and permissions don't order against text.
+ *  - A cancelled `turn_finished`, `turn_failed`, and `agent_disconnected`
+ *    flush the queue synchronously first — stop must feel like stop, and an
+ *    error must not type out leisurely.
+ *
+ * Drain model: budget is computed from *elapsed* time (not tick count), so
+ * WebKit throttling timers to ~1 s while the window is unfocused degrades to
+ * chunkier-but-current, never to a growing backlog. The rate targets clearing
+ * the current backlog in `targetLagMs` and only ratchets *up* within a
+ * continuous drain (rising mid-burst is invisible; slowing down is not), with
+ * a floor so an already-smooth stream passes through at chunk speed.
+ */
+
+export interface StreamSmootherOptions {
+  /** Drain-timer interval. Purely a scheduling grain — see elapsed-time note. */
+  tickMs?: number;
+  /** Aim to clear the standing backlog within this window. */
+  targetLagMs?: number;
+  /** Chars emitted per tick even when the backlog math says fewer. */
+  minCharsPerTick?: number;
+  /** Which sessions get paced; everything else passes through synchronously. */
+  shouldSmooth?: (sessionId: string) => boolean;
+}
+
+type TextKind = "text_chunk" | "thinking_chunk";
+type TextDelta = Extract<AgentDelta, { kind: TextKind }>;
+
+type QueueEntry =
+  | {
+      type: "text";
+      kind: TextKind;
+      /** Template for synthetic emissions (message_id, agent_id, …). */
+      env: TextDelta;
+      text: string;
+      /** Read cursor into `text` — avoids re-slicing the head on every tick. */
+      cursor: number;
+    }
+  | { type: "barrier"; env: AgentDelta };
+
+interface SessionQueue {
+  entries: QueueEntry[];
+  /** Ratcheted drain rate (chars/ms); reset when the queue empties. */
+  rate: number;
+}
+
+const DEFAULT_TICK_MS = 33;
+const DEFAULT_TARGET_LAG_MS = 450;
+const DEFAULT_MIN_CHARS_PER_TICK = 2;
+
+/** Cut point ≤ `at` that doesn't split a surrogate pair. */
+const safeCut = (text: string, at: number): number => {
+  if (at >= text.length) return text.length;
+  const code = text.charCodeAt(at - 1);
+  // High surrogate at the boundary → include its partner.
+  if (code >= 0xd800 && code <= 0xdbff) return at + 1;
+  return at;
+};
+
+export class StreamSmoother {
+  private readonly sink: (env: AgentDelta) => void;
+  private readonly tickMs: number;
+  private readonly targetLagMs: number;
+  private readonly minCharsPerTick: number;
+  private readonly shouldSmooth: (sessionId: string) => boolean;
+
+  private readonly queues = new Map<string, SessionQueue>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastTickAt = 0;
+  private disposed = false;
+
+  constructor(sink: (env: AgentDelta) => void, opts: StreamSmootherOptions = {}) {
+    this.sink = sink;
+    this.tickMs = opts.tickMs ?? DEFAULT_TICK_MS;
+    this.targetLagMs = opts.targetLagMs ?? DEFAULT_TARGET_LAG_MS;
+    this.minCharsPerTick = opts.minCharsPerTick ?? DEFAULT_MIN_CHARS_PER_TICK;
+    this.shouldSmooth = opts.shouldSmooth ?? (() => true);
+  }
+
+  ingest(env: AgentDelta): void {
+    if (this.disposed) {
+      this.sink(env);
+      return;
+    }
+
+    // Permissions never queue: the modal opens synchronously today and text
+    // has no ordering relationship with the permission stack.
+    if (env.kind === "permission_request" || env.kind === "permission_resolved") {
+      this.sink(env);
+      return;
+    }
+
+    const sessionId = "session_id" in env ? env.session_id : undefined;
+    const queue = sessionId ? this.queues.get(sessionId) : undefined;
+
+    // Stop/error/teardown: whatever is queued lands NOW, then the terminal
+    // delta follows it — still in order, just all at once.
+    const isCancelledFinish = env.kind === "turn_finished" && env.stop_reason === "cancelled";
+    if (isCancelledFinish || env.kind === "turn_failed" || env.kind === "agent_disconnected") {
+      if (sessionId) this.flushSession(sessionId);
+      this.sink(env);
+      return;
+    }
+
+    if (env.kind === "text_chunk" || env.kind === "thinking_chunk") {
+      if (!sessionId || !this.shouldSmooth(sessionId)) {
+        this.sink(env);
+        return;
+      }
+      const q = this.queue(sessionId);
+      const last = q.entries[q.entries.length - 1];
+      if (
+        last?.type === "text" &&
+        last.kind === env.kind &&
+        last.env.message_id === env.message_id
+      ) {
+        last.text += env.delta;
+      } else {
+        q.entries.push({ type: "text", kind: env.kind, env, text: env.delta, cursor: 0 });
+      }
+      this.ensureTimer();
+      return;
+    }
+
+    // Any other delta: if text is queued ahead of it, it must wait its turn.
+    if (queue && queue.entries.length > 0) {
+      queue.entries.push({ type: "barrier", env });
+      return;
+    }
+    this.sink(env);
+  }
+
+  /** Emit everything a session still holds, synchronously and in order. */
+  flushSession(sessionId: string): void {
+    const q = this.queues.get(sessionId);
+    if (!q) return;
+    this.queues.delete(sessionId);
+    for (const entry of q.entries) {
+      if (entry.type === "barrier") {
+        this.sink(entry.env);
+      } else if (entry.cursor < entry.text.length) {
+        this.sink({ ...entry.env, delta: entry.text.slice(entry.cursor) });
+      }
+    }
+    this.stopTimerIfIdle();
+  }
+
+  flushAll(): void {
+    // Safe to mutate mid-iteration: flushSession only deletes the key in hand.
+    for (const sessionId of this.queues.keys()) this.flushSession(sessionId);
+  }
+
+  dispose(): void {
+    this.flushAll();
+    this.disposed = true;
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private queue(sessionId: string): SessionQueue {
+    let q = this.queues.get(sessionId);
+    if (!q) {
+      q = { entries: [], rate: 0 };
+      this.queues.set(sessionId, q);
+    }
+    return q;
+  }
+
+  private ensureTimer(): void {
+    if (this.timer !== null) return;
+    this.lastTickAt = Date.now();
+    this.timer = setInterval(() => this.tick(), this.tickMs);
+  }
+
+  private stopTimerIfIdle(): void {
+    if (this.timer !== null && this.queues.size === 0) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private tick(): void {
+    const now = Date.now();
+    // Clamped: a first tick or a resumed throttled timer must not compute a
+    // zero/negative or absurd window.
+    const elapsed = Math.max(1, now - this.lastTickAt);
+    this.lastTickAt = now;
+
+    for (const [sessionId, q] of this.queues) {
+      const backlog = q.entries.reduce(
+        (n, e) => n + (e.type === "text" ? e.text.length - e.cursor : 0),
+        0,
+      );
+      if (backlog === 0 && q.entries.length === 0) {
+        this.queues.delete(sessionId);
+        continue;
+      }
+      // Rate to clear the current backlog within the lag window; ratchet-up
+      // only, so the reader never sees the drain visibly decelerate mid-burst.
+      q.rate = Math.max(q.rate, backlog / this.targetLagMs);
+      let budget = Math.max(this.minCharsPerTick, Math.ceil(q.rate * elapsed));
+
+      while (q.entries.length > 0) {
+        const head = q.entries[0];
+        if (head.type === "barrier") {
+          q.entries.shift();
+          this.sink(head.env);
+          continue; // barriers are free — keep draining this tick's budget
+        }
+        if (budget <= 0) break;
+        const remaining = head.text.length - head.cursor;
+        const take = safeCut(head.text, head.cursor + Math.min(budget, remaining));
+        const piece = head.text.slice(head.cursor, take);
+        head.cursor = take;
+        budget -= piece.length;
+        if (head.cursor >= head.text.length) q.entries.shift();
+        if (piece.length > 0) this.sink({ ...head.env, delta: piece });
+      }
+
+      if (q.entries.length === 0) {
+        // Fully drained: drop the ratchet so the next burst re-derives its
+        // own rate instead of inheriting this one's.
+        this.queues.delete(sessionId);
+      }
+    }
+    this.stopTimerIfIdle();
+  }
+}


### PR DESCRIPTION
## What

Native-agent (Atlas Agent) responses stream into the chat in visible lumps. A live wire probe against `ai.tryatlas.cc` confirmed the cause: Claude-via-Vertex emits text in **~400–650 ms bursts** (occasional 1–1.5 s stalls), and every hop of our pipeline — gateway, engine SSE decoder, native-agent pump, Tauri emit, RAF batch — faithfully forwards per-delta, so the bursts reach the UI intact. (Full code-read + measurements in `research/stream-smoothing.md`, repo-local.)

This adds a presentation-only `StreamSmoother` between the `atlas:agents` listener and the RAF batcher in `App.tsx`:

- Per-session char queues drained on a 33 ms tick with an **elapsed-time budget**, so WebKit-throttled timers (unfocused window) degrade to chunkier-but-current, never a growing backlog.
- **Adaptive ratchet-up rate** targeting ~450 ms lag (derived from the measured burst gap), with a floor rate so an already-smooth stream passes through at chunk speed.
- **Wire order preserved**: every non-text delta becomes a queue barrier behind the text ahead of it; `turn_finished` barriers too, so the tail keeps typing before the idle flip.
- **Stop feels like stop**: cancelled turns, `turn_failed`, and `agent_disconnected` flush synchronously. Permission deltas bypass entirely (modal latency).
- Scope-gated to native-agent sessions; ACP sessions and unknown sessions pass through untouched. The persisted transcript never sees the pacing.

## Tests

12 unit tests (`stream-smoother.test.ts`, fake timers): burst spreading, elapsed-time drain under throttling, floor-rate passthrough, barrier ordering, tail-after-finish, instant cancel/fail flush, per-session independence, surrogate-pair safety.

`bun run typecheck` clean; the 3 failing suites on this branch (`atlas-comms` CI-coverage/opt-level guards + a comms midnight test) pre-date this change and are untouched by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)