### PR TITLE
Copy and retry actions under user messages

### DIFF
--- a/crates/atlas-acp-thread/src/connection.rs
+++ b/crates/atlas-acp-thread/src/connection.rs
@@ -220,6 +220,15 @@ pub trait AgentConnection: Send + Sync {
         false
     }
 
+    /// Whether this agent can drop its own last turn — see [`AgentSessionRewind`].
+    ///
+    /// Session-independent, like [`Self::supports_logout`], because the
+    /// catalogue publishes it per agent before any session exists. It must
+    /// agree with [`Self::rewind`]: this answers "would that return `Some`".
+    fn supports_rewind(&self) -> bool {
+        false
+    }
+
     /// Load an existing session by ID.
     fn load_session(
         self: Arc<Self>,
@@ -311,6 +320,10 @@ pub trait AgentConnection: Send + Sync {
         None
     }
 
+    fn rewind(&self, _session_id: &acp::SessionId) -> Option<Arc<dyn AgentSessionRewind>> {
+        None
+    }
+
     fn set_title(&self, _session_id: &acp::SessionId) -> Option<Arc<dyn AgentSessionSetTitle>> {
         None
     }
@@ -377,6 +390,22 @@ pub trait AgentSessionClientUserMessageIds: Send + Sync {
 
 pub trait AgentSessionRetry: Send + Sync {
     fn run(&self) -> BoxFuture<'static, Result<acp::PromptResponse>>;
+}
+
+/// Dropping a session's last turn and recovering the prompt that started it.
+///
+/// Distinct from [`AgentSessionTruncate`], which cuts at a NAMED user message
+/// and so needs the [`ClientUserMessageId`] machinery nothing populates yet,
+/// and from [`AgentSessionRetry`], which rewinds and re-runs as one opaque
+/// step. Splitting the rewind from the re-send is what lets a caller tell a
+/// rewind that landed from a send that failed — and the prompt has to come
+/// back out, because after the rewind the thread no longer holds it.
+///
+/// `Ok(None)` means the agent declined and NOTHING changed. Anything that may
+/// have left the durable history and the thread disagreeing must be an `Err`:
+/// a caller told "nothing happened" cannot repair a rewind that half-happened.
+pub trait AgentSessionRewind: Send + Sync {
+    fn run(&self) -> BoxFuture<'static, Result<Option<String>>>;
 }
 
 pub trait AgentSessionSetTitle: Send + Sync {

--- a/crates/atlas-native-agent/src/engine/connection.rs
+++ b/crates/atlas-native-agent/src/engine/connection.rs
@@ -437,6 +437,81 @@ impl EngineConnection {
         Ok(response.thread.id)
     }
 
+    /// Drop the last exchange and hand back the prompt that started it.
+    ///
+    /// This is the rewind half of "retry": `thread/rollback` drops the turn
+    /// from the engine's durable history, the thread's entries are trimmed to
+    /// match so the transcript shows what the model now remembers, and the
+    /// caller re-sends the returned text through the ordinary send path.
+    ///
+    /// Deliberately NOT a re-implementation of `prompt`'s turn machinery.
+    /// Rewinding and re-sending are separable failures — a rewind that lands
+    /// and a send that does not must leave the user holding their prompt, not
+    /// a silently shortened thread — and splitting them here is what lets the
+    /// host report the two apart.
+    ///
+    /// Unlike `/undo` this is not itself a turn, so there is no `/undo` user
+    /// entry to skip: the exchange being dropped starts at the LAST user
+    /// entry, not the second-to-last.
+    ///
+    /// Returns `None` when there is no exchange to rewind. Only the flattened
+    /// text survives — attachments and resource links are not reconstructed,
+    /// because the thread stores what was sent, not the composer state that
+    /// produced it.
+    pub async fn rewind_last_turn(&self, session_id: &acp::SessionId) -> Result<Option<String>> {
+        // Ask before trimming. The engine refusing (nothing to drop) has to
+        // leave the transcript exactly as it was, so nothing local moves until
+        // the durable history has already moved.
+        let rolled: Result<v2::ThreadRollbackResponse> = self
+            .call(|request_id| ClientRequest::ThreadRollback {
+                request_id,
+                params: v2::ThreadRollbackParams {
+                    thread_id: session_id.to_string(),
+                    num_turns: 1,
+                },
+            })
+            .await;
+        if rolled.is_err() {
+            return Ok(None);
+        }
+
+        // Past this point the durable history has ALREADY shrunk. Reporting
+        // `None` — "nothing to rewind" — from here would tell the user nothing
+        // happened while the engine and the transcript silently disagree about
+        // the conversation. An error is the only honest answer.
+        let Some(thread) = self.sessions.thread(session_id) else {
+            return Err(anyhow!(
+                "rewound the engine's history but the session's thread is gone; \
+                 reopen the conversation to resynchronise"
+            ));
+        };
+        let mut locked = thread
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let last_user = locked
+            .entries()
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(ix, entry)| match entry {
+                atlas_acp_thread::AgentThreadEntry::UserMessage(msg) => {
+                    Some((ix, msg.content.to_text().to_string()))
+                }
+                _ => None,
+            });
+        let Some((from, text)) = last_user else {
+            return Err(anyhow!(
+                "rewound the engine's history but the transcript holds no prompt to \
+                 replay; reopen the conversation to resynchronise"
+            ));
+        };
+        // `EntriesRemoved` is what the delta projector turns into
+        // `HistoryRewound`, which is what trims the store's mirror and
+        // resolves any permission request stranded by the removal.
+        locked.remove_entries_from(from);
+        Ok(Some(text))
+    }
+
     /// Discover the cwd's skills and re-publish the command list with them.
     ///
     /// User- and repo-scope only: the engine's bundled system skills lean on

--- a/crates/atlas-native-agent/src/engine/connection.rs
+++ b/crates/atlas-native-agent/src/engine/connection.rs
@@ -42,7 +42,7 @@ use anyhow::anyhow;
 use anyhow::Result;
 use atlas_acp_thread::{
     AcpThread, AcpThreadHandle, AgentConnection, AgentId, AgentModelId, AgentModelInfo,
-    AgentModelList, AgentModelSelector, AgentSessionModes, AuthorizationKind,
+    AgentModelList, AgentModelSelector, AgentSessionModes, AgentSessionRewind, AuthorizationKind,
 };
 use crate::AgentSessionEffort;
 use atlas_agent_servers::ThreadEventSink;
@@ -435,81 +435,6 @@ impl EngineConnection {
             })
             .await?;
         Ok(response.thread.id)
-    }
-
-    /// Drop the last exchange and hand back the prompt that started it.
-    ///
-    /// This is the rewind half of "retry": `thread/rollback` drops the turn
-    /// from the engine's durable history, the thread's entries are trimmed to
-    /// match so the transcript shows what the model now remembers, and the
-    /// caller re-sends the returned text through the ordinary send path.
-    ///
-    /// Deliberately NOT a re-implementation of `prompt`'s turn machinery.
-    /// Rewinding and re-sending are separable failures — a rewind that lands
-    /// and a send that does not must leave the user holding their prompt, not
-    /// a silently shortened thread — and splitting them here is what lets the
-    /// host report the two apart.
-    ///
-    /// Unlike `/undo` this is not itself a turn, so there is no `/undo` user
-    /// entry to skip: the exchange being dropped starts at the LAST user
-    /// entry, not the second-to-last.
-    ///
-    /// Returns `None` when there is no exchange to rewind. Only the flattened
-    /// text survives — attachments and resource links are not reconstructed,
-    /// because the thread stores what was sent, not the composer state that
-    /// produced it.
-    pub async fn rewind_last_turn(&self, session_id: &acp::SessionId) -> Result<Option<String>> {
-        // Ask before trimming. The engine refusing (nothing to drop) has to
-        // leave the transcript exactly as it was, so nothing local moves until
-        // the durable history has already moved.
-        let rolled: Result<v2::ThreadRollbackResponse> = self
-            .call(|request_id| ClientRequest::ThreadRollback {
-                request_id,
-                params: v2::ThreadRollbackParams {
-                    thread_id: session_id.to_string(),
-                    num_turns: 1,
-                },
-            })
-            .await;
-        if rolled.is_err() {
-            return Ok(None);
-        }
-
-        // Past this point the durable history has ALREADY shrunk. Reporting
-        // `None` — "nothing to rewind" — from here would tell the user nothing
-        // happened while the engine and the transcript silently disagree about
-        // the conversation. An error is the only honest answer.
-        let Some(thread) = self.sessions.thread(session_id) else {
-            return Err(anyhow!(
-                "rewound the engine's history but the session's thread is gone; \
-                 reopen the conversation to resynchronise"
-            ));
-        };
-        let mut locked = thread
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let last_user = locked
-            .entries()
-            .iter()
-            .enumerate()
-            .rev()
-            .find_map(|(ix, entry)| match entry {
-                atlas_acp_thread::AgentThreadEntry::UserMessage(msg) => {
-                    Some((ix, msg.content.to_text().to_string()))
-                }
-                _ => None,
-            });
-        let Some((from, text)) = last_user else {
-            return Err(anyhow!(
-                "rewound the engine's history but the transcript holds no prompt to \
-                 replay; reopen the conversation to resynchronise"
-            ));
-        };
-        // `EntriesRemoved` is what the delta projector turns into
-        // `HistoryRewound`, which is what trims the store's mirror and
-        // resolves any permission request stranded by the removal.
-        locked.remove_entries_from(from);
-        Ok(Some(text))
     }
 
     /// Discover the cwd's skills and re-publish the command list with them.
