### PR TITLE
0.3.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <title>Atlas</title>
+    <!-- CSP NOTE: this inline <style> is why `src-tauri/tauri.conf.json` sets
+         `dangerousDisableAssetCspModification: ["style-src"]`. In a bundled
+         build Tauri stamps every inline <style> with a nonce and appends that
+         nonce to `style-src`; once a nonce is present browsers IGNORE
+         'unsafe-inline', so every stylesheet created at runtime (CodeMirror's
+         style-mod, sonner, mermaid) is refused and editors render unstyled.
+         Dev never shows it because Vite serves this file and Tauri applies no
+         CSP there. Keep the exclusion; do not "clean it up". -->
     <style>
       /* html / body / #root are transparent so the NSVisualEffectView blur
          applied in `src-tauri/src/lib.rs` is visible during the brief

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost https://www.gravatar.com; media-src 'self' blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost asset: http://asset.localhost blob: data: https://us.i.posthog.com; worker-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "dangerousDisableAssetCspModification": ["style-src"],
       "assetProtocol": {
         "enable": true,
         "scope": {

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -1875,7 +1875,14 @@ export function MessageInput({
               double-layer composer). The send button lives INSIDE it. */}
           <div
             className={cn(
-              "relative m-1 rounded-xl border border-[var(--border-default)] bg-[var(--bg-base)]",
+              // `min-h-[44px]`: the send button is absolutely positioned 8px
+              // from the top at 28px tall, so it needs 36px of field to sit
+              // inside. CodeMirror's own min-height normally provides it —
+              // but if its theme fails to inject (see globals.css's
+              // `.atlas-chat-cm-host` block) the field collapses and the
+              // button hangs out over the footer. The floor makes the
+              // geometry hold even with no editor mounted at all.
+              "relative m-1 min-h-[44px] rounded-xl border border-[var(--border-default)] bg-[var(--bg-base)]",
               "transition-[border-color,box-shadow] duration-150",
               // Focus treatment at HALF strength: the full border-focus +
               // /20 accent ring read far too loud on the nested surface.

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -147,6 +147,35 @@
 .atlas-chat-cm-host .cm-editor {
   border: none;
   background: transparent;
+  /* The composer is UI, not code. These three mirror the EditorView.theme in
+     `chat-input.tsx` ON PURPOSE — a duplicated @codemirror/view makes
+     `EditorView.theme()` register against one StyleModule while the view uses
+     another, and the theme silently no-ops (the trap vite.config.ts's `dedupe`
+     block documents). When that happens the composer falls back to CM's
+     defaults: monospace, ~2px inset, and a ~28px field that the 28px send
+     button — absolutely positioned 8px from the top — hangs out the bottom of.
+     Structure must not depend on an injection that can fail, so it lives here
+     too. Unlayered, so it also beats the `@layer base` .cm-editor rules that
+     dress the CODE editor in JetBrains Mono. Keep in step with chat-input.tsx. */
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-size: 13px;
+  line-height: 1.55;
+}
+.atlas-chat-cm-host .cm-scroller {
+  font-family: inherit;
+  line-height: inherit;
+  /* One line = 12 + 20 + 12. The send button's 8px inset + 28px box needs 36
+     of those 44 to sit inside the field. */
+  min-height: 44px;
+}
+.atlas-chat-cm-host .cm-content {
+  padding: 12px 16px;
+  font-family: inherit;
 }
 .atlas-chat-cm-host .cm-gutters {
   display: none;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -148,15 +148,15 @@
   border: none;
   background: transparent;
   /* The composer is UI, not code. These three mirror the EditorView.theme in
-     `chat-input.tsx` ON PURPOSE — a duplicated @codemirror/view makes
-     `EditorView.theme()` register against one StyleModule while the view uses
-     another, and the theme silently no-ops (the trap vite.config.ts's `dedupe`
-     block documents). When that happens the composer falls back to CM's
-     defaults: monospace, ~2px inset, and a ~28px field that the 28px send
-     button — absolutely positioned 8px from the top — hangs out the bottom of.
-     Structure must not depend on an injection that can fail, so it lives here
-     too. Unlayered, so it also beats the `@layer base` .cm-editor rules that
-     dress the CODE editor in JetBrains Mono. Keep in step with chat-input.tsx. */
+     `chat-input.tsx` ON PURPOSE as a belt-and-braces fallback: if CodeMirror's
+     runtime stylesheet injection ever fails again (the 2026-09 cause was the
+     Tauri CSP nonce blocking `style-src 'unsafe-inline'` in bundled builds —
+     see index.html), the composer falls back to CM's defaults: monospace,
+     ~2px inset, and a ~28px field that the 28px send button — absolutely
+     positioned 8px from the top — hangs out the bottom of. Structure must not
+     depend on an injection that can fail, so it lives here too. Unlayered, so
+     it also beats the `@layer base` .cm-editor rules that dress the CODE
+     editor in JetBrains Mono. Keep in step with chat-input.tsx. */
   font-family:
     system-ui,
     -apple-system,
@@ -447,16 +447,14 @@
     contain: layout style paint;
   }
 
-  /* CodeMirror — authoritative color overrides for production builds.
+  /* CodeMirror — fallback color overrides for production builds.
      `EditorView.theme(...)` injects styles via @codemirror/view's StyleModule
-     at runtime, which works reliably in `vite dev` (single instance, served
-     unbundled) but loses the race in `vite build` once Rollup splits the
-     lazy-loaded lang packages into separate chunks: lang chunks transitively
-     import @codemirror/view, and even with `resolve.dedupe` Tauri's WKWebView
-     can mount the theme stylesheet against a different `StyleModule` than
-     the EditorView constructor uses. Net effect: the theme is silently a
-     no-op, text inherits CodeMirror's defaults (often invisible on AMOLED
-     black) while gutters render with their base styles.
+     at runtime by appending a <style> element. In bundled builds that
+     injection has been blocked before by the Tauri CSP (a nonce on
+     index.html's inline <style> disables `style-src 'unsafe-inline'`; fixed
+     via `dangerousDisableAssetCspModification` in tauri.conf.json, see
+     index.html). When it fails, the theme is silently a no-op and text
+     inherits CodeMirror's defaults (often invisible on AMOLED black).
 
      These rules sit at the same specificity as the runtime injection so they
      always win when the runtime fails, and harmlessly co-exist when it

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,15 +25,17 @@ export default defineConfig(async () => ({
         "node_modules/decode-named-character-reference/index.js",
       ),
     },
-    // CRITICAL: dedupe CodeMirror + Lezer. In production the lang packages
-    // (lang-json, lang-rust, …) get lazy-imported as separate chunks and
-    // each transitively imports @codemirror/{state,view,language} and
-    // @lezer/{common,highlight,lr}. Without dedup Rollup can ship two copies;
-    // `EditorView.theme(...)` registers against copy A's StyleModule but the
-    // EditorView constructor uses copy B's, so the theme silently no-ops and
-    // text renders with default styling (often invisible against the dark
-    // background). The dev server doesn't hit this because Vite serves
-    // pre-bundled deps as a single instance.
+    // Dedupe CodeMirror + Lezer. The lang packages (lang-json, lang-rust, …)
+    // are lazy-imported as separate chunks and each transitively imports
+    // @codemirror/{state,view,language} and @lezer/{common,highlight,lr};
+    // without dedup Rollup can ship two copies, and facets/extensions from
+    // one copy are invisible to an EditorView built from the other.
+    //
+    // NOTE (2026-09-06): "CodeMirror unstyled in production, fine in dev" was
+    // NOT this. It was the Tauri CSP: a nonce injected into index.html's
+    // inline <style> disables `style-src 'unsafe-inline'`, blocking every
+    // runtime-injected stylesheet. See the comment in index.html and
+    // `dangerousDisableAssetCspModification` in src-tauri/tauri.conf.json.
     dedupe: [
       "@codemirror/state",
       "@codemirror/view",


### PR DESCRIPTION
<!--
Thanks for the PR. Please read CONTRIBUTING.md if you haven't already.

## Which branch should this target?

Atlas ships versioned installable builds, so `main` always equals the latest
release — work collects on a version branch (e.g. `0.2.5`) first, and the
merge of that branch into `main` is the release itself.

- Target the **current version branch** for anything that isn't a small,
  self-contained fix.
- Target **`main`** directly only if the change has no version-branch
  dependency and doesn't need to wait for the next release (a doc fix, a
  one-line hotfix).

See CONTRIBUTING.md's "Branching model" section if you're not sure which
applies.
-->

### What?

### Why?

### How?

Fixes #

## Checklist

Only the things CI can't check for you:

- [ ] Targets the current version branch, unless it's a small standalone fix
- [ ] New behaviour has a test; a bug fix has a test that fails without it
- [ ] You've run the app and used the change in a window

CI now runs, on every PR: `bun run lint`, `bun run format:check`, `bun run
typecheck`, `bun run test`, `bun run build`, `cargo test` for all 14 crates,
and `cargo test` for `src-tauri`. So there are no boxes for those — if it
compiles and passes locally, CI is checking it too.
What CI still can't judge is whether the change actually works in a window, and
whether the behaviour you added is covered by a test.

If this adds a top-level dependency or touches the telemetry pipeline, say so in **Why?** above — both need discussion, and telemetry changes need `TELEMETRY.md` updated to match.
