### PR TITLE
fix(agent-servers): bound the cancel path, the debug ring and windowed reads

### DIFF
--- a/crates/atlas-agent-servers/src/connection.rs
+++ b/crates/atlas-agent-servers/src/connection.rs
@@ -28,7 +28,9 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::debug_log::{AcpDebugLog, AcpDebugMessage, AcpDebugMessageDirection};
 use crate::handlers::{self, ClientContext};
-use crate::session::{AcpSession, ConfigOptions, SessionDirectories, SessionRegistry};
+use crate::session::{
+    AcpSession, CancelSignal, CancelWaiter, ConfigOptions, SessionDirectories, SessionRegistry,
+};
 use crate::session_list::AcpSessionList;
 
 /// Zed rejects anything below v1 outright rather than trying to degrade.
@@ -41,6 +43,22 @@ const MINIMUM_SUPPORTED_VERSION: ProtocolVersion = ProtocolVersion::V1;
 /// Reporting the RPC error would tell the user "connection closed" when the
 /// real answer — on stderr — is one tick away.
 const INITIALIZE_EXIT_GRACE: Duration = Duration::from_millis(250);
+
+/// How long an agent gets to answer its own cancellation before the turn is
+/// resolved locally.
+///
+/// `session/prompt` deliberately has no timeout — a legitimate turn runs for
+/// minutes and a flat deadline would kill working sessions. The clock starts
+/// only once the user has asked to stop, which is the point at which waiting
+/// indefinitely stops being correct: they have said they do not want the
+/// result, so the only question left is how long to be polite about it.
+///
+/// Long enough that a healthy agent always wins the race — acknowledging a
+/// cancel is a wire round-trip plus whatever teardown the agent does, well
+/// inside a second — and short enough to be a recovery rather than a second
+/// wait. Losing the race costs the turn's real stop reason and token counts,
+/// which is a fair price for a chat that unfreezes.
+const CANCEL_GRACE: Duration = Duration::from_secs(5);
 
 /// What a session's `AcpThread` events are sent to.
 ///
