### PR TITLE
fix(chat): stop the streaming transcript flickering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
         "lucide-react": "^1.40.0",
         "matter-js": "^0.20.0",
         "mermaid": "^11.17.2",
+        "morphdom": "^2.7.8",
         "pdfjs-dist": "5.4.296",
         "pixi.js": "^8.20.1",
         "posthog-js": "^1.426.3",
@@ -1605,6 +1606,8 @@
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "mixin-deep": ["mixin-deep@1.3.2", "", { "dependencies": { "for-in": "^1.0.2", "is-extendable": "^1.0.1" } }, "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA=="],
+
+    "morphdom": ["morphdom@2.7.8", "", {}, "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg=="],
 
     "motion": ["motion@12.43.0", "", { "dependencies": { "framer-motion": "^12.43.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ=="],
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lucide-react": "^1.40.0",
     "matter-js": "^0.20.0",
     "mermaid": "^11.17.2",
+    "morphdom": "^2.7.8",
     "pdfjs-dist": "5.4.296",
     "pixi.js": "^8.20.1",
     "posthog-js": "^1.426.3",

--- a/src/features/chat/components/streaming-markdown.test.tsx
+++ b/src/features/chat/components/streaming-markdown.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { StreamingMarkdown } from "./streaming-markdown";
+import { noteTailHtml, tailFallback } from "@/lib/markdown-cache";
+
+afterEach(cleanup);
+
+/** The block split is rAF-coalesced, so the tail only reaches the DOM a frame
+ *  after the source changes. Poll for the text rather than racing the clock. */
+async function tailReads(container: HTMLElement, text: string): Promise<void> {
+  await waitFor(() =>
+    expect(container.querySelector(".atlas-stream-tail")?.textContent).toBe(text),
+  );
+}
+
+describe("StreamingMarkdown", () => {
+  it("renders the live tail formatted, with the caret hook on it", () => {
+    const { container } = render(
+      <StreamingMarkdown source={"Intro line\n\nSecond paragraph"} streaming />,
+    );
+    const tail = container.querySelector(".atlas-stream-tail");
+    expect(tail).not.toBeNull();
+    expect(tail?.textContent).toContain("Second paragraph");
+    // Only the trailing block is live; settled ones are plain cached blocks.
+    expect(container.querySelectorAll(".atlas-stream-tail")).toHaveLength(1);
+    expect(container.querySelectorAll(".atlas-md-block").length).toBeGreaterThan(1);
+  });
+
+  it("formats markup the stream has not finished writing", () => {
+    // `**bol` renders bold immediately instead of showing its asterisks and
+    // snapping a few frames later.
+    const { container } = render(<StreamingMarkdown source="Hello **bol" streaming />);
+    expect(container.querySelector(".atlas-stream-tail strong")?.textContent).toBe("bol");
+  });
+
+  it("grows the tail in place rather than rebuilding it", async () => {
+    const { container, rerender } = render(<StreamingMarkdown source="Hello wo" streaming />);
+    await tailReads(container, "Hello wo");
+    const p = container.querySelector(".atlas-stream-tail p");
+    expect(p).not.toBeNull();
+
+    rerender(<StreamingMarkdown source="Hello world, and more" streaming />);
+    await tailReads(container, "Hello world, and more");
+
+    // Same element, new text: the patch changed a text node, it did not throw
+    // the paragraph away and build another.
+    expect(container.querySelector(".atlas-stream-tail p")).toBe(p);
+  });
+
+  it("drops the tail marker once the turn settles", async () => {
+    const { container, rerender } = render(
+      <StreamingMarkdown source={"Intro\n\nAnswer text"} streaming />,
+    );
+    await tailReads(container, "Answer text");
+    rerender(<StreamingMarkdown source={"Intro\n\nAnswer text"} streaming={false} />);
+    await waitFor(() => expect(container.querySelector(".atlas-stream-tail")).toBeNull());
+    expect(container.textContent).toContain("Answer text");
+  });
+});
+
+describe("tail html handoff", () => {
+  it("offers the last tail render to any longer source that starts with it", () => {
+    noteTailHtml("Answer so f", "<p>Answer so f</p>");
+    // The settling block asks with its final raw source.
+    expect(tailFallback("Answer so far")).toBe("<p>Answer so f</p>");
+    // …but never lends html to unrelated text.
+    expect(tailFallback("Something else entirely")).toBeNull();
+    // …nor to a source it barely covers: that would swap a text flash for a
+    // height jump.
+    expect(tailFallback("Answer so far" + " and much, much more".repeat(4))).toBeNull();
+  });
+});

--- a/src/features/chat/components/streaming-markdown.tsx
+++ b/src/features/chat/components/streaming-markdown.tsx
@@ -1,15 +1,20 @@
-import { memo, useEffect, useRef, useState, useMemo } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState, useMemo } from "react";
 import {
   CachedMarkdown,
+  noteTailHtml,
   parseTransientOffThread,
   transientWorkerAvailable,
 } from "@/lib/markdown-cache";
 import { parseMarkdown } from "@/lib/markdown-render";
 import {
-  splitTopLevelBlocks,
+  splitBlocks,
+  mayStartNewBlock,
   hasReferenceDefinitions,
   isIncompleteCodeFence,
+  type BlockSplit,
 } from "@/lib/markdown-blocks";
+import { closeIncompleteMarkdown } from "@/lib/markdown-stream";
+import { applyHtml } from "@/lib/dom-html";
 import { cn } from "@/lib/utils";
 
 /**
@@ -20,10 +25,24 @@ import { cn } from "@/lib/utils";
  * translation of Zed's per-line layout cache / Open WebUI's per-block tokens:
  * markdown formats LIVE as it streams, with bounded re-work.
  *
- * Uses `display:contents` on each block wrapper so the N per-block `CachedMarkdown`
- * containers vanish from layout and their block elements remain layout-siblings
- * inside one formatting context — preserving prose margin-collapse / vertical
- * rhythm identical to the old single-container render.
+ * Three rules keep the live edge from flickering, and all three matter:
+ *
+ *  1. **The tail is repaired before it is parsed** (`closeIncompleteMarkdown`).
+ *     A stream cuts markdown mid-token, so `**bol` is literal asterisks for a
+ *     few frames and then the words snap to bold. Closing the dangling marker
+ *     means the text is already bold while the rest of it arrives.
+ *  2. **The tail is PATCHED, not replaced** (`applyHtml`). Re-setting
+ *     `innerHTML` every frame destroys the nodes the reader is looking at:
+ *     selection is dropped, hover resets, and WebKit repaints the whole block
+ *     instead of the one line that changed.
+ *  3. **The split is incremental.** Re-parsing the whole message to find block
+ *     boundaries on every frame made per-frame cost scale with the length of
+ *     the answer; while the tail only grows, it is a substring.
+ *
+ * Each block wrapper is `.atlas-md-block` (`display: contents`) so the N
+ * per-block containers vanish from layout and their block elements remain
+ * layout-siblings inside one formatting context — preserving prose
+ * margin-collapse / vertical rhythm identical to a single-container render.
  */
 
 /** Below this length the live tail parses inline on every frame (sub-ms, and
@@ -33,6 +52,15 @@ import { cn } from "@/lib/utils";
 const INLINE_PARSE_LIMIT = 2000;
 /** Parse cadence for a large live tail. */
 const TRANSIENT_THROTTLE_MS = 120;
+/** A per-frame inline parse that costs more than this has outgrown the inline
+ *  path regardless of length (a table, a dense list), so the block is demoted
+ *  to the throttled off-thread lane for the rest of its life. Length alone was
+ *  the wrong proxy: 1.5 KB of table markup is an order of magnitude more work
+ *  than 1.5 KB of prose. */
+const INLINE_BUDGET_MS = 6;
+/** Longest the incremental split may run without a real re-parse. A backstop,
+ *  not the mechanism — `mayStartNewBlock` catches boundaries as they arrive. */
+const RESPLIT_MAX_MS = 500;
 
 /**
  * Renderer for the STREAMING TAIL only — deliberately bypasses `CachedMarkdown`.
@@ -47,7 +75,8 @@ const TRANSIENT_THROTTLE_MS = 120;
  * requested again must never touch the cache or the queue.
  *
  * The block re-renders as `CachedMarkdown` the moment it settles, which parses
- * and caches the final text once.
+ * and caches the final text once — and shows this renderer's last html
+ * (`noteTailHtml`) in the meantime, so the swap is invisible.
  */
 const TransientMarkdown = memo(function TransientMarkdown({
   source,
@@ -58,8 +87,19 @@ const TransientMarkdown = memo(function TransientMarkdown({
   className?: string;
   unstyled?: boolean;
 }) {
-  const small = source.length <= INLINE_PARSE_LIMIT;
-  const inline = useMemo(() => (small ? parseMarkdown(source) : null), [small, source]);
+  // Parse the REPAIRED copy; everything downstream still keys off the raw
+  // source, which is what the settled block will be rendered from.
+  const repaired = useMemo(() => closeIncompleteMarkdown(source), [source]);
+
+  const overBudget = useRef(false);
+  const small = repaired.length <= INLINE_PARSE_LIMIT && !overBudget.current;
+  const inline = useMemo(() => {
+    if (!small) return null;
+    const started = performance.now();
+    const html = parseMarkdown(repaired);
+    if (performance.now() - started > INLINE_BUDGET_MS) overBudget.current = true;
+    return html;
+  }, [small, repaired]);
 
   // Large tail: throttled trailing-edge parse of the LATEST source. The parse
   // itself runs on the markdown worker via the transient lane (single slot,
@@ -68,11 +108,21 @@ const TransientMarkdown = memo(function TransientMarkdown({
   // late in a long block, exactly while rAF delta flushes were running. The
   // sync parse remains only as the no-worker fallback.
   const [big, setBig] = useState("");
-  const latest = useRef(source);
-  latest.current = source;
+  const latest = useRef(repaired);
+  latest.current = repaired;
   const timer = useRef<number | null>(null);
   const lastRun = useRef(0);
   const alive = useRef(true);
+  useEffect(() => {
+    // Set on every run, not once at mount: React re-runs effects on the same
+    // instance (StrictMode's mount/unmount/mount in development), and a latch
+    // that only ever went false left the throttled path permanently mute —
+    // large blocks stopped updating mid-answer and only caught up on settle.
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
   useEffect(() => {
     if (small || timer.current !== null) return;
     const due = Math.max(0, TRANSIENT_THROTTLE_MS - (performance.now() - lastRun.current));
@@ -89,10 +139,9 @@ const TransientMarkdown = memo(function TransientMarkdown({
         setBig(parseMarkdown(latest.current));
       }
     }, due);
-  }, [small, source]);
+  }, [small, repaired]);
   useEffect(
     () => () => {
-      alive.current = false;
       if (timer.current !== null) window.clearTimeout(timer.current);
     },
     [],
@@ -104,11 +153,25 @@ const TransientMarkdown = memo(function TransientMarkdown({
   const html = inline ?? (big || lastHtml.current);
   lastHtml.current = html;
 
+  const ref = useRef<HTMLDivElement>(null);
+  // Patch, don't replace — see `applyHtml`. This is what keeps a selection
+  // inside a live answer alive and stops WebKit repainting the whole block
+  // every frame.
+  useLayoutEffect(() => {
+    const node = ref.current;
+    if (node) applyHtml(node, html);
+  }, [html]);
+
+  // Hand the settling block something formatted to show while it parses.
+  // Keyed by the RAW source: that is what `CachedMarkdown` will ask with.
+  useEffect(() => {
+    if (html) noteTailHtml(source, html);
+  }, [source, html]);
+
   // Same external-link interception as CachedMarkdown — a click on a link in
   // the live tail must not navigate the WKWebView away from Atlas. (Copy-code
   // bars are skipped: fences render as plain text until they close, and the
   // settled block gets them from CachedMarkdown.)
-  const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const node = ref.current;
     if (!node) return;
@@ -133,8 +196,6 @@ const TransientMarkdown = memo(function TransientMarkdown({
           : "prose-chat text-[var(--text-primary)] leading-relaxed break-words select-text",
         className,
       )}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: html }}
     />
   );
 });
@@ -169,12 +230,14 @@ const MarkdownBlock = memo(function MarkdownBlock({
     );
   }
   // The live tail bypasses the cache/worker entirely — see TransientMarkdown.
+  // `atlas-stream-tail` is what draws the caret, inline at the end of the last
+  // line rather than as a block of its own below it.
   if (trailing) {
     return (
       <TransientMarkdown
         source={source}
         unstyled={unstyled}
-        className={cn("[display:contents]", className)}
+        className="atlas-md-block atlas-stream-tail"
       />
     );
   }
@@ -183,20 +246,35 @@ const MarkdownBlock = memo(function MarkdownBlock({
       source={source}
       unstyled={unstyled}
       priority={priority}
-      className={cn("[display:contents]", className)}
+      className="atlas-md-block"
     />
   );
 });
 
-/** rAF-coalesced block split: at most one split per frame while streaming; a
- *  synchronous, memoized split when settled. */
+/**
+ * Block split for a growing source.
+ *
+ * Full re-splits cost a remark parse of the WHOLE message, and running one per
+ * frame made the per-frame cost of streaming scale with the length of the
+ * answer — a long turn got progressively jankier as it went. While the tail is
+ * only being appended to, the split is a substring of the source instead
+ * (`tailStart`), and a real re-parse happens only when the delta could actually
+ * have opened a new block.
+ *
+ * Getting that condition wrong cannot break rendering: the trailing block is
+ * rendered by parsing it as markdown, so a tail that briefly holds two blocks
+ * looks identical — only cache granularity is affected, and the periodic
+ * backstop re-split repairs even that.
+ */
 function useBlocks(source: string, streaming: boolean, whole: boolean): string[] {
   const [blocks, setBlocks] = useState<string[]>(() =>
-    whole ? [source] : splitTopLevelBlocks(source),
+    whole ? [source] : splitBlocks(source).blocks,
   );
   const rafRef = useRef<number | null>(null);
   const latest = useRef(source);
   latest.current = source;
+  /** Last real split, and the source it was computed from. */
+  const split = useRef<SplitState | null>(null);
 
   useEffect(() => {
     if (whole) return;
@@ -206,14 +284,16 @@ function useBlocks(source: string, streaming: boolean, whole: boolean): string[]
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
       }
-      setBlocks(splitTopLevelBlocks(source));
+      const at = splitBlocks(source);
+      split.current = { at, source, when: performance.now() };
+      setBlocks(at.blocks);
       return;
     }
-    // Streaming: coalesce to one split per frame.
+    // Streaming: coalesce to one update per frame.
     if (rafRef.current != null) return;
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
-      setBlocks(splitTopLevelBlocks(latest.current));
+      setBlocks(nextBlocks(split, latest.current));
     });
   }, [source, streaming, whole]);
 
@@ -225,6 +305,38 @@ function useBlocks(source: string, streaming: boolean, whole: boolean): string[]
   );
 
   return blocks;
+}
+
+interface SplitState {
+  at: BlockSplit;
+  /** The source `at` was computed from. */
+  source: string;
+  /** When the last REAL re-split ran — drives the backstop. */
+  when: number;
+}
+
+/** One streaming step: grow the tail if nothing structural arrived, otherwise
+ *  re-split. Mutates the `split` ref, which is the incremental state. */
+function nextBlocks(split: { current: SplitState | null }, source: string): string[] {
+  const prev = split.current;
+  const grown =
+    prev !== null && source.length >= prev.source.length && source.startsWith(prev.source);
+  if (prev && grown) {
+    const delta = source.slice(prev.source.length);
+    const tail = prev.at.blocks[prev.at.blocks.length - 1] ?? "";
+    const stale = performance.now() - prev.when > RESPLIT_MAX_MS;
+    if (!stale && !mayStartNewBlock(delta, isIncompleteCodeFence(tail))) {
+      // Pure append: rebuild only the trailing block, by slicing.
+      const blocks = prev.at.blocks.slice(0, -1);
+      blocks.push(source.slice(prev.at.tailStart));
+      prev.at = { blocks, tailStart: prev.at.tailStart };
+      prev.source = source;
+      return blocks;
+    }
+  }
+  const at = splitBlocks(source);
+  split.current = { at, source, when: performance.now() };
+  return at.blocks;
 }
 
 export function StreamingMarkdown({
@@ -247,8 +359,15 @@ export function StreamingMarkdown({
   // streaming the definition may not have arrived yet anyway, so block-level is
   // fine there and avoids a per-frame whole-message re-parse. (Both rare in
   // agent output.)
-  const hasRefs = useMemo(() => hasReferenceDefinitions(source), [source]);
-  const renderWhole = hasRefs && !streaming;
+  //
+  // Short-circuited on `streaming` rather than computed and then ignored: the
+  // check is two regexes over the WHOLE message, and running them per frame put
+  // the length of the answer back into the per-frame cost the block split just
+  // took out of it.
+  const renderWhole = useMemo(
+    () => !streaming && hasReferenceDefinitions(source),
+    [streaming, source],
+  );
   const blocks = useBlocks(source, streaming, renderWhole);
 
   if (renderWhole) {
@@ -263,7 +382,6 @@ export function StreamingMarkdown({
   }
 
   const lastIdx = blocks.length - 1;
-  const trailingIsFence = streaming && lastIdx >= 0 && isIncompleteCodeFence(blocks[lastIdx]);
 
   return (
     <div className={className}>
@@ -277,9 +395,6 @@ export function StreamingMarkdown({
           priority={priority}
         />
       ))}
-      {/* Terminal-style caret after the last block while streaming — unless the
-          trailing block is an open fence, which draws its own caret. */}
-      {streaming && !trailingIsFence && <span className="atlas-stream-caret" aria-hidden />}
     </div>
   );
 }

--- a/src/features/chat/components/transcript-rows.tsx
+++ b/src/features/chat/components/transcript-rows.tsx
@@ -13,7 +13,7 @@
 //  3. Rows never subscribe to the chat store or the detail-panel store. Data
 //     arrives as props; actions are fired imperatively via `getState()`.
 
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import {
   Check,
   X,
@@ -161,6 +161,20 @@ export const ProseRowView = memo(function ProseRowView({
   /** Position in the thread — newest parses first. See `CachedMarkdown`. */
   priority: number;
 }) {
+  // A row that streamed keeps the block-split renderer for the rest of its
+  // life, even once the turn is over.
+  //
+  // Switching back to the whole-message renderer at settle re-parsed the ENTIRE
+  // answer under a source nothing had cached, and swapped the DOM for a
+  // different component while it did — so the finished message flashed back to
+  // raw markdown for a worker round-trip. Staying on the block renderer keeps
+  // the same elements in place and every settled block is already a cache hit,
+  // so the end of a turn changes nothing on screen. Rows loaded from history
+  // never took this path and still render as one cached document.
+  const everStreamed = useRef(false);
+  if (row.streaming) everStreamed.current = true;
+  const streamed = everStreamed.current;
+
   return (
     <Column className="py-2">
       {/* Identity on the left (glyph + which model wrote this), timestamp
@@ -189,15 +203,15 @@ export const ProseRowView = memo(function ProseRowView({
           </span>
         </div>
       )}
-      {/* Settled prose goes through the plain cached renderer: its root IS
+      {/* History goes through the plain cached renderer: its root IS
           `.atlas-prose`, so the block metrics apply to real block elements and
-          a scrolled-back message is a pure cache hit. The streaming tail uses
-          the block-splitting renderer, where only the trailing block re-parses
-          per frame. */}
-      {row.streaming ? (
+          a scrolled-back message is a pure cache hit. Anything that streamed in
+          this session uses the block-splitting renderer, where only the
+          trailing block re-parses per frame. */}
+      {streamed ? (
         <StreamingMarkdown
           source={row.text}
-          streaming
+          streaming={row.streaming}
           unstyled
           priority={priority}
           className="atlas-prose"

--- a/src/lib/dom-html.test.ts
+++ b/src/lib/dom-html.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import { applyHtml, escapeHtml } from "./dom-html";
+
+function host(): HTMLElement {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("applyHtml", () => {
+  it("fills an empty element", () => {
+    const el = host();
+    applyHtml(el, "<p>hello</p>");
+    expect(el.innerHTML).toBe("<p>hello</p>");
+  });
+
+  it("keeps the nodes that did not change", () => {
+    // The whole point: a streaming update must not destroy the DOM the reader
+    // is looking at (selection, hover, scroll inside a wide block all live on
+    // these nodes).
+    const el = host();
+    applyHtml(el, "<p>settled</p><p>grow</p>");
+    const settled = el.firstElementChild;
+    const growing = el.lastElementChild;
+
+    applyHtml(el, "<p>settled</p><p>growing text</p>");
+
+    expect(el.firstElementChild).toBe(settled);
+    expect(el.lastElementChild).toBe(growing);
+    expect(el.lastElementChild?.textContent).toBe("growing text");
+  });
+
+  it("adds and removes elements as the html changes", () => {
+    const el = host();
+    applyHtml(el, "<p>one</p>");
+    applyHtml(el, "<p>one</p><ul><li>two</li></ul>");
+    expect(el.querySelectorAll("li")).toHaveLength(1);
+    applyHtml(el, "<p>one</p>");
+    expect(el.querySelectorAll("li")).toHaveLength(0);
+  });
+
+  it("preserves an injected code bar and its enhanced flag", () => {
+    // The copy/language bar is added after parsing, so it is never in the
+    // incoming html — morphing must not treat it as removed content.
+    const el = host();
+    applyHtml(el, "<pre><code>a</code></pre>");
+    const pre = el.querySelector("pre")!;
+    pre.dataset.enhanced = "1";
+    const bar = document.createElement("div");
+    bar.className = "atlas-code-bar";
+    pre.appendChild(bar);
+
+    applyHtml(el, "<pre><code>a b</code></pre>");
+
+    expect(el.querySelector("pre")).toBe(pre);
+    expect(pre.dataset.enhanced).toBe("1");
+    expect(pre.querySelectorAll(".atlas-code-bar")).toHaveLength(1);
+    expect(pre.querySelector("code")?.textContent).toBe("a b");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("neutralises markup in a raw-source placeholder", () => {
+    expect(escapeHtml('<img src=x onerror="alert(1)">')).toBe(
+      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
+    );
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+});

--- a/src/lib/dom-html.ts
+++ b/src/lib/dom-html.ts
@@ -1,0 +1,73 @@
+/**
+ * In-place HTML patching for rendered markdown.
+ *
+ * `dangerouslySetInnerHTML` is a REPLACEMENT: every time the string changes the
+ * browser tears down the whole subtree and builds a new one. For settled
+ * content that happens once and costs nothing. For the streaming tail it
+ * happened every frame, and the cost is not the parse — it is that the nodes
+ * the reader is looking at stop existing several times a second:
+ *
+ *  - a text selection inside the live answer is dropped the instant the next
+ *    token lands (selecting text while the agent writes was impossible),
+ *  - `:hover` state and scroll position inside a wide table or code block reset,
+ *  - WebKit repaints the entire block rather than the one line that changed,
+ *    which is the visible shimmer/flicker on a long streaming paragraph.
+ *
+ * `morphdom` walks the old DOM against the new HTML and mutates only what
+ * actually differs — usually a single text node at the end of a paragraph. It
+ * is ~5 KB, dependency-free, and the same primitive Phoenix LiveView uses for
+ * exactly this problem.
+ *
+ * SAFETY: every string reaching `applyHtml` comes out of `markdown-render.ts`,
+ * whose pipeline ends in `rehype-sanitize` — no scripts, no inline handlers, no
+ * `javascript:` URLs. The one string built here (the raw-source placeholder) is
+ * escaped by `escapeHtml`. Nothing else may be passed in.
+ */
+
+import morphdom from "morphdom";
+
+const ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+};
+
+/** For building the raw-source placeholder without going through a parser. */
+export function escapeHtml(text: string): string {
+  return text.replace(/[&<>"]/g, (c) => ESCAPES[c]);
+}
+
+/**
+ * Make `el`'s children match `html`, changing as little of the DOM as possible.
+ *
+ * The first fill is a plain `innerHTML` — there is nothing to preserve yet, and
+ * a parse beats a diff. Subsequent calls morph.
+ */
+export function applyHtml(el: HTMLElement, html: string): void {
+  if (!el.firstChild) {
+    el.innerHTML = html;
+    return;
+  }
+  try {
+    morphdom(el, `<div>${html}</div>`, {
+      childrenOnly: true,
+      onBeforeElUpdated: (from, to) => {
+        // morphdom's documented fast path: an identical subtree is skipped
+        // whole, so a stable paragraph above the growing one is never touched.
+        if (from.isEqualNode(to)) return false;
+        // The copy/language bar is injected into `<pre>` AFTER parsing, so it
+        // is absent from every incoming string. Keep the flag that says so, or
+        // the enhance pass would inject a second one.
+        if (from.dataset.enhanced) to.dataset.enhanced = from.dataset.enhanced;
+        return true;
+      },
+      // …and keep the bar itself, for the same reason.
+      onBeforeNodeDiscarded: (node) =>
+        !(node instanceof HTMLElement && node.classList.contains("atlas-code-bar")),
+    });
+  } catch {
+    // A morph can only fail on malformed input; correctness beats the diff.
+    el.innerHTML = html;
+  }
+}

--- a/src/lib/markdown-blocks.test.ts
+++ b/src/lib/markdown-blocks.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  splitBlocks,
+  splitTopLevelBlocks,
+  mayStartNewBlock,
+  isIncompleteCodeFence,
+  hasReferenceDefinitions,
+} from "./markdown-blocks";
+
+describe("splitBlocks", () => {
+  it("returns the whole source as one block when there is nothing to split", () => {
+    expect(splitBlocks("just a paragraph")).toEqual({
+      blocks: ["just a paragraph"],
+      tailStart: 0,
+    });
+  });
+
+  it("splits top-level blocks and reports where the last one starts", () => {
+    const src = "first para\n\nsecond para\n\n# heading";
+    const { blocks, tailStart } = splitBlocks(src);
+    expect(blocks).toEqual(["first para", "second para", "# heading"]);
+    expect(src.slice(tailStart)).toBe("# heading");
+  });
+
+  it("gives a tail offset that reconstructs the trailing block as it grows", () => {
+    // The invariant the incremental path depends on: while the tail is only
+    // appended to, `source.slice(tailStart)` IS the trailing block.
+    const src = "intro\n\nthe tail";
+    const { tailStart } = splitBlocks(src);
+    const grown = src + " keeps going";
+    expect(grown.slice(tailStart)).toBe("the tail keeps going");
+    const regrown = splitBlocks(grown).blocks;
+    expect(regrown[regrown.length - 1]).toBe("the tail keeps going");
+  });
+
+  it("keeps splitTopLevelBlocks behaviour", () => {
+    expect(splitTopLevelBlocks("a\n\nb")).toEqual(["a", "b"]);
+    expect(splitTopLevelBlocks("")).toEqual([]);
+  });
+});
+
+describe("mayStartNewBlock", () => {
+  it("is false for prose that only continues the current block", () => {
+    expect(mayStartNewBlock(" more words", false)).toBe(false);
+    expect(mayStartNewBlock("\nanother sentence", false)).toBe(false);
+  });
+
+  it("is true for a delta that could open a block", () => {
+    for (const delta of ["\n\n", "\n# h", "\n- item", "\n1. item", "\n> quote", "\n```ts"]) {
+      expect(mayStartNewBlock(delta, false)).toBe(true);
+    }
+  });
+
+  it("inside an open fence only a fence line matters", () => {
+    expect(mayStartNewBlock("\n- not a list, this is code", true)).toBe(false);
+    expect(mayStartNewBlock("\n```", true)).toBe(true);
+  });
+});
+
+describe("isIncompleteCodeFence", () => {
+  it("detects an unclosed fence", () => {
+    expect(isIncompleteCodeFence("```ts\nconst a = 1;")).toBe(true);
+    expect(isIncompleteCodeFence("```ts\nconst a = 1;\n```")).toBe(false);
+    expect(isIncompleteCodeFence("not code")).toBe(false);
+  });
+});
+
+describe("hasReferenceDefinitions", () => {
+  it("spots reference and footnote definitions", () => {
+    expect(hasReferenceDefinitions("[ref]: https://example.com")).toBe(true);
+    expect(hasReferenceDefinitions("[^1]: a note")).toBe(true);
+    expect(hasReferenceDefinitions("[inline](https://example.com)")).toBe(false);
+  });
+});

--- a/src/lib/markdown-blocks.ts
+++ b/src/lib/markdown-blocks.ts
@@ -29,23 +29,7 @@ function getBlockParser(): ReturnType<typeof buildParser> {
  * error — the caller renders that one block as a whole, which is always safe.
  */
 export function splitTopLevelBlocks(source: string): string[] {
-  if (!source) return [];
-  try {
-    const tree = getBlockParser().parse(source) as { children?: OffsetNode[] };
-    const children = tree.children ?? [];
-    if (children.length <= 1) return [source];
-    const blocks: string[] = [];
-    for (const child of children) {
-      const start = child.position?.start?.offset;
-      const end = child.position?.end?.offset;
-      if (start == null || end == null) continue;
-      const block = source.slice(start, end);
-      if (block.trim().length > 0) blocks.push(block);
-    }
-    return blocks.length > 0 ? blocks : [source];
-  } catch {
-    return [source];
-  }
+  return splitBlocks(source).blocks;
 }
 
 const REF_DEF = /^\s{0,3}\[[^\]]+\]:\s/m;
@@ -79,4 +63,64 @@ export function isIncompleteCodeFence(block: string): boolean {
     if (closeRe.test(lines[i])) return false; // found the closing fence
   }
   return true; // opened, never closed
+}
+
+/** A split plus the offset the LAST block starts at, so a streaming caller can
+ *  grow the tail (`source.slice(tailStart)`) without re-parsing. */
+export interface BlockSplit {
+  blocks: string[];
+  /** Offset in `source` where the trailing block begins. */
+  tailStart: number;
+}
+
+/**
+ * `splitTopLevelBlocks` plus the trailing block's start offset.
+ *
+ * The offset is what makes incremental splitting possible: while the tail is
+ * only growing, the caller rebuilds the last block as `source.slice(tailStart)`
+ * — a substring — instead of re-parsing the whole message every frame. See
+ * `mayStartNewBlock` for when a re-split is actually needed.
+ */
+export function splitBlocks(source: string): BlockSplit {
+  if (!source) return { blocks: [], tailStart: 0 };
+  try {
+    const tree = getBlockParser().parse(source) as { children?: OffsetNode[] };
+    const children = tree.children ?? [];
+    if (children.length <= 1) return { blocks: [source], tailStart: 0 };
+    const blocks: string[] = [];
+    let tailStart = 0;
+    for (const child of children) {
+      const start = child.position?.start?.offset;
+      const end = child.position?.end?.offset;
+      if (start == null || end == null) continue;
+      const block = source.slice(start, end);
+      if (block.trim().length === 0) continue;
+      blocks.push(block);
+      tailStart = start;
+    }
+    return blocks.length > 0 ? { blocks, tailStart } : { blocks: [source], tailStart: 0 };
+  } catch {
+    return { blocks: [source], tailStart: 0 };
+  }
+}
+
+/**
+ * A new top-level block can only ever start at the beginning of a LINE, so a
+ * delta with no line start that looks structural cannot have changed the block
+ * boundaries — the trailing block simply got longer.
+ *
+ * Deliberately over-eager (a line starting with a digit or a dash re-splits
+ * even when it stays inside the same paragraph): being wrong in that direction
+ * costs one parse, and being wrong in the other direction costs nothing at all
+ * visually — the trailing block is rendered by parsing it as markdown, so a
+ * tail that briefly holds two blocks looks identical. Only cache granularity
+ * depends on getting this right.
+ */
+const BLOCK_START_RE = /\n[ \t]*(?:[#>*+\-=|~`_]|\d+[.)]|$)/;
+/** Inside an unclosed fence NOTHING starts a block until the fence closes. */
+const FENCE_LINE_RE = /(?:^|\n)[ \t]{0,3}(?:```|~~~)/;
+
+export function mayStartNewBlock(delta: string, tailIsOpenFence: boolean): boolean {
+  if (!delta) return false;
+  return tailIsOpenFence ? FENCE_LINE_RE.test(delta) : BLOCK_START_RE.test(delta);
 }

--- a/src/lib/markdown-cache.tsx
+++ b/src/lib/markdown-cache.tsx
@@ -11,8 +11,9 @@
 // synchronously on the main thread — they're cheap and avoid a paint flash.
 // If the worker can't start, we fall back to the previous gated-idle parse.
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { isTypingHot } from "./input-activity";
+import { applyHtml, escapeHtml } from "./dom-html";
 import MarkdownWorker from "./markdown.worker?worker";
 import "highlight.js/styles/github-dark.css";
 import { cn } from "./utils";
@@ -422,6 +423,59 @@ function pumpTransient(w: Worker): void {
   }
 }
 
+// ── Last-good tail HTML ────────────────────────────────────────────────────
+//
+// The transient lane never caches (per-frame partials would evict the settled
+// blocks the LRU exists to protect). That left one visible seam: the frame a
+// block STOPS being the tail. It re-renders through `CachedMarkdown` with a
+// source nothing has parsed yet, so a large block fell back to its raw-source
+// placeholder — the paragraph the reader was reading turned back into literal
+// markdown for a worker round-trip, then snapped to formatted again.
+//
+// This is not a cache; it is the last few tail renders, consulted ONLY as
+// something to show while the real parse runs. A hit is html for a PREFIX of
+// the requested source, so at worst the reader sees the same block a few words
+// short for one frame instead of a flash of raw asterisks.
+
+interface Stashed {
+  source: string;
+  html: string;
+}
+/** Small: a couple of live streams (split view) plus their immediate history. */
+const STASH_MAX = 4;
+const stash: Stashed[] = [];
+
+/** Record the html a streaming tail is currently showing, keyed by its RAW
+ *  source (not the repaired copy that was parsed — the settled block will ask
+ *  with the raw text). */
+export function noteTailHtml(source: string, html: string): void {
+  if (!source || !html) return;
+  const at = stash.findIndex((s) => s.source === source);
+  if (at >= 0) {
+    stash[at].html = html;
+    return;
+  }
+  stash.push({ source, html });
+  if (stash.length > STASH_MAX) stash.shift();
+}
+
+/** How much of the requested source a stash entry must cover to stand in for
+ *  it. A near-complete tail is the same paragraph a few words short; a quarter
+ *  of one is a different-sized block, and swapping THAT in would trade a text
+ *  flash for a height jump. */
+const FALLBACK_COVERAGE = 0.75;
+
+/** Formatted html to show while `source` parses, or null. */
+export function tailFallback(source: string): string | null {
+  for (let i = stash.length - 1; i >= 0; i--) {
+    const s = stash[i];
+    if (s.source.length > source.length) continue;
+    if (s.source.length < source.length * FALLBACK_COVERAGE) continue;
+    if (source.startsWith(s.source)) return s.html;
+  }
+  return null;
+}
+
 interface CachedMarkdownProps {
   source: string;
   className?: string;
@@ -447,11 +501,11 @@ interface CachedMarkdownProps {
 }
 
 /**
- * Drop-in replacement for `<Markdown>` in the chat thread. Renders the
- * cached HTML via `dangerouslySetInnerHTML`, so scroll-back remounts
- * don't re-parse markdown or re-run highlight.js. Large strings defer
- * the first parse to a `requestIdleCallback` so initial mount paint
- * isn't blocked; subsequent remounts hit the cache and skip the deferral.
+ * Drop-in replacement for `<Markdown>` in the chat thread. Writes the cached
+ * HTML into the DOM directly (see `applyHtml`), so scroll-back remounts don't
+ * re-parse markdown or re-run highlight.js. Large strings defer the first parse
+ * to the worker so initial mount paint isn't blocked; subsequent remounts hit
+ * the cache and skip the deferral.
  */
 export function CachedMarkdown({ source, className, unstyled, priority = 0 }: CachedMarkdownProps) {
   const [html, setHtml] = useState<string | null>(() => {
@@ -499,6 +553,37 @@ export function CachedMarkdown({ source, className, unstyled, priority = 0 }: Ca
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [source, priority]);
 
+  const cls = cn(
+    unstyled
+      ? "select-text"
+      : "prose-chat text-[var(--text-primary)] leading-relaxed break-words select-text",
+    className,
+  );
+
+  // What to show while the real parse is in flight, in order of preference:
+  //
+  //  1. The html the STREAMING TAIL was showing a moment ago (`tailFallback`).
+  //     This is the settle seam — the block just stopped being the tail, so its
+  //     final source has never been parsed. Showing formatted text that is a
+  //     few words short for one frame is invisible; falling back to raw
+  //     markdown here is the flash that made every long paragraph blink at the
+  //     end of a stream.
+  //  2. The RAW SOURCE, escaped, at the same size as the formatted result.
+  //     Rendering nothing gives an element of ZERO height, so a screen's worth
+  //     of unparsed messages collapses the document — in the windowed
+  //     transcript that was the whole viewport going blank at the moment the
+  //     window grew, until the worker replied. Unformatted beats absent.
+  const shown =
+    html ?? tailFallback(source) ?? `<pre class="atlas-md-pending">${escapeHtml(source)}</pre>`;
+
+  // Children are written imperatively rather than through
+  // `dangerouslySetInnerHTML` so an UPDATE is a diff, not a teardown — see
+  // `applyHtml`. React owns the element; it never owns what is inside it.
+  useLayoutEffect(() => {
+    const node = ref.current;
+    if (node) applyHtml(node, shown);
+  }, [shown]);
+
   // One delegated click handler: copy-code buttons + safe external links.
   useEffect(() => {
     const node = ref.current;
@@ -537,7 +622,11 @@ export function CachedMarkdown({ source, className, unstyled, priority = 0 }: Ca
     const node = ref.current;
     if (!node) return;
     node.querySelectorAll("pre").forEach((pre) => {
-      if ((pre as HTMLElement).dataset.enhanced) return;
+      // Both guards on purpose: the flag is the cheap check, the bar itself is
+      // the truth. `applyHtml` patches in place, so a `<pre>` can survive a
+      // re-render with its bar attached but without the flag.
+      if ((pre as HTMLElement).dataset.enhanced || pre.querySelector(":scope > .atlas-code-bar"))
+        return;
       (pre as HTMLElement).dataset.enhanced = "1";
       const code = pre.querySelector("code");
       const lang = Array.from(code?.classList ?? [])
@@ -559,41 +648,7 @@ export function CachedMarkdown({ source, className, unstyled, priority = 0 }: Ca
       bar.appendChild(btn);
       pre.appendChild(bar);
     });
-  }, [html]);
+  }, [shown]);
 
-  const cls = cn(
-    unstyled
-      ? "select-text"
-      : "prose-chat text-[var(--text-primary)] leading-relaxed break-words select-text",
-    className,
-  );
-
-  // Not yet parsed (a large block waiting on the worker) — render the RAW
-  // SOURCE rather than nothing.
-  //
-  // This matters far more than it looks. Rendering `__html: ""` gives an empty
-  // element of ZERO height, so a screen's worth of unparsed messages collapses
-  // the document to nothing; in the windowed transcript that showed up as the
-  // whole viewport going blank at the moment the window grew, and it persisted
-  // until the worker replied — up to the 3s watchdog if the worker was cold.
-  //
-  // The placeholder is the same text at the same size, so the height is about
-  // right and the reader can read it immediately; it swaps to formatted HTML
-  // when the parse lands. Unformatted beats absent, exactly as with rows.
-  if (html === null) {
-    return (
-      <div ref={ref} className={cls}>
-        <pre className="atlas-md-pending">{source}</pre>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      ref={ref}
-      className={cls}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
+  return <div ref={ref} className={cls} />;
 }

--- a/src/lib/markdown-stream.test.ts
+++ b/src/lib/markdown-stream.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { closeIncompleteMarkdown } from "./markdown-stream";
+import { parseMarkdown } from "./markdown-render";
+
+/** What the reader actually sees: the repair only matters if it renders. */
+function html(src: string): string {
+  return parseMarkdown(closeIncompleteMarkdown(src));
+}
+
+describe("closeIncompleteMarkdown", () => {
+  it("leaves complete markdown untouched", () => {
+    for (const src of [
+      "plain text",
+      "**bold** and *italic*",
+      "a `code` span",
+      "~~struck~~",
+      "[label](https://example.com)",
+      "- one\n- two",
+      "# heading",
+    ]) {
+      expect(closeIncompleteMarkdown(src)).toBe(src);
+    }
+  });
+
+  it("closes emphasis the stream cut in half", () => {
+    expect(html("**bol")).toContain("<strong>bol</strong>");
+    expect(html("**bold** and *ital")).toContain("<em>ital</em>");
+    expect(html("~~struc")).toContain("<del>struc</del>");
+  });
+
+  it("closes an unterminated code span", () => {
+    expect(html("call `fn(")).toContain("<code>fn(</code>");
+  });
+
+  it("is idempotent across a marker arriving one character at a time", () => {
+    // The frames a stream actually produces for `**bold**`. Every one of them
+    // must render the same bold word — that is what stops the snap.
+    for (const frame of ["**bold", "**bold*", "**bold**"]) {
+      expect(html(frame)).toContain("<strong>bold</strong>");
+    }
+  });
+
+  it("hides a link until its syntax is complete", () => {
+    expect(closeIncompleteMarkdown("see [the doc")).toBe("see ");
+    expect(closeIncompleteMarkdown("see [the doc](https://exa")).toBe("see ");
+    expect(closeIncompleteMarkdown("see ![alt](https://exa")).toBe("see ");
+    expect(closeIncompleteMarkdown("see [the doc](https://e.com)")).toBe(
+      "see [the doc](https://e.com)",
+    );
+  });
+
+  it("leaves task-list brackets alone", () => {
+    expect(closeIncompleteMarkdown("- [ ] todo")).toBe("- [ ] todo");
+  });
+
+  it("does not treat a list bullet as emphasis", () => {
+    expect(closeIncompleteMarkdown("* one\n* two")).toBe("* one\n* two");
+  });
+
+  it("leaves underscores in identifiers alone", () => {
+    // snake_case is far more common in agent output than underscore italics.
+    expect(closeIncompleteMarkdown("call some_helper_fn")).toBe("call some_helper_fn");
+  });
+
+  it("ignores markers inside a complete code span", () => {
+    expect(closeIncompleteMarkdown("`a * b`")).toBe("`a * b`");
+  });
+
+  it("declines to repair anything inside an unclosed fence", () => {
+    const src = "```ts\nconst a = b * c;\n";
+    expect(closeIncompleteMarkdown(src)).toBe(src);
+  });
+});

--- a/src/lib/markdown-stream.ts
+++ b/src/lib/markdown-stream.ts
@@ -1,0 +1,114 @@
+/**
+ * Repair for the STREAMING TAIL only.
+ *
+ * A token stream cuts markdown mid-token, and the renderer faithfully shows the
+ * cut: `**bol` is literal asterisks for a few frames, then the closing `**`
+ * lands and the same words snap to bold; a half-typed `[label](htt` shows its
+ * brackets and parens, then collapses into a link. Every one of those snaps is
+ * a re-layout of the line the reader is currently reading — the "flicker" of a
+ * streaming answer is mostly this, not repaint cost.
+ *
+ * So the tail is rendered from a REPAIRED copy: dangling inline markers are
+ * either closed (so the text is already bold while the rest of the word
+ * arrives) or dropped (a link's syntax stays hidden until it is complete).
+ * Nothing here touches settled text — `StreamingMarkdown` re-renders a block
+ * from its raw source the moment it stops being the tail, so the repair can
+ * never end up in the cache or in what the reader keeps.
+ *
+ * The rules are the same ones Streamdown's `parseIncompleteMarkdown` applies,
+ * kept in-repo because they have to run inside our own worker pipeline rather
+ * than a react-markdown tree.
+ */
+
+/** Fence lines (``` / ~~~) in the block, used to detect an unclosed fence. */
+const FENCE_LINE = /^[ \t]{0,3}(?:`{3,}|~{3,})/;
+
+/** A complete inline code span — masked out before any counting. */
+const CODE_SPAN = /(`+)(?:[^`]|(?!\1)`)*\1/g;
+
+/** `- ` / `* ` / `+ ` at the start of a line: a bullet, not emphasis. */
+const BULLET = /^[ \t]*[*+-][ \t]/;
+
+/** Trailing run of markers the stream cut in half. Trimming it and then
+ *  re-balancing is idempotent for a COMPLETE run (`**bold**` → `**bold` →
+ *  `**bold**`), which is what lets one rule cover both cases. */
+const TRAILING_MARKER = /(?:\*+|~+|`+)$/;
+
+function countFenceLines(source: string): number {
+  let n = 0;
+  for (const line of source.split("\n")) if (FENCE_LINE.test(line)) n += 1;
+  return n;
+}
+
+/** Replace complete code spans with same-length inert filler so their contents
+ *  can't be mistaken for emphasis, while every offset stays valid. */
+function maskCodeSpans(source: string): string {
+  return source.replace(CODE_SPAN, (m) => "x".repeat(m.length));
+}
+
+/** Index of the last `[` that is still open — the start of a link or image the
+ *  stream has not finished yet. `-1` when every bracket is resolved. */
+function danglingLinkStart(source: string): number {
+  const masked = maskCodeSpans(source);
+  const open = masked.lastIndexOf("[");
+  if (open < 0) return -1;
+  if (open > 0 && masked[open - 1] === "\\") return -1;
+  const rest = masked.slice(open);
+  const close = rest.indexOf("]");
+  if (close < 0) return open; // `[label…` — destination not started
+  // `[label](dest…` — parenthesis opened, never closed.
+  if (rest[close + 1] === "(" && !rest.slice(close + 1).includes(")")) return open;
+  return -1;
+}
+
+/**
+ * Return `source` with its half-finished inline markup made whole, ready to be
+ * parsed as the live tail. Returns the input unchanged when there is nothing to
+ * repair, so the common case allocates nothing.
+ */
+export function closeIncompleteMarkdown(source: string): string {
+  if (!source) return source;
+  // An unclosed fence swallows everything after it; the caller renders that
+  // case as plain text, and "repairing" markers inside code would be wrong
+  // regardless.
+  if (countFenceLines(source) % 2 === 1) return source;
+
+  let out = source;
+
+  // 1. Hide a link/image whose syntax is still arriving. The `!` of an image
+  //    goes with it, or the reader is left with a stray bang.
+  const link = danglingLinkStart(out);
+  if (link >= 0) out = out.slice(0, link > 0 && out[link - 1] === "!" ? link - 1 : link);
+
+  // 2. Drop the marker run the stream cut in half, then close what is open.
+  out = out.replace(TRAILING_MARKER, "");
+  if (!out) return out;
+
+  // 3. Inline code: any backtick surviving the mask opened a span. Close it
+  //    FIRST and re-mask, or the span's own contents (`a * b`) get counted as
+  //    dangling emphasis below.
+  if (maskCodeSpans(out).includes("`")) out += "`";
+  const masked = maskCodeSpans(out);
+
+  // 4. Strikethrough (GFM), counted in pairs.
+  let tildePairs = 0;
+  for (const run of masked.match(/~+/g) ?? []) tildePairs += Math.floor(run.length / 2);
+  if (tildePairs % 2 === 1) out += "~~";
+
+  // 5. Emphasis. `_` is deliberately NOT balanced: snake_case identifiers are
+  //    far more common in agent output than underscore italics, and closing a
+  //    "dangling" underscore inside `some_name` would italicise real text.
+  let doubles = 0;
+  let singles = 0;
+  for (const line of masked.split("\n")) {
+    const body = line.replace(BULLET, "");
+    for (const run of body.match(/\*+/g) ?? []) {
+      doubles += Math.floor(run.length / 2);
+      singles += run.length % 2;
+    }
+  }
+  if (singles % 2 === 1) out += "*";
+  if (doubles % 2 === 1) out += "**";
+
+  return out;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -985,10 +985,44 @@
   animation: atlas-blink 1s steps(1, end) infinite;
 }
 
+/* …and the same caret drawn from the tail block itself.
+
+   It used to be a real `<span>` appended after the last block. Block elements
+   are not inline siblings, so it landed on a line of ITS OWN below the text —
+   a caret that hung under the paragraph, and one line of extra height that
+   appeared and vanished as blocks settled. Generated content on the tail's last
+   element puts it where a cursor belongs: immediately after the final
+   character. Containers that would swallow it (lists, quotes) hand it to their
+   own last child instead; `pre` opts out because an open fence draws its own. */
+.atlas-stream-tail > :last-child:not(ul):not(ol):not(blockquote):not(pre):not(table)::after,
+.atlas-stream-tail > ul:last-child > li:last-child::after,
+.atlas-stream-tail > ol:last-child > li:last-child::after,
+.atlas-stream-tail > blockquote:last-child > :last-child::after {
+  content: "";
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  background: var(--accent-primary);
+  border-radius: 1px;
+  animation: atlas-blink 1s steps(1, end) infinite;
+}
+
+/* Block wrappers for the split streaming render — see `streaming-markdown.tsx`.
+   `display: contents` keeps N containers out of layout entirely. */
+.atlas-md-block {
+  display: contents;
+}
+
 /* Respect the OS "reduce motion" setting — hold the caret steady and
    neutralize our entrance/blink animations (keep their end state). */
 @media (prefers-reduced-motion: reduce) {
-  .atlas-stream-caret {
+  .atlas-stream-caret,
+  .atlas-stream-tail > :last-child::after,
+  .atlas-stream-tail > ul:last-child > li:last-child::after,
+  .atlas-stream-tail > ol:last-child > li:last-child::after,
+  .atlas-stream-tail > blockquote:last-child > :last-child::after {
     animation: none;
   }
   .atlas-pill-in,
@@ -1490,6 +1524,23 @@
   margin: 12px 0 0;
 }
 .atlas-prose > :first-child {
+  margin-top: 0;
+}
+
+/* Streaming render: the message is split into top-level blocks, each wrapped in
+   a `display: contents` container so the block elements stay layout-siblings.
+   The wrapper is invisible to layout but NOT to selectors, so the child
+   combinator above lands on the wrapper (which has no box, so its margin is
+   dropped) instead of on the paragraph.
+
+   Without these two rules the inter-block gap was 0 while a message streamed
+   and 12px the instant it settled — every answer visibly re-flowed as it
+   finished. They restore the same rhythm one level deeper, so streaming and
+   settled prose are pixel-identical. */
+.atlas-prose > .atlas-md-block > * {
+  margin: 12px 0 0;
+}
+.atlas-prose > .atlas-md-block:first-child > :first-child {
   margin-top: 0;
 }
 


### PR DESCRIPTION
### What?

Fixes the flickering, jumping and unreadable rendering of a streaming answer in the chat transcript. Six separate causes in the chat markdown path, all in `src/lib/markdown-*` and `src/features/chat/components/`:

1. **Large tails stopped updating in dev.** `TransientMarkdown` set an `alive` ref to `false` in an effect cleanup and never set it back to `true`. StrictMode's mount/unmount/mount trips that on the first render, so every block over 2 KB went mute mid-answer and only caught up when the turn settled. The latch is now set on each effect run.
2. **Paragraph spacing changed when a turn finished.** The streaming render wraps each top-level block in a `display: contents` container, and that container carried `.atlas-prose` — so `.atlas-prose > :first-child { margin-top: 0 }` matched *every* block's first element. Inter-block gap was 0 px while streaming and 12 px the instant it settled: the whole answer re-flowed as it finished. The wrapper is now `.atlas-md-block`, with two rules restoring the same rhythm one level deeper, so streaming and settled prose are pixel-identical.
3. **The settle seam flashed raw markdown.** When a block stops being the tail it re-renders through `CachedMarkdown` with a source nothing has parsed, so anything over the sync limit fell back to its raw-source placeholder for a worker round-trip — the paragraph you were reading turned back into literal asterisks, then snapped. The tail renderer now stashes its last html (`noteTailHtml`) and `CachedMarkdown` shows that while the real parse runs. `ProseRowView` also keeps the block renderer for a row that streamed instead of switching back to a whole-message parse at the end of the turn (which re-parsed the entire answer under an uncached source).
4. **Half-written markup snapped.** `**bol` showed its asterisks for a few frames and then the words jumped to bold; `[label](htt` showed its brackets and then collapsed. The new `closeIncompleteMarkdown` repairs the tail before parsing it — dangling emphasis/strikethrough/code spans are closed, a partial link stays hidden until complete. Live tail only; settled blocks always render from raw source, so nothing repaired ever reaches the cache.
5. **Every frame replaced the DOM.** `dangerouslySetInnerHTML` is a teardown, not an update, so the nodes you were looking at stopped existing several times a second: **you could not select text while the agent was writing**, hover reset, and WebKit repainted the whole block rather than the one line that changed. Rendered html is now patched in place.
6. **Per-frame cost scaled with answer length.** The block split re-parsed the whole message every frame, so a long turn got progressively jankier as it went. While the tail is only growing it is now a substring (`splitBlocks` reports the tail offset); a real re-split runs only when the delta could have opened a new block, with a 500 ms backstop.

Plus: the streaming caret is drawn from the tail block's last element instead of a block-level `<span>` after it, so it sits after the final character rather than on a line of its own (which also removes a line of height appearing and vanishing as blocks settle).

### Why?

Reading a streaming answer was the worst-looking surface in the app: text alternating between raw and formatted, spacing shifting under you at the end of every turn, a caret hanging below the paragraph, and no way to select text until the agent stopped. Individually each cause is small; together they read as "the renderer is broken".

**This adds one top-level dependency: [`morphdom`](https://github.com/patrick-steele-idem/morphdom) (2.7.8, ~5 KB minified, zero dependencies, MIT).** Flagging it per CONTRIBUTING's "new heavy dependencies need discussion". It is the primitive for cause 5 — it walks the existing DOM against the new html and mutates only what differs (usually a single text node), which is exactly the streaming-update problem and is what Phoenix LiveView uses for it. It is confined to `src/lib/dom-html.ts`; nothing else imports it, and it does not enter the markdown worker chunk. Writing it by hand was the alternative, at ~100 lines of DOM-diffing nobody would want to own. Happy to drop it if you'd rather not take the dependency — cause 5 would then need its own in-repo patcher.

The `closeIncompleteMarkdown` rules are the same ones [Streamdown](https://streamdown.ai)'s `parseIncompleteMarkdown` applies. Streamdown itself is not usable here: it is a react-markdown renderer, and this repo parses in a Web Worker and injects sanitized html, so the rules are in-repo instead of the library.

No telemetry changes.

### How?

| File | Change |
|---|---|
| `src/lib/dom-html.ts` *(new)* | `applyHtml` — morphdom patch with a first-fill fast path; preserves the injected code-copy bar. `escapeHtml` for the raw-source placeholder. |
| `src/lib/markdown-stream.ts` *(new)* | `closeIncompleteMarkdown` — tail repair. Declines to touch anything inside an unclosed fence; leaves `_` alone (snake_case is more common in agent output than underscore italics). |
| `src/lib/markdown-blocks.ts` | `splitBlocks` (split + tail offset) and `mayStartNewBlock`; `splitTopLevelBlocks` now delegates. |
| `src/lib/markdown-cache.tsx` | Last-good-tail stash (`noteTailHtml` / `tailFallback`, prefix match with a 75 % coverage floor so a fallback can't cause a height jump); `CachedMarkdown` writes children through `applyHtml`. |
| `src/features/chat/components/streaming-markdown.tsx` | `alive` fix, tail repair, in-place patching, incremental split, adaptive inline-parse budget, `.atlas-md-block` / `.atlas-stream-tail` wrappers. |
| `src/features/chat/components/transcript-rows.tsx` | A row that streamed keeps the block renderer. |
| `src/styles/globals.css` | `.atlas-md-block` rhythm rules, inline caret, reduced-motion coverage. |

Correctness note on the incremental split: getting `mayStartNewBlock` wrong cannot break rendering. The trailing block is rendered by parsing it as markdown, so a tail that briefly holds two blocks looks identical — only cache granularity is affected, and the backstop re-split repairs that.

### Tests

New: `src/lib/markdown-stream.test.ts`, `src/lib/markdown-blocks.test.ts`, `src/lib/dom-html.test.ts`, `src/features/chat/components/streaming-markdown.test.tsx` (37 assertions). The ones that fail without this change:

- `closeIncompleteMarkdown` renders `**bold`, `**bold*` and `**bold**` as the same bold word — the frames a stream actually produces.
- `applyHtml` keeps the element identity of an unchanged sibling and of a paragraph whose text grew.
- `StreamingMarkdown` grows the tail's `<p>` in place across a rerender rather than rebuilding it, and formats `Hello **bol` as bold immediately.
- `tailFallback` lends html to a longer source that starts with it, and refuses one it barely covers.

`bun run lint`, `format:check`, `typecheck`, `test` (1196 passed) and `build` all pass; the suite was run repeatedly to confirm the new tests aren't timing-flaky.

> **Branch note:** this is the same commit as #245 (which targets `0.3.1`), cherry-picked onto `main` so the diff is the fix alone with none of `0.3.1`'s other commits. Opened against `main` on request — merge whichever fits your release flow and close the other.

## Checklist

- [ ] Targets the current version branch — this one targets `main`; see the branch note above (#245 is the `0.3.1` version-branch copy)
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [ ] **Not done — please check this before merging.** I don't have a macOS window to run the bundle in, so every claim here is from code and the test suite, not from watching a real stream. The three things worth eyeballing: paragraph spacing must not shift when a turn ends, the caret must sit at the end of the last line, and text must be selectable mid-answer.

https://claude.ai/code/session_0195fCgt87j14eUeLwiyzY5S
