### PR TITLE
fix(redact): route JSONL payloads through the structure-aware pass

### DIFF
--- a/crates/atlas-redact/src/lib.rs
+++ b/crates/atlas-redact/src/lib.rs
@@ -213,11 +213,12 @@ pub(crate) fn redact_link(input: &str) -> Redacted {
 /// Redact a payload whose shape is unknown — the right call for tool arguments
 /// and tool results, which are JSON-shaped most of the time but not always.
 ///
-/// If the trimmed input parses as a JSON object or array it is routed through
-/// [`redact_json`], so ids, paths and field names survive, and comes back
-/// serialised compactly. Anything else — prose, logs, a fragment that does not
-/// parse — goes through the flat [`redact`] pass. The counts are whichever
-/// path produced them; nothing is dropped in the dispatch.
+/// If the trimmed input parses as a JSON object or array, or is JSONL with one
+/// such value per line, it is routed through [`redact_json`], so ids, paths and
+/// field names survive, and comes back serialised compactly. Anything else —
+/// prose, logs, a fragment that does not parse — goes through the flat
+/// [`redact`] pass. The counts are whichever path produced them; nothing is
+/// dropped in the dispatch.
 pub fn redact_auto(input: &str) -> Redacted {
     let trimmed = input.trim();
     if trimmed.starts_with('{') || trimmed.starts_with('[') {
@@ -226,8 +227,45 @@ pub fn redact_auto(input: &str) -> Redacted {
                 return redact_json(trimmed);
             }
         }
+        // JSONL parses as no single value, so the check above declines it and
+        // the flat pass gets a document it was never meant to see. `redact_json`
+        // has always walked this shape; only the dispatch could not name it.
+        if is_jsonl(trimmed) {
+            return redact_json(trimmed);
+        }
     }
     redact(input)
+}
+
+/// Is this input JSONL: two or more lines, each its own JSON object or array?
+///
+/// An ndjson tool result, `jq -c` output, a transcript read a line at a time.
+/// The shape is JSON but it parses as no single value, so [`redact_auto`]'s
+/// whole-input check declined it and the flat pass ran over a document: every
+/// id cleared the entropy threshold and was replaced, the tally counted one
+/// per line instead of one per secret, and a span that ran past a JSON escape
+/// left a line that no longer parses.
+///
+/// Deliberately strict, in that every non-empty line must parse, so a prose
+/// payload that merely opens with a brace still takes the flat path. Lines are
+/// split the way [`redact_json`] splits them, and the first line that does not
+/// parse ends the scan, so the cost on a non-JSONL payload is one line rather
+/// than the whole input.
+fn is_jsonl(trimmed: &str) -> bool {
+    if !trimmed.contains('\n') {
+        return false;
+    }
+    let mut lines = 0usize;
+    for line in trimmed.split('\n') {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(value) if value.is_object() || value.is_array() => lines += 1,
+            _ => return false,
+        }
+    }
+    lines > 1
 }
 
 /// Redact bytes, or decline if they are not text.

--- a/crates/atlas-redact/tests/auto.rs
+++ b/crates/atlas-redact/tests/auto.rs
@@ -140,6 +140,44 @@ fn a_json_array_takes_the_structured_path_too() {
 }
 
 #[test]