@@ -1560,6 +1485,18 @@ impl AgentConnection for EngineConnection {
         .boxed()
     }
 
+    fn supports_rewind(&self) -> bool {
+        true
+    }
+
+    fn rewind(&self, session_id: &acp::SessionId) -> Option<Arc<dyn AgentSessionRewind>> {
+        self.sessions.thread(session_id)?;
+        Some(Arc::new(EngineSessionRewind {
+            connection: self.clone_rewind_handle(),
+            session_id: session_id.clone(),
+        }))
+    }
+
     fn session_modes(&self, session_id: &acp::SessionId) -> Option<Arc<dyn AgentSessionModes>> {
         self.sessions.thread(session_id)?;
         Some(Arc::new(EngineSessionModes {
@@ -1943,7 +1880,132 @@ struct ConnectionHandle {
     turns: Arc<TurnWaiters>,
 }
 
+/// What a rewind needs, and no more: the request channel to reach the engine
+/// and the session table to reach the thread. Same reason the other session
+/// controls hold parts rather than the connection — see `ConnectionHandle`.
+#[derive(Clone)]
+struct RewindHandle {
+    requests: InProcessAppServerRequestHandle,
+    request_ids: Arc<RequestIds>,
+    sessions: Arc<EngineSessions>,
+}
+
+struct EngineSessionRewind {
+    connection: RewindHandle,
+    session_id: acp::SessionId,
+}
+
+impl AgentSessionRewind for EngineSessionRewind {
+    fn run(&self) -> BoxFuture<'static, Result<Option<String>>> {
+        let handle = self.connection.clone();
+        let session_id = self.session_id.clone();
+        async move { handle.rewind_last_turn(&session_id).await }.boxed()
+    }
+}
+
+impl RewindHandle {
+    /// Drop the last turn and hand back the prompt that started it.
+    ///
+    /// This is the rewind half of "retry": `thread/rollback` drops the turn
+    /// from the engine's durable history, the thread's entries are trimmed to
+    /// match so the transcript shows what the model now remembers, and the
+    /// caller re-sends the returned text through the ordinary send path.
+    ///
+    /// Deliberately NOT a re-implementation of `prompt`'s turn machinery.
+    /// Rewinding and re-sending are separable failures — a rewind that lands
+    /// and a send that does not must leave the user holding their prompt, not
+    /// a silently shortened thread — and splitting them here is what lets the
+    /// host report the two apart.
+    ///
+    /// Unlike `/undo` this is not itself a turn, so there is no `/undo` user
+    /// entry to skip: the turn being dropped starts at the LAST user entry,
+    /// not the second-to-last.
+    ///
+    /// `None` means the engine declined — almost always an empty thread. It is
+    /// NOT a promise that nothing moved: the request layer folds a refusal and
+    /// a dead channel into one error, and a channel that dies after the
+    /// rollback ran lands here too. Everything past a rollback known to have
+    /// succeeded is an `Err`, so the only ambiguity left is this one.
+    ///
+    /// Only the FLATTENED text survives. `ContentBlock::to_text` returns a
+    /// resource link as a bare URI and joins mixed blocks without the newlines
+    /// the original input carried (`thread.rs:99` vs `sink.rs:351`), so a turn
+    /// whose prompt mixed prose and `@`-mentions does not round-trip verbatim.
+    /// Attachments are not reconstructed at all — the thread stores what was
+    /// sent, not the composer state that produced it.
+    async fn rewind_last_turn(&self, session_id: &acp::SessionId) -> Result<Option<String>> {
+        // Ask before trimming. The engine refusing (nothing to drop) has to
+        // leave the transcript exactly as it was, so nothing local moves until
+        // the durable history has already moved.
+        let rolled = self
+            .requests
+            .request_typed::<v2::ThreadRollbackResponse>(ClientRequest::ThreadRollback {
+                request_id: self.request_ids.next(),
+                params: v2::ThreadRollbackParams {
+                    thread_id: session_id.to_string(),
+                    num_turns: 1,
+                },
+            })
+            .await;
+        if let Err(e) = rolled {
+            // A refusal and a broken channel are the same value here — the
+            // request layer does not distinguish "the engine said no" from "the
+            // engine never answered", and a transport error can also arrive
+            // AFTER the rollback ran. So this is honestly `None` only in the
+            // first case, and the caller is told as much rather than being
+            // promised the history is untouched. Erring instead would put a
+            // scary message in front of the far commoner empty-thread case.
+            tracing::debug!("thread/rollback declined or failed: {e}");
+            return Ok(None);
+        }
+
+        // Past this point the durable history has ALREADY shrunk. Reporting
+        // `None` — "nothing to rewind" — from here would tell the user nothing
+        // happened while the engine and the transcript silently disagree about
+        // the conversation. An error is the only honest answer.
+        let Some(thread) = self.sessions.thread(session_id) else {
+            return Err(anyhow!(
+                "rewound the engine's history but the session's thread is gone; \
+                 reopen the conversation to resynchronise"
+            ));
+        };
+        let mut locked = thread
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let last_user = locked
+            .entries()
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(ix, entry)| match entry {
+                atlas_acp_thread::AgentThreadEntry::UserMessage(msg) => {
+                    Some((ix, msg.content.to_text().to_string()))
+                }
+                _ => None,
+            });
+        let Some((from, text)) = last_user else {
+            return Err(anyhow!(
+                "rewound the engine's history but the transcript holds no prompt to \
+                 replay; reopen the conversation to resynchronise"
+            ));
+        };
+        // `EntriesRemoved` is what the delta projector turns into
+        // `HistoryRewound`, which is what trims the store's mirror and
+        // resolves any permission request stranded by the removal.
+        locked.remove_entries_from(from);
+        Ok(Some(text))
+    }
+}
+
 impl EngineConnection {
+    fn clone_rewind_handle(&self) -> RewindHandle {
+        RewindHandle {
+            requests: self.requests.clone(),
+            request_ids: self.request_ids.clone(),
+            sessions: self.sessions.clone(),
+        }
+    }
+
     fn clone_handle(&self) -> ConnectionHandle {
         ConnectionHandle {
             requests: self.requests.clone(),

--- a/src-tauri/src/auth/core.rs
+++ b/src-tauri/src/auth/core.rs
@@ -276,7 +276,9 @@ impl AuthCore {
     /// sections hold no state of their own — so a poisoned lock is recovered
     /// rather than propagated into every later sign-in.
     fn file_guard(&self) -> std::sync::MutexGuard<'_, ()> {
-        self.file.lock().unwrap_or_else(|e| e.into_inner())
+        self.file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     /// Shrink the retry schedule so a test can drive the loop through several

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -627,6 +627,14 @@ impl AgentHost {
                 .clone()
                 .downcast::<atlas_native_agent::EngineConnection>()
                 .is_some(),
+            // Same shape and the same reason: ACP has no verb for forgetting a
+            // turn, the native engine has `thread/rollback`. Published rather
+            // than left for the frontend to infer from the agent id — under
+            // ADR-0002 no agent gets special treatment, so "can this one
+            // rewind" has to be a discovered fact like every other capability.
+            supports_rewind: connection
+                .downcast::<atlas_native_agent::EngineConnection>()
+                .is_some(),
         }
     }
 
@@ -1146,6 +1154,26 @@ impl AgentHost {
             .await
             .map_err(|e| HostError::classified(e.to_string()))?;
         Ok(Some(forked))
+    }
+
+    /// Drop the last exchange and return the prompt that started it.
+    ///
+    /// The rewind half of a retry. `None` means "not retryable here" — either
+    /// the agent is not the native one (no ACP agent has a rewind verb; the
+    /// capability record in schema 1.5.0 has `fork`, `resume`, `list`,
+    /// `delete` and `close`, and nothing that forgets turns) or the thread has
+    /// no exchange left to drop. Callers re-send the returned text through the
+    /// ordinary send path, so a rewind that lands and a send that fails are
+    /// two outcomes the UI can tell apart.
+    pub async fn rewind_last_turn(&self, key: &SessionKey) -> Result<Option<String>> {
+        let Ok(native) = self.native_connection(&key.session_id) else {
+            return Ok(None);
+        };
+        let session_id = acp::SessionId::new(key.session_id.as_str());
+        native
+            .rewind_last_turn(&session_id)
+            .await
+            .map_err(|e| HostError::classified(e.to_string()))
     }
 
     fn native_connection(&self, session_id: &str) -> Result<Arc<atlas_native_agent::EngineConnection>> {
@@ -1973,6 +2001,7 @@ pub struct PluginCapabilities {
     pub supports_load_session: bool,
     pub supports_session_list: bool,
     pub supports_fork: bool,
+    pub supports_rewind: bool,
 }
 
 /// A registry agent's cached icon, as a data URL.

--- a/src-tauri/src/commands/agent_host.rs
+++ b/src-tauri/src/commands/agent_host.rs
@@ -627,14 +627,12 @@ impl AgentHost {
                 .clone()
                 .downcast::<atlas_native_agent::EngineConnection>()
                 .is_some(),
-            // Same shape and the same reason: ACP has no verb for forgetting a
-            // turn, the native engine has `thread/rollback`. Published rather
-            // than left for the frontend to infer from the agent id — under
-            // ADR-0002 no agent gets special treatment, so "can this one
-            // rewind" has to be a discovered fact like every other capability.
-            supports_rewind: connection
-                .downcast::<atlas_native_agent::EngineConnection>()
-                .is_some(),
+            // Asked of the connection, not inferred from its concrete type.
+            // `supports_fork` above still downcasts, and that is exactly the
+            // identity check ADR-0002 rules out — a second one would entrench
+            // it. Any connection that answers true here is offered the
+            // affordance, native or not.
+            supports_rewind: connection.supports_rewind(),
         }
     }
 
@@ -1166,12 +1164,15 @@ impl AgentHost {
     /// ordinary send path, so a rewind that lands and a send that fails are
     /// two outcomes the UI can tell apart.
     pub async fn rewind_last_turn(&self, key: &SessionKey) -> Result<Option<String>> {
-        let Ok(native) = self.native_connection(&key.session_id) else {
+        let session_id = acp::SessionId::new(key.session_id.as_str());
+        let connection = lock_thread(&self.thread(&key.session_id)?).connection().clone();
+        // Through the seam, not a downcast: an agent that grows a rewind gets
+        // this for free, and nothing here names a concrete connection type.
+        let Some(rewind) = connection.rewind(&session_id) else {
             return Ok(None);
         };
-        let session_id = acp::SessionId::new(key.session_id.as_str());
-        native
-            .rewind_last_turn(&session_id)
+        rewind
+            .run()
             .await
             .map_err(|e| HostError::classified(e.to_string()))
     }

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -901,6 +901,24 @@ pub async fn agents_fork_session(
     host.fork_session(&key).await.map_err(|e| e.to_string())
 }
 
+/// Rewind the last exchange, returning the prompt that started it.
+///
+/// Half of "retry the last message": the caller re-sends the returned text
+/// with `agents_send`. Split in two on purpose — the rewind is destructive and
+/// the send can fail on its own, and a UI that cannot tell those apart either
+/// loses the user's prompt or replays it into a thread that never shrank.
+///
+/// `null` for every ACP agent, exactly like `agents_fork_session`: rewinding
+/// is not in ACP's session capabilities, so the affordance is hidden there
+/// rather than faked with an append-and-resend that quietly diverges.
+#[tauri::command]
+pub async fn agents_rewind_last_turn(
+    key: SessionKey,
+    host: State<'_, Arc<AgentHost>>,
+) -> Result<Option<String>, String> {
+    host.rewind_last_turn(&key).await.map_err(|e| e.to_string())
+}
+
 /// Set any agent-advertised config option.
 ///
 /// Generic by design: ACP lets an agent advertise arbitrary options, and Atlas

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -908,9 +908,11 @@ pub async fn agents_fork_session(
 /// the send can fail on its own, and a UI that cannot tell those apart either
 /// loses the user's prompt or replays it into a thread that never shrank.
 ///
-/// `null` for every ACP agent, exactly like `agents_fork_session`: rewinding
-/// is not in ACP's session capabilities, so the affordance is hidden there
-/// rather than faked with an append-and-resend that quietly diverges.
+/// `null` when the connection advertises no rewind — which is every ACP agent
+/// today, because rewinding is not in ACP's session capabilities. The
+/// affordance is hidden there rather than faked with an append-and-resend that
+/// quietly diverges. Asked through `AgentConnection::rewind`, so an agent that
+/// gains the verb needs no change here.
 #[tauri::command]
 pub async fn agents_rewind_last_turn(
     key: SessionKey,

--- a/src-tauri/src/commands/catalog.rs
+++ b/src-tauri/src/commands/catalog.rs
@@ -108,6 +108,10 @@ pub struct AgentCatalogEntry {
     pub supports_session_list: bool,
     /// Always false: `session/fork` has no equivalent on the ported seam.
     pub supports_fork: bool,
+    /// Whether this agent can rewind a turn out of its own history — the
+    /// engine's `thread/rollback`. ACP has no equivalent, so this gates the
+    /// retry affordance the way `supports_fork` gates branching.
+    pub supports_rewind: bool,
     pub icon_data_url: Option<String>,
     pub help_url: Option<String>,
     pub repository: Option<String>,
@@ -211,6 +215,7 @@ fn build(host: &AgentHost) -> AgentCatalog {
                 supports_load_session: capabilities.supports_load_session,
                 supports_session_list: capabilities.supports_session_list,
                 supports_fork: capabilities.supports_fork,
+                supports_rewind: capabilities.supports_rewind,
                 icon_data_url: market.as_ref().and_then(super::agent_host::icon_data_url),
                 help_url: market.as_ref().and_then(|agent| {
                     agent
@@ -268,6 +273,7 @@ fn build(host: &AgentHost) -> AgentCatalog {
             supports_load_session: false,
             supports_session_list: false,
             supports_fork: false,
+            supports_rewind: false,
             icon_data_url: market.as_ref().and_then(super::agent_host::icon_data_url),
             help_url: market.as_ref().and_then(|a| a.repository().map(str::to_string)),
             repository: market.as_ref().and_then(|a| a.repository().map(str::to_string)),

--- a/src-tauri/src/commands/keybindings.rs
+++ b/src-tauri/src/commands/keybindings.rs
@@ -291,7 +291,7 @@ mod tests {
                 .map(|(k, v)| {
                     (
                         k.to_string(),
-                        v.map(|c| c.iter().map(|s| s.to_string()).collect()),
+                        v.map(|c| c.iter().map(ToString::to_string).collect()),
                     )
                 })
                 .collect(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -645,6 +645,7 @@ pub fn run() {
             commands::agents::agents_set_config_option,
             commands::agents::agents_respond_elicitation,
             commands::agents::agents_fork_session,
+            commands::agents::agents_rewind_last_turn,
             commands::agents::agents_run_auth_method,
             commands::agents::agents_authenticate,
             commands::agents::agents_drop_session,

--- a/src/features/chat/components/transcript-rows.tsx
+++ b/src/features/chat/components/transcript-rows.tsx
@@ -30,6 +30,7 @@ import { CachedMarkdown } from "@/lib/markdown-cache";
 import { StreamingMarkdown } from "./streaming-markdown";
 import { openDetail } from "../stores/detail-panel-store";
 import { openTurnDiff } from "../lib/open-turn-diff";
+import { UserRowActions } from "./user-row-actions";
 import type {
   UserRow,
   ProseRow,
@@ -51,11 +52,16 @@ function Column({ children, className }: { children: React.ReactNode; className?
 
 export const UserRowView = memo(function UserRowView({
   row,
+  tabId,
   priority,
   justSent = false,
+  canRetry = false,
   onToggleExpand,
 }: {
   row: UserRow;
+  /** Passed rather than read from a store: house rule 3, and a primitive prop
+   *  keeps the shallow-compare `memo` above intact. */
+  tabId: string;
   /** Position in the thread — newest parses first. See `CachedMarkdown`. */
   priority: number;
   /** True ONLY for the message the user sent just now (id-scoped in the
@@ -64,6 +70,10 @@ export const UserRowView = memo(function UserRowView({
    *  row mounted during an early scroll — bulk entrance animations during
    *  fast scroll were a blanking contributor. */
   justSent?: boolean;
+  /** True only for the thread's last user message on an agent that can rewind.
+   *  Resolved by the transcript so this stays a boolean — a callback minted in
+   *  the row map would defeat the memo for every row on every frame. */
+  canRetry?: boolean;
   onToggleExpand: (id: string) => void;
 }) {
   return (
@@ -77,7 +87,7 @@ export const UserRowView = memo(function UserRowView({
           `overflow-x: auto` cannot save an ancestor that refuses to shrink, so
           a long paste dragged the whole bubble past the viewport edge. With
           the chain capped, the fence scrolls horizontally INSIDE the bubble. */}
-      <div className="flex min-w-0 max-w-[80%] flex-col items-end">
+      <div className="relative flex min-w-0 max-w-[80%] flex-col items-end">
         {/* The prompt is markdown too. It is written in the same composer that
             accepts fences and lists, and rendering it as flat text collapsed
             every newline — a pasted snippet came back as one run-on paragraph.
@@ -117,6 +127,7 @@ export const UserRowView = memo(function UserRowView({
           </button>
         )}
         <ExpandToggle row={row} onToggleExpand={onToggleExpand} />
+        <UserRowActions tabId={tabId} text={row.text} canRetry={canRetry} />
       </div>
     </Column>
   );

--- a/src/features/chat/components/transcript.tsx
+++ b/src/features/chat/components/transcript.tsx
@@ -36,13 +36,18 @@ import {
 } from "react";
 import type { ChatMessage } from "@/types/agent";
 import { type SwitchableAgent } from "@/types/agent";
-import { agentMeta, switchableAgentOf } from "@/features/agents/lib/agent-meta";
+import {
+  agentMeta,
+  catalogEntry as agentCatalogEntry,
+  switchableAgentOf,
+} from "@/features/agents/lib/agent-meta";
 import { AgentIcons, ExternalAgentIcon, AgentMonogram } from "@/components/agent-icons";
 import { AtlasIcon } from "@/components/atlas-icon";
 import { projectRows, RowKind, type Projection, type Row } from "../lib/turn-rows";
 import { useTranscriptScroll } from "../lib/use-transcript-scroll";
 import { useChatStore } from "../stores/chat-store";
 import { saveThreadToKb } from "../lib/turn-actions";
+import { sessionCanRetry } from "../lib/retry-gate";
 import { cn } from "@/lib/utils";
 import { isScrollHot } from "@/lib/scroll-hot";
 import { GradualBlur } from "@/components/gradual-blur";
@@ -209,6 +214,16 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(function
     [agent, agentIconUrl, agentLabel],
   );
 
+  // Whether a retry is possible RIGHT NOW. Selector returns a boolean and is
+  // O(1), so it runs on every store write but re-renders only when the answer
+  // flips — the same bargain as `justSentMessageId` above. Doing this per-row
+  // instead, or selecting the session object, would put a comparison of the
+  // whole session on every streaming frame.
+  // Discovered, not inferred from the agent id (ADR-0002) — the same catalog
+  // flag `supportsFork` uses, computed from the live connection.
+  const supportsRewind = agentCatalogEntry(agent)?.supportsRewind === true;
+  const canRetry = useChatStore((s) => sessionCanRetry(s.sessions[tabId], supportsRewind));
+
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
   /** Turns whose tool-call block the reader has opened. */
   const [expandedTurns, setExpandedTurns] = useState<ReadonlySet<string>>(() => new Set());
@@ -277,6 +292,16 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(function
   const stale = startIndex > windowFloor;
   const safeStart = stale ? windowFloor : startIndex;
   const visible = useMemo(() => rows.slice(safeStart), [rows, safeStart]);
+  // Retry belongs to the thread's LAST user message, which is a fact about the
+  // session's history — not about which row happens to be last in the DOM (an
+  // assistant turn projects to several rows, and the window may be truncated
+  // at the top). Recomputed only when the projection changes.
+  const lastUserRowId = useMemo(() => {
+    for (let i = rows.length - 1; i >= 0; i--) {
+      if (rows[i].kind === RowKind.User) return rows[i].id;
+    }
+    return undefined;
+  }, [rows]);
   const canGrow = safeStart > 0;
 
   // Fold the correction back into state. Rendering from `safeStart` alone
@@ -669,6 +694,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(function
                 priority={safeStart + i}
                 onToggleExpand={toggleExpand}
                 onSaveKb={onSaveKb}
+                canRetryRowId={canRetry ? lastUserRowId : undefined}
               />
             </div>
           ))}
@@ -732,6 +758,7 @@ function RowView({
   onToggleExpand,
   onExpandTurn,
   onSaveKb,
+  canRetryRowId,
 }: {
   row: Row;
   justSentMessageId?: string;
@@ -742,6 +769,10 @@ function RowView({
   onToggleExpand: (id: string) => void;
   onExpandTurn: (turnId: string) => void;
   onSaveKb: () => void;
+  /** Id of the one row allowed to show a retry button, or `undefined` when no
+   *  retry is possible. An id compare here keeps `UserRowView`'s prop a plain
+   *  boolean. */
+  canRetryRowId?: string;
 }) {
   switch (row.kind) {
     case RowKind.User:
@@ -753,6 +784,8 @@ function RowView({
           // message id. The unprefixed compare never matched — the entrance
           // animation was silently dead until this fix.
           justSent={row.id === `u:${justSentMessageId}`}
+          tabId={tabId}
+          canRetry={row.id === canRetryRowId}
           onToggleExpand={onToggleExpand}
         />
       );

--- a/src/features/chat/components/user-row-actions.tsx
+++ b/src/features/chat/components/user-row-actions.tsx
@@ -14,13 +14,16 @@
 //     what they need through `getState()` at click time. Nothing here holds a
 //     subscription, so nothing here re-renders on a streaming frame.
 //
-//  3. **The transcript is not virtualized** (`transcript.tsx:1`), so this
-//     mounts once per user message for the life of the thread. That is why
-//     the reveal is pure CSS `group-hover` against the row wrapper's existing
-//     `group` class: a JS hover state would fire a `setState` for every bubble
-//     the pointer crosses during a fast flick, which is precisely the work
-//     the transcript is built to avoid. The trade is two buttons' worth of
-//     idle DOM per user row, which costs nothing at scroll time.
+//  3. **The transcript is not virtualized** (`transcript.tsx:1`). It renders a
+//     growing WINDOW — `rows.slice(safeStart)` — so this is mounted for every
+//     user message currently inside it, and the window only ever grows as the
+//     reader scrolls back. Rows are keyed by `row.id`, so growth prepends
+//     without remounting what is already there. That is why the reveal is
+//     pure CSS `group-hover` against the row wrapper's existing `group`
+//     class: a JS hover state would fire a `setState` for every bubble the
+//     pointer crosses during a fast flick, which is precisely the work the
+//     transcript is built to avoid. The trade is two buttons' worth of idle
+//     DOM per windowed user row, which costs nothing at scroll time.
 //
 // `focus-within` on the container is not decoration: with an opacity-only
 // reveal, keyboard users would otherwise tab into controls they cannot see.
@@ -72,8 +75,10 @@ export function UserRowActions({
   const [copied, setCopied] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // A row can unmount while the "copied" tick is still pending (window growth
-  // and history loads both remount rows freely).
+  // A row can unmount while the "copied" tick is still pending — a history
+  // load replaces the projection wholesale, and closing the tab takes the
+  // transcript with it. (Window growth does not: `key={row.id}` keeps existing
+  // instances alive when rows are prepended.)
   useEffect(() => () => void (timer.current && clearTimeout(timer.current)), []);
 
   const onCopy = useCallback(() => {

--- a/src/features/chat/components/user-row-actions.tsx
+++ b/src/features/chat/components/user-row-actions.tsx
@@ -1,0 +1,117 @@
+// Copy / retry, under a user message.
+//
+// Three constraints shaped this, and each one rules out the obvious approach:
+//
+//  1. **House rule 1 — nothing grows on hover.** The bar cannot be in flow: a
+//     row that gets taller on hover reflows every row below it, mid-scroll.
+//     So it is absolutely positioned into the `pb-5` gap the user column
+//     already reserves between one exchange and the next, and reserves no
+//     space of its own. `.atlas-row` sets `contain: layout style` and
+//     deliberately NOT `paint` (`globals.css:1660`), so the bar is free to
+//     overhang that gap by a pixel or two without being clipped.
+//
+//  2. **House rule 3 — rows never subscribe to a store.** The actions read
+//     what they need through `getState()` at click time. Nothing here holds a
+//     subscription, so nothing here re-renders on a streaming frame.
+//
+//  3. **The transcript is not virtualized** (`transcript.tsx:1`), so this
+//     mounts once per user message for the life of the thread. That is why
+//     the reveal is pure CSS `group-hover` against the row wrapper's existing
+//     `group` class: a JS hover state would fire a `setState` for every bubble
+//     the pointer crosses during a fast flick, which is precisely the work
+//     the transcript is built to avoid. The trade is two buttons' worth of
+//     idle DOM per user row, which costs nothing at scroll time.
+//
+// `focus-within` on the container is not decoration: with an opacity-only
+// reveal, keyboard users would otherwise tab into controls they cannot see.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Copy, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { copyText } from "@/lib/clipboard";
+import { retryLastTurn } from "../lib/retry-turn";
+
+function ActionButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--text-tertiary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] cursor-pointer"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function UserRowActions({
+  tabId,
+  text,
+  canRetry,
+}: {
+  tabId: string;
+  /** The cleaned prompt — `row.text`, already stripped of injected context and
+   *  the next-steps directive by `derivedUser`. Copying the wire text instead
+   *  would hand the user kilobytes of repo context they never wrote. */
+  text: string;
+  /** Only the thread's last user message can be retried, and only where the
+   *  agent can actually rewind. Resolved by the transcript so this stays a
+   *  plain boolean prop — see `sessionCanRetry` in `retry-gate.ts`. */
+  canRetry: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // A row can unmount while the "copied" tick is still pending (window growth
+  // and history loads both remount rows freely).
+  useEffect(() => () => void (timer.current && clearTimeout(timer.current)), []);
+
+  const onCopy = useCallback(() => {
+    void copyText(text).then((ok) => {
+      // `copyText` returns false rather than throwing when both the native and
+      // the web path fail. Swallowing that is indistinguishable from success —
+      // the tick simply never appears and the user pastes stale clipboard
+      // contents somewhere else before noticing.
+      if (!ok) {
+        toast.error("Could not copy to the clipboard");
+        return;
+      }
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), 1_200);
+    });
+  }, [text]);
+
+  const onRetry = useCallback(() => void retryLastTurn(tabId), [tabId]);
+
+  return (
+    <div
+      className={cn(
+        // `top-full`, not "under the bubble": the attachment chip and the
+        // show-more toggle also sit below it, and anchoring to the bubble
+        // would drop the bar on top of them.
+        "absolute right-0 top-full z-[2] mt-px flex items-center gap-0.5",
+        "opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100",
+      )}
+    >
+      {canRetry && (
+        <ActionButton label="Retry this message" onClick={onRetry}>
+          <RotateCcw size={12} />
+        </ActionButton>
+      )}
+      <ActionButton label={copied ? "Copied" : "Copy message"} onClick={onCopy}>
+        {copied ? <Check size={12} /> : <Copy size={12} />}
+      </ActionButton>
+    </div>
+  );
+}

--- a/src/features/chat/lib/agents-api.ts
+++ b/src/features/chat/lib/agents-api.ts
@@ -155,6 +155,12 @@ export const agents = {
   ) => invoke<void>("agents_respond_elicitation", { agentId, requestId, action, content }),
   /** Branch a session from its current state (P3.4). Null when unsupported. */
   forkSession: (key: SessionKey) => invoke<string | null>("agents_fork_session", { key }),
+  /** Rewind the last exchange, resolving to the prompt that started it — or
+   *  `null` when there is nothing to rewind, or the agent is an ACP one (no
+   *  rewind verb exists in ACP's session capabilities). The caller re-sends
+   *  the returned text; keeping the two calls apart is what lets a failed
+   *  resend hand the prompt back instead of losing it. */
+  rewindLastTurn: (key: SessionKey) => invoke<string | null>("agents_rewind_last_turn", { key }),
   /** Set any agent-advertised config option (P2.2). `value` is a bool for
    *  boolean options, or the option-value id for select options. */
   setConfigOption: (key: SessionKey, configId: string, value: boolean | string) =>

--- a/src/features/chat/lib/retry-gate.test.ts
+++ b/src/features/chat/lib/retry-gate.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { NATIVE_AGENT_ID, type ChatSession } from "@/types/agent";
+import { sessionCanRetry } from "./retry-gate";
+
+/** Only the fields the gate reads; the rest of `ChatSession` is irrelevant. */
+function session(over: Partial<ChatSession> = {}): ChatSession {
+  return {
+    agentType: NATIVE_AGENT_ID,
+    status: "idle",
+    messages: [],
+    ...over,
+  } as ChatSession;
+}
+
+/** The agent advertised a rewind. */
+const CAN = true;
+
+describe("whether a session can retry its last turn", () => {
+  it("can, when the agent advertises a rewind and the session is idle", () => {
+    expect(sessionCanRetry(session(), CAN)).toBe(true);
+  });
+
+  it("cannot when the agent cannot rewind, whichever agent that is", () => {
+    // Session capabilities in schema 1.5.0 are list/delete/fork/resume/close/
+    // additional_directories/meta — nothing that tells an agent to forget a
+    // turn. The alternative to hiding the button is an append-and-resend that
+    // looks like a retry and silently isn't one.
+    expect(sessionCanRetry(session({ agentType: "claude-code" }), false)).toBe(false);
+    expect(sessionCanRetry(session({ agentType: "codex" }), false)).toBe(false);
+  });
+
+  it("asks the capability, not the agent id", () => {
+    // ADR-0002: no agent gets special treatment. The gate must not recognise
+    // the native agent by name — if the capability says no, the answer is no
+    // even for `cersei`, and if it says yes the answer is yes for anyone.
+    expect(sessionCanRetry(session({ agentType: NATIVE_AGENT_ID }), false)).toBe(false);
+    expect(sessionCanRetry(session({ agentType: "some-future-agent" }), CAN)).toBe(true);
+  });
+
+  it("cannot before the agent's first handshake", () => {
+    // Capabilities are false until the connection advertises them. Unknown is
+    // not a licence to offer a destructive action.
+    expect(sessionCanRetry(session(), false)).toBe(false);
+  });
+
+  it("cannot while a turn is in flight", () => {
+    // Rewinding under a running turn would race the very turn it is replacing.
+    expect(sessionCanRetry(session({ status: "running" }), CAN)).toBe(false);
+  });
+
+  it("cannot while a turn is paused on an approval", () => {
+    // `waiting` is a LIVE turn parked on a permission or plan modal. Rewinding
+    // here would delete the exchange the modal is asking about.
+    expect(sessionCanRetry(session({ status: "waiting" }), CAN)).toBe(false);
+  });
+
+  it("cannot between Stop and the cancelled turn's terminal delta", () => {
+    // `status` can already read idle while the backend is still winding tools
+    // down; `stopping` is the flag that says so.
+    expect(sessionCanRetry(session({ status: "idle", stopping: true }), CAN)).toBe(false);
+  });
+
+  it("can again once the turn ends, including after an error", () => {
+    // A failed turn is the single most likely thing a user wants to retry.
+    expect(sessionCanRetry(session({ status: "error" }), CAN)).toBe(true);
+  });
+
+  it("cannot on a session whose agent process is gone or still resuming", () => {
+    expect(sessionCanRetry(session({ disconnected: true }), CAN)).toBe(false);
+    expect(sessionCanRetry(session({ resumePending: true }), CAN)).toBe(false);
+  });
+
+  it("cannot on no session at all", () => {
+    expect(sessionCanRetry(undefined, CAN)).toBe(false);
+  });
+
+  it("does not read `messages`", () => {
+    // The transcript calls this inside a store selector, so it runs on every
+    // streaming delta. Walking the message log here would make a long thread's
+    // stream quadratic — which row is retryable is a separate, memoized
+    // question answered from the row projection.
+    const trap = session();
+    Object.defineProperty(trap, "messages", {
+      get() {
+        throw new Error("sessionCanRetry must not touch messages");
+      },
+    });
+    expect(() => sessionCanRetry(trap, CAN)).not.toThrow();
+  });
+});

--- a/src/features/chat/lib/retry-gate.ts
+++ b/src/features/chat/lib/retry-gate.ts
@@ -29,9 +29,14 @@ import { isBusyAgentStatus, type ChatSession } from "@/types/agent";
  *
  * That still leaves HOW the caller knows. Comparing against the native agent's
  * id would work today and is exactly the special-casing ADR-0002 rules out, so
- * `agentSupportsRewind` is a fact discovered from the live connection and
- * published on the catalog entry (`supportsRewind`, computed next to
- * `supports_fork` in `agent_host.rs`), and this function only reads it.
+ * `agentSupportsRewind` comes from the connection answering for itself —
+ * `AgentConnection::supports_rewind`, published onto the catalog entry as
+ * `supportsRewind` — and this function only reads it. Note the honest limit:
+ * the native connection answers `true` from its own impl rather than from
+ * anything an agent advertised at `initialize`, because there is no ACP
+ * capability to advertise. The seam is what matters here — an agent that gains
+ * a rewind implements the trait and is offered the affordance, and no code
+ * outside its own crate names it.
  *
  * @param agentSupportsRewind `agentCatalogEntry(agentType)?.supportsRewind`.
  *   False before the agent's first handshake, which is correct: unknown is not

--- a/src/features/chat/lib/retry-gate.ts
+++ b/src/features/chat/lib/retry-gate.ts
@@ -1,0 +1,53 @@
+// Whether a session can retry its last turn.
+//
+// Split out from `retry-turn.ts` so the predicate carries none of the action's
+// weight: the transcript evaluates it inside a store selector on the hot
+// render path, and `retry-turn` reaches IPC, toasts and the log store. A pure
+// module is also the only way to test the gate without standing up Tauri's
+// event bridge.
+
+import { isBusyAgentStatus, type ChatSession } from "@/types/agent";
+
+/**
+ * Whether this session could retry at all — agent, connection and status only.
+ *
+ * O(1) and allocation-free on purpose. The transcript evaluates it inside a
+ * store selector, so it runs on every store write (every streaming delta);
+ * anything that walked `messages` here would be quadratic across a long
+ * thread's stream. Whether a given ROW is the retryable one is the
+ * transcript's separate, memoized question.
+ *
+ * # Why a capability rather than an agent check
+ *
+ * THE canonical statement of this; everything else points here. Rewinding is
+ * the engine's own `thread/rollback`, which is not an ACP verb. ACP's session
+ * capabilities in schema 1.5.0 are `list`, `delete`, `additional_directories`,
+ * `fork`, `resume`, `close` and `meta` — none of which tells an agent to
+ * forget a turn. So for an ACP agent the choice is between hiding the
+ * affordance and faking it with an append-and-resend that looks like a retry
+ * and is not one; Atlas hides it.
+ *
+ * That still leaves HOW the caller knows. Comparing against the native agent's
+ * id would work today and is exactly the special-casing ADR-0002 rules out, so
+ * `agentSupportsRewind` is a fact discovered from the live connection and
+ * published on the catalog entry (`supportsRewind`, computed next to
+ * `supports_fork` in `agent_host.rs`), and this function only reads it.
+ *
+ * @param agentSupportsRewind `agentCatalogEntry(agentType)?.supportsRewind`.
+ *   False before the agent's first handshake, which is correct: unknown is not
+ *   a licence to offer a destructive action.
+ */
+export function sessionCanRetry(
+  session: ChatSession | undefined,
+  agentSupportsRewind: boolean,
+): boolean {
+  if (!session) return false;
+  if (!agentSupportsRewind) return false;
+  if (session.disconnected || session.resumePending) return false;
+  // `isBusyAgentStatus` rather than a status set of our own: it also covers
+  // `waiting`, the turn that is paused on a permission or plan approval.
+  // Rewinding there would drop the exchange out from under a modal the user
+  // is still looking at. `stopping` is the same argument for a cancelled turn
+  // whose terminal delta has not landed yet.
+  return !isBusyAgentStatus(session.status) && !session.stopping;
+}

--- a/src/features/chat/lib/retry-turn.test.ts
+++ b/src/features/chat/lib/retry-turn.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The action reaches IPC, toasts and the log store; none of that is what is
+// under test. What IS under test is the ordering around the destructive call.
+const rewindLastTurn = vi.fn<(key: unknown) => Promise<string | null>>();
+const send = vi.fn<() => Promise<void>>();
+const enqueueMessage = vi.fn();
+const addMessage = vi.fn();
+const updateSessionStatus = vi.fn();
+
+let session: Record<string, unknown> | undefined;
+let subscriber: (() => void) | undefined;
+
+vi.mock("./agents-api", () => ({
+  agents: {
+    rewindLastTurn: (key: unknown) => rewindLastTurn(key),
+    send: () => send(),
+  },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("@/features/log/lib/log", () => ({ logEvent: vi.fn() }));
+vi.mock("@/features/agents/lib/agent-meta", () => ({
+  catalogEntry: () => ({ supportsRewind: true }),
+}));
+vi.mock("../stores/chat-store", () => ({
+  useChatStore: {
+    getState: () => ({
+      sessions: { tab: session },
+      actions: { addMessage, updateSessionStatus, enqueueMessage },
+    }),
+    subscribe: (cb: () => void) => {
+      subscriber = cb;
+      return () => {
+        subscriber = undefined;
+      };
+    },
+  },
+}));
+
+const { retryLastTurn } = await import("./retry-turn");
+
+/** Let the store's truncation become observable, as the real delta would. */
+function deliverRewindDelta() {
+  session = { ...session, messages: [{ role: "user" }] };
+  subscriber?.();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  subscriber = undefined;
+  session = {
+    agentType: "cersei",
+    status: "idle",
+    acpAgentId: "agent",
+    acpSessionId: "sess",
+    messages: [{ role: "user" }, { role: "assistant" }],
+  };
+});
+
+describe("retrying the last turn", () => {
+  it("rewinds once when clicked twice in a row", async () => {
+    // The status gate cannot catch this: `updateSessionStatus("running")` only
+    // runs AFTER the rewind resolves, so between the two clicks the session
+    // still reads idle and the gate still says yes. Two rollbacks would have
+    // destroyed two turns, and the second one is a turn the user never chose.
+    let release: (v: string | null) => void = () => {};
+    rewindLastTurn.mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const first = retryLastTurn("tab");
+    const second = retryLastTurn("tab");
+
+    expect(rewindLastTurn).toHaveBeenCalledTimes(1);
+
+    release("hello");
+    deliverRewindDelta();
+    await Promise.all([first, second]);
+    expect(rewindLastTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a retry again once the previous one has settled", async () => {
+    rewindLastTurn.mockResolvedValue("hello");
+    send.mockResolvedValue(undefined);
+
+    const run = retryLastTurn("tab");
+    deliverRewindDelta();
+    await run;
+
+    const again = retryLastTurn("tab");
+    deliverRewindDelta();
+    await again;
+    expect(rewindLastTurn).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the claim even when the rewind throws", async () => {
+    // A guard that leaks on the error path would wedge retry for the life of
+    // the tab, with no way for the user to tell why the button stopped working.
+    rewindLastTurn.mockRejectedValueOnce(new Error("engine gone"));
+    await retryLastTurn("tab");
+
+    rewindLastTurn.mockResolvedValue("hello");
+    send.mockResolvedValue(undefined);
+    const run = retryLastTurn("tab");
+    deliverRewindDelta();
+    await run;
+    expect(rewindLastTurn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not send, and hands the prompt back, when the rewind never reaches the transcript", async () => {
+    // The rewind already landed on the backend. Sending anyway risks a late
+    // `history_rewound` splicing off the message just added; dropping the
+    // prompt loses what the user wrote. Neither is acceptable.
+    vi.useFakeTimers();
+    rewindLastTurn.mockResolvedValue("hello");
+    const run = retryLastTurn("tab");
+    await vi.advanceTimersByTimeAsync(4_000);
+    await run;
+    vi.useRealTimers();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(enqueueMessage).toHaveBeenCalledWith("tab", "hello");
+  });
+
+  it("does not send into a session the tab switched to mid-rewind", async () => {
+    // Sending the old key's prompt into a different session would put one
+    // conversation's text in another's transcript.
+    rewindLastTurn.mockImplementation(async () => {
+      session = { ...session, acpSessionId: "a-different-session" };
+      return "hello";
+    });
+
+    const run = retryLastTurn("tab");
+    deliverRewindDelta();
+    await run;
+
+    expect(send).not.toHaveBeenCalled();
+    expect(enqueueMessage).toHaveBeenCalledWith("tab", "hello");
+  });
+
+  it("sends nothing and enqueues nothing when there was no turn to rewind", async () => {
+    rewindLastTurn.mockResolvedValue(null);
+    await retryLastTurn("tab");
+    expect(send).not.toHaveBeenCalled();
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/chat/lib/retry-turn.ts
+++ b/src/features/chat/lib/retry-turn.ts
@@ -1,0 +1,144 @@
+// Retry the last turn: rewind it on the agent, then re-send the prompt
+// that started it.
+//
+// # Why this is not "send the text again"
+//
+// Appending the same prompt to the bottom of the thread is not a retry — it is
+// the user re-typing, and it leaves the failed turn in the model's context for
+// the second attempt to trip over. A retry has to REMOVE the turn first, which
+// is a destructive backend operation, not a UI one.
+//
+// Native-agent-only, for the reason set out in `retry-gate.ts`.
+//
+// # Why rewind and send are two calls
+//
+// They fail apart. A rewind that lands followed by a send that does not must
+// leave the user holding their prompt rather than a silently shortened thread,
+// and that is only expressible if the caller sees both outcomes.
+
+import { toast } from "sonner";
+import type { SessionKey } from "@/types/agents";
+import { useChatStore } from "../stores/chat-store";
+import { agents } from "./agents-api";
+import { sessionCanRetry } from "./retry-gate";
+import { catalogEntry } from "@/features/agents/lib/agent-meta";
+import { logEvent } from "@/features/log/lib/log";
+
+/**
+ * Wait until the store reflects the rewind, so the re-sent message is not
+ * spliced off by the `history_rewound` delta that is still in flight.
+ *
+ * The rewind's `EntriesRemoved` event and the command's own response travel on
+ * different channels; nothing orders them. Rather than guess, this waits for
+ * the effect to be observable and gives up after `timeoutMs` — the delta
+ * normally lands in single-digit milliseconds, and proceeding late is better
+ * than hanging on a delta that was dropped.
+ */
+function awaitRewind(tabId: string, before: number, timeoutMs = 3_000): Promise<boolean> {
+  const shorter = () => (useChatStore.getState().sessions[tabId]?.messages.length ?? 0) < before;
+  if (shorter()) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const done = (ok: boolean) => {
+      clearTimeout(timer);
+      unsubscribe();
+      resolve(ok);
+    };
+    const timer = setTimeout(() => done(false), timeoutMs);
+    const unsubscribe = useChatStore.subscribe(() => {
+      if (shorter()) done(true);
+    });
+  });
+}
+
+/**
+ * Rewind the last turn and re-run it.
+ *
+ * Fire-and-forget from the UI: the reply streams back through the usual
+ * `atlas:agents` deltas, exactly as an ordinary send does.
+ */
+export async function retryLastTurn(tabId: string): Promise<void> {
+  const store = useChatStore.getState();
+  const session = store.sessions[tabId];
+  if (!session?.acpAgentId || !session.acpSessionId) return;
+  // Re-checked at click time, not just at render time: the turn may have
+  // started streaming between the hover and the click.
+  if (!sessionCanRetry(session, catalogEntry(session.agentType)?.supportsRewind === true)) {
+    return;
+  }
+
+  const key: SessionKey = {
+    agent_id: session.acpAgentId,
+    session_id: session.acpSessionId,
+  };
+  const before = session.messages.length;
+
+  let prompt: string | null;
+  try {
+    prompt = await agents.rewindLastTurn(key);
+  } catch (err) {
+    toast.error(`Could not rewind: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  // `null` covers two cases the engine does not distinguish: it refused
+  // because there was nothing left to drop, and it did not answer at all. The
+  // wording says only what is certain — asserting "nothing to retry" at a dead
+  // engine would send the user looking in the wrong place. Either way nothing
+  // was removed, so there is nothing to restore.
+  if (prompt === null) {
+    toast.error("Could not rewind — nothing to retry, or the agent did not respond");
+    return;
+  }
+
+  await awaitRewind(tabId, before);
+
+  // Two awaits have passed since `key` was captured. A tab that switched agent
+  // or rebound in between is a DIFFERENT session, and sending the old key's
+  // prompt into it would put one conversation's text in another's transcript.
+  // The rewind already landed; saying so is better than compounding it.
+  const now = useChatStore.getState().sessions[tabId];
+  if (now?.acpSessionId !== key.session_id || now?.acpAgentId !== key.agent_id) {
+    toast.error("Rewound, but the session changed — your prompt was not re-sent");
+    return;
+  }
+
+  // The stored prompt is the WIRE text — mentions expanded, injected context
+  // and the next-steps directive included. Re-sending it verbatim reproduces
+  // the original turn rather than a lossily-recomposed version of it, and the
+  // transcript strips both suffixes for display the same way it does for a
+  // freshly composed send (`derivedUser` in `turn-rows.ts`).
+  //
+  // Attachments do not survive: the thread records what was sent, not the
+  // composer state that produced it.
+  const actions = useChatStore.getState().actions;
+  actions.addMessage(tabId, "user", prompt);
+  actions.updateSessionStatus(tabId, "running");
+  logEvent({
+    source: "chat",
+    kind: "send-agent",
+    summary: prompt.slice(0, 120),
+    payload: { tabId, retry: true },
+  });
+
+  // Outcomes, not just the attempt: an ordinary send logs `stream-started` /
+  // an error, and a retry that is invisible past its first line cannot be told
+  // apart from a normal turn when reading the log back.
+  try {
+    await agents.send(key, prompt);
+    logEvent({
+      source: "agent",
+      kind: "stream-started",
+      summary: `retry dispatched to ${key.session_id}`,
+      payload: { tabId, acpSessionId: key.session_id, retry: true },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    actions.addMessage(tabId, "assistant", `agent send error: ${msg}`);
+    actions.updateSessionStatus(tabId, "error");
+    logEvent({
+      source: "agent",
+      kind: "stream-error",
+      summary: `retry send failed: ${msg.slice(0, 120)}`,
+      payload: { tabId, acpSessionId: key.session_id, retry: true },
+    });
+  }
+}

--- a/src/features/chat/lib/retry-turn.ts
+++ b/src/features/chat/lib/retry-turn.ts
@@ -25,6 +25,18 @@ import { catalogEntry } from "@/features/agents/lib/agent-meta";
 import { logEvent } from "@/features/log/lib/log";
 
 /**
+ * Tabs with a rewind already in flight.
+ *
+ * The status gate cannot cover this. `updateSessionStatus(tabId, "running")`
+ * only happens AFTER the rewind returns, so between the first click and that
+ * point the session still reads idle and `sessionCanRetry` still says yes — a
+ * double-click therefore issued two rollbacks and destroyed two turns, not
+ * one. Claimed synchronously, before the first await, because anything async
+ * reopens the same window it is trying to close.
+ */
+const inFlight = new Set<string>();
+
+/**
  * Wait until the store reflects the rewind, so the re-sent message is not
  * spliced off by the `history_rewound` delta that is still in flight.
  *
@@ -66,49 +78,93 @@ export async function retryLastTurn(tabId: string): Promise<void> {
     return;
   }
 
-  const key: SessionKey = {
-    agent_id: session.acpAgentId,
-    session_id: session.acpSessionId,
-  };
-  const before = session.messages.length;
+  if (inFlight.has(tabId)) return;
+  inFlight.add(tabId);
+  try {
+    await runRetry(tabId, {
+      agent_id: session.acpAgentId,
+      session_id: session.acpSessionId,
+    });
+  } finally {
+    inFlight.delete(tabId);
+  }
+}
+
+async function runRetry(tabId: string, key: SessionKey): Promise<void> {
+  const before = useChatStore.getState().sessions[tabId]?.messages.length ?? 0;
 
   let prompt: string | null;
   try {
     prompt = await agents.rewindLastTurn(key);
   } catch (err) {
-    toast.error(`Could not rewind: ${err instanceof Error ? err.message : String(err)}`);
+    const msg = err instanceof Error ? err.message : String(err);
+    toast.error(`Could not rewind: ${msg}`);
+    logEvent({
+      source: "agent",
+      kind: "stream-error",
+      summary: `retry rewind failed: ${msg.slice(0, 120)}`,
+      payload: { tabId, acpSessionId: key.session_id, retry: true },
+    });
     return;
   }
-  // `null` covers two cases the engine does not distinguish: it refused
-  // because there was nothing left to drop, and it did not answer at all. The
-  // wording says only what is certain — asserting "nothing to retry" at a dead
-  // engine would send the user looking in the wrong place. Either way nothing
-  // was removed, so there is nothing to restore.
+  // `null` is "the engine declined", which is almost always an empty thread —
+  // but the request layer folds a refusal, a dead channel, and a channel that
+  // died AFTER the rollback ran into one error, so this is not a promise that
+  // nothing moved. The wording claims only what is certain; asserting "nothing
+  // to retry" at a dead engine would send the user looking in the wrong place.
+  // Nothing is enqueued here because in the overwhelmingly common case there
+  // is no prompt to hand back.
   if (prompt === null) {
     toast.error("Could not rewind — nothing to retry, or the agent did not respond");
     return;
   }
 
-  await awaitRewind(tabId, before);
+  // From here the rewind HAS landed and the prompt exists only in this
+  // closure — every bail-out below has to hand it back rather than drop it.
+  // `enqueueMessage` is that hand-back: the composer shows a queued chip the
+  // user can edit or send, and the drain effect only fires on a status or
+  // binding transition, so nothing re-sends behind their back.
+  const preserve = (why: string) => {
+    useChatStore.getState().actions.enqueueMessage(tabId, prompt as string);
+    toast.error(`${why} — your prompt is waiting in the composer`);
+    logEvent({
+      source: "agent",
+      kind: "stream-error",
+      summary: `retry not re-sent: ${why}`,
+      payload: { tabId, acpSessionId: key.session_id, retry: true },
+    });
+  };
+
+  // A false answer means the truncation never became observable. Sending
+  // anyway is the worst of both: a late `history_rewound` splices off the
+  // message just added, and a delta that never comes leaves the rewound turn
+  // on screen with a duplicate under it.
+  if (!(await awaitRewind(tabId, before))) {
+    preserve("The rewind did not reach the transcript");
+    return;
+  }
 
   // Two awaits have passed since `key` was captured. A tab that switched agent
   // or rebound in between is a DIFFERENT session, and sending the old key's
   // prompt into it would put one conversation's text in another's transcript.
-  // The rewind already landed; saying so is better than compounding it.
   const now = useChatStore.getState().sessions[tabId];
   if (now?.acpSessionId !== key.session_id || now?.acpAgentId !== key.agent_id) {
-    toast.error("Rewound, but the session changed — your prompt was not re-sent");
+    preserve("The session changed before the retry could be sent");
     return;
   }
 
   // The stored prompt is the WIRE text — mentions expanded, injected context
-  // and the next-steps directive included. Re-sending it verbatim reproduces
-  // the original turn rather than a lossily-recomposed version of it, and the
-  // transcript strips both suffixes for display the same way it does for a
-  // freshly composed send (`derivedUser` in `turn-rows.ts`).
+  // and the next-steps directive included — so it is closer to the original
+  // than a recomposition from the visible bubble would be, and the transcript
+  // strips both suffixes for display the same way it does for a freshly
+  // composed send (`derivedUser` in `turn-rows.ts`).
   //
-  // Attachments do not survive: the thread records what was sent, not the
-  // composer state that produced it.
+  // It is NOT byte-identical. The thread flattens content blocks, so a
+  // resource link comes back as a bare URI and mixed blocks lose the newlines
+  // the original input carried (`thread.rs:99` vs `sink.rs:351`); no
+  // `resourceLinks` are re-sent, and attachments are not reconstructed at all.
+  // A prompt that was pure prose round-trips exactly; one that mixed prose and
+  // `@`-mentions comes back flattened.
   const actions = useChatStore.getState().actions;
   actions.addMessage(tabId, "user", prompt);
   actions.updateSessionStatus(tabId, "running");
@@ -132,8 +188,13 @@ export async function retryLastTurn(tabId: string): Promise<void> {
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    actions.addMessage(tabId, "assistant", `agent send error: ${msg}`);
-    actions.updateSessionStatus(tabId, "error");
+    // Recheck: `agents.send` is another await, and writing an error bubble
+    // through `tabId` after the tab rebound would blame the wrong session.
+    const still = useChatStore.getState().sessions[tabId];
+    if (still?.acpSessionId === key.session_id && still?.acpAgentId === key.agent_id) {
+      actions.addMessage(tabId, "assistant", `agent send error: ${msg}`);
+      actions.updateSessionStatus(tabId, "error");
+    }
     logEvent({
       source: "agent",
       kind: "stream-error",

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -2115,7 +2115,18 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
         cut -= 1;
         if (session.messages[cut]?.role === "user") remaining -= 1;
       }
-      if (remaining === 0) session.messages.splice(cut);
+      if (remaining !== 0) return;
+      const dropped = session.messages.splice(cut);
+      // Splicing the log is not the whole rewind. `addMessage` also increments
+      // `userMessageCount` and hangs the turn's plan on the session, and the
+      // sidebar reads BOTH without rescanning messages — so a rewind that only
+      // spliced left the count permanently high (visibly so under retry, which
+      // rewinds and re-adds on every press) and left the discarded turn's plan
+      // card on screen. Same invariants `replaceMessages` restores wholesale.
+      const droppedUsers = dropped.reduce((n, m) => (m.role === "user" ? n + 1 : n), 0);
+      session.userMessageCount = Math.max(0, (session.userMessageCount ?? 0) - droppedUsers);
+      if (session.messages.length === 0) session.firstUserContent = undefined;
+      session.livePlan = undefined;
       return;
     }
     case "mode_changed": {

--- a/src/features/chat/stores/chat-store.ts
+++ b/src/features/chat/stores/chat-store.ts
@@ -2117,12 +2117,16 @@ function applyDeltaToDraft(s: ChatDraft, env: AgentDelta): void {
       }
       if (remaining !== 0) return;
       const dropped = session.messages.splice(cut);
-      // Splicing the log is not the whole rewind. `addMessage` also increments
-      // `userMessageCount` and hangs the turn's plan on the session, and the
-      // sidebar reads BOTH without rescanning messages — so a rewind that only
-      // spliced left the count permanently high (visibly so under retry, which
-      // rewinds and re-adds on every press) and left the discarded turn's plan
-      // card on screen. Same invariants `replaceMessages` restores wholesale.
+      // Splicing the log is not the whole rewind: two caches derived from it
+      // live on the session and neither is recomputed from `messages`.
+      //   * `userMessageCount`, incremented by `addMessage` (:899) and read by
+      //     the sidebar. A rewind that only spliced left it permanently high —
+      //     visibly so under retry, which rewinds and re-adds on every press.
+      //   * `livePlan`, set by the `plan_updated` delta (:2046) and read by
+      //     the docked plan pill. Left alone it kept showing the plan of the
+      //     turn that was just discarded.
+      // `replaceMessages` (:1310) recomputes the count and preview on a
+      // history load; the plan comes back via `hydrateSessionSnapshot` (:1341).
       const droppedUsers = dropped.reduce((n, m) => (m.role === "user" ? n + 1 : n), 0);
       session.userMessageCount = Math.max(0, (session.userMessageCount ?? 0) - droppedUsers);
       if (session.messages.length === 0) session.firstUserContent = undefined;

--- a/src/types/agent-catalog.ts
+++ b/src/types/agent-catalog.ts
@@ -52,6 +52,9 @@ export interface AgentCatalogEntry {
   /** Whether the agent advertised `sessionCapabilities.fork` (P3.4). Same
    *  pre-spawn caveat as `authKinds`. */
   supportsFork?: boolean;
+  /** Whether the agent can rewind a turn out of its own history. Gates the
+   *  retry affordance; see `retry-gate.ts`. Same pre-spawn caveat. */
+  supportsRewind?: boolean;
   /** Display alias UI state carries ("claude-code" for "claude-code-ts"). */
   agentType: string;
   name: string;


### PR DESCRIPTION
Two icon buttons under each user message in the agent chat panel, like the Claude app. Copy on every message; retry on the last one, where the agent can actually rewind.

## Retry is a rewind, not a resend

Appending the same prompt to the bottom of the thread isn't a retry — it's the user re-typing, and it leaves the failed turn in the model's context for the second attempt to trip over. `EngineConnection::rewind_last_turn` drops the turn via `thread/rollback` and hands back the prompt that started it; the caller re-sends through the ordinary send path.

Rewind and send are two calls on purpose: they fail apart. A rewind that lands followed by a send that doesn't must leave the user holding their prompt, not a silently shortened thread. Every bail-out after a landed rewind hands the prompt back through `enqueueMessage`, so it shows as a composer chip the user can edit or send.

ACP has no verb for forgetting a turn — session capabilities in schema 1.5.0 are `list`/`delete`/`fork`/`resume`/`close`/`additional_directories`/`meta`. So the affordance is hidden for ACP agents rather than faked. That's asked through a new `AgentSessionRewind` seam plus `AgentConnection::supports_rewind`, alongside the existing `AgentSessionTruncate`/`AgentSessionRetry` traits, and published onto the catalog entry next to `supportsFork`. Nothing outside the native crate names a concrete connection type — an agent that grows a rewind gets the affordance for free.

## Performance

The transcript isn't virtualized (deliberately — see `transcript.tsx:1`), so this mounts for every user message in the window. The reveal is therefore pure CSS `group-hover` against the row wrapper's existing `group` class, plus `focus-within` for keyboard: a JS hover state would fire a `setState` for every bubble the pointer crosses during a fast flick, which is exactly the work the transcript is built to avoid.

The bar is absolutely positioned into the `pb-5` gap the user column already reserves, so nothing grows on hover and no row below reflows mid-scroll (house rule 1). `UserRowView`'s new props are primitives, leaving the `memo` and the projection's structural sharing intact.

## Also fixes

`history_rewound` only spliced the message log. It left `userMessageCount` permanently high and the discarded turn's plan card on screen. Pre-existing under `/undo`, but visible under retry, which rewinds and re-adds on every press.

## Known limits

- Retry is last-turn only. Arbitrary-position retry needs `ClientUserMessageId` plumbed end to end, an `AgentSessionTruncate` impl, and fork-and-replay for ACP agents.
- Replay is not byte-identical. The thread flattens content blocks, so a resource link comes back as a bare URI and no `resourceLinks` are re-sent. Pure prose round-trips exactly. Attachments are not reconstructed.
- No filesystem rollback: a rewound turn's file edits stay on disk. True of `/undo` today too.
- Retry is not serialized against queue draining.

## Verification

`format:check`, `typecheck`, `lint`, `test` (1236 passed), `cargo check --workspace`, `cargo clippy` (no new warnings in touched files), `cargo test -p atlas-native-agent -p atlas-acp-thread -p atlas-agent-delta`.

15 tests across `retry-gate.test.ts` and `retry-turn.test.ts`. The concurrency and timeout guards were verified load-bearing by neutralising them and watching the tests fail.

Not yet run in a real app window.