@@ -380,7 +398,7 @@ impl AcpConnection {
             session_id.clone(),
             AcpSession {
                 thread: Arc::downgrade(&thread),
-                suppress_abort_err: false,
+                cancel_signal: CancelSignal::new(),
                 session_modes: None,
                 config_options: None,
                 ref_count: 1,
@@ -624,7 +642,7 @@ impl AgentConnection for AcpConnection {
                 session_id.clone(),
                 AcpSession {
                     thread: Arc::downgrade(&thread),
-                    suppress_abort_err: false,
+                    cancel_signal: CancelSignal::new(),
                     session_modes: response.modes.map(|modes| Arc::new(Mutex::new(modes))),
                     config_options: response
                         .config_options
@@ -819,19 +837,56 @@ impl AgentConnection for AcpConnection {
         let conn = self.connection.clone();
         let sessions = self.sessions.clone();
         let session_id = params.session_id.clone();
+        // Taken before the request goes out, so a cancel that lands while we
+        // are still sending is seen rather than missed. The probe is this
+        // turn's own view of it: whether a cancel fired while THIS turn was
+        // running, which is what decides an abort-shaped error's fate below.
+        let cancel_waiter =
+            sessions.with_session(&session_id, |session| session.cancel_signal.waiter());
+        let cancel_probe = cancel_waiter.as_ref().map(CancelWaiter::probe);
 
         async move {
-            let result = conn.send_request(params).block_task().await;
+            let result = match cancel_waiter {
+                Some(waiter) => {
+                    let request = conn.send_request(params).block_task();
+                    futures::pin_mut!(request);
+                    let deadline = async move {
+                        waiter.cancelled().await;
+                        tokio::time::sleep(CANCEL_GRACE).await;
+                    };
+                    futures::pin_mut!(deadline);
 
-            // Consume the flag whatever the outcome, so a cancel cannot leak
-            // into a later turn's error handling.
-            let suppress_abort_err = sessions
-                .with_session(&session_id, |session| {
-                    let suppress = session.suppress_abort_err;
-                    session.suppress_abort_err = false;
-                    suppress
-                })
-                .unwrap_or(false);
+                    match futures::future::select(request, deadline).await {
+                        futures::future::Either::Left((result, _)) => result,
+                        futures::future::Either::Right(((), _)) => {
+                            // The agent was told to stop and did not answer, so
+                            // answer for it.
+                            //
+                            // Dropping the request future is not merely giving
+                            // up locally: the SDK's `SentRequestCancellation`
+                            // has a `Drop` that sends a cancellation for the
+                            // abandoned request id (`jsonrpc.rs:4742`), so the
+                            // agent is told again, through the channel it
+                            // ignored the first time. A reply that arrives
+                            // after this has no waiter, which is what
+                            // "cancelled" means.
+                            tracing::warn!(
+                                session = %session_id,
+                                grace_ms = CANCEL_GRACE.as_millis(),
+                                "agent did not acknowledge a cancel; resolving the turn locally"
+                            );
+                            return Ok(acp::PromptResponse::new(acp::StopReason::Cancelled));
+                        }
+                    }
+                }
+                // No session to hang a clock on. The request is still the right
+                // thing to await; an unknown session id fails on its own.
+                None => conn.send_request(params).block_task().await,
+            };
+
+            // Read, not consumed: this turn's own answer, so it cannot be
+            // spent by a sibling turn or inherited by a later one.
+            let suppress_abort_err = cancel_probe.is_some_and(|probe| probe.fired());
 
             let err = match result {
                 Ok(response) => return Ok(response),
@@ -875,12 +930,18 @@ impl AgentConnection for AcpConnection {
     }
 
     fn cancel(&self, session_id: &acp::SessionId) {
-        self.sessions.with_session(session_id, |session| {
-            session.suppress_abort_err = true;
-        });
+        let signal = self
+            .sessions
+            .with_session(session_id, |session| session.cancel_signal.clone());
         let _ = self
             .connection
             .send_notification(acp::CancelNotification::new(session_id.clone()));
+        // After the notification, not before: a healthy agent should get the
+        // whole grace period to answer it, and starting the clock first would
+        // spend part of that on our own write.
+        if let Some(signal) = signal {
+            signal.fire();
+        }
     }
 
     fn request_elicitations(&self) -> Option<ElicitationStoreHandle> {

--- a/crates/atlas-agent-servers/src/debug_log.rs
+++ b/crates/atlas-agent-servers/src/debug_log.rs
@@ -17,6 +17,53 @@ use agent_client_protocol::schema::v1 as acp;
 /// Zed's cap, kept as-is. A chatty agent must not grow this without bound.
 const MAX_DEBUG_BACKLOG_MESSAGES: usize = 2000;
 
+/// Total payload bytes the ring may retain, across every message in it.
+///
+/// A message cap alone does not bound memory, because a message is not a
+/// bounded thing: Atlas's own `fs/read_text_file` response carries the whole
+/// file, and `connection.rs` tees every outgoing line in here before the write.
+/// An agent reading sixty 2 MB files — the ordinary behaviour of a coding
+/// agent, not an attack — parked 120 MB in this ring, and at the 2000-message
+/// cap the same workload reaches gigabytes.
+pub const MAX_DEBUG_BACKLOG_BYTES: usize = 4 * 1024 * 1024;
+
+/// The largest single payload kept verbatim. Anything longer is replaced by
+/// [`elided_payload`], which keeps the shape of the conversation — direction,
+/// method, id, and how big the body was — and drops the body itself.
+///
+/// Sized so an ordinary RPC is never touched and a file transfer always is.
+pub const MAX_DEBUG_MESSAGE_BYTES: usize = 16 * 1024;
+
+/// The fixed cost of an elided message: the marker object and the envelope
+/// around it. Anything variable-length the message still carries — a method
+/// name, an error's own message — is measured and added, so this is a floor
+/// that is enforced rather than a number that is asserted.
+const ELIDED_MESSAGE_BYTES: usize = 128;
+
+/// How much of an error's `message` survives elision. An `acp::Error` message
+/// is specified as "a concise single sentence", so this is generous for a
+/// well-behaved agent and a bound on one that is not.
+const MAX_ERROR_MESSAGE_BYTES: usize = 1024;
+
+/// Cut `text` to at most `max` bytes, on a character boundary.
+fn truncate_on_char_boundary(text: &mut String, max: usize) {
+    if text.len() <= max {
+        return;
+    }
+    let mut cut = max;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    text.truncate(cut);
+}
+
+/// What replaces a payload too big to keep. A marker object rather than `None`,
+/// so a reader can tell "there was a body, it was 2 MB" from "there was no
+/// body" — the two mean different things when reading a transcript.
+fn elided_payload(bytes: usize) -> serde_json::Value {
+    serde_json::json!({ "atlasElided": { "bytes": bytes } })
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AcpDebugMessageDirection {
     Incoming,
@@ -129,12 +176,80 @@ impl AcpDebugMessage {
 
         Some(Self { direction, message })
     }
+
+    /// Drop the body, keep the envelope, and report what is left.
+    ///
+    /// `original_bytes` is the wire length this message came from, kept in the
+    /// marker so a reader can see what was dropped. Stderr is the exception:
+    /// its text *is* the payload and [`AcpDebugLog::trailing_stderr`] is what
+    /// explains an agent's death, so an over-long line is cut to a prefix
+    /// rather than replaced — the reason an agent died is at the start of what
+    /// it printed, not the end.
+    fn elide_payload(&mut self, original_bytes: usize) -> usize {
+        match &mut self.message {
+            AcpDebugMessageContent::Request { method, params, .. }
+            | AcpDebugMessageContent::Notification { method, params, .. } => {
+                *params = Some(elided_payload(original_bytes));
+                ELIDED_MESSAGE_BYTES + method.len()
+            }
+            AcpDebugMessageContent::Response { result, .. } => {
+                // The error arm elides too. "An error carries a message, not a
+                // body" was an assumption about output an agent controls, not
+                // something enforced: `data` is an unbounded `Value`, and
+                // `parse_value` puts the WHOLE error object in it as a string
+                // when it fails to deserialize. An oversized error line would
+                // have been kept verbatim while being charged as if elided,
+                // which is the one shape that defeats the budget entirely.
+                match result {
+                    Ok(payload) => {
+                        *payload = Some(elided_payload(original_bytes));
+                        ELIDED_MESSAGE_BYTES
+                    }
+                    Err(err) => {
+                        err.data = Some(elided_payload(original_bytes));
+                        truncate_on_char_boundary(&mut err.message, MAX_ERROR_MESSAGE_BYTES);
+                        ELIDED_MESSAGE_BYTES + err.message.len()
+                    }
+                }
+            }
+            AcpDebugMessageContent::Stderr { line } => {
+                let mut text = line.to_string();
+                truncate_on_char_boundary(&mut text, MAX_DEBUG_MESSAGE_BYTES);
+                *line = Arc::from(format!("{text}… [{original_bytes} bytes]"));
+                line.len()
+            }
+        }
+    }
+}
+
+/// A message plus what it costs to keep, so eviction can be driven by bytes
+/// without re-measuring the payload on every insert.
+struct RetainedMessage {
+    message: AcpDebugMessage,
+    bytes: usize,
 }
 
 #[derive(Default)]
 struct AcpDebugLogState {
-    messages: VecDeque<AcpDebugMessage>,
+    messages: VecDeque<RetainedMessage>,
     subscribers: Vec<tokio::sync::mpsc::UnboundedSender<AcpDebugMessage>>,
+    /// Running sum of `messages[..].bytes`, maintained on both ends.
+    retained_bytes: usize,
+}
+
+impl AcpDebugLogState {
+    /// The only two ways the deque changes, so the running total cannot drift
+    /// away from the messages it is counting.
+    fn push_back(&mut self, retained: RetainedMessage) {
+        self.retained_bytes = self.retained_bytes.saturating_add(retained.bytes);
+        self.messages.push_back(retained);
+    }
+
+    fn pop_front(&mut self) {
+        if let Some(retained) = self.messages.pop_front() {
+            self.retained_bytes = self.retained_bytes.saturating_sub(retained.bytes);
+        }
+    }
 }
 
 #[derive(Clone, Default)]
@@ -156,7 +271,11 @@ impl AcpDebugLog {
         tokio::sync::mpsc::UnboundedReceiver<AcpDebugMessage>,
     ) {
         let mut state = self.lock();
-        let backlog = state.messages.iter().cloned().collect();
+        let backlog = state
+            .messages
+            .iter()
+            .map(|retained| retained.message.clone())
+            .collect();
         let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
         state.subscribers.push(sender);
         (backlog, receiver)
@@ -167,23 +286,64 @@ impl AcpDebugLog {
         if messages.is_empty() {
             return;
         }
-        self.record_messages(messages);
+
+        // The wire line is the honest measure of what this costs, and it is
+        // already in hand — measuring the parsed payload would mean
+        // re-serialising it. A line over the cap has its body dropped here,
+        // before anything retains it, and reports what it shrank to.
+        //
+        // A batch line charges its full length to every message in it. That
+        // over-counts, which is the safe direction: the budget binds sooner,
+        // never later.
+        let line_bytes = line.len();
+        let retained = messages
+            .into_iter()
+            .map(|mut message| {
+                let bytes = if line_bytes > MAX_DEBUG_MESSAGE_BYTES {
+                    message.elide_payload(line_bytes)
+                } else {
+                    line_bytes
+                };
+                RetainedMessage { message, bytes }
+            })
+            .collect();
+
+        self.record_messages(retained);
     }
 
-    fn record_messages(&self, messages: Vec<AcpDebugMessage>) {
+    fn record_messages(&self, messages: Vec<RetainedMessage>) {
         let mut state = self.lock();
 
         state.subscribers.retain(|sender| !sender.is_closed());
-        for message in messages {
-            if state.messages.len() == MAX_DEBUG_BACKLOG_MESSAGES {
-                state.messages.pop_front();
+        for retained in messages {
+            let message = retained.message.clone();
+            state.push_back(retained);
+
+            // Two caps, both enforced from the front. The message cap bounds a
+            // chatty agent; the byte cap bounds a verbose one, which the
+            // message cap alone never could. `len() > 1` keeps the newest
+            // message even if it alone is over budget, so the ring can never
+            // answer "nothing happened" to something that just did.
+            while state.messages.len() > MAX_DEBUG_BACKLOG_MESSAGES
+                || (state.retained_bytes > MAX_DEBUG_BACKLOG_BYTES && state.messages.len() > 1)
+            {
+                state.pop_front();
             }
-            state.messages.push_back(message.clone());
 
             for sender in &state.subscribers {
                 let _ = sender.send(message.clone());
             }
         }
+    }
+
+    /// What the ring is charging itself for, which is what
+    /// [`MAX_DEBUG_BACKLOG_BYTES`] bounds.
+    ///
+    /// An estimate, deliberately biased high: a batch line charges its whole
+    /// length to each message in it. Read it as "the budget's own view of the
+    /// ring", not as a measurement of heap.
+    pub fn retained_bytes(&self) -> usize {
+        self.lock().retained_bytes
     }
 
     /// The run of stderr lines at the very end of the log.
@@ -196,6 +356,7 @@ impl AcpDebugLog {
         let mut lines = state
             .messages
             .iter()
+            .map(|retained| &retained.message)
             .rev()
             .take_while(|message| matches!(&message.message, AcpDebugMessageContent::Stderr { .. }))
             .filter_map(|message| match &message.message {

--- a/crates/atlas-agent-servers/src/handlers.rs
+++ b/crates/atlas-agent-servers/src/handlers.rs
@@ -432,29 +432,50 @@ fn read_text_file(
     roots: &[PathBuf],
 ) -> anyhow::Result<String> {
     let path = resolve_within_roots(path, roots)?;
-    let content = std::fs::read_to_string(&path)?;
     if line.is_none() && limit.is_none() {
-        return Ok(content);
+        return Ok(std::fs::read_to_string(&path)?);
     }
 
+    // Stream when a window was asked for. `read_to_string` first would load the
+    // whole file to hand back one line of it — and `line`/`limit` exist
+    // precisely so a client does not have to do that. It also decided the
+    // encoding of the whole file: a byte the caller never asked for could fail
+    // a read of a range that is perfectly good text.
     let skip = line.unwrap_or(1).saturating_sub(1) as usize;
     let take = limit.map(|limit| limit as usize).unwrap_or(usize::MAX);
-    let selected: Vec<&str> = content.lines().skip(skip).take(take).collect();
+
+    let file = std::fs::File::open(&path)?;
+    // `read_to_string` used to be what rejected a directory. Opening one
+    // succeeds on unix and only the *read* fails — which a `limit: 0` window
+    // never performs, so without this an unreadable path would answer with a
+    // confident empty string instead of an error.
+    if file.metadata()?.is_dir() {
+        return Err(std::io::Error::from(std::io::ErrorKind::IsADirectory).into());
+    }
+    let mut selected = Vec::new();
+    for line in std::io::BufRead::lines(std::io::BufReader::new(file))
+        .skip(skip)
+        .take(take)
+    {
+        selected.push(line?);
+    }
     Ok(selected.join("\n"))
 }
 
 /// Reject a path outside every root in `roots`, before it ever reaches
-/// `std::fs`. `path` may not exist yet (a write's target), so this resolves
-/// `.`/`..` lexically rather than calling `canonicalize` on it directly —
-/// canonicalize only the roots, which are expected to exist, and compare
-/// against those.
+/// `std::fs`. `path` may not exist yet (a write's target), so `.`/`..` are
+/// resolved lexically first and then the deepest part of the result that *does*
+/// exist is canonicalized — see [`canonicalize_deepest_ancestor`].
 ///
-/// Lexical resolution does not chase symlinks inside an allowed root, so a
-/// symlink planted there that points back out is not caught here — the ACP
-/// permission prompt (`request_permission`) is the place for that class of
-/// check, same as Zed's own model. This closes the reported gap: an agent
-/// handing back an absolute path or a `../` climb outside every granted
-/// directory.
+/// That two-step is what makes the check hold against symlinks: a link planted
+/// inside a granted root that points back out is followed while resolving the
+/// ancestor, so the comparison sees where the path really lands rather than
+/// where it appears to. The planted-symlink test below pins it.
+///
+/// A root that cannot be canonicalized grants nothing. It is the only
+/// fail-closed choice available: the alternative is comparing a canonical
+/// target against a non-canonical root, which is a different namespace and
+/// therefore not a comparison at all.
 fn resolve_within_roots(path: &Path, roots: &[PathBuf]) -> anyhow::Result<PathBuf> {
     // ONE namespace for both sides. The first version compared a lexically
     // normalized target against canonicalized roots — two namespaces, papered
@@ -466,9 +487,17 @@ fn resolve_within_roots(path: &Path, roots: &[PathBuf]) -> anyhow::Result<PathBu
     // disk — and re-joining the not-yet-existing tail closes both.
     let resolved = canonicalize_deepest_ancestor(&normalize_lexically(path));
     for root in roots {
-        let canon_root = root
-            .canonicalize()
-            .unwrap_or_else(|_| normalize_lexically(root));
+        // A root that is gone grants nothing. Falling back to a lexical form
+        // here would compare a canonical target against a non-canonical root —
+        // two namespaces again, which is the bug this function already carries
+        // a note about.
+        let Ok(canon_root) = root.canonicalize() else {
+            tracing::warn!(
+                root = %root.display(),
+                "granted directory cannot be resolved; refusing paths under it"
+            );
+            continue;
+        };
         if resolved.starts_with(&canon_root) {
             return Ok(resolved);
         }
@@ -648,6 +677,135 @@ mod fs_bound_tests {
         );
         let _ = std::fs::remove_dir_all(&cwd);
         let _ = std::fs::remove_dir_all(&extra_dir);
+    }
+
+    /// ATL-236. The old body ran `read_to_string` before looking at `line` or
+    /// `limit`, so a windowed read paid for the whole file.
+    ///
+    /// Proven by encoding rather than by size, because a size test can only
+    /// ever be slow and suggestive: bytes that are not UTF-8 sit *after* the
+    /// requested line, so a whole-file read cannot succeed and a streaming
+    /// read cannot fail. It is the same defect, made deterministic.
+    #[test]
+    fn a_windowed_read_does_not_pay_for_the_rest_of_the_file() {
+        let root = test_root();
+        let path = root.join("mixed.log");
+
+        let mut bytes = b"the line that was asked for\n".to_vec();
+        bytes.extend_from_slice(&[0xff, 0xfe, 0x00]);
+        bytes.push(b'\n');
+        std::fs::write(&path, &bytes).expect("write fixture");
+
+        assert!(
+            std::fs::read_to_string(&path).is_err(),
+            "fixture is pointless unless a whole-file read of it fails"
+        );
+
+        let out = read_text_file(&path, Some(1), Some(1), std::slice::from_ref(&root))
+            .expect("a windowed read must not decode past its window");
+        assert_eq!(out, "the line that was asked for");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The window itself still has to be right — a streaming rewrite is only
+    /// worth anything if `line` stays 1-based and `limit` still counts lines.
+    #[test]
+    fn line_is_one_based_and_limit_counts_lines() {
+        let root = test_root();
+        let path = root.join("numbers.txt");
+        std::fs::write(&path, "one\ntwo\nthree\nfour\nfive\n").expect("write fixture");
+        let roots = std::slice::from_ref(&root);
+
+        assert_eq!(
+            read_text_file(&path, None, None, roots).expect("whole file"),
+            "one\ntwo\nthree\nfour\nfive\n",
+            "an unwindowed read is byte-for-byte, trailing newline included"
+        );
+        assert_eq!(
+            read_text_file(&path, Some(2), Some(2), roots).expect("window"),
+            "two\nthree"
+        );
+        assert_eq!(
+            read_text_file(&path, Some(1), None, roots).expect("from the top"),
+            "one\ntwo\nthree\nfour\nfive"
+        );
+        assert_eq!(
+            read_text_file(&path, None, Some(1), roots).expect("first line only"),
+            "one"
+        );
+        assert_eq!(
+            read_text_file(&path, Some(99), Some(3), roots).expect("past the end"),
+            "",
+            "a window past the end is empty, not an error"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A granted directory that no longer exists cannot be compared against,
+    /// so it grants nothing. The alternative — comparing a canonical target
+    /// against a lexical root — is the two-namespace bug this function was
+    /// already fixed for once.
+    #[test]
+    fn a_root_that_cannot_be_resolved_grants_nothing() {
+        // Canonical on purpose. `temp_dir()` is a symlink on macOS
+        // (`/var/…` → `/private/var/…`), and under a symlinked root the old
+        // lexical fallback happened to reject anyway — so this test passed
+        // against the very code it was written to rule out. The difference is
+        // only observable when the root is already in the canonical namespace.
+        let root = test_root().canonicalize().expect("canonicalize the root");
+        let target = root.join("file.txt");
+        assert!(
+            resolve_within_roots(&target, std::slice::from_ref(&root)).is_ok(),
+            "sanity: the root grants while it exists"
+        );
+
+        std::fs::remove_dir_all(&root).expect("remove the root");
+        assert!(
+            resolve_within_roots(&target, std::slice::from_ref(&root)).is_err(),
+            "a vanished root must not still grant paths under it"
+        );
+    }
+
+    /// A zero-length window pulls nothing from the iterator, so an error that
+    /// only surfaces on read — a directory — would never be raised. The old
+    /// whole-file read failed first and got this right by accident; the
+    /// streaming version has to mean it.
+    #[test]
+    fn an_unreadable_path_is_an_error_even_for_an_empty_window() {
+        let root = test_root();
+        let dir = root.join("a-directory");
+        std::fs::create_dir_all(&dir).expect("create the directory");
+        let roots = std::slice::from_ref(&root);
+
+        for (line, limit) in [(None, Some(0)), (Some(1), Some(0)), (None, None), (Some(1), None)] {
+            assert!(
+                read_text_file(&dir, line, limit, roots).is_err(),
+                "reading a directory answered successfully for line={line:?} limit={limit:?}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The containment check has to run before the file is opened, not after.
+    #[test]
+    fn a_read_outside_the_roots_is_refused() {
+        let root = test_root();
+        let outside = test_root();
+        let secret = outside.join("secret.txt");
+        std::fs::write(&secret, "not yours\n").expect("write fixture");
+
+        let err = read_text_file(&secret, Some(1), Some(1), std::slice::from_ref(&root))
+            .expect_err("a read outside every granted directory must be refused");
+        assert!(
+            err.to_string().contains("outside this session's granted"),
+            "unexpected refusal reason: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
     }
 }
 

--- a/crates/atlas-agent-servers/src/lib.rs
+++ b/crates/atlas-agent-servers/src/lib.rs
@@ -14,9 +14,13 @@
 //! - **Ref-counted `close_session` with pending-load dedup**, so a second opener
 //!   joins the in-flight load and the session is only really closed once the
 //!   last handle goes.
-//! - **`suppress_abort_err`**, which turns an agent's "operation was aborted"
-//!   internal error into a clean `StopReason::Cancelled` when we are the ones
-//!   who cancelled.
+//! - **[`session::CancelSignal`]**, which does two jobs a cancel needs and the
+//!   wire notification cannot do alone. It turns an agent's "operation was
+//!   aborted" internal error into a clean `StopReason::Cancelled` when we are
+//!   the ones who cancelled — per turn, so a cancel cannot be spent on a turn
+//!   it was not meant for. And it is the deadline: `cancel` is a notification
+//!   with no response and no obligation, so an agent that ignores it left the
+//!   prompt pending forever, and the chat could only be recovered by quitting.
 //! - **`LoadError::Exited { status, stderr }` fanned out to every live session**,
 //!   so an agent dying mid-turn surfaces in the conversation.
 //!
@@ -66,6 +70,7 @@ pub use connection::{
 };
 pub use debug_log::{
     AcpDebugLog, AcpDebugMessage, AcpDebugMessageContent, AcpDebugMessageDirection,
+    MAX_DEBUG_BACKLOG_BYTES, MAX_DEBUG_MESSAGE_BYTES,
 };
 pub use handlers::ClientContext;
 pub use host_env::sanitize_host_env;
@@ -73,5 +78,8 @@ pub use server::{
     env_quirks, load_proxy_env, AgentServer, AgentServerDelegate, ConnectOptions,
     CustomAgentServer, ExternalAgentServer,
 };
-pub use session::{AcpSession, ConfigOptions, SessionDirectories, SessionRegistry};
+pub use session::{
+    AcpSession, CancelProbe, CancelSignal, CancelWaiter, ConfigOptions, SessionDirectories,
+    SessionRegistry,
+};
 pub use session_list::AcpSessionList;

--- a/crates/atlas-agent-servers/src/session.rs
+++ b/crates/atlas-agent-servers/src/session.rs
@@ -13,18 +13,116 @@ pub struct AcpSession {
     /// Weak so a thread the UI has dropped does not keep living because the
     /// connection still lists its session.
     pub thread: Weak<Mutex<AcpThread>>,
-    /// Set by `cancel` and consumed by the next `prompt` result.
+    /// Fired by `cancel`, awaited by the in-flight `prompt`. See [`CancelSignal`].
     ///
-    /// Some agents answer a cancelled turn with an internal error whose text is
-    /// "This operation was aborted" rather than a clean `Cancelled` stop reason.
-    /// Without this flag that surfaces as an error toast for something the user
-    /// deliberately did.
-    pub suppress_abort_err: bool,
+    /// This replaced a `suppress_abort_err: bool` that `cancel` set and the
+    /// next `prompt` result consumed. Some agents answer a cancelled turn with
+    /// an internal error reading "This operation was aborted" rather than a
+    /// clean `Cancelled` stop reason, and that must not surface as an error
+    /// toast for something the user deliberately did — but one bool for a
+    /// whole session is answered by whichever turn resolves first, which is
+    /// not necessarily the turn it was set for.
+    pub cancel_signal: CancelSignal,
     pub session_modes: Option<Arc<Mutex<acp::SessionModeState>>>,
     pub config_options: Option<ConfigOptions>,
     /// How many handles are open on this session. `close_session` only reaches
     /// the wire when this hits zero.
     pub ref_count: usize,
+}
+
+/// The local half of cancelling a turn.
+///
+/// `cancel` is a *notification* on the wire — there is no response and no
+/// obligation on the agent to act. An agent that is wedged (deadlocked, blocked
+/// on a network call, stopped) ignores it, and nothing else in the stack has a
+/// clock, so the prompt future stayed pending forever and the chat could only
+/// be recovered by quitting Atlas.
+///
+/// This is the clock. `prompt` waits on it and gives the agent a bounded grace
+/// period to answer its own cancellation before resolving the turn locally.
+///
+/// A generation counter rather than a `Notify` on purpose: a receiver takes its
+/// snapshot before the request is sent, so a cancel that lands in the gap
+/// between sending and awaiting is still seen rather than missed.
+#[derive(Clone)]
+pub struct CancelSignal {
+    tx: Arc<tokio::sync::watch::Sender<u64>>,
+}
+
+impl Default for CancelSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CancelSignal {
+    pub fn new() -> Self {
+        Self {
+            tx: Arc::new(tokio::sync::watch::channel(0).0),
+        }
+    }
+
+    /// Idempotent by construction: the composer leaves its stop button live
+    /// while a stop is pending, so a user watching nothing happen presses it
+    /// again. Each press is another generation, and every waiter already
+    /// waiting is woken by the first.
+    pub fn fire(&self) {
+        self.tx.send_modify(|generation| *generation += 1);
+    }
+
+    /// Resolves on the next [`fire`](Self::fire) *after* this call. Call it
+    /// before sending the request the cancel would apply to.
+    pub fn waiter(&self) -> CancelWaiter {
+        CancelWaiter {
+            rx: self.tx.subscribe(),
+        }
+    }
+}
+
+pub struct CancelWaiter {
+    rx: tokio::sync::watch::Receiver<u64>,
+}
+
+impl CancelWaiter {
+    /// A handle that answers "has a cancel fired since this waiter was taken",
+    /// without consuming the waiter. Holds a receiver, never the sender, so it
+    /// cannot keep a closed session's signal alive.
+    pub fn probe(&self) -> CancelProbe {
+        CancelProbe {
+            rx: self.rx.clone(),
+        }
+    }
+
+    /// Waits for a cancel. Never resolves if none comes — a legitimate turn
+    /// runs for as long as it runs, which is why this is not a request timeout.
+    pub async fn cancelled(mut self) {
+        // A dropped sender means the session was removed from the registry,
+        // which happens on close or teardown. Nobody is going to answer that
+        // turn, so it counts: parking here instead would leak the request
+        // future, and its `Arc<dyn AgentConnection>` with it, for the life of
+        // the process.
+        let _ = self.rx.changed().await;
+    }
+}
+
+/// Whether this turn's own cancel has fired.
+///
+/// The rule it encodes: a turn suppresses an "operation was aborted" error
+/// only if a cancel was fired for its session *while it was running*. A
+/// session-wide bool could not express that — it was set by one turn and
+/// consumed by whichever resolved first, so a cancel could be spent on a turn
+/// it was never meant for, and a turn started after a cancel could inherit a
+/// suppression it never asked for.
+pub struct CancelProbe {
+    rx: tokio::sync::watch::Receiver<u64>,
+}
+
+impl CancelProbe {
+    pub fn fired(&self) -> bool {
+        // `Err` is a dropped sender: the session is gone, which is not a
+        // cancel anyone asked for, so an error on this turn is real.
+        self.rx.has_changed().unwrap_or(false)
+    }
 }
 
 /// A session whose `session/load` or `session/new` RPC is still in flight.

--- a/crates/atlas-agent-servers/tests/connect.rs
+++ b/crates/atlas-agent-servers/tests/connect.rs
@@ -212,9 +212,17 @@ async fn a_missing_binary_fails_to_spawn() {
     );
 }
 
-/// An agent that never answers `initialize` must not hang the connect forever.
+/// The handshake has no timeout, and this pins that as the current state
+/// rather than as a guarantee.
+///
+/// Named for what it checks. It used to be called
+/// `an_agent_that_never_answers_does_not_hang_forever`, which claimed the
+/// opposite of its own assertion: it passes *because* the connect hangs. The
+/// cancel grace added for a wedged turn does not apply here — there is no
+/// session to cancel until `initialize` returns, so recovery on this path is
+/// still the caller's problem (`AgentHost::kill`).
 #[tokio::test]
-async fn an_agent_that_never_answers_does_not_hang_forever() {
+async fn an_agent_that_never_answers_initialize_leaves_the_connect_pending() {
     let connect = connect(command("/bin/sh", &["-c", "sleep 30"]));
     let result = tokio::time::timeout(std::time::Duration::from_secs(2), connect).await;
 
@@ -695,4 +703,489 @@ async fn an_embedded_terminal_in_tool_call_meta_is_created_and_streams() {
         Some(0),
         "the meta exit must land"
     );
+}
+
+/// Handshakes, opens a session, then goes silent on `session/prompt` — and
+/// ignores `session/cancel` too, which is the whole point. A wedged agent is
+/// alive (so nothing detects an exit) and unresponsive (so nothing on the wire
+/// resolves the turn).
+const WEDGED_AGENT: &str = r#"
+import sys, json
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method = msg.get("method")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": 1, "agentCapabilities": {}, "authMethods": [],
+            "agentInfo": {"name": "wedged-agent", "version": "9.9.9"}}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {"sessionId": "session-1"}})
+    # session/prompt and session/cancel deliberately get no answer.
+"#;
+
+fn wedged_agent_command() -> Option<AgentServerCommand> {
+    Some(AgentServerCommand {
+        path: PathBuf::from(python()?),
+        args: vec!["-c".to_string(), WEDGED_AGENT.to_string()],
+        env: Some(HashMap::new()),
+    })
+}
+
+/// ATL-232. `cancel` is a notification — no response, no obligation — so an
+/// agent that ignores it left the prompt future pending forever and the only
+/// way out was quitting Atlas. The turn now resolves locally once the agent has
+/// had its grace period to answer for itself.
+///
+/// Deliberately a real child process over real pipes: the defect is that
+/// nothing in the stack owns a clock, and a mock transport would supply the
+/// very thing whose absence is under test.
+#[tokio::test]
+async fn a_cancel_the_agent_ignores_still_ends_the_turn() {
+    use atlas_acp_thread::AgentConnection as _;
+
+    let Some(command) = wedged_agent_command() else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let connection = Arc::new(connect(command).await.expect("handshake failed"));
+    let thread = connection
+        .clone()
+        .new_session(vec![std::env::temp_dir()])
+        .await
+        .expect("session/new failed");
+    let session_id = thread
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .session_id()
+        .clone();
+
+    let prompt = tokio::spawn(connection.clone().prompt(acp::PromptRequest::new(
+        session_id.clone(),
+        vec![acp::ContentBlock::from("do something slow")],
+    )));
+
+    // Let the prompt actually reach the wire, so this exercises "cancel during
+    // a live turn" rather than "cancel before the request went out".
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(!prompt.is_finished(), "the agent was supposed to go silent");
+
+    connection.cancel(&session_id);
+
+    // Generous against the grace period: what is under test is that a bound
+    // exists at all, not its exact value.
+    let response = tokio::time::timeout(std::time::Duration::from_secs(30), prompt)
+        .await
+        .expect("the turn outlived its cancel grace — this is the ATL-232 hang")
+        .expect("prompt task panicked")
+        .expect("a cancelled turn is a normal stop, not an error");
+
+    assert_eq!(
+        response.stop_reason,
+        acp::StopReason::Cancelled,
+        "a locally-resolved cancel must still read as cancelled"
+    );
+}
+
+/// Pressing Stop twice is what a user does when nothing appears to happen, and
+/// the composer leaves the button live while a stop is pending. Every press
+/// must be harmless.
+#[tokio::test]
+async fn cancelling_repeatedly_is_harmless() {
+    use atlas_acp_thread::AgentConnection as _;
+
+    let Some(command) = wedged_agent_command() else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let connection = Arc::new(connect(command).await.expect("handshake failed"));
+    let thread = connection
+        .clone()
+        .new_session(vec![std::env::temp_dir()])
+        .await
+        .expect("session/new failed");
+    let session_id = thread
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .session_id()
+        .clone();
+
+    let prompt = tokio::spawn(connection.clone().prompt(acp::PromptRequest::new(
+        session_id.clone(),
+        vec![acp::ContentBlock::from("do something slow")],
+    )));
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    for _ in 0..5 {
+        connection.cancel(&session_id);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    let response = tokio::time::timeout(std::time::Duration::from_secs(30), prompt)
+        .await
+        .expect("repeated cancels must not postpone the deadline")
+        .expect("prompt task panicked")
+        .expect("a cancelled turn is a normal stop, not an error");
+    assert_eq!(response.stop_reason, acp::StopReason::Cancelled);
+
+    // Cancelling a turn that already ended must not panic or wedge anything.
+    connection.cancel(&session_id);
+}
+
+/// The grace period only starts when the user asks to stop. A turn nobody
+/// cancelled must not be capped by it, or every legitimate long turn dies at
+/// the deadline — the exact failure a flat request timeout would have caused.
+#[tokio::test]
+async fn an_uncancelled_turn_is_not_capped_by_the_grace_period() {
+    use atlas_acp_thread::AgentConnection as _;
+
+    let Some(command) = wedged_agent_command() else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let connection = Arc::new(connect(command).await.expect("handshake failed"));
+    let thread = connection
+        .clone()
+        .new_session(vec![std::env::temp_dir()])
+        .await
+        .expect("session/new failed");
+    let session_id = thread
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .session_id()
+        .clone();
+
+    let prompt = tokio::spawn(connection.clone().prompt(acp::PromptRequest::new(
+        session_id,
+        vec![acp::ContentBlock::from("a turn that takes a while")],
+    )));
+
+    // Well past the grace period, with no cancel sent.
+    tokio::time::sleep(std::time::Duration::from_secs(7)).await;
+    assert!(
+        !prompt.is_finished(),
+        "an uncancelled turn was resolved by the cancel deadline — the clock \
+         must not start until the user asks to stop"
+    );
+    prompt.abort();
+}
+
+// ------------------------------------------------------------------ fs/* gaps
+//
+// ATL-233's containment check and ATL-236's coverage list meet here. The check
+// itself has unit tests; what had never been exercised was the path an agent
+// actually takes to reach it — a real `fs/write_text_file` request, over a real
+// pipe, against a session whose granted roots the test chose.
+
+/// Asks the client to write and then read a path OUTSIDE the granted root, and
+/// records what it was told. Reporting through a file because the outcome is
+/// the agent's, not the thread's: what is under test is what the agent was
+/// allowed to do, which no amount of reading our own state can answer.
+const FS_ESCAPE_AGENT: &str = r#"
+import sys, json
+outside = OUTSIDE
+result_file = RESULT_FILE
+pending = {}
+outcome = {}
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+prompt_id = None
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method = msg.get("method")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": 1, "agentCapabilities": {}, "authMethods": [],
+            "agentInfo": {"name": "fs-escape-agent", "version": "9.9.9"}}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {"sessionId": "session-1"}})
+    elif method == "session/prompt":
+        prompt_id = msg["id"]
+        pending[300] = "write"
+        send({"jsonrpc": "2.0", "id": 300, "method": "fs/write_text_file",
+              "params": {"sessionId": "session-1", "path": outside,
+                         "content": "written by the agent, outside the project root\n"}})
+    elif msg.get("id") in pending:
+        which = pending.pop(msg["id"])
+        outcome[which] = "error" if "error" in msg else "ok"
+        if which == "write":
+            pending[301] = "read"
+            send({"jsonrpc": "2.0", "id": 301, "method": "fs/read_text_file",
+                  "params": {"sessionId": "session-1", "path": outside}})
+        else:
+            open(result_file, "w").write(json.dumps(outcome))
+            send({"jsonrpc": "2.0", "id": prompt_id, "result": {"stopReason": "end_turn"}})
+"#;
+
+fn fs_escape_agent_command(outside: &std::path::Path, result_file: &std::path::Path) -> Option<AgentServerCommand> {
+    let script = FS_ESCAPE_AGENT
+        .replace("OUTSIDE", &format!("{:?}", outside.display().to_string()))
+        .replace("RESULT_FILE", &format!("{:?}", result_file.display().to_string()));
+    Some(AgentServerCommand {
+        path: PathBuf::from(python()?),
+        args: vec!["-c".to_string(), script],
+        env: Some(HashMap::new()),
+    })
+}
+
+/// ATL-233. The agent is a child process with the user's own privileges, so
+/// this is not a privilege boundary — it is the backstop for a model steered by
+/// repository content, and the containment a self-sandboxing agent delegated to
+/// us. `create_dir_all` running before the write is the concrete half: a
+/// refused write must not leave a directory tree behind as a side effect.
+#[tokio::test]
+async fn an_agent_cannot_write_outside_the_sessions_granted_directories() {
+    use atlas_acp_thread::AgentConnection as _;
+
+    let base = std::env::temp_dir().join(format!(
+        "atlas-fs-escape-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let granted = base.join("project");
+    let escaped = base.join("NOT-the-project/deep/nested/escaped.txt");
+    let result_file = base.join("outcome.json");
+    std::fs::create_dir_all(&granted).expect("create the granted root");
+
+    let Some(command) = fs_escape_agent_command(&escaped, &result_file) else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let connection = Arc::new(connect(command).await.expect("handshake failed"));
+    let thread = connection
+        .clone()
+        .new_session(vec![granted.clone()])
+        .await
+        .expect("session/new failed");
+    let session_id = thread
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .session_id()
+        .clone();
+
+    connection
+        .clone()
+        .prompt(acp::PromptRequest::new(
+            session_id,
+            vec![acp::ContentBlock::from("go outside")],
+        ))
+        .await
+        .expect("the turn itself should end normally");
+
+    let outcome: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&result_file).expect("agent wrote no outcome"))
+            .expect("outcome is json");
+
+    assert_eq!(
+        outcome["write"], "error",
+        "the write was serviced rather than refused: {outcome}"
+    );
+    assert_eq!(
+        outcome["read"], "error",
+        "the read was serviced rather than refused: {outcome}"
+    );
+    assert!(
+        !escaped.exists(),
+        "a refused write still put a file on disk at {}",
+        escaped.display()
+    );
+    assert!(
+        !escaped.parent().expect("a parent").exists(),
+        "a refused write still created directories outside the root"
+    );
+    assert!(
+        !base.join("NOT-the-project").exists(),
+        "create_dir_all ran before the containment check"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+/// ATL-236 gap 1. Every fake agent in this suite emits well-formed JSON, and
+/// the only malformed-input test sat at the debug-log layer — a helper, not the
+/// transport. A garbage line from a real agent must be survivable: agents print
+/// stray output, and losing the connection over one line loses the session.
+#[tokio::test]
+async fn a_garbage_line_from_the_agent_does_not_kill_the_connection() {
+    let script = r#"
+import sys, json
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+sys.stdout.write("this is not json at all\n")
+sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    if msg.get("method") == "initialize":
+        sys.stdout.write("{ not valid json either\n")
+        sys.stdout.flush()
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": 1, "agentCapabilities": {}, "authMethods": [],
+            "agentInfo": {"name": "noisy-agent", "version": "9.9.9"}}})
+    elif msg.get("method") == "session/new":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {"sessionId": "session-1"}})
+"#;
+    let Some(python) = python() else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let command = AgentServerCommand {
+        path: PathBuf::from(python),
+        args: vec!["-c".to_string(), script.to_string()],
+        env: Some(HashMap::new()),
+    };
+
+    use atlas_acp_thread::AgentConnection as _;
+    let connection = Arc::new(
+        tokio::time::timeout(std::time::Duration::from_secs(10), connect(command))
+            .await
+            .expect("a garbage line stalled the handshake")
+            .expect("a garbage line killed the handshake"),
+    );
+    assert_eq!(connection.telemetry_id().as_ref(), "noisy-agent");
+
+    connection
+        .clone()
+        .new_session(vec![std::env::temp_dir()])
+        .await
+        .expect("the connection must still be usable after the garbage");
+}
+
+/// ATL-236 gap 2. Start-up death and drop-kill were covered; dying *mid-turn*
+/// was not. The prompt must fail rather than hang — the agent is gone, so
+/// nothing will ever answer it.
+#[tokio::test]
+async fn an_agent_that_dies_mid_prompt_fails_the_turn_rather_than_hanging() {
+    use atlas_acp_thread::AgentConnection as _;
+
+    let script = r#"
+import sys, json, os
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method = msg.get("method")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {
+            "protocolVersion": 1, "agentCapabilities": {}, "authMethods": [],
+            "agentInfo": {"name": "dying-agent", "version": "9.9.9"}}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": {"sessionId": "session-1"}})
+    elif method == "session/prompt":
+        sys.stderr.write("agent crashed mid-turn\n")
+        sys.stderr.flush()
+        os._exit(7)
+"#;
+    let Some(python) = python() else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let command = AgentServerCommand {
+        path: PathBuf::from(python),
+        args: vec!["-c".to_string(), script.to_string()],
+        env: Some(HashMap::new()),
+    };
+
+    let connection = Arc::new(connect(command).await.expect("handshake failed"));
+    let thread = connection
+        .clone()
+        .new_session(vec![std::env::temp_dir()])
+        .await
+        .expect("session/new failed");
+    let session_id = thread
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .session_id()
+        .clone();
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        connection.clone().prompt(acp::PromptRequest::new(
+            session_id,
+            vec![acp::ContentBlock::from("crash please")],
+        )),
+    )
+    .await
+    .expect("a dead agent left the prompt pending");
+
+    assert!(
+        result.is_err(),
+        "an agent that died mid-turn reported success: {result:?}"
+    );
+}
+
+/// ATL-236 gap 4, aimed at the machinery this change introduced: the cancel
+/// deadline is a `watch` channel read from one task and fired from another,
+/// and everything else in this suite drives it from a single thread.
+///
+/// Scope, stated honestly because the obvious reading is wrong: this does NOT
+/// prove that a cancel landing between the waiter being taken and the request
+/// being written is seen. `prompt(...)` is `spawn`'s argument, so the waiter
+/// is taken on this task before the canceller is spawned — that ordering is
+/// deterministic and would hold on a current-thread runtime too. What that
+/// property actually rests on is the `subscribe()` snapshot, pinned directly
+/// in `a_cancel_belongs_to_the_turns_it_interrupted` (tests/units.rs).
+///
+/// What this adds is real concurrency around the deadline: several tasks
+/// firing the signal while another awaits it, on four worker threads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_cancel_racing_the_prompt_is_still_seen() {
+    use atlas_acp_thread::AgentConnection as _;
+
+    let Some(command) = wedged_agent_command() else {
+        eprintln!("skipping: no python3 on this machine");
+        return;
+    };
+    let connection = Arc::new(connect(command).await.expect("handshake failed"));
+    let thread = connection
+        .clone()
+        .new_session(vec![std::env::temp_dir()])
+        .await
+        .expect("session/new failed");
+    let session_id = thread
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .session_id()
+        .clone();
+
+    // No sleep between the two: the cancel is meant to land in the window
+    // between the prompt being created and its request being written.
+    let prompt = tokio::spawn(connection.clone().prompt(acp::PromptRequest::new(
+        session_id.clone(),
+        vec![acp::ContentBlock::from("race me")],
+    )));
+    let canceller = tokio::spawn({
+        let connection = connection.clone();
+        let session_id = session_id.clone();
+        async move {
+            for _ in 0..3 {
+                connection.cancel(&session_id);
+                tokio::task::yield_now().await;
+            }
+        }
+    });
+
+    canceller.await.expect("canceller panicked");
+    let response = tokio::time::timeout(std::time::Duration::from_secs(30), prompt)
+        .await
+        .expect("a cancel racing the prompt was dropped, and the turn hung")
+        .expect("prompt task panicked")
+        .expect("a cancelled turn is a normal stop, not an error");
+    assert_eq!(response.stop_reason, acp::StopReason::Cancelled);
 }

--- a/crates/atlas-agent-servers/tests/units.rs
+++ b/crates/atlas-agent-servers/tests/units.rs
@@ -36,7 +36,7 @@ fn registered(registry: &SessionRegistry, id: &str) -> Arc<Mutex<AcpThread>> {
         session_id(id),
         AcpSession {
             thread: Arc::downgrade(&thread),
-            suppress_abort_err: false,
+            cancel_signal: CancelSignal::new(),
             session_modes: None,
             config_options: None,
             ref_count: 1,
@@ -120,25 +120,54 @@ fn a_dropped_thread_is_reported_as_an_unknown_session() {
     assert!(registry.thread(&session_id("s1")).is_err());
 }
 
+/// The property the cancel deadline rests on: a cancel belongs to the turns
+/// that were already running when it fired, and to no others.
+///
+/// This replaced a session-wide `suppress_abort_err` bool that `cancel` set
+/// and the first turn to resolve consumed — so a cancel could be spent on a
+/// turn it was not meant for, and a turn started afterwards could inherit a
+/// suppression nobody asked for.
+#[test]
+fn a_cancel_belongs_to_the_turns_it_interrupted() {
+    let signal = CancelSignal::new();
+
+    // A turn already running when the cancel lands.
+    let during = signal.waiter().probe();
+    assert!(!during.fired(), "nothing has been cancelled yet");
+
+    signal.fire();
+    assert!(during.fired(), "the running turn's own cancel");
+
+    // A turn that starts afterwards must not inherit it.
+    let after = signal.waiter().probe();
+    assert!(
+        !after.fired(),
+        "a later turn inherited a cancel meant for an earlier one"
+    );
+
+    // And a second cancel reaches the later turn, without needing the first
+    // to have been consumed by anyone.
+    signal.fire();
+    assert!(after.fired());
+    assert!(during.fired(), "reading a probe must not consume it");
+}
+
+/// One signal per session, so cancelling one chat cannot end another's turn.
 #[test]
 fn cancel_state_is_stored_per_session() {
     let registry = SessionRegistry::new();
-    let _thread = registered(&registry, "s1");
+    let _one = registered(&registry, "s1");
+    let _two = registered(&registry, "s2");
 
-    registry.with_session(&session_id("s1"), |session| {
-        session.suppress_abort_err = true;
-    });
-    let taken = registry.with_session(&session_id("s1"), |session| {
-        let was = session.suppress_abort_err;
-        session.suppress_abort_err = false;
-        was
-    });
+    let watching_two = registry
+        .with_session(&session_id("s2"), |session| session.cancel_signal.waiter().probe())
+        .expect("s2 exists");
 
-    assert_eq!(taken, Some(true));
-    assert_eq!(
-        registry.with_session(&session_id("s1"), |s| s.suppress_abort_err),
-        Some(false),
-        "the flag is consumed, so a cancel cannot leak into a later turn"
+    registry.with_session(&session_id("s1"), |session| session.cancel_signal.fire());
+
+    assert!(
+        !watching_two.fired(),
+        "cancelling one session cancelled another"
     );
 }
 
@@ -252,6 +281,189 @@ fn a_line_that_is_not_json_is_ignored_rather_than_recorded() {
 
     let (backlog, _rx) = log.subscribe();
     assert!(backlog.is_empty());
+}
+
+/// ATL-235. The message cap alone never bounded memory, because Atlas tees its
+/// own `fs/read_text_file` responses in here and those carry whole files. Sixty
+/// 2 MB reads — ordinary behaviour for a coding agent — parked 120 MB.
+#[test]
+fn reading_big_files_does_not_grow_the_ring_past_its_byte_budget() {
+    let log = AcpDebugLog::new();
+
+    let file = "x".repeat(2 * 1024 * 1024);
+    for id in 0..60 {
+        let line = format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"result":{{"content":"{file}"}}}}"#
+        );
+        log.record_line(AcpDebugMessageDirection::Outgoing, &line);
+    }
+
+    // Asserted against the measured 120 MB, not against the constant: a bound
+    // stated only in terms of the thing being tuned goes vacuous the moment
+    // someone raises it.
+    let pushed_through = 60 * file.len();
+    assert!(
+        log.retained_bytes() < pushed_through / 100,
+        "ring holds {} bytes of the {pushed_through} pushed through it",
+        log.retained_bytes()
+    );
+    assert!(log.retained_bytes() <= MAX_DEBUG_BACKLOG_BYTES);
+
+    // The conversation is still legible — the bodies went, the exchange did not.
+    let (backlog, _rx) = log.subscribe();
+    assert_eq!(backlog.len(), 60, "messages were dropped, not just bodies");
+    assert!(
+        !format!("{:?}", backlog.last().expect("a message")).contains(&file),
+        "an oversized body survived verbatim"
+    );
+}
+
+/// Elision handles one huge message; this is the other half. Enough
+/// individually-reasonable messages still add up, and only the byte budget
+/// catches that — which is why the message cap alone was never a bound.
+#[test]
+fn the_byte_budget_evicts_even_when_no_single_message_is_oversized() {
+    let log = AcpDebugLog::new();
+
+    let body = "z".repeat(MAX_DEBUG_MESSAGE_BYTES - 128);
+    let line = format!(r#"{{"jsonrpc":"2.0","method":"session/update","params":{{"t":"{body}"}}}}"#);
+    assert!(
+        line.len() <= MAX_DEBUG_MESSAGE_BYTES,
+        "fixture must stay under the per-message cap or it tests elision instead"
+    );
+
+    // Enough to pass the byte budget twice over, and far short of the 2000
+    // message cap, so only the byte budget can be what evicts.
+    let sent = (MAX_DEBUG_BACKLOG_BYTES * 2).div_ceil(line.len());
+    assert!(sent < 2000, "fixture must not reach the message cap");
+    for _ in 0..sent {
+        log.record_line(AcpDebugMessageDirection::Incoming, &line);
+    }
+
+    assert!(
+        log.retained_bytes() <= MAX_DEBUG_BACKLOG_BYTES,
+        "ring holds {} bytes after {sent} in-cap messages, budget is {}",
+        log.retained_bytes(),
+        MAX_DEBUG_BACKLOG_BYTES
+    );
+    let (backlog, _rx) = log.subscribe();
+    assert!(
+        backlog.len() < sent,
+        "nothing was evicted: {} messages held of {sent} sent, all under the \
+         per-message cap and under the 2000-message cap",
+        backlog.len()
+    );
+}
+
+/// The envelope has to outlive the body, or the ring stops being a record of
+/// the conversation and becomes a record of its small half.
+#[test]
+fn an_elided_message_keeps_its_method_and_says_what_it_dropped() {
+    let log = AcpDebugLog::new();
+
+    let big = "y".repeat(MAX_DEBUG_MESSAGE_BYTES * 2);
+    let line = format!(
+        r#"{{"jsonrpc":"2.0","id":7,"method":"fs/read_text_file","params":{{"content":"{big}"}}}}"#
+    );
+    log.record_line(AcpDebugMessageDirection::Outgoing, &line);
+
+    let (backlog, _rx) = log.subscribe();
+    let AcpDebugMessageContent::Request { method, params, .. } =
+        &backlog.first().expect("one message").message
+    else {
+        panic!("expected a request, got {:?}", backlog.first());
+    };
+
+    assert_eq!(method.as_ref(), "fs/read_text_file");
+    let params = params.as_ref().expect("a marker, not an absent body");
+    assert_eq!(
+        params["atlasElided"]["bytes"].as_u64(),
+        Some(line.len() as u64),
+        "the marker should say how big the dropped body was: {params}"
+    );
+}
+
+/// The elision had a hole exactly where an agent controls the size. An error
+/// response's `data` is an unbounded value, and `parse_value` puts the whole
+/// error object in it as a string when it cannot deserialize — so an oversized
+/// error line was kept verbatim while being charged as if it had been elided,
+/// and the byte budget never fired for it.
+#[test]
+fn an_oversized_error_response_is_elided_like_any_other_payload() {
+    let log = AcpDebugLog::new();
+
+    let big = "e".repeat(MAX_DEBUG_MESSAGE_BYTES * 4);
+    let line = format!(
+        r#"{{"jsonrpc":"2.0","id":9,"error":{{"code":-32603,"message":"boom","data":"{big}"}}}}"#
+    );
+    log.record_line(AcpDebugMessageDirection::Incoming, &line);
+
+    assert!(
+        log.retained_bytes() < line.len() / 4,
+        "an error body was charged as elided but kept whole: {} bytes held of a {} byte line",
+        log.retained_bytes(),
+        line.len()
+    );
+
+    let (backlog, _rx) = log.subscribe();
+    assert!(
+        !format!("{:?}", backlog.first().expect("one message")).contains(&big),
+        "the error body survived verbatim"
+    );
+}
+
+/// Enough oversized error lines must still be evicted. This is the budget
+/// itself, on the message shape that used to escape it.
+#[test]
+fn oversized_error_responses_are_bounded_in_aggregate() {
+    let log = AcpDebugLog::new();
+
+    let big = "e".repeat(MAX_DEBUG_MESSAGE_BYTES * 4);
+    for id in 0..200 {
+        let line = format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":-32603,"message":"boom","data":"{big}"}}}}"#
+        );
+        log.record_line(AcpDebugMessageDirection::Incoming, &line);
+    }
+
+    // Measured from the ring's actual contents, not from its own accounting.
+    // Asserting `retained_bytes() <= budget` would have passed while the bug
+    // was live, because the bug WAS the accounting: it reported ~128 bytes for
+    // a message it kept whole, so the budget it is compared against never
+    // fired. A test of a self-reported number cannot catch a self-report that
+    // lies.
+    let (backlog, _rx) = log.subscribe();
+    let held: usize = backlog.iter().map(|m| format!("{m:?}").len()).sum();
+    assert!(
+        held < 200 * big.len() / 10,
+        "the ring really holds {held} bytes after {} bytes of error responses",
+        200 * big.len()
+    );
+    assert!(log.retained_bytes() <= MAX_DEBUG_BACKLOG_BYTES);
+}
+
+/// `trailing_stderr` is what turns "process exited" into a reason, so a huge
+/// stderr line has to be cut rather than dropped — and the reason an agent
+/// died is at the start of what it printed.
+#[test]
+fn an_oversized_stderr_line_is_cut_but_still_explains_itself() {
+    let log = AcpDebugLog::new();
+
+    let mut line = String::from("Error: cannot find module 'foo'");
+    line.push_str(&"!".repeat(MAX_DEBUG_MESSAGE_BYTES * 2));
+    log.record_line(AcpDebugMessageDirection::Stderr, &line);
+
+    let trailing = log.trailing_stderr().expect("stderr should still explain");
+    assert!(
+        trailing.starts_with("Error: cannot find module 'foo'"),
+        "the reason was cut away: {}",
+        &trailing[..60.min(trailing.len())]
+    );
+    assert!(
+        trailing.len() < line.len(),
+        "an oversized stderr line was retained whole"
+    );
+    assert!(log.retained_bytes() <= MAX_DEBUG_BACKLOG_BYTES);
 }
 
 #[test]

--- a/src/features/chat/components/chat-panel.tsx
+++ b/src/features/chat/components/chat-panel.tsx
@@ -828,6 +828,23 @@ export function ChatPanel({ tabId }: ChatPanelProps) {
     const cs = useChatStore.getState();
     const s = cs.sessions[tabId];
     if (!s?.acpAgentId || !s.acpSessionId) return;
+
+    // Pressing Stop again while a stop is already pending means the first one
+    // did not appear to work, so escalate to killing the process. The backend
+    // resolves a cancel the agent ignores after a grace period, which covers a
+    // wedged *turn*; an agent that is wedged outright would hang the next turn
+    // too, and this is the way out of that without quitting Atlas.
+    //
+    // Killing drops the connection, which takes its exit-watch task with it —
+    // so no `agent_disconnected` arrives to clear the flags. We asked for this,
+    // so we record it ourselves, which is also what raises the Restart banner.
+    if (s.stopping) {
+      cs.actions.noteAgentKilled(tabId);
+      cs.actions.clearQueue(tabId);
+      cs.actions.clearPermissionsForSession(s.acpSessionId);
+      agents.kill(s.acpAgentId).catch(() => {});
+      return;
+    }
     // Do NOT flip to idle optimistically: the backend may still be winding
     // tools down, and lying "idle" here let a new send race the still-live
     // turn (interleaved deltas; native history loss). Mark stop-requested

--- a/src/features/chat/stores/chat-store.force-stop.test.ts
+++ b/src/features/chat/stores/chat-store.force-stop.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+//
+// The store half of force-stopping a wedged agent (ATL-232).
+//
+// A cancel the agent ignores is now resolved by the backend after a grace
+// period, which unfreezes the turn. An agent that is wedged outright would
+// hang the next turn too, so a second press of Stop kills the process — and
+// killing drops the connection along with the exit-watch task that would have
+// sent `agent_disconnected`. Nothing arrives to end the turn, so the store has
+// to record it. What this pins is that it records ALL of it: a session left
+// `running` under a Restart banner offers the user a Stop button for a process
+// that no longer exists.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => undefined) }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+  emit: vi.fn(async () => {}),
+}));
+
+import { isBusyAgentStatus } from "@/types/agent";
+import { useChatStore } from "./chat-store";
+
+const TAB = "tab-1";
+const ACP_SESSION = "acp-session-1";
+
+function boundSession() {
+  const { actions } = useChatStore.getState();
+  actions.createSession(TAB, "claude-code");
+  actions.setAcpBinding(TAB, "agent-1", ACP_SESSION, "/tmp");
+  return () => useChatStore.getState().sessions[TAB];
+}
+
+describe("force-stopping a wedged agent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useChatStore.setState({ sessions: {}, activeSessionId: null });
+  });
+
+  it("leaves the composer idle and the session restartable", () => {
+    const session = boundSession();
+    const { actions } = useChatStore.getState();
+
+    actions.updateSessionStatus(TAB, "running");
+    actions.setStopping(TAB, true);
+    expect(isBusyAgentStatus(session().status)).toBe(true);
+
+    actions.noteAgentKilled(TAB);
+
+    expect(session().disconnected).toBe(true);
+    expect(session().stopping).toBeUndefined();
+    expect(session().inflightToolIds).toBeUndefined();
+    expect(isBusyAgentStatus(session().status)).toBe(false);
+  });
+
+  it("keeps the transcript and the binding a restart resumes from", () => {
+    const session = boundSession();
+    const { actions } = useChatStore.getState();
+
+    actions.addMessage(TAB, "user", "do the thing");
+    const before = session().messages.length;
+    expect(before).toBeGreaterThan(0);
+
+    actions.noteAgentKilled(TAB);
+
+    expect(session().messages.length).toBe(before);
+    expect(session().acpSessionId).toBe(ACP_SESSION);
+    expect(session().acpAgentId).toBe("agent-1");
+  });
+
+  it("is harmless for a session that is not there", () => {
+    expect(() => useChatStore.getState().actions.noteAgentKilled("no-such-tab")).not.toThrow();
+  });
+});

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -348,6 +348,8 @@ interface ChatActions {
     setStopping: (sessionId: string, on: boolean) => void;
     /** Flag/clear "the backing agent process died" (drives Restart + rebind). */
     setDisconnected: (sessionId: string, on: boolean) => void;
+    /** The user force-killed the agent from the composer. */
+    noteAgentKilled: (sessionId: string) => void;
     setSessionTitle: (sessionId: string, title: string) => void;
     setTranscriptLoading: (sessionId: string, loading: boolean) => void;
     /** Mark a resumed session as bound-but-not-yet-loaded. See
@@ -958,6 +960,26 @@ export const useChatStore = createSelectors(
           set((s) => {
             const session = s.sessions[sessionId];
             if (session) session.stopping = on || undefined;
+          }),
+        // Killing an agent drops its connection, and the exit-watch task that
+        // would have produced `agent_disconnected` goes with it. So nothing
+        // arrives to end the turn: this records what that delta does, plus the
+        // turn terminal Rust normally emits ahead of it (`agent_disconnected`
+        // above is written assuming the status is already error). Without the
+        // status and tool-call reset the composer keeps offering Stop for a
+        // process that no longer exists, underneath a Restart banner.
+        //
+        // The transcript is deliberately untouched — the conversation survives
+        // and `acpSessionId` is what a restart resumes from.
+        noteAgentKilled: (sessionId) =>
+          set((s) => {
+            const session = s.sessions[sessionId];
+            if (!session) return;
+            session.status = "error";
+            session.stopping = undefined;
+            session.retryStatus = undefined;
+            session.inflightToolIds = undefined;
+            session.disconnected = true;
           }),
         setSessionTitle: (sessionId, title) =>
           set((s) => {


### PR DESCRIPTION
### What?

The `crates/atlas-agent-servers` children of ATL-212, end to end: ATL-232, ATL-233, ATL-234, ATL-235, ATL-236.

Verified before changing anything, because two of them had already been fixed by later commits and the tickets did not know:

| Ticket | State on `0.3.1` before this branch | Here |
| -- | -- | -- |
| ATL-234 clippy gate | **already green** (`787d652a`) — `cargo clippy --all-targets -- -D warnings` exits 0 | no code, closed as verified |
| ATL-233 path escape | **substantially fixed** (`b1852ced`) — `resolve_within_roots` exists and holds | the remainder: wire tests, a stale doc comment, one fail-closed case |
| ATL-232 wedged agent | **fully open** | fixed |
| ATL-235 debug ring | **fully open** | fixed |
| ATL-236 whole-file reads + coverage | **fully open** | fixed |

Baseline was 53 tests passing and clippy clean, not the 44-and-red the umbrella issue records.

### Why?

**ATL-232.** `cancel` is an ACP notification — no response, no obligation on the agent. An agent that is alive but not answering ignored it, nothing below this layer had a clock, and `session/prompt` stayed pending forever. The only `Duration` in the 1706-line `connection.rs` was the handshake's `INITIALIZE_EXIT_GRACE`. The user's only way out was quitting Atlas.

**ATL-235.** The ring capped 2000 *messages*, and a message is not a bounded thing: `connection.rs` tees every outgoing line into it before the write, including `fs/read_text_file` responses that carry whole files. The ticket measured 120 MB held after sixty 2 MB reads.

**ATL-236.** `read_text_file` ran `read_to_string` before looking at `line`/`limit`, so one line of a 2 GB file cost 2 GB — the parameters exist precisely so a client need not do that.

### How?

**The cancel clock.** `CancelSignal` is a `watch` generation counter on the session. `cancel` fires it after the notification goes out; `prompt` takes a waiter synchronously, before the request is sent, and races the request against "cancelled, then five seconds". A flat request timeout would have been the wrong shape — legitimate turns run for minutes — so the clock starts only once the user has said they do not want the result. Dropping the abandoned request also re-sends a protocol cancel, via the SDK's `SentRequestCancellation::drop`.

The same counter **replaces `suppress_abort_err`**. That was one bool per session, set by `cancel` and consumed by whichever turn resolved first, so a cancel could be spent on a turn it was not meant for and a later turn could inherit a suppression nobody asked for. Overlapping turns are reachable from the permission modal, which cancels the permission and sends a new message in the same handler. A turn now reads its own probe: it suppresses an abort-shaped error only if a cancel fired while it was running, and reading does not consume.

**The UI.** The composer already clears its stop-requested flag on `turn_finished`, so the backend fix alone unfreezes the chat. A second press of Stop escalates to killing the process, for an agent wedged badly enough that the next turn would hang too. Killing drops the connection along with the exit-watch task, so no `agent_disconnected` delta ever arrives — `noteAgentKilled` records what that delta would have, plus the turn terminal Rust normally emits ahead of it. Without the status reset the composer offers Stop for a process that no longer exists, underneath a Restart banner.

**The ring.** A 4 MiB byte budget with front eviction, and payloads over 16 KiB replaced by a marker naming the size they were. Gating it off — the ticket's first suggestion — would have been wrong: `trailing_stderr` reads this buffer and is what turns "process exited" into a reason. For the same reason an oversized stderr line is cut to a prefix rather than elided; the reason an agent died is at the start of what it printed.

**The read.** Streams when a window is asked for, whole-file fast path when it is not. A zero-length window pulls nothing from the iterator, so a directory is rejected explicitly — the old whole-file read failed first and got that right by accident.

### On the tests

Every fix was checked by reverting it and watching a named test fail. That pass caught **three tests of my own that could not fail**:

- the first ring test asserted against the very constant it was tuning, so raising the constant made it vacuous — it now asserts against the 120 MB the ticket measured;
- the vanished-root test passed against the code it was written to rule out, because `temp_dir()` is a symlink on macOS and the old lexical fallback happened to reject there too;
- the aggregate error-budget test asserted a self-reported number while the bug being fixed *was* that the number lied — it now measures the ring's actual contents.

The third came out of review along with the real bug beneath it: elision skipped the error arm, so an oversized error response was kept whole while being charged as if elided. `acp::Error::data` is unbounded and the parser stuffs the entire error object into it when it cannot deserialize — the one message shape that defeated the budget completely.

ATL-236's coverage gaps are closed with real child processes over real pipes rather than mocks: an agent that goes silent on `session/prompt`, one that dies mid-turn, one that emits a garbage line, one that asks to write outside the session's granted roots, and a multi-threaded cancel racing the prompt it cancels.

### Verified

macOS 26.2, rustc 1.97.0.

| command | result |
|---|---|
| `cargo test --locked -p atlas-agent-servers` | 72 passed, 0 failed (was 53) |
| `cargo clippy --all-targets -- -D warnings` | exit 0 |
| `cargo build --locked --workspace` | clean |
| `npx oxlint src/` | exit 0 |
| `npx vitest run` | 1208 passed, 3 pre-existing failures |

The three frontend failures are identical with this branch stashed: `morphdom` is in `package.json` but missing from local `node_modules`, and `bun-singletons` sees a duplicate `immer`. Local install state, not code.

### Not done, deliberately

- **No `rust-toolchain.toml` pin.** ATL-234 raises it and scopes it out; an unpinned `dtolnay/rust-toolchain@stable` can still redden every clippy-gated crate at once.
- **No automatic connection teardown when the deadline fires.** It would kill sibling sessions on the same agent that the user never asked to stop. The explicit kill is the path for that.

### Found while here, not fixed

- `close_session` (`connection.rs:773`) and `initialize` await with no deadline, so closing a tab on a wedged agent still hangs. Same defect class ATL-232 names; `prompt` got a clock and these did not. The renamed handshake test now documents that honestly instead of claiming a guarantee it never checked.
- `src-tauri/src/commands/fs.rs:275` has the same lexical-root fallback removed from `handlers.rs` here, in the path that decides whether to serve a file asset.
- `crates/atlas-agent-manager/src/manager.rs:883` reaches `caps.prompt` directly, bypassing `AcpConnection::prompt` and everything above. Dead today — nothing implements the trait that reaches it — but unprotected when something does.

## Checklist

- [x] Targets the current version branch
- [x] New behaviour has a test; a bug fix has a test that fails without it
- [ ] You've run the app and used the change in a window. Verified through the crate's own suite against real child processes instead; the wedged-agent case needs an agent that hangs on purpose.
