### PR TITLE
fix(timeline): cap the model cell at its column so it stops covering the agent chip

### DIFF
--- a/src/features/artifacts/components/session-list.test.tsx
+++ b/src/features/artifacts/components/session-list.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+/**
+ * The Timeline row's model column.
+ *
+ * `prettyModel` shortens the families it knows and returns the raw id for
+ * everything else, so `google/gemini-3.1-pro-preview` reaches the row at its
+ * full 29 characters. The cell is `justify-self-end`, which sizes it to
+ * `fit-content`, and `truncate`'s `white-space: nowrap` puts its min-content at
+ * the width of the whole string — a floor `fit-content` cannot go below. It came
+ * out 192px wide in a 92px track and, anchored to the track's END, grew leftward
+ * over the agent chip; the ellipsis never appeared, because the box was never
+ * clipped.
+ *
+ * happy-dom has no layout engine, so this asserts the width cap rather than
+ * measuring it — the cap is the whole fix, and its absence is the bug.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// `globals: false` in vitest.config.ts — auto-cleanup is not registered.
+beforeEach(cleanup);
+
+// The list drops the model column below `COMPACT_WIDTH`, and every happy-dom
+// measurement is 0, so without these two the column under test never renders.
+vi.mock("../lib/shared-resize-observer", () => ({ observeSize: () => () => {} }));
+Object.defineProperty(HTMLElement.prototype, "clientWidth", { configurable: true, value: 900 });
+
+import { SessionList } from "./session-list";
+import type { BoardSession } from "../types";
+
+function session(overrides: Partial<BoardSession> = {}): BoardSession {
+  return {
+    id: "as-1",
+    title: "Work",
+    agent: "claude-code",
+    model: null,
+    source: "external_jsonl",
+    startedAt: "2026-06-01T16:10:00.000Z",
+    updatedAt: "2026-06-01T16:12:00.000Z",
+    lastActivityAt: "2026-06-01T16:12:00.000Z",
+    activeSeconds: 120,
+    wallSeconds: 120,
+    messageCount: 4,
+    toolCallCount: 0,
+    checkpointCount: 0,
+    branches: [],
+    insertions: 0,
+    deletions: 0,
+    filesTouched: 0,
+    totalTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    contextUsed: null,
+    contextSize: null,
+    needsAttention: false,
+    attentionReason: null,
+    projectPath: "/tmp/atlas",
+    projectName: "atlas",
+    ...overrides,
+  };
+}
+
+describe("SessionList model column", () => {
+  it("keeps a long model name inside its column", () => {
+    render(
+      <SessionList
+        sessions={[session({ model: "google/gemini-3.1-pro-preview" })]}
+        loading={false}
+        filtered={false}
+        onOpen={() => {}}
+      />,
+    );
+
+    const cell = screen.getByText("google/gemini-3.1-pro-preview");
+    const classes = cell.className.split(/\s+/);
+
+    expect(classes).toContain("truncate");
+    // A nowrap cell that is not stretched has to be capped at its track, or it
+    // sizes to its content and overflows. Either spelling of the cap will do.
+    expect(classes.some((c) => c === "max-w-full" || c === "w-full")).toBe(true);
+  });
+});

--- a/src/features/artifacts/components/session-list.tsx
+++ b/src/features/artifacts/components/session-list.tsx
@@ -250,8 +250,17 @@ const SessionRow = memo(function SessionRow({
 
       <AgentChip agent={session.agent} />
 
+      {/* `max-w-full` is what makes `truncate` work here. `justify-self-end`
+          takes the cell out of `stretch`, so its width becomes `fit-content` —
+          and `truncate`'s `white-space: nowrap` puts min-content at the width of
+          the whole string, which `fit-content` cannot go below. A model id
+          `prettyModel` doesn't shorten (`google/gemini-3.1-pro-preview`) came out
+          192px wide in the 92px track, and since the cell is anchored to the
+          track's END it grew leftward, across the agent chip. Capping the width
+          at the track lets the ellipsis do its job. A short name still shrinks to
+          fit and sits at the right edge, exactly as before. */}
       {!compact && (
-        <span className="justify-self-end truncate font-mono text-[11px] text-[var(--text-tertiary)]">
+        <span className="max-w-full justify-self-end truncate font-mono text-[11px] text-[var(--text-tertiary)]">
           {prettyModel(session.model) ?? ""}
         </span>
       )}


### PR DESCRIPTION
### What?

One class on the Timeline row's model cell — `max-w-full` — plus a test that fails without it.

### Why?

The cell is `justify-self-end`, which takes it out of `stretch` and sizes it to `fit-content`. `truncate` sets `white-space: nowrap`, so the cell's min-content is the width of the whole string, and `fit-content` cannot go below min-content. A model id `prettyModel` doesn't shorten — `google/gemini-3.1-pro-preview` — therefore ignores the 92px track. Anchored to the *end* of that track, it grows leftward, straight over the 28px agent chip, and the ellipsis never appears because the box is never clipped.

Measured in Chromium with the row's exact grid (`22px minmax(0,1fr) 28px 92px 68px`, `gap-4`, 900px row):

| cell | width | overlaps the chip |
|---|---|---|
| `justify-self-end truncate` | 192.1px | yes |
| `+ max-w-full` | 92.0px | no |
| `+ max-w-full`, short name (`Opus 5`) | 39.8px | no |

### How?

`max-w-full` caps the cell at its grid area, and `clientWidth 92 < scrollWidth 192` — the ellipsis engages. Nothing else is needed: `truncate`'s `overflow: hidden` already resolves the grid item's `min-width: auto` to zero, so an added `min-w-0` measures identically (I checked both). A short name still shrinks to fit and sits at the right edge, so rows that were fine look unchanged.

The cluster row is unaffected — it renders `<span />` into the agent and model columns.

Left alone deliberately: whether 92px is a useful width for a provider-prefixed id, and whether `prettyModel` should strip the prefix. Both change what the row *says* rather than containing it, which reads like the design call the issue raises at the end — happy to follow up if you want it in this release.

The test renders `SessionList` under happy-dom with a long model. happy-dom has no layout engine, so it asserts the cap rather than measuring the overflow — `observeSize` is mocked and `clientWidth` stubbed, since the list otherwise measures 0 and drops the model column into the compact grid.

Fixes #250

### Verification

`bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` (1216 passed, 3 skipped). Reverting the one class turns the new test red. No Rust touched.

Not run in the packaged app — the geometry was verified against a standalone Chromium repro of the row's grid rather than a Tauri window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