+fn a_jsonl_payload_takes_the_structured_path_too() {
+    // JSONL parses as no single value, so the dispatch declined it and the flat
+    // pass ran over a document: ids shredded by the entropy layer, one count per
+    // line instead of one per secret, and a span that ran past a JSON escape
+    // leaving a line that no longer parses.
+    let input = concat!(
+        r#"{"message_id": "xJ3kQ9vB2mZ7pL5rT8wN4cF6yH1sD0gA", "content": "hi"}"#,
+        "\n",
+        r#"{"message_id": "aB9zQ2vX7mK4pL8rT3wN6cF1yH5sD0gE", "content": "API_KEY=supersecretvalue123"}"#,
+        "\n",
+        r#"{"cmd": "psql \"host=db.internal user=app password=hunter2 sslmode=require\""}"#,
+    );
+    let out = redact_auto(input);
+
+    assert!(!out.text.contains("supersecretvalue123"), "secret survived: {}", out.text);
+    assert!(!out.text.contains("hunter2"), "secret survived: {}", out.text);
+    for id in ["xJ3kQ9vB2mZ7pL5rT8wN4cF6yH1sD0gA", "aB9zQ2vX7mK4pL8rT3wN6cF1yH5sD0gE"] {
+        assert!(out.text.contains(id), "message id shredded: {}", out.text);
+    }
+    assert_eq!(out.counts.total(), 2, "counted per line, not per secret: {}", out.text);
+    for line in out.text.split('\n') {
+        serde_json::from_str::<serde_json::Value>(line)
+            .unwrap_or_else(|e| panic!("line no longer parses: {e}\n  {line}"));
+    }
+}
+
+#[test]
+fn a_multi_line_payload_that_is_not_jsonl_still_takes_the_flat_path() {
+    // One JSON line and then prose. Every line has to parse before the
+    // structured path claims the input, or a log that happens to open with a
+    // brace would come back re-serialised line by line.
+    let input = "{\"tool\": \"read\"}\nthen it printed API_KEY=supersecretvalue123";
+    let out = redact_auto(input);
+    assert!(!out.text.contains("supersecretvalue123"), "secret survived: {}", out.text);
+    assert!(out.text.contains("then it printed API_KEY="), "prose lost: {}", out.text);
+}
+
+#[test]
 fn a_scalar_json_value_is_not_treated_as_a_document() {
     // A bare quoted string parses as JSON, but flat redaction is the right
     // treatment: there is no structure to preserve.
@@ -155,6 +193,8 @@ fn redact_auto_is_idempotent() {
         r#"note: {"password": "hunter2"} failed"#.to_string(),
         format!(r#"{{"url": "https://{}@github.com/org/repo"}}"#, fixtures::github_pat()),
         r#"password: "hunter2""#.to_string(),
+        "{\"message_id\": \"xJ3kQ9vB2mZ7pL5rT8wN4cF6yH1sD0gA\"}\n{\"password\": \"hunter2\"}"
+            .to_string(),
     ];
     for input in inputs {
         let once = redact_auto(&input);


### PR DESCRIPTION
### What?

`redact_auto` sent JSONL payloads to the flat redactor instead of the JSON walker. `redact_json` has handled JSONL since it was written ("Accepts a single JSON value or JSONL (one value per line)"); only the dispatch in front of it could not name the shape, so the walker was never reached.

### Why?

The dispatch decides by parsing the whole input as one `serde_json::Value`, and JSONL parses as no single value, so it fell through to `redact`. Three things follow, and they are the three reasons the walker exists.

`Capture::record_tool_call` in `crates/atlas-checkpoint/src/capture.rs` scrubs every tool `arguments` and `result` through `redact_auto`, and its own doc comment names the first two: the flat pass "shreds the identifiers the walk exists to protect (`{"message_id": …}`)", because every id clears the entropy threshold, and it counts one replacement per line rather than one per secret, which inflates the redaction tally `scrub_or_flag` hands to `add_redaction_counts` and the app shows on the promotion and import confirmations.

The third is worse. A flat span that runs past a JSON escape leaves a line that no longer parses. This input:

```
{"cmd": "psql \"host=db.internal user=app password=hunter2 sslmode=require\""}
```

came back as:

```
{"cmd": "psql \"[REDACTED]""}
```

The keyword-DSN span ends at `require\`, taking the backslash of the closing `\"` with it, so the string terminates early and the trailing quote is stray. The walker never has this problem because serde re-escapes the leaf on the way out.

None of this is hypothetical for Atlas. ACP-hosted Claude Code writes JSONL transcripts that `crates/atlas-checkpoint/src/import.rs` already reads, and an agent that cats, tails or greps one of those files puts JSONL straight into a tool result, which is the highest-risk content in a Session.

### How?

`is_jsonl` claims an input when it has two or more lines and every non-empty line parses as its own JSON object or array; `redact_auto` hands those to `redact_json`. It is strict on purpose, so a payload that merely opens with a brace and then continues in prose keeps the flat path. It stops at the first line that does not parse, so a non-JSONL payload costs one line rather than a second parse of the whole input, and it only runs at all once the existing whole-input parse has already failed.

`a_jsonl_payload_takes_the_structured_path_too` in `crates/atlas-redact/tests/auto.rs` covers all three symptoms in one fixture: both ids survive, both secrets are gone, the count is 2 rather than 3, and every output line still parses. On the unmodified source it fails at the first shredded id. `a_multi_line_payload_that_is_not_jsonl_still_takes_the_flat_path` pins the other direction, and the JSONL case is added to the existing `redact_auto_is_idempotent` list.

Verified on macOS 26.2 with rustc 1.95.0, running what CI runs per crate:

| command | result |
|---|---|
| `cd crates/atlas-redact && cargo test --locked` | 119 passed, 0 failed |
| `cd crates/atlas-redact && cargo clippy --locked --all-targets` | clean |
| `cd crates/atlas-redact && cargo clippy --locked --all-targets -- -D warnings` | clean |
| the same suite with `src/lib.rs` reverted, tests kept | `a_jsonl_payload_takes_the_structured_path_too` FAILED, "message id shredded" |
| `cd crates/atlas-checkpoint && cargo test --locked` | 365 passed, 0 failed |

## Checklist

- [x] Targets the current version branch, unless it's a small standalone fix
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [ ] You've run the app and used the change in a window. Verified through `atlas-checkpoint`'s suite instead, which is the crate that calls `redact_auto`.
