### PR TITLE
fix(chat): stop the streaming answer freezing mid-sentence

### DIFF
--- a/src/features/chat/components/streaming-markdown.test.tsx
+++ b/src/features/chat/components/streaming-markdown.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, afterEach } from "vitest";
-import { render, cleanup, waitFor } from "@testing-library/react";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
 import { StreamingMarkdown } from "./streaming-markdown";
 import { noteTailHtml, tailFallback } from "@/lib/markdown-cache";
 
@@ -8,6 +8,13 @@ afterEach(cleanup);
 
 /** The block split is rAF-coalesced, so the tail only reaches the DOM a frame
  *  after the source changes. Poll for the text rather than racing the clock. */
+async function frame(): Promise<void> {
+  await act(async () => {
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
 async function tailReads(container: HTMLElement, text: string): Promise<void> {
   await waitFor(() =>
     expect(container.querySelector(".atlas-stream-tail")?.textContent).toBe(text),
@@ -46,6 +53,31 @@ describe("StreamingMarkdown", () => {
     // Same element, new text: the patch changed a text node, it did not throw
     // the paragraph away and build another.
     expect(container.querySelector(".atlas-stream-tail p")).toBe(p);
+  });
+
+  it("never stops rendering the tail, however expensive a frame was", async () => {
+    // The regression this guards: an early parse that ran long used to demote
+    // the block to a throttled off-thread lane FOR GOOD, so the reader watched
+    // four words and a blinking caret until the whole answer landed at once.
+    // Render a deliberately heavy tail first, then keep streaming a cheap one.
+    const heavy = "| a | b |\n| --- | --- |\n" + "| one | two |\n".repeat(60);
+    const { container, rerender } = render(<StreamingMarkdown source={heavy} streaming />);
+    await frame();
+    for (const text of ["Here", "Here are", "Here are five", "Here are five jokes"]) {
+      rerender(<StreamingMarkdown source={text} streaming />);
+      await frame();
+      expect(container.querySelector(".atlas-stream-tail")?.textContent).toBe(text);
+    }
+  });
+
+  it("keeps an oversized tail streaming as plain text instead of stalling", async () => {
+    const huge = "word ".repeat(2000); // > STREAM_PLAIN_LIMIT
+    const { container, rerender } = render(<StreamingMarkdown source={huge} streaming />);
+    await frame();
+    expect(container.textContent).toContain("word");
+    rerender(<StreamingMarkdown source={huge + "END"} streaming />);
+    await frame();
+    expect(container.textContent).toContain("END");
   });
 
   it("drops the tail marker once the turn settles", async () => {

--- a/src/features/chat/components/streaming-markdown.tsx
+++ b/src/features/chat/components/streaming-markdown.tsx
@@ -1,11 +1,6 @@
 import { memo, useEffect, useLayoutEffect, useRef, useState, useMemo } from "react";
-import {
-  CachedMarkdown,
-  noteTailHtml,
-  parseTransientOffThread,
-  transientWorkerAvailable,
-} from "@/lib/markdown-cache";
-import { parseMarkdown } from "@/lib/markdown-render";
+import { CachedMarkdown, noteTailHtml } from "@/lib/markdown-cache";
+import { parseMarkdownStreaming } from "@/lib/markdown-render";
 import {
   splitBlocks,
   mayStartNewBlock,
@@ -25,8 +20,12 @@ import { cn } from "@/lib/utils";
  * translation of Zed's per-line layout cache / Open WebUI's per-block tokens:
  * markdown formats LIVE as it streams, with bounded re-work.
  *
- * Three rules keep the live edge from flickering, and all three matter:
+ * Four rules keep the live edge honest, and all four matter:
  *
+ *  0. **The tail parses synchronously, every frame, with nothing in the way.**
+ *     No throttle, no queue, no worker, no state the renderer can get stuck
+ *     in. Everything else here exists to make that affordable — the tail is
+ *     one block, and it is parsed without syntax highlighting.
  *  1. **The tail is repaired before it is parsed** (`closeIncompleteMarkdown`).
  *     A stream cuts markdown mid-token, so `**bol` is literal asterisks for a
  *     few frames and then the words snap to bold. Closing the dangling marker
@@ -45,19 +44,30 @@ import { cn } from "@/lib/utils";
  * margin-collapse / vertical rhythm identical to a single-container render.
  */
 
-/** Below this length the live tail parses inline on every frame (sub-ms, and
- *  the per-frame cadence is what makes text format as it streams). Above it,
- *  parses are throttled — a long block's growth is mostly invisible mid-word
- *  anyway. Mirrors `SYNC_LIMIT` in markdown-cache. */
-const INLINE_PARSE_LIMIT = 2000;
-/** Parse cadence for a large live tail. */
-const TRANSIENT_THROTTLE_MS = 120;
-/** A per-frame inline parse that costs more than this has outgrown the inline
- *  path regardless of length (a table, a dense list), so the block is demoted
- *  to the throttled off-thread lane for the rest of its life. Length alone was
- *  the wrong proxy: 1.5 KB of table markup is an order of magnitude more work
- *  than 1.5 KB of prose. */
-const INLINE_BUDGET_MS = 6;
+/**
+ * Hard ceiling on the live tail.
+ *
+ * Above it the tail renders as plain text until it settles — the same
+ * degradation an unclosed code fence already gets. A ceiling, NOT a throttle: a
+ * single top-level block this large is pathological, and text that keeps
+ * arriving unformatted is strictly better than formatted text that stops
+ * arriving.
+ *
+ * The design this replaces demoted an expensive tail to a 120 ms off-thread
+ * lane and latched that demotion for the life of the block. That is what froze
+ * answers mid-sentence: one slow parse — the FIRST one, before the pipeline is
+ * warm — and the block never rendered live again, so the reader watched four
+ * words and a blinking caret until the turn ended and the settled render
+ * dumped the whole answer at once. A renderer must not have a state it cannot
+ * leave, and the live tail must not depend on anything asynchronous.
+ *
+ * 6 KB is set from measurement: the stream pipeline costs roughly 2 ms per KB
+ * (a typical tail block — one paragraph — is well under 1 ms), so this keeps
+ * the per-frame parse inside a frame's budget with room to spare, while
+ * sitting far above any ordinary paragraph, list or table.
+ */
+const STREAM_PLAIN_LIMIT = 6000;
+
 /** Longest the incremental split may run without a real re-parse. A backstop,
  *  not the mechanism — `mayStartNewBlock` catches boundaries as they arrive. */
 const RESPLIT_MAX_MS = 500;
@@ -66,17 +76,24 @@ const RESPLIT_MAX_MS = 500;
  * Renderer for the STREAMING TAIL only — deliberately bypasses `CachedMarkdown`.
  *
  * The tail's source is a new unique string every applied frame, which made the
- * cached path pathological twice over: small tails wrote a partial into the LRU
- * per frame (evicting the settled blocks the cache exists to protect — the
- * scroll-back re-parse the cache was built to prevent), and large tails queued a
- * NEW worker parse per frame with no cancellation of superseded sources — a
- * ten-second paragraph enqueued hundreds of dead parses drained two at a time,
- * while the visible tail lagged the stale queue. A string that will never be
- * requested again must never touch the cache or the queue.
+ * cached path pathological: every frame wrote a partial into the LRU, evicting
+ * the settled blocks the cache exists to protect. A string that will never be
+ * requested again must never touch the cache.
+ *
+ * So it parses here, synchronously, on every frame — and that is the whole
+ * design. It is affordable because of what it is NOT parsing: the tail is ONE
+ * top-level block (settled blocks are cached and never re-touched), and the
+ * stream pipeline skips syntax highlighting, which is the expensive half. What
+ * remains is a few hundred bytes of remark on most frames.
+ *
+ * Nothing here is throttled, queued, or deferred to a worker. Every one of
+ * those is a way for the live edge to fall behind the text, and the live edge
+ * falling behind the text is the only bug the reader ever notices.
  *
  * The block re-renders as `CachedMarkdown` the moment it settles, which parses
- * and caches the final text once — and shows this renderer's last html
- * (`noteTailHtml`) in the meantime, so the swap is invisible.
+ * and caches the final text once, with highlighting — and shows this
+ * renderer's last html (`noteTailHtml`) in the meantime, so the swap is
+ * invisible.
  */
 const TransientMarkdown = memo(function TransientMarkdown({
   source,
@@ -90,68 +107,7 @@ const TransientMarkdown = memo(function TransientMarkdown({
   // Parse the REPAIRED copy; everything downstream still keys off the raw
   // source, which is what the settled block will be rendered from.
   const repaired = useMemo(() => closeIncompleteMarkdown(source), [source]);
-
-  const overBudget = useRef(false);
-  const small = repaired.length <= INLINE_PARSE_LIMIT && !overBudget.current;
-  const inline = useMemo(() => {
-    if (!small) return null;
-    const started = performance.now();
-    const html = parseMarkdown(repaired);
-    if (performance.now() - started > INLINE_BUDGET_MS) overBudget.current = true;
-    return html;
-  }, [small, repaired]);
-
-  // Large tail: throttled trailing-edge parse of the LATEST source. The parse
-  // itself runs on the markdown worker via the transient lane (single slot,
-  // latest-wins, no cache/queue) — synchronously it was O(tail length) of
-  // unified/rehype work on the main thread every 120ms, growing multi-frame
-  // late in a long block, exactly while rAF delta flushes were running. The
-  // sync parse remains only as the no-worker fallback.
-  const [big, setBig] = useState("");
-  const latest = useRef(repaired);
-  latest.current = repaired;
-  const timer = useRef<number | null>(null);
-  const lastRun = useRef(0);
-  const alive = useRef(true);
-  useEffect(() => {
-    // Set on every run, not once at mount: React re-runs effects on the same
-    // instance (StrictMode's mount/unmount/mount in development), and a latch
-    // that only ever went false left the throttled path permanently mute —
-    // large blocks stopped updating mid-answer and only caught up on settle.
-    alive.current = true;
-    return () => {
-      alive.current = false;
-    };
-  }, []);
-  useEffect(() => {
-    if (small || timer.current !== null) return;
-    const due = Math.max(0, TRANSIENT_THROTTLE_MS - (performance.now() - lastRun.current));
-    timer.current = window.setTimeout(() => {
-      timer.current = null;
-      lastRun.current = performance.now();
-      if (transientWorkerAvailable()) {
-        void parseTransientOffThread(latest.current).then((html) => {
-          // null/"" = superseded or timed out — skip the tick; a newer parse
-          // is on the way (and settling re-renders through CachedMarkdown).
-          if (alive.current && html) setBig(html);
-        });
-      } else {
-        setBig(parseMarkdown(latest.current));
-      }
-    }, due);
-  }, [small, repaired]);
-  useEffect(
-    () => () => {
-      if (timer.current !== null) window.clearTimeout(timer.current);
-    },
-    [],
-  );
-
-  // Crossing the small→large boundary leaves `big` one throttle tick behind;
-  // hold the last rendered html rather than flashing blank for that tick.
-  const lastHtml = useRef("");
-  const html = inline ?? (big || lastHtml.current);
-  lastHtml.current = html;
+  const html = useMemo(() => parseMarkdownStreaming(repaired), [repaired]);
 
   const ref = useRef<HTMLDivElement>(null);
   // Patch, don't replace — see `applyHtml`. This is what keeps a selection
@@ -200,6 +156,37 @@ const TransientMarkdown = memo(function TransientMarkdown({
   );
 });
 
+/**
+ * The tail as plain text — an unclosed fence, or a block past the ceiling.
+ *
+ * `mono` for a fence, because that IS code and it snaps to a highlighted block
+ * the moment the fence closes. Prose font otherwise: an oversized block is a
+ * wall of prose, and setting it in monospace would make the switch at settle a
+ * far bigger visual jump than the markdown markers it briefly shows.
+ */
+function PlainTail({
+  source,
+  className,
+  mono,
+}: {
+  source: string;
+  className?: string;
+  mono: boolean;
+}) {
+  return (
+    <pre
+      className={cn(
+        "whitespace-pre-wrap break-words select-text text-[var(--text-primary)]",
+        mono ? "font-mono text-[13px] leading-relaxed" : "atlas-md-pending",
+        className,
+      )}
+    >
+      {source}
+      <span className="atlas-stream-caret" aria-hidden />
+    </pre>
+  );
+}
+
 /** One top-level block. `trailing` = the last, still-streaming block. */
 const MarkdownBlock = memo(function MarkdownBlock({
   source,
@@ -214,20 +201,12 @@ const MarkdownBlock = memo(function MarkdownBlock({
   unstyled?: boolean;
   priority?: number;
 }) {
-  // A still-open code fence renders as plain text (no per-frame re-highlight of a
-  // growing block); it snaps to highlighted once the closing fence streams in.
-  if (trailing && isIncompleteCodeFence(source)) {
-    return (
-      <pre
-        className={cn(
-          "whitespace-pre-wrap break-words font-mono text-[13px] leading-relaxed text-[var(--text-primary)] select-text",
-          className,
-        )}
-      >
-        {source}
-        <span className="atlas-stream-caret" aria-hidden />
-      </pre>
-    );
+  // A still-open code fence renders as plain text (no per-frame re-highlight of
+  // a growing block); it snaps to highlighted once the closing fence streams
+  // in. Same for a tail past the ceiling — see `STREAM_PLAIN_LIMIT`.
+  const openFence = trailing && isIncompleteCodeFence(source);
+  if (trailing && (openFence || source.length > STREAM_PLAIN_LIMIT)) {
+    return <PlainTail source={source} className={className} mono={openFence} />;
   }
   // The live tail bypasses the cache/worker entirely — see TransientMarkdown.
   // `atlas-stream-tail` is what draws the caret, inline at the end of the last

--- a/src/features/chat/components/transcript-stream.test.tsx
+++ b/src/features/chat/components/transcript-stream.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+//
+// End-to-end repro for "the answer freezes part-way and lands all at once".
+//
+// Drives the transcript the way a real turn does — one immutable `messages`
+// array per applied frame, the trailing assistant message growing by a few
+// tokens each time — and asserts the DOM has the whole text after every frame.
+// A freeze shows up as the rendered text staying behind the source.
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { Transcript } from "./transcript";
+import type { ChatMessage } from "@/types/agent";
+
+afterEach(cleanup);
+
+const ANSWER = `Here are five jokes, one per language:
+
+🇪🇸 **Spanish**
+
+— ¿Por qué el libro de matemáticas estaba triste? — ¡Porque tenía demasiados problemas!
+
+🇫🇷 **French**
+
+— Qu'est-ce qu'un crocodile qui surveille les bagages ? — Un sac à dents !
+
+🇩🇪 **German**
+
+— Warum können Geister so schlecht lügen? — Weil man durch sie hindurchsehen kann!
+`;
+
+function msgs(assistantText: string): ChatMessage[] {
+  return [
+    {
+      id: "u1",
+      role: "user",
+      content: "tell me a joke in 5 different languages",
+      toolCalls: [],
+      fileChanges: [],
+      plan: null,
+      timestamp: "2026-09-07T15:19:00.000Z",
+    },
+    {
+      id: "a1",
+      role: "assistant",
+      content: assistantText,
+      mode: "text",
+      toolCalls: [],
+      fileChanges: [],
+      plan: null,
+      timestamp: "2026-09-07T15:19:01.000Z",
+    },
+  ];
+}
+
+/** Let the rAF-coalesced split and the layout effects settle. */
+async function settleFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+/** Text as the reader sees it: whitespace-normalised, markdown markers gone. */
+function visible(el: HTMLElement): string {
+  return (el.textContent ?? "").replace(/\s+/g, " ").trim();
+}
+
+describe("Transcript streaming", () => {
+  it("keeps the rendered answer in step with the source, frame by frame", async () => {
+    // Chunks of a few words, the shape a token stream actually has.
+    const steps: string[] = [];
+    for (let n = 4; n < ANSWER.length; n += 17) steps.push(ANSWER.slice(0, n));
+    steps.push(ANSWER);
+
+    const { container, rerender } = render(
+      <Transcript
+        tabId="t1"
+        acpSessionId="s1"
+        messages={msgs(steps[0])}
+        isStreaming
+        agentType="claude-code"
+      />,
+    );
+    await settleFrame();
+
+    const behind: string[] = [];
+    for (const step of steps) {
+      rerender(
+        <Transcript
+          tabId="t1"
+          acpSessionId="s1"
+          messages={msgs(step)}
+          isStreaming
+          agentType="claude-code"
+        />,
+      );
+      await settleFrame();
+
+      // The last few words of the source must be on screen. Compare on words:
+      // markdown markers are consumed by the renderer, and the tail repair may
+      // legitimately hide a marker that is still arriving.
+      const words = step
+        .replace(/[*_`~#]/g, " ")
+        .split(/\s+/)
+        .filter(Boolean);
+      const lastWord = words[words.length - 1];
+      const shown = visible(container);
+      if (lastWord && lastWord.length > 2 && !shown.includes(lastWord)) {
+        behind.push(`len ${step.length}: missing ${JSON.stringify(lastWord)}`);
+      }
+    }
+
+    expect(behind).toEqual([]);
+  });
+
+  it("shows the whole answer once the turn settles", async () => {
+    const { container, rerender } = render(
+      <Transcript tabId="t2" acpSessionId="s2" messages={msgs("Here")} isStreaming />,
+    );
+    await settleFrame();
+    rerender(
+      <Transcript tabId="t2" acpSessionId="s2" messages={msgs(ANSWER)} isStreaming={false} />,
+    );
+    await settleFrame();
+    expect(visible(container)).toContain("Warum können Geister so schlecht lügen");
+  });
+});

--- a/src/lib/markdown-cache.tsx
+++ b/src/lib/markdown-cache.tsx
@@ -240,11 +240,6 @@ function pump(): void {
     inFlight += 1;
     item.dispatch();
   }
-  // Queue drained → the streaming tail may take the worker (see the transient
-  // lane's yield rule below).
-  if (inFlight === 0 && queue.length === 0) {
-    kickTransient();
-  }
 }
 
 /** Raise a queued item's priority — the same source can be requested again by a
@@ -335,98 +330,10 @@ function parseLarge(source: string, priority: number): Promise<string> {
   return pending.get(source)!;
 }
 
-// ── Transient (streaming-tail) lane ────────────────────────────────────────
-//
-// The live tail's source is a new unique string every throttle tick, so it
-// must never touch the LRU (per-frame partials would evict the settled blocks
-// the cache protects) or the priority queue (hundreds of dead parses drained
-// two at a time — the original pathology StreamingMarkdown documents). This
-// lane is the worker path built for exactly that shape: ONE in-flight parse,
-// and a single "next" slot where a newer source REPLACES the queued one —
-// superseded tails are never parsed at all.
-
-let transientBusy = false;
-let transientNext: { source: string; resolve: (html: string | null) => void } | null = null;
-
-/** Whether the transient lane can run off-thread right now. When false the
- *  caller should parse synchronously itself (the pre-worker behavior). */
-export function transientWorkerAvailable(): boolean {
-  return ensureWorker() !== null;
-}
-
-/**
- * Parse a streaming-tail source off the main thread, latest-wins. Resolves
- * `null` when the request was superseded by a newer tail or timed out — the
- * caller skips that tick (a newer parse is already on the way, and settling
- * re-renders through `CachedMarkdown` regardless). Never caches.
- */
-export function parseTransientOffThread(source: string): Promise<string | null> {
-  const w = ensureWorker();
-  if (!w) return Promise.resolve(null);
-  return new Promise((resolve) => {
-    if (transientNext) transientNext.resolve(null); // superseded before dispatch
-    transientNext = { source, resolve };
-    pumpTransient(w);
-  });
-}
-
-/** Run the transient job if the worker is idle and the settled-block queue is
- *  empty. Split out so `pump()` can kick it when the queue drains. */
-function kickTransient(): void {
-  if (!transientNext) return;
-  const w = ensureWorker();
-  if (w) pumpTransient(w);
-}
-
-function pumpTransient(w: Worker): void {
-  if (transientBusy || !transientNext) return;
-  // YIELD to settled-block parses. The worker is one serial thread: scroll
-  // just revealed those blocks and the reader is looking at raw-text
-  // placeholders, while the tail is mid-word growth that can happily skip a
-  // tick (latest-wins keeps only the newest source anyway). Without this
-  // rule the 120ms tail cadence kept the worker ~always busy during a
-  // stream, and scroll-back blocks stayed unformatted for seconds.
-  if (inFlight > 0 || queue.length > 0) return;
-  const job = transientNext;
-  transientNext = null;
-  transientBusy = true;
-  const id = ++seq;
-  let settled = false;
-  const finish = (html: string) => {
-    if (settled) return;
-    settled = true;
-    waiters.delete(id);
-    transientBusy = false;
-    job.resolve(html);
-    const next = ensureWorker();
-    if (next) pumpTransient(next);
-  };
-  waiters.set(id, { source: job.source, finish });
-  // Same watchdog contract as parseLarge, but the fallback is "skip this
-  // tick" rather than a main-thread parse — the next throttle tick retries,
-  // and a stream that ended settles through CachedMarkdown anyway.
-  window.setTimeout(() => {
-    if (!settled) {
-      if (!workerEverAnswered) workerBroken = true;
-      settled = true;
-      waiters.delete(id);
-      transientBusy = false;
-      job.resolve(null);
-      const next = ensureWorker();
-      if (next) pumpTransient(next);
-    }
-  }, 3000);
-  try {
-    w.postMessage({ id, source: job.source });
-  } catch {
-    finish(""); // resolve with empty → caller skips the tick
-  }
-}
-
 // ── Last-good tail HTML ────────────────────────────────────────────────────
 //
-// The transient lane never caches (per-frame partials would evict the settled
-// blocks the LRU exists to protect). That left one visible seam: the frame a
+// The streaming tail never caches (per-frame partials would evict the settled
+// blocks the LRU exists to protect). That leaves one visible seam: the frame a
 // block STOPS being the tail. It re-renders through `CachedMarkdown` with a
 // source nothing has parsed yet, so a large block fell back to its raw-source
 // placeholder — the paragraph the reader was reading turned back into literal

--- a/src/lib/markdown-render.ts
+++ b/src/lib/markdown-render.ts
@@ -309,6 +309,33 @@ function getProcessor(): Processor {
   return processor;
 }
 
+/**
+ * Second processor for the STREAMING TAIL: identical to the one above minus
+ * `rehype-highlight`.
+ *
+ * The tail re-parses on every animation frame, so its cost is the one that
+ * decides whether an answer streams smoothly. Highlighting dominates that cost
+ * and buys nothing while the text is arriving — a fence is still open (rendered
+ * as plain text by the caller) or it just closed and the SETTLED render, which
+ * runs once and is cached, highlights it properly a frame later. Zed and
+ * Streamdown draw the same line: format live, colourise on settle.
+ */
+let streamProcessor: Processor | null = null;
+function getStreamProcessor(): Processor {
+  if (!streamProcessor) {
+    streamProcessor = unified()
+      .use(remarkParse)
+      .use(remarkGfm)
+      .use(remarkRehype, { allowDangerousHtml: false })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .use(rehypeMentionChips as any)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .use(rehypeSanitize, SANITIZE_SCHEMA as any)
+      .use(rehypeStringify) as unknown as Processor;
+  }
+  return streamProcessor;
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
@@ -324,6 +351,16 @@ function escapeHtml(s: string): string {
 export function parseMarkdown(src: string): string {
   try {
     return String(getProcessor().processSync(src));
+  } catch {
+    return `<p>${escapeHtml(src)}</p>`;
+  }
+}
+
+/** `parseMarkdown` for the live streaming tail — same output, no syntax
+ *  highlighting. See `getStreamProcessor`. */
+export function parseMarkdownStreaming(src: string): string {
+  try {
+    return String(getStreamProcessor().processSync(src));
   } catch {
     return `<p>${escapeHtml(src)}</p>`;
   }


### PR DESCRIPTION
### What?

Fixes the freeze in the two recordings: a streaming answer renders its first few words, stops dead with the caret still blinking, and then the entire reply appears at once when the turn ends.

Frame-by-frame from the videos (1 fps): `Thinking 4.4s` → `Here|` → `Here|` → … nine seconds … → the whole answer. The second recording is the same shape on a different agent (`— Cosa fa un p` for ~12 s), so it is not agent-specific.

Reproduced before fixing. `transcript-stream.test.tsx` drives the transcript one applied frame at a time and compares the DOM against the source; on the previous build it reports the DOM stalling and never catching up:

```
[ 'len 21: missing "jokes,"', 'len 38: missing "language:"', 'len 55: missing "Spanish"', … 14 entries ]
```

Tracing the hook confirmed the split was fine — it produced the correct tail on every frame — and the DOM simply stopped following it. So the bug is in the live-tail renderer, not the store, the projection, or the event stream.

### Why?

**The tail renderer had two ways to render a block and could get permanently stuck in the wrong one.**

Blocks over 2 KB were demoted to a throttled off-thread lane, and after my previous PR (#245) so was any block whose first parse ran over a 6 ms budget — a demotion that latched for the life of the block. The first parse of a turn is the expensive one, before the pipeline is warm, so the latch fired almost immediately, on a tail of four or five characters. From then on that block's rendering depended on a lane that yields to the settled-block queue and carries a 3 s watchdog, so it starved for seconds at a time.

That is the freeze exactly: `Here` renders, the budget latch trips, and the block never renders live again. The blinking caret is CSS, so it keeps going and the UI looks alive while the text is frozen.

The 6 ms budget was mine and it was the wrong idea. The 2 KB/off-thread split predates it and is the same failure mode at a higher threshold — long paragraphs froze this way before #245 too, which is the behaviour originally reported as "streaming is buggy".

### How?

**The live tail parses synchronously, every frame, with nothing in the way.** No throttle, no queue, no worker, no state the renderer can get stuck in. A renderer must not have a state it cannot leave, and the live edge must not depend on anything asynchronous.

That is affordable because of what it is *not* parsing:

- The tail is **one top-level block**. Settled blocks are cached and never re-touched (that part of #245 stands), so the per-frame input is a paragraph, not an answer.
- It goes through a new **`parseMarkdownStreaming`** — the same pipeline minus `rehype-highlight`, which is the expensive half and buys nothing while text is still arriving. An open fence renders as plain text regardless, and the settled render (once, cached) highlights it properly a frame later. Zed and Streamdown draw the same line: **format live, colourise on settle.**

Measured on this pipeline: **~2 ms per KB, with a typical tail block well under 1 ms**, and roughly half the cost of the full pipeline when fences are present. (Numbers are `min` over 300 runs on a heavily loaded box, so treat them as an upper bound and as relative rather than absolute.)

The one remaining bound is a **ceiling, not a throttle**: past 6 KB a single block renders as plain text — still streaming, still live, in the prose font — and settles to full markdown a moment later. That is the same degradation an unclosed code fence already gets. Text that keeps arriving unformatted beats formatted text that stops arriving.

With the tail no longer able to fall behind, the off-thread transient lane in `markdown-cache.tsx` has no callers and is deleted (~90 lines: `parseTransientOffThread`, `transientWorkerAvailable`, the single-slot pump, its watchdog, and the `pump()` hook that fed it).

Everything else from #245 is untouched and still doing its job: incomplete-markup repair, morphdom patching, the incremental block split, the tail-html handoff at the settle seam, the block rhythm rules, and the inline caret.

| File | Change |
|---|---|
| `src/lib/markdown-render.ts` | `parseMarkdownStreaming` — same pipeline, no `rehype-highlight` |
| `src/features/chat/components/streaming-markdown.tsx` | tail parses inline per frame; budget latch, throttle and worker path removed; 6 KB plain-text ceiling |
| `src/lib/markdown-cache.tsx` | transient lane deleted |

### Tests

- `transcript-stream.test.tsx` *(new)* — the repro. Streams an answer through the real `Transcript` in ~17-char steps and asserts the DOM carries the newest word after every frame. Fails on the previous build with the list above.
- `streaming-markdown.test.tsx` — two new cases: a tail stays live *after* a deliberately expensive frame (the latch regression), and an oversized tail keeps streaming as plain text instead of stalling.

`bun run lint`, `format:check`, `typecheck`, `test` (1200 passed) and `build` all pass.

## Checklist

- [x] Targets the current version branch (`0.3.1`)
- [x] New behaviour has a test; the bug fix has a test that fails without it
- [ ] **Not done — please check before merging.** No macOS window here, so this is verified against the recordings and the repro test, not by watching a live stream. Worth eyeballing: text should now advance continuously instead of in one lump at the end, and a fenced code block should appear plain while it streams and gain colours the moment it closes.

https://claude.ai/code/session_0195fCgt87j14eUeLwiyzY5S
